### PR TITLE
feat: core rpc cookie

### DIFF
--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -6,8 +6,10 @@ const QUALIFIER: &str = ""; // Typically empty on macOS and Linux
 const ORGANIZATION: &str = "";
 const APPLICATION: &str = "Dash-Evo-Tool";
 
-pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
-    let proj_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or_else(|| {
+const CORE_APPLICATION: &str = "DashCore";
+
+fn user_data_dir_path(app: &str) -> Result<PathBuf, std::io::Error> {
+    let proj_dirs = ProjectDirs::from(QUALIFIER, ORGANIZATION, app).ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "Failed to determine project directories",
@@ -15,6 +17,15 @@ pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
     })?;
     Ok(proj_dirs.config_dir().to_path_buf())
 }
+
+pub fn app_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
+    user_data_dir_path(APPLICATION)
+}
+
+pub fn core_user_data_dir_path() -> Result<PathBuf, std::io::Error> {
+    user_data_dir_path(CORE_APPLICATION)
+}
+
 pub fn create_app_user_data_directory_if_not_exists() -> Result<(), std::io::Error> {
     let app_data_dir = app_user_data_dir_path()?;
     fs::create_dir_all(&app_data_dir)?;

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -111,7 +111,7 @@ impl AppContext {
             let client = match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {
                 Ok(client) => Ok(client),
                 Err(_) => {
-                    eprintln!(
+                    tracing::info!(
                         "Failed to authenticate using .cookie file at {:?}, falling back to user/pass",
                         cookie_path
                     );

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -1,8 +1,9 @@
 mod refresh_wallet_info;
 mod start_dash_qt;
 
+use crate::app_dir::core_user_data_dir_path;
 use crate::backend_task::BackendTaskSuccessResult;
-use crate::config::Config;
+use crate::config::{Config, NetworkConfig};
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
 use dash_sdk::dashcore_rpc::RpcApi;
@@ -53,62 +54,15 @@ impl AppContext {
                 tracing::info!("Getting best chain locks for testnet and mainnet");
 
                 // Load configs
-                let config = match Config::load() {
-                    Ok(config) => config,
-                    Err(e) => {
-                        return Err(format!("Failed to load config: {}", e));
-                    }
-                };
-                let maybe_mainnet_config = config.config_for_network(Network::Dash);
-                let maybe_testnet_config = config.config_for_network(Network::Testnet);
+                let config = Config::load().map_err(|e| format!("Failed to load config: {}", e))?;
 
-                // Get mainnet best chainlock
-                let mainnet_result = if let Some(mainnet_config) = maybe_mainnet_config {
-                    let mainnet_addr = format!(
-                        "http://{}:{}",
-                        mainnet_config.core_host, mainnet_config.core_rpc_port
-                    );
-                    let mainnet_client = Client::new(
-                        &mainnet_addr,
-                        Auth::UserPass(
-                            mainnet_config.core_rpc_user.to_string(),
-                            mainnet_config.core_rpc_password.to_string(),
-                        ),
-                    )
-                    .map_err(|_| "Failed to create mainnet client".to_string())?;
-                    mainnet_client.get_best_chain_lock().map_err(|e| {
-                        format!(
-                            "Failed to get best chain lock for mainnet: {}",
-                            e.to_string()
-                        )
-                    })
-                } else {
-                    Err("Mainnet config not found".to_string())
-                };
-
-                // Get testnet best chainlock
-                let testnet_result = if let Some(testnet_config) = maybe_testnet_config {
-                    let testnet_addr = format!(
-                        "http://{}:{}",
-                        testnet_config.core_host, testnet_config.core_rpc_port
-                    );
-                    let testnet_client = Client::new(
-                        &testnet_addr,
-                        Auth::UserPass(
-                            testnet_config.core_rpc_user.to_string(),
-                            testnet_config.core_rpc_password.to_string(),
-                        ),
-                    )
-                    .map_err(|_| "Failed to create testnet client".to_string())?;
-                    testnet_client.get_best_chain_lock().map_err(|e| {
-                        format!(
-                            "Failed to get best chain lock for testnet: {}",
-                            e.to_string()
-                        )
-                    })
-                } else {
-                    Err("Testnet config not found".to_string())
-                };
+                // Get chain locks
+                let mainnet_result =
+                    Self::get_best_chain_lock(config.config_for_network(Network::Dash), "mainnet");
+                let testnet_result = Self::get_best_chain_lock(
+                    config.config_for_network(Network::Testnet),
+                    "testnet",
+                );
 
                 // Handle results
                 match (mainnet_result, testnet_result) {
@@ -137,6 +91,51 @@ impl AppContext {
                 .start_dash_qt(network, custom_dash_qt, overwrite_dash_conf)
                 .map_err(|e| e.to_string())
                 .map(|_| BackendTaskSuccessResult::None),
+        }
+    }
+
+    fn get_best_chain_lock(
+        config: &Option<NetworkConfig>,
+        network_name: &str,
+    ) -> Result<ChainLock, String> {
+        if let Some(network_config) = config {
+            let addr = format!(
+                "http://{}:{}",
+                network_config.core_host, network_config.core_rpc_port
+            );
+
+            let cookie_path = core_user_data_dir_path()
+                .expect("unable to extract core data dir")
+                .join(".cookie");
+
+            // Try cookie authentication first
+            let client = match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {
+                Ok(client) => Ok(client),
+                Err(_) => {
+                    eprintln!(
+                        "Failed to authenticate using .cookie file at {:?}, falling back to user/pass",
+                        cookie_path
+                    );
+                    Client::new(
+                        &addr,
+                        Auth::UserPass(
+                            network_config.core_rpc_user.to_string(),
+                            network_config.core_rpc_password.to_string(),
+                        ),
+                    )
+                }
+            }
+                .map_err(|_| format!("Failed to create {} client", network_name))?;
+
+            client.get_best_chain_lock().map_err(|e| {
+                format!(
+                    "Failed to get best chain lock for {}: {}",
+                    network_name,
+                    e.to_string()
+                )
+            })
+        } else {
+            Err(format!("{} config not found", network_name))
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -94,11 +94,9 @@ impl AppContext {
             Ok(client) => Ok(client),
             Err(_) => {
                 // If cookie auth fails, try user/password authentication
-                eprintln!(
-                    "Failed to authenticate using .cookie file at {:?}, falling back to user/pass1, {:?}, {:?}",
+                tracing::info!(
+                    "Failed to authenticate using .cookie file at {:?}, falling back to user/pass",
                     cookie_path,
-                    network_config.core_rpc_user.to_string(),
-                    network_config.core_rpc_password.to_string(),
                 );
                 Client::new(
                     &addr,
@@ -108,12 +106,7 @@ impl AppContext {
                     ),
                 )
             }
-        };
-
-        if core_client.is_ok() {
-            println!("Core client created successfully");
-        }
-        let core_client = core_client.expect("Failed to create CoreClient");
+        }.expect("Failed to create CoreClient");
 
         let wallets: BTreeMap<_, _> = db
             .get_wallets(&network)

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -1,8 +1,9 @@
-use crate::app_dir::core_user_data_dir_path;
-use crate::config::NetworkConfig;
+use crate::app_dir::{core_cookie_path, core_user_data_dir_path};
+use crate::config::{Config, NetworkConfig};
 use crate::context::AppContext;
 use crate::database::Database;
 use dash_sdk::core::LowLevelDashCoreClient as CoreClient;
+use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::error::ContextProviderError;
 use dash_sdk::platform::ContextProvider;
@@ -21,8 +22,9 @@ impl Provider {
     /// Create new ContextProvider.
     ///
     /// Note that you have to bind it to app context using [Provider::set_app_context()].
-    pub fn new(db: Arc<Database>, config: &NetworkConfig) -> Result<Self, String> {
-        let cookie_path = core_user_data_dir_path().unwrap().join(".cookie");
+    pub fn new(db: Arc<Database>, network: Network, config: &NetworkConfig) -> Result<Self, String> {
+        let cookie_path = core_cookie_path(network, &config.devnet_name)
+            .expect("Failed to get core cookie path");
 
         // Read the cookie from disk
         let cookie = std::fs::read_to_string(cookie_path);


### PR DESCRIPTION
This PR implements a change in behavior where cookie authentication with dash core will be the default attempted configuration.

When dash core is launched with RPC on, but w/o a user/pw combo it will use cookie authentication by default. Where the cookie is placed in core's directory. As long as DET can read this cookie it can use it.

This branch changes the default behavior to always try cookie auth, but doesn't change any of the setup process, so the vast majority of users will still use user/pw auth. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced flexible handling of user data directories across different environments.
  - Added a new authentication mechanism that first attempts secure file-based credentials before falling back to traditional login.

- **Refactor**
  - Streamlined network connection and error handling processes to enhance overall reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->