### PR TITLE
feat: application data directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ arboard = { version = "3.4.0", default-features = false, features = [
     "windows-sys",
 ] }
 enum_dispatch = "0.3.13"
+directories = "5.0"
 
 rusqlite = { version = "0.32.1",  features = ["functions"]}
 serde_yaml = "0.9.34+deprecated"

--- a/src/app.rs
+++ b/src/app.rs
@@ -106,7 +106,8 @@ impl AppState {
         create_app_user_data_directory_if_not_exists();
         copy_mainnet_env_file_if_not_exists();
         initialize_logger();
-        let db = Arc::new(Database::new(app_user_data_file_path("data.db".to_string())).unwrap());
+        let db_file_path = app_user_data_file_path("data.db").expect("should create db file path");
+        let db = Arc::new(Database::new(db_file_path).unwrap());
         db.initialize().unwrap();
 
         let settings = db.get_settings().expect("expected to get settings");

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::vec;
 use tokio::sync::mpsc;
+use crate::app_dir::{app_user_data_file_path, copy_mainnet_env_file_if_not_exists, create_app_user_data_directory_if_not_exists};
 
 #[derive(Debug, From)]
 pub enum TaskResult {
@@ -99,8 +100,10 @@ impl BitOrAssign for AppAction {
 }
 impl AppState {
     pub fn new() -> Self {
+        create_app_user_data_directory_if_not_exists();
+        copy_mainnet_env_file_if_not_exists();
         initialize_logger();
-        let db = Arc::new(Database::new("identities.db").unwrap());
+        let db = Arc::new(Database::new(app_user_data_file_path("data.db".to_string())).unwrap());
         db.initialize().unwrap();
 
         let settings = db.get_settings().expect("expected to get settings");

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,7 @@
+use crate::app_dir::{
+    app_user_data_file_path, copy_mainnet_env_file_if_not_exists,
+    create_app_user_data_directory_if_not_exists,
+};
 use crate::context::AppContext;
 use crate::database::Database;
 use crate::logging::initialize_logger;
@@ -18,7 +22,6 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::vec;
 use tokio::sync::mpsc;
-use crate::app_dir::{app_user_data_file_path, copy_mainnet_env_file_if_not_exists, create_app_user_data_directory_if_not_exists};
 
 #[derive(Debug, From)]
 pub enum TaskResult {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use crate::app_dir::{
-    app_user_data_file_path, copy_mainnet_env_file_if_not_exists,
+    app_user_data_file_path, copy_env_file_if_not_exists,
     create_app_user_data_directory_if_not_exists,
 };
 use crate::context::AppContext;
@@ -104,7 +104,7 @@ impl BitOrAssign for AppAction {
 impl AppState {
     pub fn new() -> Self {
         create_app_user_data_directory_if_not_exists().expect("Failed to create app user_data directory");
-        copy_mainnet_env_file_if_not_exists();
+        copy_env_file_if_not_exists();
         initialize_logger();
         let db_file_path = app_user_data_file_path("data.db").expect("should create db file path");
         let db = Arc::new(Database::new(db_file_path).unwrap());

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl BitOrAssign for AppAction {
 }
 impl AppState {
     pub fn new() -> Self {
-        create_app_user_data_directory_if_not_exists();
+        create_app_user_data_directory_if_not_exists().expect("Failed to create app user_data directory");
         copy_mainnet_env_file_if_not_exists();
         initialize_logger();
         let db_file_path = app_user_data_file_path("data.db").expect("should create db file path");

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const QUALIFIER: &str = ""; // Typically empty on macOS and Linux
-const ORGANIZATION: &str = "DashCoreGroup";
+const ORGANIZATION: &str = "";
 const APPLICATION: &str = "DashEvoTool";
 
 pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -40,10 +40,10 @@ pub fn app_user_data_file_path(filename: &str) -> Result<PathBuf, std::io::Error
     Ok(app_data_dir.join(filename))
 }
 
-pub fn copy_mainnet_env_file_if_not_exists() {
+pub fn copy_env_file_if_not_exists() {
     let app_data_dir = app_user_data_dir_path().expect("Failed to determine application data directory");
-    let env_mainnet_file = app_data_dir.join(".env".to_string());
-    if env_mainnet_file.exists() && env_mainnet_file.is_file() {
+    let env_file = app_data_dir.join(".env".to_string());
+    if env_file.exists() && env_file.is_file() {
     } else {
         let env_example_file = PathBuf::from(".env.example");
         let target_env_file_path = app_user_data_file_path(".env").expect("should create target env file path");

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -16,9 +16,15 @@ pub fn create_app_user_data_directory_if_not_exists() {
     fs::create_dir_all(app_data_dir).expect("Failed to create config directory");
 }
 
-pub fn app_user_data_file_path(filename: String) -> PathBuf {
+pub fn app_user_data_file_path(filename: &str) -> Result<PathBuf, std::io::Error> {
+    if filename.is_empty() || filename.contains(std::path::is_separator) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid filename",
+        ));
+    }
     let app_data_dir = app_user_data_dir_path();
-    app_data_dir.join(filename)
+    Ok(app_data_dir.join(filename))
 }
 
 pub fn copy_mainnet_env_file_if_not_exists() {
@@ -27,9 +33,10 @@ pub fn copy_mainnet_env_file_if_not_exists() {
     if env_mainnet_file.exists() && env_mainnet_file.is_file() {
     } else {
         let env_example_file = PathBuf::from(".env.example");
+        let target_env_file_path = app_user_data_file_path(".env").expect("should create target env file path");
         fs::copy(
             &env_example_file,
-            app_user_data_file_path(".env".parse().unwrap()),
+            target_env_file_path,
         )
         .expect("Failed to copy main net env file");
     }

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use directories::ProjectDirs;
+
+const QUALIFIER: &str = "";  // Typically empty on macOS and Linux
+const ORGANIZATION: &str = "DashCoreGroup";
+const APPLICATION: &str = "DashEvoTool";
+
+pub fn app_user_data_dir_path() -> PathBuf {
+    let proj_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
+        .expect("Failed to get project directories");
+    proj_dirs.config_dir().to_path_buf()
+}
+pub fn create_app_user_data_directory_if_not_exists() {
+    let app_data_dir = app_user_data_dir_path();
+    fs::create_dir_all(app_data_dir).expect("Failed to create config directory");
+}
+
+pub fn app_user_data_file_path(filename: String) -> PathBuf {
+    let app_data_dir = app_user_data_dir_path();
+    app_data_dir.join(filename)
+}
+
+pub fn copy_mainnet_env_file_if_not_exists() {
+    let app_data_dir = app_user_data_dir_path();
+    let env_mainnet_file = app_data_dir.join(".env".to_string());
+    if env_mainnet_file.exists() && env_mainnet_file.is_file() {
+
+    } else {
+        let env_example_file = PathBuf::from(".env.example");
+        fs::copy(&env_example_file, app_user_data_file_path(".env".parse().unwrap())).expect("Failed to copy main net env file");
+    }
+}

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -6,14 +6,27 @@ const QUALIFIER: &str = ""; // Typically empty on macOS and Linux
 const ORGANIZATION: &str = "DashCoreGroup";
 const APPLICATION: &str = "DashEvoTool";
 
-pub fn app_user_data_dir_path() -> PathBuf {
+pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
     let proj_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION)
-        .expect("Failed to get project directories");
-    proj_dirs.config_dir().to_path_buf()
+        .ok_or_else(|| std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Failed to determine project directories",
+        ))?;
+    Ok(proj_dirs.config_dir().to_path_buf())
 }
-pub fn create_app_user_data_directory_if_not_exists() {
-    let app_data_dir = app_user_data_dir_path();
-    fs::create_dir_all(app_data_dir).expect("Failed to create config directory");
+pub fn create_app_user_data_directory_if_not_exists() -> Result<(), std::io::Error> {
+    let app_data_dir = app_user_data_dir_path()?;
+    fs::create_dir_all(&app_data_dir)?;
+
+    // Verify directory permissions
+    let metadata = fs::metadata(&app_data_dir)?;
+    if !metadata.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "Created path is not a directory",
+        ));
+    }
+    Ok(())
 }
 
 pub fn app_user_data_file_path(filename: &str) -> Result<PathBuf, std::io::Error> {
@@ -23,12 +36,12 @@ pub fn app_user_data_file_path(filename: &str) -> Result<PathBuf, std::io::Error
             "Invalid filename",
         ));
     }
-    let app_data_dir = app_user_data_dir_path();
+    let app_data_dir = app_user_data_dir_path()?;
     Ok(app_data_dir.join(filename))
 }
 
 pub fn copy_mainnet_env_file_if_not_exists() {
-    let app_data_dir = app_user_data_dir_path();
+    let app_data_dir = app_user_data_dir_path().expect("Failed to determine application data directory");
     let env_mainnet_file = app_data_dir.join(".env".to_string());
     if env_mainnet_file.exists() && env_mainnet_file.is_file() {
     } else {

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -1,8 +1,8 @@
+use directories::ProjectDirs;
 use std::fs;
 use std::path::{Path, PathBuf};
-use directories::ProjectDirs;
 
-const QUALIFIER: &str = "";  // Typically empty on macOS and Linux
+const QUALIFIER: &str = ""; // Typically empty on macOS and Linux
 const ORGANIZATION: &str = "DashCoreGroup";
 const APPLICATION: &str = "DashEvoTool";
 
@@ -25,9 +25,12 @@ pub fn copy_mainnet_env_file_if_not_exists() {
     let app_data_dir = app_user_data_dir_path();
     let env_mainnet_file = app_data_dir.join(".env".to_string());
     if env_mainnet_file.exists() && env_mainnet_file.is_file() {
-
     } else {
         let env_example_file = PathBuf::from(".env.example");
-        fs::copy(&env_example_file, app_user_data_file_path(".env".parse().unwrap())).expect("Failed to copy main net env file");
+        fs::copy(
+            &env_example_file,
+            app_user_data_file_path(".env".parse().unwrap()),
+        )
+        .expect("Failed to copy main net env file");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,8 @@ impl Config {
     /// Loads the configuration for all networks from environment variables and `.env` file.
     pub fn load() -> Result<Self, ConfigError> {
         // Load the .env file if available
-        if let Err(err) = dotenvy::from_path(app_user_data_file_path(".env".to_string())) {
+        let env_file_path = app_user_data_file_path(".env").expect("should create .env file path");
+        if let Err(err) = dotenvy::from_path(env_file_path) {
             tracing::warn!(
                 ?err,
                 "Failed to load .env file. Continuing with environment variables."

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use dash_sdk::dapi_client::AddressList;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::sdk::Uri;
 use serde::Deserialize;
+use crate::app_dir::app_user_data_file_path;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
@@ -59,7 +60,7 @@ impl Config {
     /// Loads the configuration for all networks from environment variables and `.env` file.
     pub fn load() -> Result<Self, ConfigError> {
         // Load the .env file if available
-        if let Err(err) = dotenvy::from_path(".env") {
+        if let Err(err) = dotenvy::from_path(app_user_data_file_path(".env".to_string())) {
             tracing::warn!(
                 ?err,
                 "Failed to load .env file. Continuing with environment variables."

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 
+use crate::app_dir::app_user_data_file_path;
 use dash_sdk::dapi_client::AddressList;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::sdk::Uri;
 use serde::Deserialize;
-use crate::app_dir::app_user_data_file_path;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,11 @@
 use std::panic;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
+use crate::app_dir::app_user_data_file_path;
 
 pub fn initialize_logger() {
     // Initialize log file, with improved error handling
-    let log_file = match std::fs::File::create("explorer.log") {
+    let log_file = match std::fs::File::create(app_user_data_file_path("explorer.log".to_string())) {
         Ok(file) => file,
         Err(e) => panic!("Failed to create log file: {:?}", e),
     };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,11 +1,12 @@
+use crate::app_dir::app_user_data_file_path;
 use std::panic;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
-use crate::app_dir::app_user_data_file_path;
 
 pub fn initialize_logger() {
     // Initialize log file, with improved error handling
-    let log_file = match std::fs::File::create(app_user_data_file_path("explorer.log".to_string())) {
+    let log_file = match std::fs::File::create(app_user_data_file_path("explorer.log".to_string()))
+    {
         Ok(file) => file,
         Err(e) => panic!("Failed to create log file: {:?}", e),
     };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,8 @@ use tracing_subscriber::EnvFilter;
 
 pub fn initialize_logger() {
     // Initialize log file, with improved error handling
-    let log_file = match std::fs::File::create(app_user_data_file_path("explorer.log".to_string()))
+    let log_file_path = app_user_data_file_path("explorer.log").expect("should create log file path");
+    let log_file = match std::fs::File::create(log_file_path)
     {
         Ok(file) => file,
         Err(e) => panic!("Failed to create log file: {:?}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,12 @@ mod logging;
 mod sdk_wrapper;
 mod ui;
 
+mod app_dir;
 mod components;
 mod context;
 mod context_provider;
 mod model;
 mod platform;
-mod app_dir;
 
 fn main() -> eframe::Result<()> {
     // Initialize the Tokio runtime

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod context;
 mod context_provider;
 mod model;
 mod platform;
+mod app_dir;
 
 fn main() -> eframe::Result<()> {
     // Initialize the Tokio runtime

--- a/src/ui/withdraws_status_screen.rs
+++ b/src/ui/withdraws_status_screen.rs
@@ -215,12 +215,18 @@ impl WithdrawsStatusScreen {
         if selected != old_selected {
             self.pagination_items_per_page.set(selected);
         }
-        println!("computing with:{}", self.pagination_items_per_page.get() as usize);
-        let total_pages = (data.withdrawals.len() + (self.pagination_items_per_page.get() as usize) - 1) / (self.pagination_items_per_page.get() as usize);
+        println!(
+            "computing with:{}",
+            self.pagination_items_per_page.get() as usize
+        );
+        let total_pages =
+            (data.withdrawals.len() + (self.pagination_items_per_page.get() as usize) - 1)
+                / (self.pagination_items_per_page.get() as usize);
         let mut current_page = self.pagination_current_page.get().min(total_pages - 1); // Clamp to valid page range
-        // Calculate the slice of data for the current page
+                                                                                        // Calculate the slice of data for the current page
         let start_index = current_page * (self.pagination_items_per_page.get() as usize);
-        let end_index = (start_index + (self.pagination_items_per_page.get() as usize)).min(data.withdrawals.len());
+        let end_index = (start_index + (self.pagination_items_per_page.get() as usize))
+            .min(data.withdrawals.len());
         ui.separator();
         TableBuilder::new(ui)
             .striped(true)


### PR DESCRIPTION
- On startup, application data directory is created depending on the target architecture (for example):
```
macOS: ~/Library/Application Support/MyApp/
Windows: C:\Users\<User>\AppData\Roaming\MyApp\config
Linux: /home/<user>/.config/MyApp/
```
- Database is created and used from that directory
- Same for logging file
- In application data directory, if ".env" is missing, then ".env.example" is copied as ".env"
	

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new module for managing application user data directories and files.
	- Enhanced the user interface for displaying withdrawal data with improved pagination controls.

- **Improvements**
	- Updated initialization logic to ensure necessary directories and files are created.
	- Enhanced error handling for log file creation and configuration loading.

- **Bug Fixes**
	- Improved pagination logic to prevent out-of-bounds access in withdrawal data display.

These updates enhance user experience and application reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->