### PR TITLE
fix: max withdrawal amount

### DIFF
--- a/src/ui/identities/withdraw_from_identity_screen.rs
+++ b/src/ui/identities/withdraw_from_identity_screen.rs
@@ -105,7 +105,7 @@ impl WithdrawalScreen {
             ui.text_edit_singleline(&mut self.withdrawal_amount);
 
             if ui.button("Max").clicked() {
-                let expected_max_amount = self.max_amount.saturating_sub(5000000) as f64 * 1e-11;
+                let expected_max_amount = self.max_amount.saturating_sub(500000000) as f64 * 1e-11;
 
                 // Use flooring and format the result with 4 decimal places
                 let floored_amount = (expected_max_amount * 10_000.0).floor() / 10_000.0;
@@ -114,6 +114,8 @@ impl WithdrawalScreen {
                 self.withdrawal_amount = format!("{:.4}", floored_amount);
             }
         });
+
+        tracing::info!("Withdrawal amount: {}", self.withdrawal_amount);
     }
 
     fn render_address_input(&mut self, ui: &mut Ui) {


### PR DESCRIPTION
We weren't leaving a great enough buffer for gas fees when calculating max withdrawal amount. Off by 1000x.