### PR TITLE
release: provide zip for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
         description: "Version (i.e. v0.1.0)"
         required: true
 
+permissions:
+  id-token: write
+  attestations: write
+
 jobs:
   build-and-release:
     name: Build and Release Dash Evo Tool
@@ -23,19 +27,19 @@ jobs:
           - name: "linux-amd64"
             runs-on: "ubuntu-20.04"
             target: "x86_64-unknown-linux-gnu"
-            platform: "amd64"
+            platform: "amd64-linux"
           - name: "linux-arm64"
             runs-on: ["self-hosted", "Linux", "ARM64", "ubuntu20.04"]  # Array of tags for ARM64
             target: "aarch64-unknown-linux-gnu"
-            platform: "arm64"
+            platform: "arm64-linux"
           - name: "macos-amd64"
             runs-on: "macos-13"
             target: "x86_64-apple-darwin"
-            platform: "mac-x86"
+            platform: "amd64-mac"
           - name: "macos-arm64"
             runs-on: "macos-latest"
             target: "aarch64-apple-darwin"
-            platform: "mac-arm"
+            platform: "arm64-mac"
           - name: "Windows"
             runs-on: "ubuntu-20.04"
             target: "x86_64-pc-windows-gnu"
@@ -47,6 +51,24 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+
+      - name: Setup prerequisites
+        run: |
+          mkdir -p dash-evo-tool/
+          cp .env.example dash-evo-tool/.env
+          cp -r dash_core_configs/ dash-evo-tool/dash_core_configs
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -67,19 +89,19 @@ jobs:
 
       - name: Install protoc (AMD)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip 
+        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip
         env:
           PROTOC: /usr/local/bin/protoc
 
       - name: Install protoc (Windows)
         if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
-        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip 
+        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip
         env:
           PROTOC: /usr/local/bin/protoc
 
       - name: Install protoc (Mac x64)
         if: ${{ matrix.target == 'x86_64-apple-darwin' }}
-        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-osx-x86_64.zip && sudo unzip -o protoc-25.2-osx-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-osx-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-osx-x86_64.zip && uname -a 
+        run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-osx-x86_64.zip && sudo unzip -o protoc-25.2-osx-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-osx-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-osx-x86_64.zip && uname -a
         env:
           PROTOC: /usr/local/bin/protoc
 
@@ -92,78 +114,56 @@ jobs:
       - name: Windows libsql
         if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
         run: curl -OL https://www.sqlite.org/2024/sqlite-dll-win-x64-3460100.zip && sudo unzip -o sqlite-dll-win-x64-3460100.zip -d winlibs && sudo chown -R runner:docker winlibs/ && pwd && ls -lah && cd winlibs && x86_64-w64-mingw32-dlltool -d sqlite3.def -l libsqlite3.a && ls -lah && cd ..
-  
+
       - name: Build project
-        run: cargo build --release --target ${{ matrix.target }}
+        run: |
+          cargo build --release --target ${{ matrix.target }}
+          mv target/${{ matrix.target }}/release/dash-evo-tool${{ matrix.ext }} dash-evo-tool/dash-evo-tool${{ matrix.ext }}
         env:
           CC_x86_64_pc_windows_gnu: x86_64-w64-mingw32-gcc
           AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
           CFLAGS_x86_64_pc_windows_gnu: "-O2"
 
-      - name: Windows debug (find release file..)
-        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
-        run: tree target/
+      - name: Package release
+        run: |
+          zip -r dash-evo-tool-${{ matrix.platform }}.zip dash-evo-tool/
+
+      - name: Attest
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'dash-evo-tool-${{ matrix.platform }}.zip'
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dash-evo-tool-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/dash-evo-tool${{ matrix.ext }}
-
-    #continue-on-error: true
+          name: dash-evo-tool-${{ matrix.platform }}.zip
+          path: dash-evo-tool-${{ matrix.platform }}.zip
 
   release:
     name: Create GitHub Release
     needs: build-and-release
     runs-on: ubuntu-latest
     steps:
