### PR TITLE
feat: broadcast decoded state transitions

### DIFF
--- a/src/backend_task/broadcast_state_transition.rs
+++ b/src/backend_task/broadcast_state_transition.rs
@@ -1,0 +1,23 @@
+use dash_sdk::{
+    dpp::state_transition::StateTransition,
+    platform::transition::broadcast::BroadcastStateTransition, Sdk,
+};
+
+use crate::context::AppContext;
+
+use super::BackendTaskSuccessResult;
+
+impl AppContext {
+    pub async fn broadcast_state_transition(
+        &self,
+        state_transition: StateTransition,
+        sdk: &Sdk,
+    ) -> Result<BackendTaskSuccessResult, String> {
+        match state_transition.broadcast_and_wait(sdk, None).await {
+            Ok(_) => Ok(BackendTaskSuccessResult::Message(
+                "State transition broadcasted successfully".to_string(),
+            )),
+            Err(e) => Err(format!("Error broadcasting state transition: {}", e)),
+        }
+    }
+}

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -9,6 +9,7 @@ use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use contested_names::ScheduledDPNSVote;
 use dash_sdk::dpp::prelude::DataContract;
+use dash_sdk::dpp::state_transition::StateTransition;
 use dash_sdk::dpp::voting::votes::Vote;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
 use dash_sdk::platform::{Document, Identifier};
@@ -16,6 +17,7 @@ use dash_sdk::query_types::{Documents, IndexMap};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+pub mod broadcast_state_transition;
 pub mod contested_names;
 pub mod contract;
 pub mod core;
@@ -31,6 +33,7 @@ pub(crate) enum BackendTask {
     ContestedResourceTask(ContestedResourceTask),
     CoreTask(CoreTask),
     WithdrawalTask(WithdrawalsTask),
+    BroadcastStateTransition(StateTransition),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -87,6 +90,10 @@ impl AppContext {
             BackendTask::CoreTask(core_task) => self.run_core_task(core_task).await,
             BackendTask::WithdrawalTask(withdrawal_task) => {
                 self.run_withdraws_task(withdrawal_task, &sdk).await
+            }
+            BackendTask::BroadcastStateTransition(state_transition) => {
+                self.broadcast_state_transition(state_transition, &sdk)
+                    .await
             }
         }
     }

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -1,20 +1,33 @@
 use crate::app::AppAction;
+use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::{RootScreenType, ScreenLike};
+use crate::ui::{MessageType, RootScreenType, ScreenLike};
+
 use base64::{engine::general_purpose::STANDARD, Engine};
+use dash_sdk::dpp::prelude::TimestampMillis;
 use dash_sdk::dpp::serialization::PlatformDeserializable;
 use dash_sdk::dpp::state_transition::StateTransition;
