### PR TITLE
feat: load app with only testnet config

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -105,10 +105,13 @@ impl AppState {
         let mainnet_app_context = AppContext::new(Network::Dash, db.clone());
         let testnet_app_context = AppContext::new(Network::Testnet, db.clone());
 
-        let app_context = if testnet_app_context.is_some() && mainnet_app_context.is_none() {
+        let app_context = if mainnet_app_context.is_some() {
+            mainnet_app_context.clone().unwrap()
+        } else if testnet_app_context.is_some() {
             testnet_app_context.clone().unwrap()
         } else {
-            mainnet_app_context.clone().unwrap()
+            println!("No valid network configurations found in .env file or environment variables");
+            std::process::exit(1);
         };
 
         let identities_screen = IdentitiesScreen::new(&app_context);

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,8 +104,15 @@ impl AppState {
 
         let settings = db.get_settings().expect("expected to get settings");
 
-        let mainnet_app_context =
-            AppContext::new(Network::Dash, db.clone()).expect("expected Dash config for mainnet");
+        let mainnet_app_context = match AppContext::new(Network::Dash, db.clone()) {
+            Some(context) => context,
+            None => {
+                eprintln!(
+                    "Error: Failed to create the AppContext. Expected Dash config for mainnet."
+                );
+                std::process::exit(1);
+            }
+        };
         let testnet_app_context = AppContext::new(Network::Testnet, db.clone());
 
         let mut identities_screen = IdentitiesScreen::new(&mainnet_app_context);

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,10 @@ impl Config {
             }
         };
 
+        if mainnet_config.is_none() || testnet_config.is_none() {
+            panic!("Configs could not be properly loaded from .env file or environment variables")
+        }
+
         Config {
             mainnet_config,
             testnet_config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ impl Config {
     pub fn load() -> Result<Self, ConfigError> {
         // Load the .env file if available
         if let Err(err) = dotenvy::from_path(".env") {
-            tracing::warn!(
+            tracing::error!(
                 ?err,
                 "Failed to load .env file. Continuing with environment variables."
             );
@@ -94,9 +94,7 @@ impl Config {
         if mainnet_config.is_none() && testnet_config.is_none() {
             return Err(ConfigError::NoValidConfigs);
         } else if mainnet_config.is_none() {
-            return Err(ConfigError::LoadError(
-                "Failed to load mainnet configuration".into(),
-            ));
+            tracing::warn!("Failed to load mainnet configuration");
         } else if testnet_config.is_none() {
             tracing::warn!(
                 "Failed to load testnet configuration, but successfully loaded mainnet config"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Config {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
-    #[error("Failed to load configurations: {0}")]
+    #[error("{0}")]
     LoadError(String),
     #[error("No valid network configurations found in .env file or environment variables")]
     NoValidConfigs,
@@ -96,10 +96,6 @@ impl Config {
         } else if mainnet_config.is_none() {
             return Err(ConfigError::LoadError(
                 "Failed to load mainnet configuration".into(),
-            ));
-        } else if testnet_config.is_none() {
-            return Err(ConfigError::LoadError(
-                "Failed to load testnet configuration".into(),
             ));
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,12 +93,6 @@ impl Config {
 
         if mainnet_config.is_none() && testnet_config.is_none() {
             return Err(ConfigError::NoValidConfigs);
-        } else if mainnet_config.is_none() {
-            tracing::warn!("Failed to load mainnet configuration");
-        } else if testnet_config.is_none() {
-            tracing::warn!(
-                "Failed to load testnet configuration, but successfully loaded mainnet config"
-            );
         }
 
         Ok(Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,10 @@ impl Config {
             return Err(ConfigError::LoadError(
                 "Failed to load mainnet configuration".into(),
             ));
+        } else if testnet_config.is_none() {
+            tracing::warn!(
+                "Failed to load testnet configuration, but successfully loaded mainnet config"
+            );
         }
 
         Ok(Config {

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,7 +39,7 @@ impl AppContext {
             Ok(config) => config,
             Err(e) => {
                 println!("Failed to load config: {e}");
-                return None;
+                std::process::exit(1);
             }
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,13 @@ pub struct AppContext {
 
 impl AppContext {
     pub fn new(network: Network, db: Arc<Database>) -> Option<Arc<Self>> {
-        let config = Config::load();
+        let config = match Config::load() {
+            Ok(config) => config,
+            Err(e) => {
+                println!("Failed to load config: {e}");
+                return None;
+            }
+        };
 
         let network_config = config.config_for_network(network).clone()?;
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -116,6 +116,11 @@ impl NetworkChooserScreen {
         // Display status indicator
         ui.colored_label(status_color, if is_working { "Online" } else { "Offline" });
 
+        if network == Network::Testnet && self.testnet_app_context.is_none() {
+            ui.label("(No configs for testnet loaded)");
+            return AppAction::None;
+        }
+
         // Display wallet count
         let wallet_count = format!(
             "{}",


### PR DESCRIPTION
Allow users to load the app with configs for testnet only (and no configs for mainnet)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for configuration loading, improving robustness.
	- Updated network chooser logic to handle optional application contexts.

- **Bug Fixes**
	- Improved handling of missing network configurations to prevent application crashes.

- **Documentation**
	- Added error messages for configuration failures to assist users in troubleshooting.

- **Refactor**
	- Refined application state management to allow optional contexts, simplifying error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->