### PR TITLE
feat: refresh identities

### DIFF
--- a/src/platform/contested_names/query_dpns_contested_resources.rs
+++ b/src/platform/contested_names/query_dpns_contested_resources.rs
@@ -61,7 +61,7 @@ impl AppContext {
         sender
             .send(TaskResult::Refresh)
             .await
-            .expect("expected to send refresh");
+            .map_err(|e| e.to_string())?;
 
         // Create a semaphore with 15 permits
         let semaphore = Arc::new(Semaphore::new(24));

--- a/src/platform/identity/mod.rs
+++ b/src/platform/identity/mod.rs
@@ -1,9 +1,11 @@
 mod add_key_to_identity;
 mod load_identity;
+mod refresh_identity;
 mod register_dpns_name;
 mod register_identity;
 mod withdraw_from_identity;
 
+use crate::app::TaskResult;
 use crate::context::AppContext;
 use crate::model::qualified_identity::{
     EncryptedPrivateKeyTarget, IdentityType, QualifiedIdentity,
@@ -22,6 +24,7 @@ use dash_sdk::platform::{Identity, IdentityPublicKey};
 use dash_sdk::Sdk;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
+use tokio::sync::mpsc;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IdentityInputToLoad {
@@ -165,6 +168,7 @@ pub(crate) enum IdentityTask {
     AddKeyToIdentity(QualifiedIdentity, IdentityPublicKey, [u8; 32]),
     WithdrawFromIdentity(QualifiedIdentity, Option<Address>, Credits, Option<KeyID>),
     RegisterDpnsName(RegisterDpnsNameInput),
+    RefreshIdentity(QualifiedIdentity), // can we take a reference here instead of owned?
 }
 
 fn verify_key_input(
@@ -343,7 +347,12 @@ impl AppContext {
         Ok(key)
     }
 
-    pub async fn run_identity_task(&self, task: IdentityTask, sdk: &Sdk) -> Result<(), String> {
+    pub async fn run_identity_task(
+        &self,
+        task: IdentityTask,
+        sdk: &Sdk,
+        sender: mpsc::Sender<TaskResult>,
+    ) -> Result<(), String> {
         match task {
             IdentityTask::LoadIdentity(input) => self.load_identity(sdk, input).await,
             IdentityTask::WithdrawFromIdentity(qualified_identity, to_address, credits, id) => {
@@ -358,6 +367,9 @@ impl AppContext {
                 self.register_identity(registration_info).await
             }
             IdentityTask::RegisterDpnsName(input) => self.register_dpns_name(sdk, input).await,
+            IdentityTask::RefreshIdentity(qualified_identity) => {
+                self.refresh_identity(sdk, qualified_identity, sender).await
+            }
         }
     }
 }

--- a/src/platform/identity/mod.rs
+++ b/src/platform/identity/mod.rs
@@ -168,7 +168,7 @@ pub(crate) enum IdentityTask {
     AddKeyToIdentity(QualifiedIdentity, IdentityPublicKey, [u8; 32]),
     WithdrawFromIdentity(QualifiedIdentity, Option<Address>, Credits, Option<KeyID>),
     RegisterDpnsName(RegisterDpnsNameInput),
-    RefreshIdentity(QualifiedIdentity), // can we take a reference here instead of owned?
+    RefreshIdentity(QualifiedIdentity),
 }
 
 fn verify_key_input(

--- a/src/platform/identity/refresh_identity.rs
+++ b/src/platform/identity/refresh_identity.rs
@@ -60,6 +60,7 @@ impl AppContext {
         self.insert_local_qualified_identity(&qualified_identity_to_update)
             .map_err(|e| e.to_string())?;
 
+        // Send refresh message to refresh the Identities Screen
         sender
             .send(TaskResult::Refresh)
             .await

--- a/src/platform/identity/refresh_identity.rs
+++ b/src/platform/identity/refresh_identity.rs
@@ -1,0 +1,70 @@
+use crate::app::TaskResult;
+use crate::context::AppContext;
+use crate::model::qualified_identity::QualifiedIdentity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::{Fetch, Identity};
+use dash_sdk::Sdk;
+use tokio::sync::mpsc;
+
+impl AppContext {
+    pub(super) async fn refresh_identity(
+        &self,
+        sdk: &Sdk,
+        qualified_identity: QualifiedIdentity,
+        sender: mpsc::Sender<TaskResult>,
+    ) -> Result<(), String> {
+        // Fetch the latest state of the identity from Platform
+        let refreshed_identity =
+            match Identity::fetch_by_identifier(sdk, qualified_identity.identity.id()).await {
+                Ok(identity_option) => match identity_option {
+                    Some(identity) => identity,
+                    None => {
+                        return Err(format!(
+                            "Identity with id {} not found in Platform state",
+                            qualified_identity.identity.id().to_string(Encoding::Base58)
+                        ))
+                    }
+                },
+                Err(e) => return Err(e.to_string()),
+            };
+
+        // Get local identities
+        let mut local_qualified_identities = match self.load_local_qualified_identities() {
+            Ok(identities) => identities,
+            Err(e) => return Err(e.to_string()),
+        };
+
+        // Find the local identity to update
+        let old_identity_index = match local_qualified_identities
+            .iter()
+            .position(|qi| qi.identity.id() == refreshed_identity.id())
+        {
+            Some(index) => index,
+            None => {
+                return Err(format!(
+                    "Identity with id {} not found in local identities",
+                    refreshed_identity.id().to_string(Encoding::Base58)
+                ))
+            }
+        };
+
+        // Remove the outdated identity from local state
+        let mut qualified_identity_to_update =
+            local_qualified_identities.remove(old_identity_index);
+
+        // Update the identity
+        qualified_identity_to_update.identity = refreshed_identity;
+
+        // Insert the updated identity into local state
+        self.insert_local_qualified_identity(&qualified_identity_to_update)
+            .map_err(|e| e.to_string())?;
+
+        sender
+            .send(TaskResult::Refresh)
+            .await
+            .expect("expected to send refresh");
+
+        Ok(())
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -64,7 +64,7 @@ impl AppContext {
                     .await
             }
             BackendTask::IdentityTask(identity_task) => self
-                .run_identity_task(identity_task, &sdk)
+                .run_identity_task(identity_task, &sdk, sender)
                 .await
                 .map(|_| BackendTaskSuccessResult::None),
             BackendTask::DocumentTask(document_task) => {

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -4,11 +4,12 @@ use crate::model::qualified_identity::EncryptedPrivateKeyTarget::{
     PrivateKeyOnMainIdentity, PrivateKeyOnVoterIdentity,
 };
 use crate::model::qualified_identity::{IdentityType, QualifiedIdentity};
+use crate::platform::identity::IdentityTask;
+use crate::platform::BackendTask;
 use crate::ui::add_key_screen::AddKeyScreen;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::key_info_screen::KeyInfoScreen;
-use crate::ui::transfers::TransferScreen;
 use crate::ui::withdrawals::WithdrawalScreen;
 use crate::ui::{RootScreenType, Screen, ScreenLike, ScreenType};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
@@ -20,7 +21,6 @@ use eframe::egui::{self, Context};
 use eframe::emath::Align;
 use egui::{Color32, Frame, Margin, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 pub struct IdentitiesScreen {
@@ -183,6 +183,7 @@ impl IdentitiesScreen {
                         .column(Column::initial(200.0).resizable(true)) // Identity ID
                         .column(Column::initial(100.0).resizable(true)) // Balance
                         .column(Column::initial(100.0).resizable(true)) // Type
+                        .column(Column::initial(80.0).resizable(true)) // Refresh
                         .column(Column::initial(80.0).resizable(true)) // Keys
                         .column(Column::initial(80.0).resizable(true)) // Withdraw
                         // .column(Column::initial(80.0).resizable(true)) // Transfer
@@ -198,6 +199,9 @@ impl IdentitiesScreen {
                             });
                             header.col(|ui| {
                                 ui.heading("Type");
+                            });
+                            header.col(|ui| {
+                                ui.heading("Refresh");
                             });
                             header.col(|ui| {
                                 ui.heading("Keys");
@@ -229,6 +233,16 @@ impl IdentitiesScreen {
                                     });
                                     row.col(|ui| {
                                         ui.label(format!("{}", qualified_identity.identity_type));
+                                    });
+                                    row.col(|ui| {
+                                        if ui.button("Refresh").clicked() {
+                                            action =
+                                                AppAction::BackendTask(BackendTask::IdentityTask(
+                                                    IdentityTask::RefreshIdentity(
+                                                        qualified_identity.clone(),
+                                                    ),
+                                                ));
+                                        }
                                     });
                                     row.col(|ui| {
                                         for (key_id, key) in public_keys.iter() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a refresh functionality for identities, allowing users to update their identity data directly from the UI.
	- Added a "Refresh" column in the identities table with a button to trigger the refresh action.

- **Bug Fixes**
	- Enhanced error handling for identity refresh operations to provide clearer feedback on failures.
	- Improved error handling in the `query_dpns_contested_resources` method to prevent panics and allow better error propagation.

- **Documentation**
	- Updated method signatures and descriptions to reflect the new functionality and parameters related to identity tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->