### PR TITLE
feat: rename app dir to match eguix auto-generated dir

### DIFF
--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 const QUALIFIER: &str = ""; // Typically empty on macOS and Linux
 const ORGANIZATION: &str = "";
-const APPLICATION: &str = "DashEvoTool";
+const APPLICATION: &str = "Dash-Evo-Tool";
 
 pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
     let proj_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or_else(|| {


### PR DESCRIPTION
Rename app dir to "Dash-Evo-Tool" to match qguix auto-generated dir.
