### PR TITLE
fix: load private keys when loading a user identity

### DIFF
--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -159,7 +159,7 @@ impl AddExistingIdentityScreen {
                 // For User, show multiple key inputs
                 for (i, key) in self.keys_input.iter_mut().enumerate() {
                     ui.horizontal(|ui| {
-                        ui.label(format!("Key {}:", i + 1));
+                        ui.label(format!("Private Key {} (Hex or WIF):", i + 1));
                         ui.text_edit_singleline(key);
                         if ui.button("-").clicked() {
                             keys_to_remove.push(i);


### PR DESCRIPTION
Loading the private keys when adding a new user identity was not implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced identity loading functionality with improved error handling for user identities.
	- Updated user interface to clarify input expectations by changing "Key" to "Private Key."
	- Added buttons to fill identity fields with random data for testing purposes.
	- Improved loading status display to show elapsed time during the process.

- **Bug Fixes**
	- Refined logic for removing keys to enhance safety and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->