### PR TITLE
fix: filter messages in vote scheduling screen

### DIFF
--- a/src/ui/dpns_vote_scheduling_screen.rs
+++ b/src/ui/dpns_vote_scheduling_screen.rs
@@ -160,7 +160,7 @@ impl ScheduleVoteScreen {
                     if chosen_time > self.ending_time {
                         self.message = Some((
                             MessageType::Error,
-                            "Scheduled time is after contest end time.".to_string(),
+                            "Error inserting scheduled votes: Scheduled time is after contest end time.".to_string(),
                         ));
                         return AppAction::None;
                     }
@@ -178,7 +178,10 @@ impl ScheduleVoteScreen {
         }
 
         if scheduled_votes.is_empty() {
-            self.message = Some((MessageType::Error, "No votes selected.".to_string()));
+            self.message = Some((
+                MessageType::Error,
+                "Error inserting scheduled votes: No votes selected.".to_string(),
+            ));
             return AppAction::None;
         }
 
@@ -271,7 +274,9 @@ impl ScreenLike for ScheduleVoteScreen {
             if let Some(message) = &self.message {
                 match message.0 {
                     MessageType::Error => {
-                        ui.colored_label(Color32::DARK_RED, message.1.clone());
+                        if message.1.contains("Error inserting scheduled votes") {
+                            ui.colored_label(Color32::DARK_RED, message.1.clone());
+                        }
                     }
                     MessageType::Success => {
                         if message.1.contains("Votes scheduled") {

--- a/src/ui/dpns_vote_scheduling_screen.rs
+++ b/src/ui/dpns_vote_scheduling_screen.rs
@@ -274,7 +274,9 @@ impl ScreenLike for ScheduleVoteScreen {
                         ui.colored_label(Color32::DARK_RED, message.1.clone());
                     }
                     MessageType::Success => {
-                        action = self.show_success(ui);
+                        if message.1.contains("Votes scheduled") {
+                            action = self.show_success(ui);
+                        }
                     }
                     MessageType::Info => {
                         ui.colored_label(Color32::DARK_BLUE, message.1.clone());


### PR DESCRIPTION
We were sorting backend messages by message type, but we also need to filter the message content to prevent messages from other screens triggering events on this screen. Really, we need to do this on every screen and probably come up with a better system for it. I view this as more of a quick patch-up