### PR TITLE
fix: load the correct wallet in screen for register dpns name

### DIFF
--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -75,12 +75,12 @@ impl RegisterDpnsNameScreen {
             .collect();
         let selected_qualified_identity = qualified_identities.first().cloned();
 
-        let selected_wallet =
-            if let Some(wallet) = app_context.wallets.read().unwrap().values().next() {
-                Some(wallet.clone())
-            } else {
-                None
-            };
+        let mut error_message: Option<String> = None;
+        let selected_wallet = get_selected_wallet(
+            &selected_qualified_identity,
+            app_context,
+            &mut error_message,
+        );
 
         let show_identity_selector = qualified_identities.len() > 0;
         Self {
@@ -93,7 +93,7 @@ impl RegisterDpnsNameScreen {
             selected_wallet,
             wallet_password: String::new(),
             show_password: false,
-            error_message: None,
+            error_message,
         }
     }
 


### PR DESCRIPTION
I had fixed this a few days ago but it got overwritten somehow.

Load the correct wallet when opening the screen for registering dpns name.

The wallet that the screen wants to unlock doesn't always align with the first identity in the identity selector.