### PR TITLE
feat: disable zmq connectivity detection for windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,6 @@ crossbeam-channel = "0.5.13"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 zmq = "0.10"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+zeromq = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,11 @@ image = { version = "0.25.2", default-features = false, features = ["png"] }
 bitflags = "2.6.0"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 rust-embed = "8.5.0"
-zmq = "0.10"
 zeroize = "1.8.1"
 zxcvbn = "3.1.0"
 argon2 = "0.5"           # For Argon2 key derivation
 aes-gcm = "0.10" # For AES-256-GCM encryption
 crossbeam-channel = "0.5.13"
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+zmq = "0.10"

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,8 +49,8 @@ pub struct AppState {
     pub chosen_network: Network,
     pub mainnet_app_context: Arc<AppContext>,
     pub testnet_app_context: Option<Arc<AppContext>>,
-    pub mainnet_core_zmq_listener: Option<CoreZMQListener>,
-    pub testnet_core_zmq_listener: Option<CoreZMQListener>,
+    pub mainnet_core_zmq_listener: CoreZMQListener,
+    pub testnet_core_zmq_listener: CoreZMQListener,
     pub core_message_receiver: mpsc::Receiver<(ZMQMessage, Network)>,
     pub task_result_sender: tokiompsc::Sender<TaskResult>, // Channel sender for sending task results
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
@@ -189,40 +189,24 @@ impl AppState {
         // Create a channel for communication with the InstantSendListener
         let (core_message_sender, core_message_receiver) = mpsc::channel();
 
-        #[cfg(target_os = "windows")]
-        let mainnet_core_zmq_listener: Option<CoreZMQListener> = None;
-
-        #[cfg(not(target_os = "windows"))]
-        let mainnet_core_zmq_listener: Option<CoreZMQListener> = {
-            // Pass the sender to the listener when creating it
-            let zmq_listener = CoreZMQListener::spawn_listener(
-                Network::Dash,
-                "tcp://127.0.0.1:23708",
-                core_message_sender.clone(), // Clone the sender for each listener
-                Some(mainnet_app_context.sx_zmq_status.clone()),
-            ).expect("Failed to create mainnet InstantSend listener");
-            Some(zmq_listener)
-        };
+        let mainnet_core_zmq_listener = CoreZMQListener::spawn_listener(
+            Network::Dash,
+            "tcp://127.0.0.1:23708",
+            core_message_sender.clone(), // Clone the sender for each listener
+            Some(mainnet_app_context.sx_zmq_status.clone()),
+        ).expect("Failed to create mainnet InstantSend listener");
 
         let tx_zmq_status_option = match testnet_app_context {
             Some(ref context) => Some(context.sx_zmq_status.clone()),
             None => None,
         };
 
-        #[cfg(target_os = "windows")]
-        let testnet_core_zmq_listener: Option<CoreZMQListener> = None;
-
-        #[cfg(not(target_os = "windows"))]
-        let testnet_core_zmq_listener: Option<CoreZMQListener> = {
-            let zmq_listener = CoreZMQListener::spawn_listener(
-                Network::Testnet,
-                "tcp://127.0.0.1:23709",
-                core_message_sender, // Use the original sender or create a new one if needed
-                tx_zmq_status_option,
-            )
-                .expect("Failed to create testnet InstantSend listener");
-            Some(zmq_listener) // or however you construct `Data`
-        };
+        let testnet_core_zmq_listener = CoreZMQListener::spawn_listener(
+            Network::Testnet,
+            "tcp://127.0.0.1:23709",
+            core_message_sender, // Use the original sender or create a new one if needed
+            tx_zmq_status_option,
+        ).expect("Failed to create testnet InstantSend listener");
 
         Self {
             main_screens: [

--- a/src/components/core_zmq_listener.rs
+++ b/src/components/core_zmq_listener.rs
@@ -11,6 +11,8 @@ use std::sync::{
 };
 use std::thread;
 use std::time::Duration;
+
+#[cfg(not(target_os = "windows"))]
 use zmq::Context;
 
 pub struct CoreZMQListener {
@@ -34,6 +36,7 @@ pub const IS_LOCK_SIG_MSG: &[u8; 12] = b"rawtxlocksig";
 pub const CHAIN_LOCKED_BLOCK_MSG: &[u8; 12] = b"rawchainlock";
 
 impl CoreZMQListener {
+    #[cfg(not(target_os = "windows"))]
     pub fn spawn_listener(
         network: Network,
         endpoint: &str,

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -127,7 +127,10 @@ pub fn add_top_panel(
         .exact_height(50.0)
         .show(ctx, |ui| {
             egui::menu::bar(ui, |ui| {
-                action |= add_connection_indicator(ui, app_context);
+                #[cfg(not(target_os = "windows"))]
+                {
+                    action |= add_connection_indicator(ui, app_context);
+                }
 
                 // Left-aligned content with location view
                 action |= add_location_view(ui, location);


### PR DESCRIPTION
Disables ZMQ connectivity detection functionality for Windows build

Under Windows the native `zeromq` is used while `zmq` is used for any other target os.
For the moment, ZMQ connectivity detection feature is available only with `zmq`.

Tested with: `cargo build --target x86_64-pc-windows-gnu` successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced conditional dependency for ZeroMQ, enhancing compatibility with non-Windows platforms.
	- Added flexibility in the application state management by allowing optional ZMQ listeners based on the operating system.

- **Bug Fixes**
	- Improved error handling and adaptability for core ZMQ listener initialization across different operating systems.

- **Documentation**
	- Updated comments and documentation to reflect changes in the handling of OS-specific functionality.

- **Refactor**
	- Streamlined the logic for initializing listeners and adding UI components based on the target OS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->