### PR TITLE
fix: correct way to print version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 edition = "2021"
 default-run = "dash-evo-tool"
 rust-version = "1.81"
+build = "build.rs"
 
 [build]
 rustflags = [

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    // Fetch the version from CARGO_PKG_VERSION
+    let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "??".to_string());
+
+    // Generate a Rust file with the version constant
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("version.rs");
+    fs::write(
+        dest_path,
+        format!(r#"pub const VERSION: &str = "{}";"#, version),
+    ).expect("Failed to write version.rs");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ mod model;
 mod sdk_wrapper;
 mod ui;
 
+include!(concat!(env!("OUT_DIR"), "/version.rs"));
+
 fn main() -> eframe::Result<()> {
+    println!("running v{}", VERSION);
     check_cpu_compatibility();
     // Initialize the Tokio runtime
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -32,9 +35,8 @@ fn main() -> eframe::Result<()> {
             centered: true,       // Center window on startup if not maximized
             ..Default::default()
         };
-        let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "".to_string());
         eframe::run_native(
-            &format!("Dash Evo Tool v{}", version),
+            &format!("Dash Evo Tool v{}", VERSION),
             native_options,
             Box::new(|_cc| Ok(Box::new(app::AppState::new()))),
         )


### PR DESCRIPTION
`CARGO_PKG_VERSION` is not accessible when running outside of `cargo run`.
This PR fixes the way Version string is taken from Cargo.toml and printed to the Window title