### PR TITLE
refactor: remove unneeded CURRENT_DB_VERSION in database init

### DIFF
--- a/src/backend_task/contested_names/query_dpns_contested_resources.rs
+++ b/src/backend_task/contested_names/query_dpns_contested_resources.rs
@@ -40,7 +40,7 @@ impl AppContext {
             let (contested_resources) = ContestedResource::fetch_many(&sdk, query.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!("error fetching contested resources: {}", e);
+                    tracing::error!("Error fetching contested resources: {}", e);
                     if let dash_sdk::Error::Proof(
                         dash_sdk::ProofVerifierError::GroveDBProofVerificationError {
                             proof_bytes,
@@ -89,7 +89,7 @@ impl AppContext {
                             return e;
                         }
                     }
-                    format!("error fetching contested resources: {}", e)
+                    format!("Error fetching contested resources: {}", e)
                 })?;
 
             let contested_resources_len = contested_resources.0.len();

--- a/src/backend_task/contested_names/query_dpns_vote_contenders.rs
+++ b/src/backend_task/contested_names/query_dpns_vote_contenders.rs
@@ -48,8 +48,8 @@ impl AppContext {
             ContenderWithSerializedDocument::fetch_many(&sdk, contenders_query.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!("error fetching contested resources: {}", e);
-                    format!("error fetching contested resources: {}", e)
+                    tracing::error!("Error fetching contested resources: {}", e);
+                    format!("Error fetching contested resources: {}", e)
                 })?;
         self.db
             .insert_or_update_contenders(name, &contenders, document_type, self)

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,8 +4,7 @@ use rusqlite::{params, Connection};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 1;
-pub const CURRENT_DB_VERSION: u16 = 2;
+pub const DEFAULT_DB_VERSION: u16 = 2;
 pub const DEFAULT_NETWORK: &str = "dash";
 
 impl Database {
@@ -15,10 +14,10 @@ impl Database {
             self.create_tables()?;
             self.set_default_version()?;
         } else {
-            // Perform version check and back up and recreate the database if outdated.
-            if let Some(current_version) = self.is_outdated()? {
+            // If outdated, back up and either migrate or recreate the database.
+            if let Some(existing_version) = self.is_outdated()? {
                 self.backup_db(db_file_path)?;
-                if let Err(e) = self.try_perform_migration(current_version, CURRENT_DB_VERSION) {
+                if let Err(e) = self.try_perform_migration(existing_version, DEFAULT_DB_VERSION) {
                     // The migration failed
                     println!("Migration failed: {:?}", e);
                     self.recreate_db(db_file_path)?;
@@ -76,7 +75,8 @@ impl Database {
         }
     }
 
-    /// Checks if the current database version is below the minimum supported version.
+    /// Checks if the version in the existing database settings is below DEFAULT_DB_VERSION.
+    /// If outdated, returns the version in the existing database settings
     fn is_outdated(&self) -> rusqlite::Result<Option<u16>> {
         let conn = self.conn.lock().unwrap();
         let version: u16 = conn
@@ -86,14 +86,14 @@ impl Database {
                 |row| row.get(0),
             )
             .unwrap_or(0); // Default to version 0 if there's no version set
-        if version < CURRENT_DB_VERSION {
+        if version < DEFAULT_DB_VERSION {
             Ok(Some(version))
         } else {
             Ok(None)
         }
     }
 
-    /// Backs up the existing database with a unique timestamped filename, recreates `data.db`, and refreshes the connection.
+    /// Backs up the existing database with a unique timestamped filename in backups directory.
     fn backup_db(&self, db_file_path: &Path) -> rusqlite::Result<()> {
         if db_file_path.exists() {
             // Create a "backups" folder in the same directory as `data.db` if not exists
@@ -112,15 +112,16 @@ impl Database {
             let backup_filename = format!("data_backup_{}.db", timestamp);
             let backup_path = backups_dir.join(backup_filename);
 
-            // Rename `data.db` to the unique backup file
+            // Copy `data.db` to the unique backup file
             fs::copy(db_file_path, &backup_path)
                 .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?;
             println!("Old database backed up to {:?}", backup_path);
         }
+
         Ok(())
     }
 
-    /// Backs up the existing database with a unique timestamped filename, recreates `data.db`, and refreshes the connection.
+    /// Recreates `data.db`, and refreshes the connection.
     fn recreate_db(&self, db_file_path: &Path) -> rusqlite::Result<()> {
         // Remove the existing database file if it exists
         if db_file_path.exists() {

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -15,9 +15,9 @@ impl Database {
             self.set_default_version()?;
         } else {
             // If outdated, back up and either migrate or recreate the database.
-            if let Some(existing_version) = self.is_outdated()? {
+            if let Some(current_version) = self.is_outdated()? {
                 self.backup_db(db_file_path)?;
-                if let Err(e) = self.try_perform_migration(existing_version, DEFAULT_DB_VERSION) {
+                if let Err(e) = self.try_perform_migration(current_version, DEFAULT_DB_VERSION) {
                     // The migration failed
                     println!("Migration failed: {:?}", e);
                     self.recreate_db(db_file_path)?;
@@ -75,8 +75,8 @@ impl Database {
         }
     }
 
-    /// Checks if the version in the existing database settings is below DEFAULT_DB_VERSION.
-    /// If outdated, returns the version in the existing database settings
+    /// Checks if the version in the current database settings is below DEFAULT_DB_VERSION.
+    /// If outdated, returns the version in the current database settings
     fn is_outdated(&self) -> rusqlite::Result<Option<u16>> {
         let conn = self.conn.lock().unwrap();
         let version: u16 = conn


### PR DESCRIPTION
There was no apparent need for both CURRENT_DB_VERSION and DEFAULT_DB_VERSION.

Also updated commenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and logging for fetching contested resources and vote contenders with consistent capitalization in error messages.
  
- **Chores**
	- Updated database initialization logic, including version handling and comments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->