### PR TITLE
fix: refresh owned dpns names

### DIFF
--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -2,6 +2,7 @@ mod add_key_to_identity;
 mod load_identity;
 mod load_identity_from_wallet;
 mod refresh_identity;
+mod refresh_loaded_identities_dpns_names;
 mod register_dpns_name;
 mod register_identity;
 mod top_up_identity;
@@ -255,6 +256,7 @@ pub(crate) enum IdentityTask {
     Transfer(QualifiedIdentity, Identifier, Credits, Option<KeyID>),
     RegisterDpnsName(RegisterDpnsNameInput),
     RefreshIdentity(QualifiedIdentity),
+    RefreshLoadedIdentitiesOwnedDPNSNames,
 }
 
 fn verify_key_input(
@@ -466,6 +468,9 @@ impl AppContext {
             }
             IdentityTask::TopUpIdentity(top_up_info) => {
                 self.top_up_identity(top_up_info, sender).await
+            }
+            IdentityTask::RefreshLoadedIdentitiesOwnedDPNSNames => {
+                self.refresh_loaded_identities_dpns_names().await
             }
         }
     }

--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -470,7 +470,7 @@ impl AppContext {
                 self.top_up_identity(top_up_info, sender).await
             }
             IdentityTask::RefreshLoadedIdentitiesOwnedDPNSNames => {
-                self.refresh_loaded_identities_dpns_names().await
+                self.refresh_loaded_identities_dpns_names(sender).await
             }
         }
     }

--- a/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
+++ b/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
@@ -1,0 +1,75 @@
+use super::BackendTaskSuccessResult;
+use crate::context::AppContext;
+use crate::model::qualified_identity::DPNSNameInfo;
+use dash_sdk::dpp::document::DocumentV0Getters;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::platform_value::Value;
+use dash_sdk::drive::query::{WhereClause, WhereOperator};
+use dash_sdk::platform::{Document, DocumentQuery, FetchMany};
+
+impl AppContext {
+    pub(super) async fn refresh_loaded_identities_dpns_names(
+        &self,
+    ) -> Result<BackendTaskSuccessResult, String> {
+        let qualified_identities = self
+            .load_local_qualified_identities()
+            .map_err(|e| format!("Error refreshing owned DPNS names: Database error: {}", e))?;
+
+        for mut qualified_identity in qualified_identities {
+            let identity_id = qualified_identity.identity.id();
+
+            // Fetch DPNS names using SDK
+            let dpns_names_document_query = DocumentQuery {
+                data_contract: self.dpns_contract.clone(),
+                document_type_name: "domain".to_string(),
+                where_clauses: vec![WhereClause {
+                    field: "records.identity".to_string(),
+                    operator: WhereOperator::Equal,
+                    value: Value::Identifier(identity_id.into()),
+                }],
+                order_by_clauses: vec![],
+                limit: 100,
+                start: None,
+            };
+
+            let owned_dpns_names = Document::fetch_many(&self.sdk, dpns_names_document_query)
+                .await
+                .map(|document_map| {
+                    document_map
+                        .values()
+                        .filter_map(|maybe_doc| {
+                            maybe_doc.as_ref().and_then(|doc| {
+                                let name = doc
+                                    .get("normalizedLabel")
+                                    .map(|label| label.to_str().unwrap_or_default());
+                                let acquired_at = doc
+                                    .created_at()
+                                    .into_iter()
+                                    .chain(doc.transferred_at())
+                                    .max();
+
+                                match (name, acquired_at) {
+                                    (Some(name), Some(acquired_at)) => Some(DPNSNameInfo {
+                                        name: name.to_string(),
+                                        acquired_at,
+                                    }),
+                                    _ => None,
+                                }
+                            })
+                        })
+                        .collect::<Vec<DPNSNameInfo>>()
+                })
+                .map_err(|e| format!("Error refreshing owned DPNS names: {}", e))?;
+
+            qualified_identity.dpns_names = owned_dpns_names;
+
+            // Update qualified identity in the database
+            self.update_local_qualified_identity(&qualified_identity)
+                .map_err(|e| format!("Error refreshing owned DPNS names: Database error: {}", e))?;
+        }
+
+        Ok(BackendTaskSuccessResult::Message(
+            "Successfully refreshed loaded identities dpns names".to_string(),
+        ))
+    }
+}

