### PR TITLE
fix: improper confirmation pop-up rendering on transfer screen

### DIFF
--- a/src/ui/identities/transfers/mod.rs
+++ b/src/ui/identities/transfers/mod.rs
@@ -140,6 +140,7 @@ impl TransferScreen {
                     self.error_message = Some("Invalid identifier".to_string());
                     self.transfer_credits_status =
                         TransferCreditsStatus::ErrorMessage("Invalid identifier".to_string());
+                    self.confirmation_popup = false;
                     return;
                 } else {
                     match Identifier::from_string_try_encodings(
@@ -152,6 +153,7 @@ impl TransferScreen {
                             self.transfer_credits_status = TransferCreditsStatus::ErrorMessage(
                                 "Invalid identifier".to_string(),
                             );
+                            self.confirmation_popup = false;
                             return;
                         }
                     }
@@ -161,6 +163,7 @@ impl TransferScreen {
                     self.error_message = Some("No selected key".to_string());
                     self.transfer_credits_status =
                         TransferCreditsStatus::ErrorMessage("No selected key".to_string());
+                    self.confirmation_popup = false;
                     return;
                 };
 
@@ -343,7 +346,7 @@ impl ScreenLike for TransferScreen {
                     .fill(Color32::from_rgb(0, 128, 255))
                     .frame(true)
                     .rounding(3.0);
-                if ui.add(button).clicked() || ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                if ui.add(button).clicked() {
                     self.confirmation_popup = true;
                 }
 
@@ -352,6 +355,7 @@ impl ScreenLike for TransferScreen {
                 }
 
                 // Handle transfer status messages
+                ui.add_space(5.0);
                 match &self.transfer_credits_status {
                     TransferCreditsStatus::NotStarted => {
                         // Do nothing


### PR DESCRIPTION
If there's an error, close the confirmation pop-up.

Also, only submit transfer on button click rather than pressing enter, since the "enter" from wallet unlock was triggering it.