### PR TITLE
v0.8.2-dev to master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-evo-tool"
-version = "0.8.0"
+version = "0.8.2"
 license = "MIT"
 edition = "2021"
 default-run = "dash-evo-tool"


### PR DESCRIPTION
 - Added filters in dpns screens so users can search active/past contests and owned names by name
 - Added a selector in the voting screen so users can set all their nodes to "Vote Now" "Schedule" or "No Vote". Before it defaulted to "Vote Now" and there was no way to switch it. This is convenient for users with many nodes.
 - Bumped version in Cargo.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 0.8.2.

- **New Features**
  - Enhanced the contested names interface with new filtering options for active, past, and owned entries.
  - Introduced bulk voting functionality, allowing users to quickly select vote actions or schedule votes with custom timings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->