### PR TITLE
fix: store egui config in app dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::env;
-
+use crate::app_dir::{app_user_data_dir_path, create_app_user_data_directory_if_not_exists};
 use crate::cpu_compatibility::check_cpu_compatibility;
 
 mod app;
@@ -17,6 +17,10 @@ mod sdk_wrapper;
 mod ui;
 
 fn main() -> eframe::Result<()> {
+    create_app_user_data_directory_if_not_exists()
+        .expect("Failed to create app user_data directory");
+    let app_data_dir = app_user_data_dir_path()
+        .expect("Failed to get app user_data directory path");
     check_cpu_compatibility();
     // Initialize the Tokio runtime
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -30,6 +34,7 @@ fn main() -> eframe::Result<()> {
         let native_options = eframe::NativeOptions {
             persist_window: true, // Persist window size and position
             centered: true,       // Center window on startup if not maximized
+            persistence_path: Some(app_data_dir.join("app.ron")),
             ..Default::default()
         };
         let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "".to_string());


### PR DESCRIPTION
Force egui to store its config file in app dir (and stop creating directories Dash-Evo-Tool-v<version>)