### PR TITLE
feat: hide document button

### DIFF
--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -75,6 +75,10 @@ pub fn add_left_panel(
         .show(ctx, |ui| {
             ui.vertical_centered(|ui| {
                 for (label, screen_type, icon_path) in buttons.iter() {
+                    if *screen_type == RootScreenType::RootScreenDocumentQuery {
+                        continue; // Skip rendering the document button for now
+                    }
+
                     let texture: Option<TextureHandle> = load_icon(ctx, icon_path);
                     let is_selected = selected_screen == *screen_type;
                     let button_color = if is_selected {


### PR DESCRIPTION
The purpose of this PR is to hide the document page on the left panel. We do this because the document screen isn't ready yet.