### PR TITLE
feat: clean up top up screen

### DIFF
--- a/src/ui/components/wallet_unlock.rs
+++ b/src/ui/components/wallet_unlock.rs
@@ -46,7 +46,7 @@ pub trait ScreenWithWalletUnlock {
 
             // Only render the unlock prompt if the wallet requires a password and is locked
             if wallet.uses_password && !wallet.is_open() {
-                ui.add_space(10.0);
+                ui.add_space(20.0);
                 if let Some(alias) = &wallet.alias {
                     ui.label(format!(
                         "This wallet ({}) is locked. Please enter the password to unlock it:",
@@ -55,6 +55,8 @@ pub trait ScreenWithWalletUnlock {
                 } else {
                     ui.label("This wallet is locked. Please enter the password to unlock it:");
                 }
+
+                ui.add_space(5.0);
 
                 let mut unlocked = false;
 

--- a/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
@@ -1,7 +1,7 @@
 use crate::app::AppAction;
 use crate::ui::identities::add_new_identity_screen::FundingMethod;
 use crate::ui::identities::top_up_identity_screen::{TopUpIdentityScreen, WalletFundedScreenStep};
-use egui::Ui;
+use egui::{Color32, RichText, Ui};
 
 impl TopUpIdentityScreen {
     fn render_choose_funding_asset_lock(&mut self, ui: &mut egui::Ui) {
@@ -90,11 +90,22 @@ impl TopUpIdentityScreen {
         );
         ui.add_space(10.0);
         self.render_choose_funding_asset_lock(ui);
+        ui.add_space(10.0);
 
-        if ui.button("Create Identity").clicked() {
+        // Top up button
+        let mut new_style = (**ui.style()).clone();
+        new_style.spacing.button_padding = egui::vec2(10.0, 5.0);
+        ui.set_style(new_style);
+        let button = egui::Button::new(RichText::new("Top Up Identity").color(Color32::WHITE))
+            .fill(Color32::from_rgb(0, 128, 255))
+            .frame(true)
+            .rounding(3.0);
+        if ui.add(button).clicked() {
             self.error_message = None;
             action |= self.top_up_identity_clicked(FundingMethod::UseUnusedAssetLock);
         }
+
+        ui.add_space(20.0);
 
         match step {
             WalletFundedScreenStep::WaitingForPlatformAcceptance => {

--- a/src/ui/identities/top_up_identity_screen/by_using_unused_balance.rs
+++ b/src/ui/identities/top_up_identity_screen/by_using_unused_balance.rs
@@ -1,7 +1,7 @@
 use crate::app::AppAction;
 use crate::ui::identities::add_new_identity_screen::FundingMethod;
 use crate::ui::identities::top_up_identity_screen::{TopUpIdentityScreen, WalletFundedScreenStep};
-use egui::Ui;
+use egui::{Color32, RichText, Ui};
 
 impl TopUpIdentityScreen {
     fn show_wallet_balance(&self, ui: &mut egui::Ui) {
@@ -27,14 +27,16 @@ impl TopUpIdentityScreen {
     ) -> AppAction {
         let mut action = AppAction::None;
 
-        self.show_wallet_balance(ui);
-
-        ui.add_space(10.0);
-
         ui.heading(format!(
             "{}. How much of your wallet balance would you like to transfer?",
             step_number
         ));
+
+        ui.add_space(10.0);
+
+        self.show_wallet_balance(ui);
+
+        ui.add_space(10.0);
 
         step_number += 1;
 
@@ -47,10 +49,22 @@ impl TopUpIdentityScreen {
             return action;
         };
 
-        if ui.button("Top Up Identity").clicked() {
+        ui.add_space(10.0);
+
+        // Top up button
+        let mut new_style = (**ui.style()).clone();
+        new_style.spacing.button_padding = egui::vec2(10.0, 5.0);
+        ui.set_style(new_style);
+        let button = egui::Button::new(RichText::new("Top Up Identity").color(Color32::WHITE))
+            .fill(Color32::from_rgb(0, 128, 255))
+            .frame(true)
+            .rounding(3.0);
+        if ui.add(button).clicked() {
             self.error_message = None;
             action = self.top_up_identity_clicked(FundingMethod::UseWalletBalance);
         }
+
+        ui.add_space(20.0);
 
         match step {
             WalletFundedScreenStep::WaitingForAssetLock => {

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -114,8 +114,6 @@ impl TopUpIdentityScreen {
             return action;
         };
 
-        ui.add_space(10.0);
-
         ui.heading(
             format!(
                 "{}. Select how much you would like to transfer?",


### PR DESCRIPTION
The Top Up Screen flow didn't make sense since we would ask which loaded wallet to use to top up with even though the top up method might not require any loaded wallet. So I fixed the flow to only ask for loaded wallet if necessary, and also cleaned up with UI.