### PR TITLE
fix: network chooser screen statuses

### DIFF
--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -43,7 +43,7 @@ impl AppContext {
                         self.network,
                     ))
                 })
-                .map_err(|e| e.to_string()),
+                .map_err(|e| format!("Failed to get best chain lock: {}", e.to_string())),
             CoreTask::RefreshWalletInfo(wallet) => self.refresh_wallet_info(wallet),
             CoreTask::StartDashQT(network, custom_dash_qt, overwrite_dash_conf) => self
                 .start_dash_qt(network, custom_dash_qt, overwrite_dash_conf)

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, RwLock};
 #[derive(Debug, Clone)]
 pub(crate) enum CoreTask {
     GetBestChainLock,
-    GetBothBestChainLocks,
+    GetBestChainLocksTestnetAndMainnet,
     RefreshWalletInfo(Arc<RwLock<Wallet>>),
     StartDashQT(Network, Option<String>, bool),
 }
@@ -61,7 +61,7 @@ impl AppContext {
                         )
                     })
             }
-            CoreTask::GetBothBestChainLocks => {
+            CoreTask::GetBestChainLocksTestnetAndMainnet => {
                 // Load config
                 let config = match Config::load() {
                     Ok(config) => config,

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -2,15 +2,18 @@ mod refresh_wallet_info;
 mod start_dash_qt;
 
 use crate::backend_task::BackendTaskSuccessResult;
+use crate::config::Config;
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
 use dash_sdk::dashcore_rpc::RpcApi;
+use dash_sdk::dashcore_rpc::{Auth, Client};
 use dash_sdk::dpp::dashcore::{Address, ChainLock, Network, OutPoint, Transaction, TxOut};
 use std::sync::{Arc, RwLock};
 
 #[derive(Debug, Clone)]
 pub(crate) enum CoreTask {
     GetBestChainLock,
+    GetBothBestChainLocks,
     RefreshWalletInfo(Arc<RwLock<Wallet>>),
     StartDashQT(Network, Option<String>, bool),
 }
@@ -29,21 +32,122 @@ impl PartialEq for CoreTask {
 pub(crate) enum CoreItem {
     ReceivedAvailableUTXOTransaction(Transaction, Vec<(OutPoint, TxOut, Address)>),
     ChainLock(ChainLock, Network),
+    BothChainLocks(ChainLock, ChainLock),
 }
 
 impl AppContext {
     pub async fn run_core_task(&self, task: CoreTask) -> Result<BackendTaskSuccessResult, String> {
         match task {
-            CoreTask::GetBestChainLock => self
-                .core_client
-                .get_best_chain_lock()
-                .map(|chain_lock| {
-                    BackendTaskSuccessResult::CoreItem(CoreItem::ChainLock(
-                        chain_lock,
-                        self.network,
-                    ))
-                })
-                .map_err(|e| format!("Failed to get best chain lock: {}", e.to_string())),
+            CoreTask::GetBestChainLock => {
+                let network_string = match self.network {
+                    Network::Dash => "mainnet",
+                    Network::Testnet => "testnet",
+                    _ => "network",
+                };
+
+                self.core_client
+                    .get_best_chain_lock()
+                    .map(|chain_lock| {
+                        BackendTaskSuccessResult::CoreItem(CoreItem::ChainLock(
+                            chain_lock,
+                            self.network,
+                        ))
+                    })
+                    .map_err(|e| {
+                        format!(
+                            "Failed to get best chain lock for {}: {}",
+                            network_string,
+                            e.to_string()
+                        )
+                    })
+            }
+            CoreTask::GetBothBestChainLocks => {
+                // Load config
+                let config = match Config::load() {
+                    Ok(config) => config,
+                    Err(e) => {
+                        return Err(format!("Failed to load config: {}", e));
+                    }
+                };
+
+                // Get mainnet best chainlock
+                let mainnet_config = config
+                    .config_for_network(Network::Dash)
+                    .clone()
+                    .ok_or("Failed to get mainnet config".to_string())?;
+                let mainnet_addr = format!(
+                    "http://{}:{}",
+                    mainnet_config.core_host, mainnet_config.core_rpc_port
+                );
+                let mainnet_client = Client::new(
+                    &mainnet_addr,
+                    Auth::UserPass(
+                        mainnet_config.core_rpc_user.to_string(),
+                        mainnet_config.core_rpc_password.to_string(),
+                    ),
+                )
+                .map_err(|_| "Failed to create mainnet client".to_string())?;
+                let mainnet_result = mainnet_client.get_best_chain_lock().map_err(|e| {
+                    format!(
+                        "Failed to get best chain lock for mainnet: {}",
+                        e.to_string()
+                    )
+                });
+
+                // Get testnet best chainlock
+                let testnet_config = config
+                    .config_for_network(Network::Testnet)
+                    .clone()
+                    .ok_or("Failed to get testnet config".to_string())?;
+                let testnet_addr = format!(
+                    "http://{}:{}",
+                    testnet_config.core_host, testnet_config.core_rpc_port
+                );
+                let testnet_client = Client::new(
+                    &testnet_addr,
+                    Auth::UserPass(
+                        testnet_config.core_rpc_user.to_string(),
+                        testnet_config.core_rpc_password.to_string(),
+                    ),
+                )
+                .map_err(|_| "Failed to create testnet client".to_string())?;
+                let testnet_result = testnet_client.get_best_chain_lock().map_err(|e| {
+                    format!(
+                        "Failed to get best chain lock for testnet: {}",
+                        e.to_string()
+                    )
+                });
+
+                // Handle results
+                match (mainnet_result, testnet_result) {
+                    (Ok(mainnet_chainlock), Ok(testnet_chainlock)) => {
+                        Ok(BackendTaskSuccessResult::CoreItem(
+                            CoreItem::BothChainLocks(mainnet_chainlock, testnet_chainlock),
+                        ))
+                    }
+                    (Ok(mainnet_chainlock), Err(testnet_err)) => {
+                        tracing::error!("{}", testnet_err);
+                        Ok(BackendTaskSuccessResult::CoreItem(CoreItem::ChainLock(
+                            mainnet_chainlock,
+                            Network::Dash,
+                        )))
+                    }
+                    (Err(mainnet_err), Ok(testnet_chainlock)) => {
+                        tracing::error!("{}", mainnet_err);
+                        Ok(BackendTaskSuccessResult::CoreItem(CoreItem::ChainLock(
+                            testnet_chainlock,
+                            Network::Testnet,
+                        )))
+                    }
+                    (Err(_), Err(_)) => {
+                        tracing::error!(
+                            "Failed to get best chain lock for both mainnet and testnet",
+                        );
+                        Err("Failed to get best chain lock for both mainnet and testnet"
+                            .to_string())
+                    }
+                }
+            }
             CoreTask::RefreshWalletInfo(wallet) => self.refresh_wallet_info(wallet),
             CoreTask::StartDashQT(network, custom_dash_qt, overwrite_dash_conf) => self
                 .start_dash_qt(network, custom_dash_qt, overwrite_dash_conf)

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -254,8 +254,8 @@ impl NetworkChooserScreen {
 }
 
 impl ScreenLike for NetworkChooserScreen {
-    fn display_message(&mut self, message: &str, message_type: super::MessageType) {
-        if message_type == MessageType::Error && message.contains("Failed to get best chain lock") {
+    fn display_message(&mut self, message: &str, _message_type: super::MessageType) {
+        if message.contains("Failed to get best chain lock") {
             if message.contains("mainnet") {
                 self.mainnet_core_status_online = false;
             }

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -195,7 +195,7 @@ impl NetworkChooserScreen {
             } else {
                 &self.testnet_app_context.as_ref().unwrap()
             };
-            app_action |=
+            app_action =
                 AppAction::AddScreen(Screen::AddNewWalletScreen(AddNewWalletScreen::new(context)));
         }
 
@@ -216,7 +216,7 @@ impl NetworkChooserScreen {
 
         // Add a button to start the network
         if ui.button("Start").clicked() {
-            app_action |= AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(
+            app_action = AppAction::BackendTask(BackendTask::CoreTask(CoreTask::StartDashQT(
                 network,
                 self.custom_dash_qt_path.clone(),
                 self.overwrite_dash_conf,
@@ -290,7 +290,7 @@ impl ScreenLike for NetworkChooserScreen {
                 .expect("Time went backwards");
             if let Some(time) = self.recheck_time {
                 if current_time.as_millis() as u64 >= time {
-                    action |=
+                    action =
                         AppAction::BackendTask(BackendTask::CoreTask(CoreTask::GetBestChainLocks));
                     self.recheck_time = Some((current_time + recheck_time).as_millis() as u64);
                 }

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -35,11 +35,6 @@ impl NetworkChooserScreen {
         custom_dash_qt_path: Option<String>,
         overwrite_dash_conf: bool,
     ) -> Self {
-        let current_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards");
-        let recheck_time = Some((current_time + Duration::from_secs(5)).as_millis() as u64);
-
         Self {
             mainnet_app_context: mainnet_app_context.clone(),
             testnet_app_context: testnet_app_context.cloned(),
@@ -47,7 +42,7 @@ impl NetworkChooserScreen {
             mainnet_core_status_online: false,
             testnet_core_status_online: false,
             status_checked: false,
-            recheck_time,
+            recheck_time: None,
             custom_dash_qt_path,
             custom_dash_qt_error_message: None,
             overwrite_dash_conf,
@@ -301,7 +296,6 @@ impl ScreenLike for NetworkChooserScreen {
         }
     }
     fn ui(&mut self, ctx: &Context) -> AppAction {
-        //let _ = self.current_app_context().db.get_settings();
         let mut action = add_top_panel(
             ctx,
             self.current_app_context(),

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -2,7 +2,6 @@ use crate::app::AppAction;
 use crate::backend_task::core::{CoreItem, CoreTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
-use crate::model::password_info::PasswordInfo;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::wallet::add_new_wallet_screen::AddNewWalletScreen;
@@ -20,7 +19,6 @@ pub struct NetworkChooserScreen {
     pub current_network: Network,
     pub mainnet_core_status_online: bool,
     pub testnet_core_status_online: bool,
-    status_checked: bool,
     pub recheck_time: Option<TimestampMillis>,
     custom_dash_qt_path: Option<String>,
     custom_dash_qt_error_message: Option<String>,
@@ -41,7 +39,6 @@ impl NetworkChooserScreen {
             current_network,
             mainnet_core_status_online: false,
             testnet_core_status_online: false,
-            status_checked: false,
             recheck_time: None,
             custom_dash_qt_path,
             custom_dash_qt_error_message: None,

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -311,7 +311,7 @@ impl ScreenLike for NetworkChooserScreen {
             if let Some(time) = self.recheck_time {
                 if current_time.as_millis() as u64 >= time {
                     action |= AppAction::BackendTask(BackendTask::CoreTask(
-                        CoreTask::GetBothBestChainLocks,
+                        CoreTask::GetBestChainLocksTestnetAndMainnet,
                     ));
                     self.recheck_time = Some((current_time + recheck_time).as_millis() as u64);
                 }


### PR DESCRIPTION
 - Fixed: network statuses would never switch from Online to Offline unless the app restarts
 - Fixed: only the currently active network status would update automatically

Now we check both networks every 3 seconds while the screen is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced network status handling with simultaneous retrieval of chain locks from both mainnet and testnet.
	- Introduced a new mechanism for rechecking network status every three seconds.

- **Bug Fixes**
	- Improved error handling and configuration loading for network tasks.

- **Refactor**
	- Simplified state management in the network chooser screen by removing unnecessary fields and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->