### PR TITLE
fix: key not found error message

### DIFF
--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -177,8 +177,10 @@ impl Signer for QualifiedIdentity {
             )
             .map_err(|e| ProtocolError::Generic(e))?
             .ok_or(ProtocolError::Generic(format!(
-                "{:?} not found in {:?}",
-                identity_public_key, self
+                "Key {} ({}) not found in identity {:?}",
+                identity_public_key.id(),
+                identity_public_key.purpose(),
+                self.identity.id().to_string(Encoding::Base58)
             )))?;
         match identity_public_key.key_type() {
             KeyType::ECDSA_SECP256K1 | KeyType::ECDSA_HASH160 => {


### PR DESCRIPTION
The old error message printed the entire IdentityPublicKey and the entire QualifiedIdentity

This error message was huge - like 50,000 chars for my identity that has a bunch of keys.

So I changed the error message to look like this `Error: Protocol error: Generic Error: Key 1 (AUTHENTICATION) not found in identity "JBxLb52DKv2BHwdg7zf2tM84qKUfXqoEu1fQw3zKYQyY"`