-      - name: Download Linux X64
-        uses: actions/download-artifact@v3
+      - name: Download Linux AMD64 Artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dash-evo-tool-x86_64-unknown-linux-gnu
-          path: ./release/dash-evo-tool-x86_64-unknown-linux-gnu/
-
-      - name: Download Linux ARM
-        uses: actions/download-artifact@v3
+          name: dash-evo-tool-amd64-linux.zip
+      - name: Download Linux Arm64 Artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dash-evo-tool-aarch64-unknown-linux-gnu
-          path: ./release/dash-evo-tool-aarch64-unknown-linux-gnu/
-
-      - name: Download Mac x64
-        uses: actions/download-artifact@v3
+          name: dash-evo-tool-arm64-linux.zip
+      - name: Download MacOS AMD64 Artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dash-evo-tool-x86_64-apple-darwin
-          path: ./release/dash-evo-tool-x86_64-apple-darwin/
-
-      - name: Download Mac ARM
-        uses: actions/download-artifact@v3
+          name: dash-evo-tool-amd64-mac.zip
+      - name: Download MacOS ARM64 Artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dash-evo-tool-aarch64-apple-darwin
-          path: ./release/dash-evo-tool-aarch64-apple-darwin/
-
-      - name: Download Windows
-        uses: actions/download-artifact@v3
+          name: dash-evo-tool-arm64-mac.zip
+      - name: Download Windows Artifact
+        uses: actions/download-artifact@v4
         with:
-          name: dash-evo-tool-x86_64-pc-windows-gnu
-          path: ./release/dash-evo-tool-x86_64-pc-windows-gnu/
-
-      - name: Rename Linux X64 file
-        run: mv ./release/dash-evo-tool-x86_64-unknown-linux-gnu/dash-evo-tool ./release/dash-evo-tool-x86_64-linux
-
-      - name: Rename Linux ARM file
-        run: mv ./release/dash-evo-tool-aarch64-unknown-linux-gnu/dash-evo-tool ./release/dash-evo-tool-aarch64-linux
-
-      - name: Rename Mac x64 file
-        run: mv ./release/dash-evo-tool-x86_64-apple-darwin/dash-evo-tool ./release/dash-evo-tool-x86_64-mac
-
-      - name: Rename Mac ARM file
-        run: mv ./release/dash-evo-tool-aarch64-apple-darwin/dash-evo-tool ./release/dash-evo-tool-aarch64-mac
-
-      - name: Rename Windows file
-        run: mv ./release/dash-evo-tool-x86_64-pc-windows-gnu/dash-evo-tool.exe ./release/dash-evo-tool.exe
-
-      - name: Check dir
-        run: ls -lah ./release/dash-evo-tool-aarch64-apple-darwin
+          name: dash-evo-tool-windows.zip
 
       - name: Publish release
         uses: softprops/action-gh-release@v1
@@ -172,10 +172,10 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: |
-            ./release/dash-evo-tool-x86_64-linux
-            ./release/dash-evo-tool-aarch64-linux
-            ./release/dash-evo-tool-x86_64-mac
-            ./release/dash-evo-tool-aarch64-mac
-            ./release/dash-evo-tool.exe
+            ./dash-evo-tool-amd64-linux.zip
+            ./dash-evo-tool-arm64-linux.zip
+            ./dash-evo-tool-amd64-mac.zip
+            ./dash-evo-tool-arm64-mac.zip
+            ./dash-evo-tool-windows.zip
           draft: false
           prerelease: true


### PR DESCRIPTION
This provides attested to zips as release artifacts as opposed to raw binaries. 

You can see a build in my repo here: https://github.com/PastaPastaPasta/dash-evo-tool/actions/runs/11451944148

Note that my repo excluded arm64 (as GitHub doesn't provide those runners), so that part is **untested**. Additionally, my run doesn't actually publish the release as I haven't setup a "GITHUB_SECRET" as was done in this repo. Should work, but needs to be tested in this repo / with arm64 linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced GitHub Actions workflow for improved release process of the Dash Evo Tool.
  - Introduced caching for the Cargo registry and setup of prerequisites.
  - New packaging step to create zip files for the built tool.

- **Improvements**
  - Updated platform identifiers for better clarity and organization.
  - Streamlined installation commands for various architectures.
  - Refined artifact upload and download steps with standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->