--- a/src/ui/dpns_contested_names_screen.rs
+++ b/src/ui/dpns_contested_names_screen.rs
@@ -236,12 +236,10 @@ impl DPNSContestedNamesScreen {
             ui.add_space(10.0);
             ui.label("Please check back later or try refreshing the list.");
             ui.add_space(20.0);
-            if self.refreshing {
-                if ui.button("Refresh").clicked() {
+            if ui.button("Refresh").clicked() {
+                if self.refreshing {
                     app_action |= AppAction::None;
-                }
-            } else {
-                if ui.button("Refresh").clicked() {
+                } else {
                     match self.dpns_subscreen {
                         DPNSSubscreen::Active => {
                             app_action |=

--- a/src/ui/dpns_contested_names_screen.rs
+++ b/src/ui/dpns_contested_names_screen.rs
@@ -184,8 +184,8 @@ impl DPNSContestedNamesScreen {
             let now = Utc::now();
             let elapsed = now.signed_duration_since(*timestamp);
 
-            // Automatically dismiss the error message after 5 seconds
-            if elapsed.num_seconds() > 5 {
+            // Automatically dismiss the error message after 10 seconds
+            if elapsed.num_seconds() > 10 {
                 self.dismiss_error();
             }
         }

--- a/src/ui/dpns_contested_names_screen.rs
+++ b/src/ui/dpns_contested_names_screen.rs
@@ -957,10 +957,8 @@ impl ScreenLike for DPNSContestedNamesScreen {
         match action {
             AppAction::BackendTask(BackendTask::ContestedResourceTask(
                 ContestedResourceTask::QueryDPNSContestedResources,
-            )) => {
-                self.refreshing = true;
-            }
-            AppAction::BackendTask(BackendTask::IdentityTask(
+            ))
+            | AppAction::BackendTask(BackendTask::IdentityTask(
                 IdentityTask::RefreshLoadedIdentitiesOwnedDPNSNames,
             )) => {
                 self.refreshing = true;

--- a/src/ui/dpns_contested_names_screen.rs
+++ b/src/ui/dpns_contested_names_screen.rs
@@ -241,13 +241,7 @@ impl DPNSContestedNamesScreen {
                     app_action |= AppAction::None;
                 } else {
                     match self.dpns_subscreen {
-                        DPNSSubscreen::Active => {
-                            app_action |=
-                                AppAction::BackendTask(BackendTask::ContestedResourceTask(
-                                    ContestedResourceTask::QueryDPNSContestedResources,
-                                ));
-                        }
-                        DPNSSubscreen::Past => {
+                        DPNSSubscreen::Active | DPNSSubscreen::Past => {
                             app_action |=
                                 AppAction::BackendTask(BackendTask::ContestedResourceTask(
                                     ContestedResourceTask::QueryDPNSContestedResources,
@@ -830,13 +824,7 @@ impl ScreenLike for DPNSContestedNamesScreen {
     fn ui(&mut self, ctx: &Context) -> AppAction {
         self.check_error_expiration();
         let mut top_panel_refresh_button = match self.dpns_subscreen {
-            DPNSSubscreen::Active => (
-                "Refresh",
-                DesiredAppAction::BackendTask(BackendTask::ContestedResourceTask(
-                    ContestedResourceTask::QueryDPNSContestedResources,
-                )),
-            ),
-            DPNSSubscreen::Past => (
+            DPNSSubscreen::Active | DPNSSubscreen::Past => (
                 "Refresh",
                 DesiredAppAction::BackendTask(BackendTask::ContestedResourceTask(
                     ContestedResourceTask::QueryDPNSContestedResources,


### PR DESCRIPTION
Refresh button wasn't actually refreshing owned DPNS names on that DPNS subscreen. It was just doing a contested resource query for the other subscreens.

Also made it so that self.refreshing is set to false if the screen changes. Otherwise, the refresh button can get stuck in a Refreshing state.