### PR TITLE
fix: wallet unlock in register dpns name screen

### DIFF
--- a/src/ui/components/wallet_unlock.rs
+++ b/src/ui/components/wallet_unlock.rs
@@ -61,8 +61,8 @@ pub trait ScreenWithWalletUnlock {
                 // Capture necessary values before the closure
                 let show_password = self.show_password();
                 let mut local_show_password = show_password; // Local copy of show_password
+                let mut local_error_message = self.error_message().cloned(); // Local variable for error message
                 let wallet_password_mut = self.wallet_password_mut(); // Mutable reference to the password
-                let mut local_error_message = None; // Local variable for error message
 
                 ui.horizontal(|ui| {
                     let password_input = ui.add(

--- a/src/ui/components/wallet_unlock.rs
+++ b/src/ui/components/wallet_unlock.rs
@@ -47,7 +47,14 @@ pub trait ScreenWithWalletUnlock {
             // Only render the unlock prompt if the wallet requires a password and is locked
             if wallet.uses_password && !wallet.is_open() {
                 ui.add_space(10.0);
-                ui.label("This wallet is locked. Please enter the password to unlock it:");
+                if let Some(alias) = &wallet.alias {
+                    ui.label(format!(
+                        "This wallet ({}) is locked. Please enter the password to unlock it:",
+                        alias
+                    ));
+                } else {
+                    ui.label("This wallet is locked. Please enter the password to unlock it:");
+                }
 
                 let mut unlocked = false;
 

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -76,7 +76,6 @@ impl RegisterDpnsNameScreen {
         let selected_qualified_identity = qualified_identities.first().cloned();
 
         let mut error_message: Option<String> = None;
-
         let selected_wallet = get_selected_wallet(
             &selected_qualified_identity,
             app_context,

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -42,21 +42,6 @@ pub struct RegisterDpnsNameScreen {
 }
 
 impl RegisterDpnsNameScreen {
-    pub fn select_identity(&mut self, identity_id: Identifier) {
-        // Find the qualified identity with the matching identity_id
-        if let Some(qi) = self
-            .qualified_identities
-            .iter()
-            .find(|(qi, _)| qi.identity.id() == &identity_id)
-        {
-            // Set the selected_qualified_identity to the found identity
-            self.selected_qualified_identity = Some(qi.clone());
-        } else {
-            // If not found, you might want to handle this case
-            // For now, we'll set selected_qualified_identity to None
-            self.selected_qualified_identity = None;
-        }
-    }
     pub fn new(app_context: &Arc<AppContext>) -> Self {
         let security_level_of_contract = app_context
             .dpns_contract
@@ -89,11 +74,15 @@ impl RegisterDpnsNameScreen {
             })
             .collect();
         let selected_qualified_identity = qualified_identities.first().cloned();
-        let selected_wallet = if let Some(wallet) = app_context.wallets.read().unwrap().first() {
-            Some(wallet.clone())
-        } else {
-            None
-        };
+
+        let mut error_message: Option<String> = None;
+
+        let selected_wallet = get_selected_wallet(
+            &selected_qualified_identity,
+            app_context,
+            &mut error_message,
+        );
+
         let show_identity_selector = qualified_identities.len() > 0;
         Self {
             show_identity_selector,
@@ -105,7 +94,23 @@ impl RegisterDpnsNameScreen {
             selected_wallet,
             wallet_password: String::new(),
             show_password: false,
-            error_message: None,
+            error_message,
+        }
+    }
+
+    pub fn select_identity(&mut self, identity_id: Identifier) {
+        // Find the qualified identity with the matching identity_id
+        if let Some(qi) = self
+            .qualified_identities
+            .iter()
+            .find(|(qi, _)| qi.identity.id() == &identity_id)
+        {
+            // Set the selected_qualified_identity to the found identity
+            self.selected_qualified_identity = Some(qi.clone());
+        } else {
+            // If not found, you might want to handle this case
+            // For now, we'll set selected_qualified_identity to None
+            self.selected_qualified_identity = None;
         }
     }
 
@@ -169,29 +174,22 @@ impl RegisterDpnsNameScreen {
                             {
                                 self.selected_qualified_identity = Some(qualified_identity.clone());
 
-                                if let Some((qualified_identity, _)) =  self.selected_qualified_identity.as_ref() {
-                                    let dpns_contract = &self.app_context.dpns_contract;
+                                // Reset the error message
+                                self.error_message = None;
 
-                                    let preorder_document_type = dpns_contract
-                                        .document_type_for_name("preorder")
-                                        .expect("DPNS preorder document type not found");
+                                // Update the selected wallet using the helper function
+                                self.selected_wallet = get_selected_wallet(
+                                    &self.selected_qualified_identity,
+                                    &self.app_context,
+                                    &mut self.error_message,
+                                );
 
-                                    let public_key = match qualified_identity
-                                        .document_signing_key(&preorder_document_type)
-                                        .ok_or(
-                                            "Identity doesn't have an authentication key for signing document transitions"
-                                                .to_string(),
-                                        ) {
-                                        Ok(public_key) => public_key,
-                                        Err(e) => {
-                                            self.error_message = Some(e);
-                                            return;
-                                        }
-                                    };
-
-                                    if let Some((_, PrivateKeyData::AtWalletDerivationPath(wallet_derivation_path))) = qualified_identity.private_keys.private_keys.get(&(PrivateKeyTarget::PrivateKeyOnMainIdentity, public_key.id())) {
-                                        self.selected_wallet = qualified_identity.associated_wallets.get(&wallet_derivation_path.wallet_seed_hash).cloned()
-                                    }
+                                // Optionally handle the case where no wallet is found
+                                if self.selected_wallet.is_none() && self.error_message.is_none() {
+                                    self.error_message = Some(
+                                        "No associated wallet found for the selected identity."
+                                            .to_string(),
+                                    );
                                 }
                             }
                         }
@@ -442,4 +440,46 @@ pub fn is_contested_name(name: &str) -> bool {
         }
     }
     true
+}
+
+pub fn get_selected_wallet<PublicKey>(
+    selected_qualified_identity: &Option<(QualifiedIdentity, Vec<PublicKey>)>,
+    app_context: &AppContext,
+    error_message: &mut Option<String>,
+) -> Option<Arc<RwLock<Wallet>>> {
+    let (qualified_identity, _) = selected_qualified_identity.as_ref()?;
+
+    let dpns_contract = &app_context.dpns_contract;
+
+    let preorder_document_type = match dpns_contract.document_type_for_name("preorder") {
+        Ok(doc_type) => doc_type,
+        Err(e) => {
+            *error_message = Some(format!("DPNS preorder document type not found: {}", e));
+            return None;
+        }
+    };
+
+    let public_key = match qualified_identity.document_signing_key(&preorder_document_type) {
+        Some(key) => key,
+        None => {
+            *error_message = Some(
+                "Identity doesn't have an authentication key for signing document transitions"
+                    .to_string(),
+            );
+            return None;
+        }
+    };
+
+    let key = (PrivateKeyTarget::PrivateKeyOnMainIdentity, public_key.id());
+
+    if let Some((_, PrivateKeyData::AtWalletDerivationPath(wallet_derivation_path))) =
+        qualified_identity.private_keys.private_keys.get(&key)
+    {
+        qualified_identity
+            .associated_wallets
+            .get(&wallet_derivation_path.wallet_seed_hash)
+            .cloned()
+    } else {
+        None
+    }
 }

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -172,7 +172,6 @@ impl RegisterDpnsNameScreen {
                                 .clicked()
                             {
                                 self.selected_qualified_identity = Some(qualified_identity.clone());
-                                self.error_message = None;
                                 self.selected_wallet = get_selected_wallet(
                                     &self.selected_qualified_identity,
                                     &self.app_context,

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -106,10 +106,17 @@ impl RegisterDpnsNameScreen {
         {
             // Set the selected_qualified_identity to the found identity
             self.selected_qualified_identity = Some(qi.clone());
+            // Update the selected wallet
+            self.selected_wallet = get_selected_wallet(
+                &self.selected_qualified_identity,
+                &self.app_context,
+                &mut self.error_message,
+            );
         } else {
             // If not found, you might want to handle this case
             // For now, we'll set selected_qualified_identity to None
             self.selected_qualified_identity = None;
+            self.selected_wallet = None;
         }
     }
 

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -172,24 +172,12 @@ impl RegisterDpnsNameScreen {
                                 .clicked()
                             {
                                 self.selected_qualified_identity = Some(qualified_identity.clone());
-
-                                // Reset the error message
                                 self.error_message = None;
-
-                                // Update the selected wallet using the helper function
                                 self.selected_wallet = get_selected_wallet(
                                     &self.selected_qualified_identity,
                                     &self.app_context,
                                     &mut self.error_message,
                                 );
-
-                                // Optionally handle the case where no wallet is found
-                                if self.selected_wallet.is_none() && self.error_message.is_none() {
-                                    self.error_message = Some(
-                                        "No associated wallet found for the selected identity."
-                                            .to_string(),
-                                    );
-                                }
                             }
                         }
                     });


### PR DESCRIPTION
3 fixes: 

1. In register dpns name screen, we didn't know which wallet we were unlocking, so display it
2. In register dpns name screen, we weren't setting the correct wallet on screen load
3. In wallet unlocks in general, if there was an error message, we would set the error message and then immediately reset it to None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced user interface feedback for wallet unlocking, including wallet alias in the label.
	- Improved error handling during wallet selection and unlocking processes.

- **Bug Fixes**
	- Refined error message retention during wallet unlocking attempts.

- **Refactor**
	- Streamlined wallet selection logic for better organization and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->