### PR TITLE
fix: handle identity refresh errors

### DIFF
--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -455,9 +455,10 @@ impl AppContext {
                 self.register_identity(registration_info, sender).await
             }
             IdentityTask::RegisterDpnsName(input) => self.register_dpns_name(sdk, input).await,
-            IdentityTask::RefreshIdentity(qualified_identity) => {
-                self.refresh_identity(sdk, qualified_identity, sender).await
-            }
+            IdentityTask::RefreshIdentity(qualified_identity) => self
+                .refresh_identity(sdk, qualified_identity, sender)
+                .await
+                .map_err(|e| format!("Error refreshing identity: {:?}", e)),
             IdentityTask::Transfer(qualified_identity, to_identifier, credits, id) => {
                 self.transfer_to_identity(qualified_identity, to_identifier, credits, id)
                     .await

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -839,7 +839,7 @@ impl ScreenLike for IdentitiesScreen {
     }
 
     fn display_message(&mut self, message: &str, message_type: crate::ui::MessageType) {
-        if message.contains("Error refreshing identities")
+        if message.contains("Error refreshing identity")
             || message.contains("Successfully refreshed identity")
         {
             self.refreshing_status = IdentitiesRefreshingStatus::NotRefreshing;


### PR DESCRIPTION
If there was an error refreshing identities, the screen's refreshing status wasn't being set to false.