### PR TITLE
fix: active contest vote tallies were not being updated with refresh button

### DIFF
--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -430,9 +430,9 @@ impl Database {
                     existing_names.insert(name.clone());
                     if last_updated.is_none()
                         || (app_context.network == Network::Testnet
-                            && last_updated.unwrap() > one_hour_ago)
+                            && last_updated.unwrap() < one_hour_ago)
                         || (app_context.network == Network::Dash
-                            && last_updated.unwrap() > two_weeks_ago)
+                            && last_updated.unwrap() < two_weeks_ago)
                     {
                         names_to_be_updated.push((name, last_updated));
                     }

--- a/src/platform/contested_names/query_dpns_contested_resources.rs
+++ b/src/platform/contested_names/query_dpns_contested_resources.rs
@@ -55,7 +55,7 @@ impl AppContext {
 
         let names_to_be_updated = self
             .db
-            .insert_name_contests_as_normalized_names(contested_resources_as_strings, &self)
+            .insert_name_contests_as_normalized_names(contested_resources_as_strings.clone(), &self)
             .map_err(|e| e.to_string())?;
 
         sender
@@ -63,7 +63,7 @@ impl AppContext {
             .await
             .expect("expected to send refresh");
 
-        // Create a semaphore with 15 permits
+        // Create a semaphore with 24 permits
         let semaphore = Arc::new(Semaphore::new(24));
 
         let mut handles = Vec::new();
@@ -99,7 +99,7 @@ impl AppContext {
 
         handles.push(handle);
 
-        for name in names_to_be_updated {
+        for name in contested_resources_as_strings {
             // Clone the semaphore, sdk, and sender for each task
             let semaphore = semaphore.clone();
             let sdk = sdk.clone();

--- a/src/platform/contested_names/query_dpns_contested_resources.rs
+++ b/src/platform/contested_names/query_dpns_contested_resources.rs
@@ -58,6 +58,8 @@ impl AppContext {
             .insert_name_contests_as_normalized_names(contested_resources_as_strings.clone(), &self)
             .map_err(|e| e.to_string())?;
 
+        tracing::info!("N: {}", names_to_be_updated.len());
+
         sender
             .send(TaskResult::Refresh)
             .await
@@ -99,7 +101,7 @@ impl AppContext {
 
         handles.push(handle);
 
-        for name in contested_resources_as_strings {
+        for name in names_to_be_updated {
             // Clone the semaphore, sdk, and sender for each task
             let semaphore = semaphore.clone();
             let sdk = sdk.clone();

--- a/src/platform/contested_names/query_dpns_contested_resources.rs
+++ b/src/platform/contested_names/query_dpns_contested_resources.rs
@@ -55,17 +55,15 @@ impl AppContext {
 
         let names_to_be_updated = self
             .db
-            .insert_name_contests_as_normalized_names(contested_resources_as_strings.clone(), &self)
+            .insert_name_contests_as_normalized_names(contested_resources_as_strings, &self)
             .map_err(|e| e.to_string())?;
-
-        tracing::info!("N: {}", names_to_be_updated.len());
 
         sender
             .send(TaskResult::Refresh)
             .await
             .expect("expected to send refresh");
 
-        // Create a semaphore with 24 permits
+        // Create a semaphore with 15 permits
         let semaphore = Arc::new(Semaphore::new(24));
 
         let mut handles = Vec::new();

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -62,14 +62,14 @@ impl RegisterDpnsNameScreen {
                 .show_ui(ui, |ui| {
                     // Loop through the qualified identities and display each as selectable
                     for qualified_identity in &self.qualified_identities {
-                        let id = qualified_identity.identity.id(); // Extract the Identifier
-
                         // Display each QualifiedIdentity as a selectable item
                         if ui
                             .selectable_value(
                                 &mut self.selected_qualified_identity,
                                 Some(qualified_identity.clone()),
-                                id.to_string(Encoding::Base58),
+                                qualified_identity.alias.as_ref().unwrap_or(
+                                    &qualified_identity.identity.id().to_string(Encoding::Base58),
+                                ),
                             )
                             .clicked()
                         {


### PR DESCRIPTION
The function `insert_name_contests_as_normalized_names` was returning only names that have not been updated for over an hour, and these names were being used to update the UI showing the contest states. But on testnet, contests only last one hour. So the votes for those names were not being displayed. So instead, we check the network and if it's testnet, we only update the contests created in the past hour, and on mainnet, created in the past two weeks.

Also, in registering dpns names, display aliases instead of identifiers.