### PR TITLE
docs: mentions app dir and its location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Before you begin, ensure you have met the following requirements:
 
 - **Rust**: Install Rust using [rustup](https://rustup.rs/):
 
-  ```
+  ``` shell
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
   ```
 
 - Update Rust to the latest version:
 
-  ```
+  ``` shell
   rustup update
   ```
 
@@ -58,19 +58,19 @@ To install Dash Evo Tool:
 
 1. **Clone the repository**:
 
-   ```
+   ``` shell
    git clone https://github.com/dashpay/dash-evo-tool.git
    ```
 
 2. **Navigate to the project directory**:
 
-   ```
+   ``` shell
    cd dash-evo-tool
    ```
 
 3. **Build the project**:
 
-   ```
+   ``` shell
    cargo build --release
    ```
 
@@ -80,7 +80,7 @@ To install Dash Evo Tool:
 
 Run the application using:
 
-```
+``` shell
 cargo run
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ To install Dash Evo Tool:
 
 ## Getting Started
 
-### Create `.env` File
-
-Create a new file in the root of the dash-evo-tool directory named `.env` and copy the contents of `.env.example` into it. No changes to the file are necessary in this version.
-
 ### Start the App
 
 Run the application using:
@@ -87,6 +83,16 @@ Run the application using:
 ```
 cargo run
 ```
+
+### Application directory
+
+When the application runs for the first time, it creates a application directory and stores an `.env` file in it (based on [`.env.example`](.env.example)). It also stores application data in the directory. If you need to update the `.env` file, locate it in the application directory for your Operating System:
+
+| Operating System | Application Directory Path |
+| - | - |
+| macOS | `~/Library/Application Support/Dash-Evo-Tool/` |
+| Windows | `C:\Users\<User>\AppData\Roaming\Dash-Evo-Tool\config` |
+| Linux | `/home/<user>/.config/dash-evo-tool/` |
 
 ### Connect to a Network
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cargo run
 
 ### Application directory
 
-When the application runs for the first time, it creates a application directory and stores an `.env` file in it (based on [`.env.example`](.env.example)). It also stores application data in the directory. If you need to update the `.env` file, locate it in the application directory for your Operating System:
+When the application runs for the first time, it creates an application directory and stores an `.env` file in it (based on [`.env.example`](.env.example)). It also stores application data in the directory. If you need to update the `.env` file, locate it in the application directory for your Operating System:
 
 | Operating System | Application Directory Path |
 | - | - |


### PR DESCRIPTION
Since #22, an app dir is used to store data and the .env file. Remove section about manually creating .env and mention where the app dir is on each platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and usability of the `README.md` file.
	- Added `shell` tag for better syntax highlighting in code blocks.
	- Introduced a new section on the application directory for enhanced user guidance.
	- Removed the previous section on creating a `.env` file, as it is now automatically generated by the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->