### PR TITLE
refactor: renamed amd64 to x86_64 in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "linux-amd64"
+          - name: "linux-x86_64"
             runs-on: "ubuntu-20.04"
             target: "x86_64-unknown-linux-gnu"
-            platform: "amd64-linux"
+            platform: "x86_64-linux"
           - name: "linux-arm64"
             runs-on: ["self-hosted", "Linux", "ARM64", "ubuntu20.04"]  # Array of tags for ARM64
             target: "aarch64-unknown-linux-gnu"
             platform: "arm64-linux"
-          - name: "macos-amd64"
+          - name: "macos-x86_64"
             runs-on: "macos-13"
             target: "x86_64-apple-darwin"
-            platform: "amd64-mac"
+            platform: "x86_64-mac"
           - name: "macos-arm64"
             runs-on: "macos-latest"
             target: "aarch64-apple-darwin"


### PR DESCRIPTION
Addressed issue: #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated naming conventions for architecture identifiers in the release workflow, enhancing consistency across Linux and macOS platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->