### PR TITLE
fix: limit 100 in dpns end time query

### DIFF
--- a/src/backend_task/contested_names/query_ending_times.rs
+++ b/src/backend_task/contested_names/query_ending_times.rs
@@ -1,7 +1,6 @@
 use crate::context::AppContext;
 use crate::model::proof_log_item::{ProofLogItem, RequestType};
 use chrono::{DateTime, Duration, Utc};
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
 use dash_sdk::dpp::voting::vote_polls::VotePoll;
 use dash_sdk::drive::query::VotePollsByEndDateDriveQuery;
@@ -22,54 +21,44 @@ impl AppContext {
         let now: DateTime<Utc> = Utc::now();
         let start_time_dt = now - Duration::weeks(2);
         let end_time_dt = now + Duration::weeks(2);
-        let start_time = Some((start_time_dt.timestamp_millis() as u64, true));
+        let mut start_time = Some((start_time_dt.timestamp_millis() as u64, true));
         let end_time = Some((end_time_dt.timestamp_millis() as u64, true));
 
-        let end_time_query = VotePollsByEndDateDriveQuery {
-            start_time,
-            end_time,
-            limit: None,
-            offset: None,
-            order_ascending: true,
-        };
+        let mut contests_end_times = BTreeMap::new();
 
         const MAX_RETRIES: usize = 3;
         let mut retries = 0;
 
-        let mut contests_end_times = BTreeMap::new();
-
         loop {
-            match VotePoll::fetch_many(&sdk, end_time_query.clone()).await {
+            let end_time_query = VotePollsByEndDateDriveQuery {
+                start_time,
+                end_time,
+                limit: Some(100),
+                offset: None,
+                order_ascending: true,
+            };
+
+            let new_end_times = match VotePoll::fetch_many(&sdk, end_time_query.clone()).await {
                 Ok(vote_polls) => {
+                    let mut end_times = BTreeMap::new();
                     for (timestamp, vote_poll_list) in vote_polls {
                         let contests = vote_poll_list.into_iter().filter_map(|vote_poll| {
                             let VotePoll::ContestedDocumentResourceVotePoll(
                                 ContestedDocumentResourceVotePoll {
-                                    contract_id,
-                                    document_type_name,
-                                    index_name,
+                                    contract_id: _,
+                                    document_type_name: _,
+                                    index_name: _,
                                     index_values,
                                 },
                             ) = vote_poll;
-                            if contract_id != self.dpns_contract.id() {
-                                return None;
-                            }
-                            if document_type_name != "domain" {
-                                return None;
-                            }
-                            if index_name != "parentNameAndLabel" {
-                                return None;
-                            }
-                            if index_values.len() != 2 {
-                                return None;
-                            }
+
                             index_values
                                 .get(1)
                                 .and_then(|a| a.to_str().ok().map(|a| (a.to_string(), timestamp)))
                         });
-                        contests_end_times.extend(contests);
+                        end_times.extend(contests);
                     }
-                    break;
+                    end_times
                 }
                 Err(e) => {
                     tracing::error!("Error fetching vote polls: {}", e);
@@ -140,6 +129,19 @@ impl AppContext {
                         return Err(format!("Error fetching vote polls: {}", e));
                     }
                 }
+            };
+
+            contests_end_times.extend(new_end_times.clone());
+
+            if new_end_times.len() == 0 {
+                break;
+            }
+
+            let last_found_ending_time = new_end_times.values().max();
+            if let Some(last_found_ending_time) = last_found_ending_time {
+                start_time = Some((*last_found_ending_time, false));
+            } else {
+                break;
             }
         }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,7 +13,7 @@ pub fn initialize_logger() {
     };
 
     let filter = EnvFilter::try_new(
-        "error,info,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug",
+        "error,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug",
     )
         .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e));
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,7 +13,7 @@ pub fn initialize_logger() {
     };
 
     let filter = EnvFilter::try_new(
-        "error,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug",
+        "error,info,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug",
     )
         .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e));
 


### PR DESCRIPTION
Limit the queries for DPNS contest ending times to 100 results per query so we don't get errors.

Also, take end time queries and contender queries outside of the resources query loop so we don't keep repeating them.