### PR TITLE
feat: detect CPU incompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ default-run = "dash-evo-tool"
 rust-version = "1.81"
 
 [build]
-rustflags = ["-C", "target-cpu=generic"]
+rustflags = [
+    "-C", "target-feature=+avx,-avx2,-avx512f,-avx512cd,-avx512er,-avx512pf,-avx512bw,-avx512dq,-avx512vl"
+]
 
 [dependencies]
 bip39 = { version = "2.1.0", features = ["all-languages", "rand"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ zmq = "0.10"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 zeromq = "0.4.1"
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+native-dialog = "0.7.0"
+raw-cpuid = "11.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 default-run = "dash-evo-tool"
 rust-version = "1.81"
 
+[build]
+rustflags = ["-C", "target-cpu=generic"]
+
 [dependencies]
 bip39 = { version = "2.1.0", features = ["all-languages", "rand"] }
 derive_more = "1.0.0"

--- a/src/cpu_compatibility.rs
+++ b/src/cpu_compatibility.rs
@@ -1,0 +1,38 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use native_dialog::MessageDialog;
+
+pub fn check_cpu_compatibility() {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        use raw_cpuid::CpuId;
+
+        let cpuid = CpuId::new();
+
+        if let Some(feature_info) = cpuid.get_feature_info() {
+            let avx_supported = feature_info.has_avx();
+            let avx2_supported = cpuid
+                .get_extended_feature_info()
+                .map_or(false, |ext_info| ext_info.has_avx2());
+            let avx512_supported = cpuid
+                .get_extended_feature_info()
+                .map_or(false, |ext_info| ext_info.has_avx512f()); // AVX-512 Foundation
+            if (!avx_supported || !avx2_supported) || !avx512_supported {
+                MessageDialog::new()
+                    .set_type(native_dialog::MessageType::Error)
+                    .set_title("Compatibility Error")
+                    .set_text("Your CPU does not support AVX/AVX2/AVX512 instructions. Please use a compatible CPU.")
+                    .show_alert()
+                    .unwrap();
+                std::process::exit(1);
+            }
+        } else {
+            MessageDialog::new()
+                .set_type(native_dialog::MessageType::Error)
+                .set_title("Compatibility Error")
+                .set_text("Unable to determine CPU features.")
+                .show_alert()
+                .unwrap();
+            std::process::exit(1);
+        }
+    }
+}

--- a/src/cpu_compatibility.rs
+++ b/src/cpu_compatibility.rs
@@ -9,18 +9,35 @@ pub fn check_cpu_compatibility() {
         let cpuid = CpuId::new();
 
         if let Some(feature_info) = cpuid.get_feature_info() {
-            let avx_supported = feature_info.has_avx();
-            let avx2_supported = cpuid
-                .get_extended_feature_info()
-                .map_or(false, |ext_info| ext_info.has_avx2());
-            let avx512_supported = cpuid
-                .get_extended_feature_info()
-                .map_or(false, |ext_info| ext_info.has_avx512f()); // AVX-512 Foundation
-            if (!avx_supported || !avx2_supported) || !avx512_supported {
+            if !feature_info.has_avx() {
                 MessageDialog::new()
                     .set_type(native_dialog::MessageType::Error)
                     .set_title("Compatibility Error")
-                    .set_text("Your CPU does not support AVX/AVX2/AVX512 instructions. Please use a compatible CPU.")
+                    .set_text("Your CPU does not support AVX instructions. Please use a compatible CPU.")
+                    .show_alert()
+                    .unwrap();
+                std::process::exit(1);
+            }
+            let avx2_supported = cpuid
+                .get_extended_feature_info()
+                .map_or(false, |ext_info| ext_info.has_avx2());
+            if !avx2_supported {
+                MessageDialog::new()
+                    .set_type(native_dialog::MessageType::Error)
+                    .set_title("Compatibility Error")
+                    .set_text("Your CPU does not support AVX2 instructions. Please use a compatible CPU.")
+                    .show_alert()
+                    .unwrap();
+                std::process::exit(1);
+            }
+            let avx512_supported = cpuid
+                .get_extended_feature_info()
+                .map_or(false, |ext_info| ext_info.has_avx512f()); // AVX-512 Foundation
+            if !avx512_supported {
+                MessageDialog::new()
+                    .set_type(native_dialog::MessageType::Error)
+                    .set_title("Compatibility Error")
+                    .set_text("Your CPU does not support AVX512 instructions. Please use a compatible CPU.")
                     .show_alert()
                     .unwrap();
                 std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use crate::cpu_compatibility::check_cpu_compatibility;
+
 mod app;
 mod app_dir;
 mod backend_task;
@@ -5,6 +7,7 @@ mod components;
 mod config;
 mod context;
 mod context_provider;
+mod cpu_compatibility;
 mod database;
 mod logging;
 mod model;
@@ -12,6 +15,7 @@ mod sdk_wrapper;
 mod ui;
 
 fn main() -> eframe::Result<()> {
+    check_cpu_compatibility();
     // Initialize the Tokio runtime
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(40)


### PR DESCRIPTION
Applicable only for x86 and x86_64 architecture:
If any of the following CPU instructions are not supported then a message box appears informing about hardware incompatibility. And the terminates the program.
- `avx`, `avx2`, `avx512`