### PR TITLE
feat: retry vote poll end times query and insert proof logs

### DIFF
--- a/src/backend_task/contested_names/query_dpns_vote_contenders.rs
+++ b/src/backend_task/contested_names/query_dpns_vote_contenders.rs
@@ -1,5 +1,6 @@
 use crate::app::TaskResult;
 use crate::context::AppContext;
+use crate::model::proof_log_item::{ProofLogItem, RequestType};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dash_sdk::dpp::platform_value::Value;
@@ -60,6 +61,56 @@ impl AppContext {
                 }
                 Err(e) => {
                     tracing::error!("Error fetching vote contenders: {}", e);
+                    if let dash_sdk::Error::Proof(
+                        dash_sdk::ProofVerifierError::GroveDBProofVerificationError {
+                            proof_bytes,
+                            path_query,
+                            height,
+                            time_ms,
+                            error,
+                        },
+                    ) = &e
+                    {
+                        // Encode the query using bincode
+                        let encoded_query = match bincode::encode_to_vec(
+                            &contenders_query,
+                            bincode::config::standard(),
+                        )
+                        .map_err(|encode_err| {
+                            tracing::error!("Error encoding query: {}", encode_err);
+                            format!("Error encoding query: {}", encode_err)
+                        }) {
+                            Ok(encoded_query) => encoded_query,
+                            Err(e) => return Err(e),
+                        };
+
+                        // Encode the path_query using bincode
+                        let verification_path_query_bytes =
+                            match bincode::encode_to_vec(&path_query, bincode::config::standard())
+                                .map_err(|encode_err| {
+                                    tracing::error!("Error encoding path_query: {}", encode_err);
+                                    format!("Error encoding path_query: {}", encode_err)
+                                }) {
+                                Ok(encoded_path_query) => encoded_path_query,
+                                Err(e) => return Err(e),
+                            };
+
+                        if let Err(e) = self
+                            .db
+                            .insert_proof_log_item(ProofLogItem {
+                                request_type: RequestType::GetContestedResourceIdentityVotes,
+                                request_bytes: encoded_query,
+                                verification_path_query_bytes,
+                                height: *height,
+                                time_ms: *time_ms,
+                                proof_bytes: proof_bytes.clone(),
+                                error: Some(error.clone()),
+                            })
+                            .map_err(|e| e.to_string())
+                        {
+                            return Err(e);
+                        }
+                    }
                     let error_str = e.to_string();
                     if error_str.contains("try another server")
                         || error_str.contains(

--- a/src/backend_task/contested_names/query_dpns_vote_contenders.rs
+++ b/src/backend_task/contested_names/query_dpns_vote_contenders.rs
@@ -59,7 +59,7 @@ impl AppContext {
                         .map_err(|e| e.to_string());
                 }
                 Err(e) => {
-                    tracing::error!("Error fetching contested resources: {}", e);
+                    tracing::error!("Error fetching vote contenders: {}", e);
                     let error_str = e.to_string();
                     if error_str.contains("try another server")
                         || error_str.contains(
@@ -73,7 +73,7 @@ impl AppContext {
                                 e
                             );
                             return Err(format!(
-                                "Error fetching contested resources after retries: {}",
+                                "Error fetching vote contenders after retries: {}",
                                 e
                             ));
                         } else {
@@ -81,7 +81,7 @@ impl AppContext {
                         }
                     } else {
                         // For other errors, return immediately
-                        return Err(format!("Error fetching contested resources: {}", e));
+                        return Err(format!("Error fetching vote contenders: {}", e));
                     }
                 }
             }

--- a/src/backend_task/contested_names/query_ending_times.rs
+++ b/src/backend_task/contested_names/query_ending_times.rs
@@ -1,4 +1,5 @@
 use crate::context::AppContext;
+use crate::model::proof_log_item::{ProofLogItem, RequestType};
 use chrono::{DateTime, Duration, Utc};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
@@ -32,43 +33,118 @@ impl AppContext {
             order_ascending: true,
         };
 
+        const MAX_RETRIES: usize = 3;
+        let mut retries = 0;
+
         let mut contests_end_times = BTreeMap::new();
 
-        for (timestamp, vote_poll) in VotePoll::fetch_many(&sdk, end_time_query)
-            .await
-            .map_err(|e| format!("error querying vote poll end times: {}", e))?
-        {
-            let contests = vote_poll.into_iter().filter_map(|vote_poll| {
-                let VotePoll::ContestedDocumentResourceVotePoll(
-                    ContestedDocumentResourceVotePoll {
-                        contract_id,
-                        document_type_name,
-                        index_name,
-                        index_values,
-                    },
-                ) = vote_poll;
-                if contract_id != self.dpns_contract.id() {
-                    return None;
+        loop {
+            match VotePoll::fetch_many(&sdk, end_time_query.clone()).await {
+                Ok(vote_polls) => {
+                    for (timestamp, vote_poll_list) in vote_polls {
+                        let contests = vote_poll_list.into_iter().filter_map(|vote_poll| {
+                            let VotePoll::ContestedDocumentResourceVotePoll(
+                                ContestedDocumentResourceVotePoll {
+                                    contract_id,
+                                    document_type_name,
+                                    index_name,
+                                    index_values,
+                                },
+                            ) = vote_poll;
+                            if contract_id != self.dpns_contract.id() {
+                                return None;
+                            }
+                            if document_type_name != "domain" {
+                                return None;
+                            }
+                            if index_name != "parentNameAndLabel" {
+                                return None;
+                            }
+                            if index_values.len() != 2 {
+                                return None;
+                            }
+                            index_values
+                                .get(1)
+                                .and_then(|a| a.to_str().ok().map(|a| (a.to_string(), timestamp)))
+                        });
+                        contests_end_times.extend(contests);
+                    }
+                    break;
                 }
-                if document_type_name != "domain" {
-                    return None;
-                }
-                if index_name != "parentNameAndLabel" {
-                    return None;
-                }
-                if index_values.len() != 2 {
-                    return None;
-                }
-                index_values
-                    .get(1)
-                    .and_then(|a| a.to_str().ok().map(|a| (a.to_string(), timestamp)))
-            });
+                Err(e) => {
+                    tracing::error!("Error fetching vote polls: {}", e);
+                    if let dash_sdk::Error::Proof(
+                        dash_sdk::ProofVerifierError::GroveDBProofVerificationError {
+                            proof_bytes,
+                            path_query,
+                            height,
+                            time_ms,
+                            error,
+                        },
+                    ) = &e
+                    {
+                        // Encode the query using bincode
+                        let encoded_query = match bincode::encode_to_vec(
+                            &end_time_query,
+                            bincode::config::standard(),
+                        )
+                        .map_err(|encode_err| {
+                            tracing::error!("Error encoding query: {}", encode_err);
+                            format!("Error encoding query: {}", encode_err)
+                        }) {
+                            Ok(encoded_query) => encoded_query,
+                            Err(e) => return Err(e),
+                        };
 
-            contests_end_times.extend(contests);
+                        // Encode the path_query using bincode
+                        let verification_path_query_bytes =
+                            match bincode::encode_to_vec(&path_query, bincode::config::standard())
+                                .map_err(|encode_err| {
+                                    tracing::error!("Error encoding path_query: {}", encode_err);
+                                    format!("Error encoding path_query: {}", encode_err)
+                                }) {
+                                Ok(encoded_path_query) => encoded_path_query,
+                                Err(e) => return Err(e),
+                            };
+
+                        if let Err(e) = self
+                            .db
+                            .insert_proof_log_item(ProofLogItem {
+                                request_type: RequestType::GetVotePollsByEndDate,
+                                request_bytes: encoded_query,
+                                verification_path_query_bytes,
+                                height: *height,
+                                time_ms: *time_ms,
+                                proof_bytes: proof_bytes.clone(),
+                                error: Some(error.clone()),
+                            })
+                            .map_err(|e| e.to_string())
+                        {
+                            return Err(e);
+                        }
+                    }
+                    if e.to_string().contains("try another server")
+                        || e.to_string().contains(
+                            "contract not found when querying from value with contract info",
+                        )
+                    {
+                        retries += 1;
+                        if retries > MAX_RETRIES {
+                            tracing::error!("Max retries reached for query: {}", e);
+                            return Err(format!("Error fetching vote polls after retries: {}", e));
+                        } else {
+                            // Retry
+                            continue;
+                        }
+                    } else {
+                        return Err(format!("Error fetching vote polls: {}", e));
+                    }
+                }
+            }
         }
 
         self.db
             .update_ending_time(contests_end_times, self)
-            .map_err(|e| format!("error updating ending time: {}", e))
+            .map_err(|e| format!("Error updating ending time: {}", e))
     }
 }


### PR DESCRIPTION
Insert proof logs into the db for dpns end time query and dpns vote contender query, and also add retry logic to end time query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced retry mechanisms for fetching contested resources, vote contenders, and vote polls, improving reliability during transient errors.
  - Improved error logging for better tracking of issues related to proof verification and server errors.

- **UI Improvements**
  - Updated timestamp rendering in the DPNS Contested Names screen to display "now" for recent events, enhancing user experience.

- **Documentation**
  - Clarified database initialization and migration processes in comments for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->