-use eframe::egui::{self, Context, ScrollArea, TextEdit, Ui};
+use eframe::egui::{self, Color32, Context, ScrollArea, TextEdit, Ui};
+use egui::RichText;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(PartialEq)]
+pub enum TransitionBroadcastStatus {
+    NotStarted,
+    Submitting(TimestampMillis),
+    Error(String),
+    Complete,
+}
 
 pub struct TransitionVisualizerScreen {
     pub app_context: Arc<AppContext>,
     input_data: String,
     parsed_json: Option<String>,
-    error_message: Option<String>,
+    broadcast_status: TransitionBroadcastStatus,
 }
 
 impl TransitionVisualizerScreen {
@@ -23,14 +36,13 @@ impl TransitionVisualizerScreen {
             app_context: app_context.clone(),
             input_data: String::new(),
             parsed_json: None,
-            error_message: None,
+            broadcast_status: TransitionBroadcastStatus::NotStarted,
         }
     }
 
     fn parse_input(&mut self) {
-        // Clear previous messages
+        // Clear previous parse results, but let's not overwrite broadcast_status
         self.parsed_json = None;
-        self.error_message = None;
 
         // Try to decode the input as hex first
         let decoded_bytes = hex::decode(&self.input_data).or_else(|_| {
@@ -48,23 +60,30 @@ impl TransitionVisualizerScreen {
                         match serde_json::to_string_pretty(&state_transition) {
                             Ok(json) => self.parsed_json = Some(json),
                             Err(e) => {
-                                self.error_message =
-                                    Some(format!("Failed to serialize to JSON: {}", e))
+                                self.broadcast_status = TransitionBroadcastStatus::Error(format!(
+                                    "Failed to serialize to JSON: {}",
+                                    e
+                                ));
                             }
                         }
                     }
                     Err(e) => {
-                        self.error_message =
-                            Some(format!("Failed to parse state transition: {}", e))
+                        self.broadcast_status = TransitionBroadcastStatus::Error(format!(
+                            "Failed to parse state transition: {}",
+                            e
+                        ));
                     }
                 }
             }
-            Err(e) => self.error_message = Some(e),
+            Err(e) => {
+                self.broadcast_status = TransitionBroadcastStatus::Error(e);
+            }
         }
     }
 
     fn show_input_field(&mut self, ui: &mut Ui) {
         ui.label("Enter hex or base64 encoded state transition:");
+        ui.add_space(5.0);
         let response = ui.add(
             TextEdit::multiline(&mut self.input_data)
                 .desired_rows(6)
@@ -72,38 +91,145 @@ impl TransitionVisualizerScreen {
                 .code_editor(),
         );
 
-        // If the user changes the input, parse it again
+        ui.add_space(10.0);
+
         if response.changed() {
+            // Re-parse
             self.parse_input();
         }
     }
 
-    fn show_output(&self, ui: &mut Ui) {
+    fn show_output(&mut self, ui: &mut Ui) -> AppAction {
+        let mut app_action = AppAction::None;
+
         ui.separator();
+        ui.add_space(10.0);
         ui.label("Parsed State Transition:");
 
+        // Show the JSON if we have it
         ScrollArea::vertical().show(ui, |ui| {
-            ui.set_width(ui.available_width()); // Make the scroll area take the entire width
-
             if let Some(ref json) = self.parsed_json {
+                ui.add_space(5.0);
                 ui.add(
                     TextEdit::multiline(&mut json.clone())
                         .desired_rows(10)
-                        .desired_width(ui.available_width()) // Make the output take the entire width
-                        .font(egui::TextStyle::Monospace), // Use a monospace font for JSON
+                        .desired_width(ui.available_width())
+                        .font(egui::TextStyle::Monospace),
                 );
-            } else if let Some(ref error) = self.error_message {
-                ui.colored_label(egui::Color32::RED, error);
+
+                ui.add_space(10.0);
+
+                // If we’re not done or not in the middle of broadcasting, we can show the button
+                if matches!(
+                    self.broadcast_status,
+                    TransitionBroadcastStatus::NotStarted | TransitionBroadcastStatus::Error(_)
+                ) {
+                    if let TransitionBroadcastStatus::Submitting(_) = self.broadcast_status {
+                        // Broadcast button
+                        let mut new_style = (**ui.style()).clone();
+                        new_style.spacing.button_padding = egui::vec2(10.0, 5.0);
+                        ui.set_style(new_style);
+                        let button = egui::Button::new(
+                            RichText::new("Broadcast Transition to Platform").color(Color32::WHITE),
+                        )
+                        .fill(Color32::from_rgb(0, 128, 255))
+                        .frame(true)
+                        .rounding(3.0);
+                        if ui.add(button).clicked() {
+                            // Mark as submitting
+                            let now = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .expect("Time went backwards")
+                                .as_secs();
+                            self.broadcast_status = TransitionBroadcastStatus::Submitting(now);
+                            // Kick off the backend task
+                            match StateTransition::deserialize_from_bytes(
+                                &hex::decode(&self.input_data).unwrap(),
+                            ) {
+                                Ok(state_transition) => {
+                                    app_action = AppAction::BackendTask(
+                                        BackendTask::BroadcastStateTransition(state_transition),
+                                    );
+                                }
+                                Err(e) => {
+                                    self.broadcast_status = TransitionBroadcastStatus::Error(
+                                        format!("Failed to parse state transition: {}", e),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
             } else {
-                ui.label("No valid state transition parsed yet.");
+                // If parsed_json is None
+                if matches!(self.broadcast_status, TransitionBroadcastStatus::NotStarted) {
+                    ui.label("No valid state transition parsed yet.");
+                }
             }
         });
+
+        // Show status
+        ui.add_space(5.0);
+        match &self.broadcast_status {
+            TransitionBroadcastStatus::NotStarted => {}
+            TransitionBroadcastStatus::Submitting(start_time) => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Time went backwards")
+                    .as_secs();
+                let elapsed_seconds = now - start_time;
+
+                let display_time = if elapsed_seconds < 60 {
+                    format!(
+                        "{} second{}",
+                        elapsed_seconds,
+                        if elapsed_seconds == 1 { "" } else { "s" }
+                    )
+                } else {
+                    let minutes = elapsed_seconds / 60;
+                    let seconds = elapsed_seconds % 60;
+                    format!(
+                        "{} minute{} and {} second{}",
+                        minutes,
+                        if minutes == 1 { "" } else { "s" },
+                        seconds,
+                        if seconds == 1 { "" } else { "s" }
+                    )
+                };
+
+                ui.label(format!(
+                    "Broadcasting... Time taken so far: {}",
+                    display_time
+                ));
+            }
+            TransitionBroadcastStatus::Error(msg) => {
+                ui.colored_label(Color32::DARK_RED, format!("Error: {}", msg));
+            }
+            TransitionBroadcastStatus::Complete => {
+                ui.colored_label(
+                    Color32::DARK_GREEN,
+                    "Successfully broadcasted state transition.",
+                );
+            }
+        }
+
+        app_action
     }
 }
 
 impl ScreenLike for TransitionVisualizerScreen {
-    fn refresh(&mut self) {
-        // No-op for this screen
+    fn display_message(&mut self, message: &str, message_type: MessageType) {
+        match message_type {
+            MessageType::Success => {
+                self.broadcast_status = TransitionBroadcastStatus::Complete;
+            }
+            MessageType::Error => {
+                self.broadcast_status = TransitionBroadcastStatus::Error(message.to_string());
+            }
+            MessageType::Info => {
+                // Could do nothing or handle info
+            }
+        }
     }
 
     fn ui(&mut self, ctx: &Context) -> AppAction {
@@ -124,7 +250,7 @@ impl ScreenLike for TransitionVisualizerScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             self.show_input_field(ui);
-            self.show_output(ui);
+            action |= self.show_output(ui);
         });
 
         action


### PR DESCRIPTION
Add button for broadcasting decoded state transitions in the Tools screen. Cleaned up the whole subscreen too.