### PR TITLE
feat: custom dash-qt path and conf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ derive_more = "1.0.0"
 accesskit = "=0.16.1"
 egui = { version = "0.29.1" }
 egui_extras = "0.29.1"
+rfd = "0.15.1"
 qrcode = "0.14.1"
 eframe = { version = "0.29.1", features = ["persistence"] }
 strum = { version = "0.26.1", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,11 +152,9 @@ impl AppState {
         let mut withdraws_status_screen = WithdrawsStatusScreen::new(&mainnet_app_context);
 
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings.clone() {
-            Some((
-               ..,
-                db_custom_dash_qt_path,
-                db_overwrite_dash_qt,
-            )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
+            Some((.., db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
+                (db_custom_dash_qt_path, db_overwrite_dash_qt)
+            }
             _ => {
                 // Default values: Use system default path and overwrite conf
                 (None, true)

--- a/src/app.rs
+++ b/src/app.rs
@@ -153,14 +153,13 @@ impl AppState {
 
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings.clone() {
             Some((
-                _network,
-                _root_screen_type,
-                _password_info,
+               ..,
                 db_custom_dash_qt_path,
                 db_overwrite_dash_qt,
             )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
             _ => {
-                (None, true) // Default values
+                // Default values: Use system default path and overwrite conf
+                (None, true)
             }
         };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -123,7 +123,7 @@ impl AppState {
 
         let password_info = settings
             .clone()
-            .map(|(_, _, password_info)| password_info)
+            .map(|(_, _, password_info, _, _)| password_info)
             .flatten();
 
         let mainnet_app_context =
@@ -150,10 +150,22 @@ impl AppState {
         let mut proof_log_screen = ProofLogScreen::new(&mainnet_app_context);
         let mut document_query_screen = DocumentQueryScreen::new(&mainnet_app_context);
         let mut withdraws_status_screen = WithdrawsStatusScreen::new(&mainnet_app_context);
+
+        let (custom_dash_qt_path, overwrite_dash_conf) = match settings.clone() {
+            Some((_network, _root_screen_type, _password_info, db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
+                (db_custom_dash_qt_path, db_overwrite_dash_qt)
+            }
+            _ => {
+                (None, true) // Default values
+            }
+        };
+
         let mut network_chooser_screen = NetworkChooserScreen::new(
             &mainnet_app_context,
             testnet_app_context.as_ref(),
             Network::Dash,
+            custom_dash_qt_path,
+            overwrite_dash_conf,
         );
 
         let mut wallets_balances_screen = WalletsBalancesScreen::new(&mainnet_app_context);
@@ -162,7 +174,7 @@ impl AppState {
 
         let mut chosen_network = Network::Dash;
 
-        if let Some((network, screen_type, password_info)) = settings {
+        if let Some((network, screen_type, password_info, _, _)) = settings {
             selected_main_screen = screen_type;
             chosen_network = network;
             if chosen_network == Network::Testnet && testnet_app_context.is_some() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,9 +152,13 @@ impl AppState {
         let mut withdraws_status_screen = WithdrawsStatusScreen::new(&mainnet_app_context);
 
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings.clone() {
-            Some((_network, _root_screen_type, _password_info, db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
-                (db_custom_dash_qt_path, db_overwrite_dash_qt)
-            }
+            Some((
+                _network,
+                _root_screen_type,
+                _password_info,
+                db_custom_dash_qt_path,
+                db_overwrite_dash_qt,
+            )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
             _ => {
                 (None, true) // Default values
             }

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, RwLock};
 pub(crate) enum CoreTask {
     GetBestChainLock,
     RefreshWalletInfo(Arc<RwLock<Wallet>>),
-    StartDashQT(Network),
+    StartDashQT(Network, Option<String>, bool),
 }
 impl PartialEq for CoreTask {
     fn eq(&self, other: &Self) -> bool {
@@ -44,8 +44,8 @@ impl AppContext {
                 })
                 .map_err(|e| e.to_string()),
             CoreTask::RefreshWalletInfo(wallet) => self.refresh_wallet_info(wallet),
-            CoreTask::StartDashQT(network) => self
-                .start_dash_qt(network)
+            CoreTask::StartDashQT(network, custom_dash_qt, overwrite_dash_conf) => self
+                .start_dash_qt(network, custom_dash_qt, overwrite_dash_conf)
                 .map_err(|e| e.to_string())
                 .map(|_| BackendTaskSuccessResult::None),
         }

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -19,7 +19,7 @@ impl PartialEq for CoreTask {
         match (self, other) {
             (CoreTask::GetBestChainLock, CoreTask::GetBestChainLock) => true,
             (CoreTask::RefreshWalletInfo(_), CoreTask::RefreshWalletInfo(_)) => true,
-            (CoreTask::StartDashQT(_,_,_), CoreTask::StartDashQT(_,_,_)) => true,
+            (CoreTask::StartDashQT(_, _, _), CoreTask::StartDashQT(_, _, _)) => true,
             _ => false,
         }
     }

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -19,6 +19,7 @@ impl PartialEq for CoreTask {
         match (self, other) {
             (CoreTask::GetBestChainLock, CoreTask::GetBestChainLock) => true,
             (CoreTask::RefreshWalletInfo(_), CoreTask::RefreshWalletInfo(_)) => true,
+            (CoreTask::StartDashQT(_,_,_), CoreTask::StartDashQT(_,_,_)) => true,
             _ => false,
         }
     }

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -49,7 +49,7 @@ impl AppContext {
                 ))
             }
         };
-        
+
         let mut command = Command::new(&dash_qt_path);
         command.stdout(Stdio::null()).stderr(Stdio::null()); // Suppress output
 

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -49,25 +49,21 @@ impl AppContext {
                 ))
             }
         };
+        
+        let mut command = Command::new(&dash_qt_path);
+        command.stdout(Stdio::null()).stderr(Stdio::null()); // Suppress output
 
         if overwrite_dash_conf {
             // Construct the full path to the config file
             let current_dir = env::current_dir()?;
             let config_path = current_dir.join(config_file);
-
-            // Start Dash-Qt with the appropriate config
-            Command::new(&dash_qt_path)
-                .arg(format!("-conf={}", config_path.display()))
-                .stdout(Stdio::null()) // Optional: Suppress output
-                .stderr(Stdio::null())
-                .spawn()?; // Spawn the Dash-Qt process
-        } else {
-            // Start Dash-Qt
-            Command::new(&dash_qt_path)
-                .stdout(Stdio::null()) // Optional: Suppress output
-                .stderr(Stdio::null())
-                .spawn()?; // Spawn the Dash-Qt process
+            command.arg(format!("-conf={}", config_path.display()));
+        } else if network == Network::Testnet {
+            command.arg("-testnet");
         }
+
+        // Spawn the Dash-Qt process
+        command.spawn()?;
 
         Ok(())
     }

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -8,19 +8,20 @@ use std::{env, io};
 
 impl AppContext {
     /// Function to start Dash QT based on the selected network
-    pub(super) fn start_dash_qt(&self, network: Network) -> io::Result<()> {
-        // Determine the path to Dash-Qt based on the operating system
-        let dash_qt_path: PathBuf = if cfg!(target_os = "macos") {
-            PathBuf::from("/Applications/Dash-Qt.app/Contents/MacOS/Dash-Qt")
-        } else if cfg!(target_os = "windows") {
-            // Retrieve the PROGRAMFILES environment variable and construct the path
-            let program_files = env::var("PROGRAMFILES")
-                .map(PathBuf::from)
-                .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e))?;
-
-            program_files.join("DashCore\\dash-qt.exe")
-        } else {
-            PathBuf::from("/usr/local/bin/dash-qt") // Linux path
+    pub(super) fn start_dash_qt(&self, network: Network, custom_dash_qt:Option<String>, overwrite_dash_conf: bool) -> io::Result<()> {
+        let dash_qt_path = match custom_dash_qt {
+            Some(ref custom_path) => PathBuf::from(custom_path),
+            None => {
+                if cfg!(target_os = "macos") {
+                    PathBuf::from("/Applications/Dash-Qt.app/Contents/MacOS/Dash-Qt")
+                } else if cfg!(target_os = "windows") {
+                    // Retrieve the PROGRAMFILES environment variable or default to "C:\\Program Files"
+                    let program_files = env::var("PROGRAMFILES").unwrap_or_else(|_| "C:\\Program Files".to_string());
+                    PathBuf::from(program_files).join("DashCore\\dash-qt.exe")
+                } else {
+                    PathBuf::from("/usr/local/bin/dash-qt") // Default Linux path
+                }
+            }
         };
 
         // Ensure the Dash-Qt binary path exists
@@ -43,16 +44,25 @@ impl AppContext {
             }
         };
 
-        // Construct the full path to the config file
-        let current_dir = env::current_dir()?;
-        let config_path = current_dir.join(config_file);
+        if (overwrite_dash_conf) {
+            // Construct the full path to the config file
+            let current_dir = env::current_dir()?;
+            let config_path = current_dir.join(config_file);
 
-        // Start Dash-Qt with the appropriate config
-        Command::new(&dash_qt_path)
-            .arg(format!("-conf={}", config_path.display()))
-            .stdout(Stdio::null()) // Optional: Suppress output
-            .stderr(Stdio::null())
-            .spawn()?; // Spawn the Dash-Qt process
+            // Start Dash-Qt with the appropriate config
+            Command::new(&dash_qt_path)
+                .arg(format!("-conf={}", config_path.display()))
+                .stdout(Stdio::null()) // Optional: Suppress output
+                .stderr(Stdio::null())
+                .spawn()?; // Spawn the Dash-Qt process
+        }
+        else {
+            // Start Dash-Qt
+            Command::new(&dash_qt_path)
+                .stdout(Stdio::null()) // Optional: Suppress output
+                .stderr(Stdio::null())
+                .spawn()?; // Spawn the Dash-Qt process
+        }
 
         Ok(())
     }

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -8,7 +8,12 @@ use std::{env, io};
 
 impl AppContext {
     /// Function to start Dash QT based on the selected network
-    pub(super) fn start_dash_qt(&self, network: Network, custom_dash_qt:Option<String>, overwrite_dash_conf: bool) -> io::Result<()> {
+    pub(super) fn start_dash_qt(
+        &self,
+        network: Network,
+        custom_dash_qt: Option<String>,
+        overwrite_dash_conf: bool,
+    ) -> io::Result<()> {
         let dash_qt_path = match custom_dash_qt {
             Some(ref custom_path) => PathBuf::from(custom_path),
             None => {
@@ -16,7 +21,8 @@ impl AppContext {
                     PathBuf::from("/Applications/Dash-Qt.app/Contents/MacOS/Dash-Qt")
                 } else if cfg!(target_os = "windows") {
                     // Retrieve the PROGRAMFILES environment variable or default to "C:\\Program Files"
-                    let program_files = env::var("PROGRAMFILES").unwrap_or_else(|_| "C:\\Program Files".to_string());
+                    let program_files = env::var("PROGRAMFILES")
+                        .unwrap_or_else(|_| "C:\\Program Files".to_string());
                     PathBuf::from(program_files).join("DashCore\\dash-qt.exe")
                 } else {
                     PathBuf::from("/usr/local/bin/dash-qt") // Default Linux path
@@ -55,8 +61,7 @@ impl AppContext {
                 .stdout(Stdio::null()) // Optional: Suppress output
                 .stderr(Stdio::null())
                 .spawn()?; // Spawn the Dash-Qt process
-        }
-        else {
+        } else {
             // Start Dash-Qt
             Command::new(&dash_qt_path)
                 .stdout(Stdio::null()) // Optional: Suppress output

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -50,7 +50,7 @@ impl AppContext {
             }
         };
 
-        if (overwrite_dash_conf) {
+        if overwrite_dash_conf {
             // Construct the full path to the config file
             let current_dir = env::current_dir()?;
             let config_path = current_dir.join(config_file);

--- a/src/components/core_zmq_listener.rs
+++ b/src/components/core_zmq_listener.rs
@@ -232,7 +232,7 @@ impl CoreZMQListener {
                         .recv(&mut addr_msg, 0)
                         .expect("Failed to receive address message");
 
-                    let data = event_msg.as_ref();
+                    let data: &[u8] = event_msg.as_ref(); // Explicitly annotate the type
                     if data.len() >= 6 {
                         let event_number = u16::from_le_bytes([data[0], data[1]]);
                         let endpoint = addr_msg.as_str().unwrap_or("");

--- a/src/context.rs
+++ b/src/context.rs
@@ -221,7 +221,17 @@ impl AppContext {
     }
 
     /// Retrieves the current `RootScreenType` from the settings
-    pub fn get_settings(&self) -> Result<Option<(Network, RootScreenType, Option<PasswordInfo>, Option<String>, bool)>> {
+    pub fn get_settings(
+        &self,
+    ) -> Result<
+        Option<(
+            Network,
+            RootScreenType,
+            Option<PasswordInfo>,
+            Option<String>,
+            bool,
+        )>,
+    > {
         self.db.get_settings()
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -221,7 +221,7 @@ impl AppContext {
     }
 
     /// Retrieves the current `RootScreenType` from the settings
-    pub fn get_settings(&self) -> Result<Option<(Network, RootScreenType, Option<PasswordInfo>)>> {
+    pub fn get_settings(&self) -> Result<Option<(Network, RootScreenType, Option<PasswordInfo>, Option<String>, bool)>> {
         self.db.get_settings()
     }
 

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,8 @@ use rusqlite::{params, Connection};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 2;
+pub const DEFAULT_DB_VERSION: u16 = 3;
+
 pub const DEFAULT_NETWORK: &str = "dash";
 
 impl Database {
@@ -33,6 +34,9 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16) -> rusqlite::Result<()> {
         match version {
+            3 => {
+                self.add_custom_dash_qt_columns()?;
+            }
             2 => {
                 self.initialize_proof_log_table()?;
             }
@@ -175,6 +179,8 @@ impl Database {
             main_password_nonce BLOB,
             network TEXT NOT NULL,
             start_root_screen INTEGER NOT NULL,
+            custom_dash_qt_path TEXT,
+            overwrite_dash_conf INTEGER,
             database_version INTEGER NOT NULL
         )",
             [],

--- a/src/database/settings.rs
+++ b/src/database/settings.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
 use crate::database::Database;
 use crate::model::password_info::PasswordInfo;
 use crate::ui::RootScreenType;
 use dash_sdk::dpp::dashcore::Network;
 use rusqlite::{params, Result};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 impl Database {
@@ -62,8 +62,14 @@ impl Database {
     }
 
     pub fn add_custom_dash_qt_columns(&self) -> Result<()> {
-        self.execute("ALTER TABLE settings ADD COLUMN custom_dash_qt_path TEXT DEFAULT NULL;", ())?;
-        self.execute("ALTER TABLE settings ADD COLUMN overwrite_dash_conf INTEGER DEFAULT NULL;", ())?;
+        self.execute(
+            "ALTER TABLE settings ADD COLUMN custom_dash_qt_path TEXT DEFAULT NULL;",
+            (),
+        )?;
+        self.execute(
+            "ALTER TABLE settings ADD COLUMN overwrite_dash_conf INTEGER DEFAULT NULL;",
+            (),
+        )?;
 
         Ok(())
     }
@@ -82,7 +88,17 @@ impl Database {
     }
 
     /// Retrieves the settings from the database.
-    pub fn get_settings(&self) -> Result<Option<(Network, RootScreenType, Option<PasswordInfo>, Option<String>, bool)>> {
+    pub fn get_settings(
+        &self,
+    ) -> Result<
+        Option<(
+            Network,
+            RootScreenType,
+            Option<PasswordInfo>,
+            Option<String>,
+            bool,
+        )>,
+    > {
         // Query the settings row
         let conn = self.conn.lock().unwrap();
         let mut stmt =
@@ -115,7 +131,13 @@ impl Database {
             let root_screen_type = RootScreenType::from_int(start_root_screen)
                 .ok_or_else(|| rusqlite::Error::InvalidQuery)?;
 
-            Ok((parsed_network, root_screen_type, password_data, custom_dash_qt_path, overwrite_dash_conf.unwrap_or(true)))
+            Ok((
+                parsed_network,
+                root_screen_type,
+                password_data,
+                custom_dash_qt_path,
+                overwrite_dash_conf.unwrap_or(true),
+            ))
         });
 
         match result {

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -92,11 +92,18 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
         };
         response.clone().on_hover_text(tooltip_text);
 
-        let settings = app_context.db.get_settings().expect("Failed to db get settings");
+        let settings = app_context
+            .db
+            .get_settings()
+            .expect("Failed to db get settings");
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings {
-            Some((_network, _root_screen_type, _password_info, db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
-                (db_custom_dash_qt_path, db_overwrite_dash_qt)
-            }
+            Some((
+                _network,
+                _root_screen_type,
+                _password_info,
+                db_custom_dash_qt_path,
+                db_overwrite_dash_qt,
+            )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
             _ => {
                 (None, true) // Default values
             }
@@ -105,7 +112,11 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
         // Handle click to start DashQT if disconnected
         if response.clicked() && !connected {
             let network = app_context.network;
-            action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network, custom_dash_qt_path, overwrite_dash_conf)));
+            action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(
+                network,
+                custom_dash_qt_path,
+                overwrite_dash_conf,
+            )));
         }
     });
 

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -97,11 +97,9 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
             .get_settings()
             .expect("Failed to db get settings");
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings {
-            Some((
-                ..,
-                db_custom_dash_qt_path,
-                db_overwrite_dash_qt,
-            )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
+            Some((.., db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
+                (db_custom_dash_qt_path, db_overwrite_dash_qt)
+            }
             _ => {
                 // Default values: Use system default path and overwrite conf
                 (None, true)

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -92,10 +92,20 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
         };
         response.clone().on_hover_text(tooltip_text);
 
+        let settings = app_context.db.get_settings().expect("Failed to db get settings");
+        let (custom_dash_qt_path, overwrite_dash_conf) = match settings {
+            Some((_network, _root_screen_type, _password_info, db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
+                (db_custom_dash_qt_path, db_overwrite_dash_qt)
+            }
+            _ => {
+                (None, true) // Default values
+            }
+        };
+
         // Handle click to start DashQT if disconnected
         if response.clicked() && !connected {
             let network = app_context.network;
-            action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network)));
+            action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network, custom_dash_qt_path, overwrite_dash_conf)));
         }
     });
 

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -98,14 +98,13 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
             .expect("Failed to db get settings");
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings {
             Some((
-                _network,
-                _root_screen_type,
-                _password_info,
+                ..,
                 db_custom_dash_qt_path,
                 db_overwrite_dash_qt,
             )) => (db_custom_dash_qt_path, db_overwrite_dash_qt),
             _ => {
-                (None, true) // Default values
+                // Default values: Use system default path and overwrite conf
+                (None, true)
             }
         };
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -69,7 +69,7 @@ impl NetworkChooserScreen {
     }
 
     /// Render the network selection table
-    fn render_network_table(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
+    fn render_network_table(&mut self, ui: &mut Ui) -> AppAction {
         let mut app_action = AppAction::None;
         ui.heading("Choose Network");
 
@@ -303,7 +303,7 @@ impl ScreenLike for NetworkChooserScreen {
         );
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            action |= self.render_network_table(ui, ctx);
+            action |= self.render_network_table(ui);
         });
 
         action

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -112,7 +112,7 @@ impl NetworkChooserScreen {
                                         } else { //linux
                                             String::from("dash-qt")
                                         };
-                                        if file_name.contains(required_file_name.as_str()) {
+                                        if file_name.ends_with(required_file_name.as_str()) {
                                             self.custom_dash_qt_path = Some(path.display().to_string());
                                             self.custom_dash_qt_error_message = None;
                                             self.current_app_context().db.update_dash_core_execution_settings(self.custom_dash_qt_path.clone(), self.overwrite_dash_conf).expect("Expected to save db settings");

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -12,6 +12,7 @@ use dash_sdk::dpp::identity::TimestampMillis;
 use eframe::egui::{self, Color32, Context, Ui};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use crate::model::password_info::PasswordInfo;
 
 pub struct NetworkChooserScreen {
     pub mainnet_app_context: Arc<AppContext>,
@@ -21,6 +22,9 @@ pub struct NetworkChooserScreen {
     pub testnet_core_status_online: bool,
     status_checked: bool,
     pub recheck_time: Option<TimestampMillis>,
+    custom_dash_qt_path: Option<String>,
+    custom_dash_qt_error_message: Option<String>,
+    overwrite_dash_conf: bool,
 }
 
 impl NetworkChooserScreen {
@@ -28,6 +32,8 @@ impl NetworkChooserScreen {
         mainnet_app_context: &Arc<AppContext>,
         testnet_app_context: Option<&Arc<AppContext>>,
         current_network: Network,
+        custom_dash_qt_path: Option<String>,
+        overwrite_dash_conf: bool,
     ) -> Self {
         Self {
             mainnet_app_context: mainnet_app_context.clone(),
@@ -37,6 +43,9 @@ impl NetworkChooserScreen {
             testnet_core_status_online: false,
             status_checked: false,
             recheck_time: None,
+            custom_dash_qt_path,
+            custom_dash_qt_error_message: None,
+            overwrite_dash_conf,
         }
     }
 
@@ -60,7 +69,7 @@ impl NetworkChooserScreen {
     }
 
     /// Render the network selection table
-    fn render_network_table(&mut self, ui: &mut Ui) -> AppAction {
+    fn render_network_table(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
         let mut app_action = AppAction::None;
         ui.heading("Choose Network");
 
@@ -81,6 +90,77 @@ impl NetworkChooserScreen {
 
                 // Render Testnet
                 app_action |= self.render_network_row(ui, Network::Testnet, "Testnet");
+            });
+        egui::CollapsingHeader::new("Show more advanced settings")
+            .default_open(false) // The grid is hidden by default
+            .show(ui, |ui| {
+                egui::Grid::new("advanced_settings")
+                    .show(ui, |ui| {
+                        ui.label("Custom Dash-QT path:");
+
+                        if ui.button("Select file").clicked() {
+                            if let Some(path) = rfd::FileDialog::new().pick_file() {
+                                {
+                                    let file_name = path.file_name().and_then(|f| f.to_str());
+                                    if let Some(file_name) = file_name {
+                                        self.custom_dash_qt_path = None;
+                                        self.custom_dash_qt_error_message = None;
+                                        let required_file_name = if cfg!(target_os = "windows") {
+                                            String::from("dash-qt.exe")
+                                        } else if cfg!(target_os = "macos") {
+                                            String::from("dash-qt")
+                                        } else { //linux
+                                            String::from("dash-qt")
+                                        };
+                                        if file_name.contains(required_file_name.as_str()) {
+                                            self.custom_dash_qt_path = Some(path.display().to_string());
+                                            self.custom_dash_qt_error_message = None;
+                                            self.current_app_context().db.update_dash_core_execution_settings(self.custom_dash_qt_path.clone(), self.overwrite_dash_conf).expect("Expected to save db settings");
+                                        } else {
+                                            self.custom_dash_qt_error_message = Some(format!("Invalid file: Please select a valid '{}'.", required_file_name));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if let Some(ref file) = self.custom_dash_qt_path {
+                            ui.label(format!("Selected: {}", file));
+                        } else if let Some(ref error) = self.custom_dash_qt_error_message {
+                            ui.colored_label(egui::Color32::RED, error);
+                        } else {
+                            ui.label("");
+                        }
+                        if self.custom_dash_qt_path.is_some() || self.custom_dash_qt_error_message.is_some() {
+                            if ui.button("clear").clicked() {
+                                self.custom_dash_qt_path = None;
+                                self.custom_dash_qt_error_message = None;
+                            }
+                        }
+                        ui.end_row();
+
+                        if ui.checkbox(&mut self.overwrite_dash_conf, "Overwrite dash.conf").clicked() {
+                            self.current_app_context().db.update_dash_core_execution_settings(self.custom_dash_qt_path.clone(), self.overwrite_dash_conf).expect("Expected to save db settings");
+                        }
+                        if !self.overwrite_dash_conf {
+                            ui.end_row();
+                            if self.current_network == Network::Dash {
+                                ui.colored_label(egui::Color32::ORANGE, "The following lines must be included in the custom Mainnet dash.conf:");
+                                ui.end_row();
+                                ui.label("zmqpubrawtxlocksig=tcp://0.0.0.0:23708");
+                                ui.end_row();
+                                ui.label("zmqpubrawchainlock=tcp://0.0.0.0:23708");
+                            }
+                            else { //Testnet
+                                ui.colored_label(egui::Color32::ORANGE, "The following lines must be included in the custom Testnet dash.conf:");
+                                ui.end_row();
+                                ui.label("zmqpubrawtxlocksig=tcp://0.0.0.0:23709");
+                                ui.end_row();
+                                ui.label("zmqpubrawchainlock=tcp://0.0.0.0:23709");
+                            }
+                        }
+
+                    });
             });
         app_action
     }
@@ -158,7 +238,7 @@ impl NetworkChooserScreen {
         // Add a button to start the network
         if ui.button("Start").clicked() {
             app_action |=
-                AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network)));
+                AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network, self.custom_dash_qt_path.clone(), self.overwrite_dash_conf)));
             // in 5 seconds
             self.recheck_time = Some(
                 (SystemTime::now()
@@ -200,6 +280,7 @@ impl ScreenLike for NetworkChooserScreen {
         }
     }
     fn ui(&mut self, ctx: &Context) -> AppAction {
+        //let _ = self.current_app_context().db.get_settings();
         let mut action = add_top_panel(
             ctx,
             self.current_app_context(),
@@ -219,7 +300,7 @@ impl ScreenLike for NetworkChooserScreen {
         );
 
         egui::CentralPanel::default().show(ctx, |ui| {
-            action |= self.render_network_table(ui);
+            action |= self.render_network_table(ui, ctx);
         });
 
         action

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -2,6 +2,7 @@ use crate::app::AppAction;
 use crate::backend_task::core::{CoreItem, CoreTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
+use crate::model::password_info::PasswordInfo;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::wallet::add_new_wallet_screen::AddNewWalletScreen;
@@ -12,7 +13,6 @@ use dash_sdk::dpp::identity::TimestampMillis;
 use eframe::egui::{self, Color32, Context, Ui};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use crate::model::password_info::PasswordInfo;
 
 pub struct NetworkChooserScreen {
     pub mainnet_app_context: Arc<AppContext>,
@@ -237,8 +237,11 @@ impl NetworkChooserScreen {
 
         // Add a button to start the network
         if ui.button("Start").clicked() {
-            app_action |=
-                AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(network, self.custom_dash_qt_path.clone(), self.overwrite_dash_conf)));
+            app_action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(
+                network,
+                self.custom_dash_qt_path.clone(),
+                self.overwrite_dash_conf,
+            )));
             // in 5 seconds
             self.recheck_time = Some(
                 (SystemTime::now()


### PR DESCRIPTION
In the Network Chooser Screen, possibility to:

- select custom Dash-Qt path instead of the hardcoded default ones
- select possibility to disable dash.conf overwrite

Both settings are persistent in database.
Database version was bumped to 3 and migration queries were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced settings management with the ability to specify a custom Dash-QT path and overwrite configuration settings.
  - Added advanced settings section in the Network Chooser Screen for better user configuration.
  
- **Bug Fixes**
  - Improved error handling during database initialization and migration processes.

- **Documentation**
  - Updated method signatures and descriptions to reflect new parameters and functionality.

These updates improve user experience and flexibility when configuring Dash-QT settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->