### PR TITLE
feat: dont display seconds in dpns screen last updated column

### DIFF
--- a/src/ui/dpns_contested_names_screen.rs
+++ b/src/ui/dpns_contested_names_screen.rs
@@ -412,10 +412,14 @@ impl DPNSContestedNamesScreen {
                                                 let relative_time =
                                                     HumanTime::from(datetime).to_string();
 
-                                                ui.label(relative_time);
+                                                if relative_time.contains("seconds") {
+                                                    ui.label("now");
+                                                } else {
+                                                    ui.label(relative_time);
+                                                }
                                             } else {
-                                                // Handle case where the timestamp is invalid
-                                                ui.label("Invalid timestamp");
+                                            // Handle case where the timestamp is invalid
+                                            ui.label("Invalid timestamp");
                                             }
                                         } else {
                                             ui.label("Fetching");
@@ -529,7 +533,11 @@ impl DPNSContestedNamesScreen {
                                                 let relative_time =
                                                     HumanTime::from(datetime).to_string();
 
-                                                ui.label(relative_time);
+                                                if relative_time.contains("seconds") {
+                                                    ui.label("now");
+                                                } else {
+                                                    ui.label(relative_time);
+                                                }
                                             } else {
                                                 // Handle case where the timestamp is invalid
                                                 ui.label("Invalid timestamp");


### PR DESCRIPTION
If it's been less than a minute since last updating the names, just say "now" instead of seeing the seconds increasing.