### PR TITLE
feat: forget wallet

### DIFF
--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -17,7 +17,9 @@ pub(crate) enum CoreTask {
     GetBestChainLocks,
     RefreshWalletInfo(Arc<RwLock<Wallet>>),
     StartDashQT(Network, Option<String>, bool),
+    ForgetWallet(Arc<RwLock<Wallet>>),
 }
+
 impl PartialEq for CoreTask {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -105,6 +107,16 @@ impl AppContext {
                 .start_dash_qt(network, custom_dash_qt, overwrite_dash_conf)
                 .map_err(|e| e.to_string())
                 .map(|_| BackendTaskSuccessResult::None),
+            CoreTask::ForgetWallet(wallet) => {
+                let seed_hash = wallet
+                    .read()
+                    .expect("Wallet lock was poisoned")
+                    .seed_hash()
+                    .clone();
+                self.forget_wallet(seed_hash)
+                    .map_err(|e| e.to_string())
+                    .map(|_| BackendTaskSuccessResult::Message("Wallet forgotten".to_string()))
+            }
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -530,6 +530,16 @@ impl AppContext {
         Ok(())
     }
 
+    pub fn forget_wallet(&self, seed_hash: [u8; 32]) -> Result<()> {
+        self.db.forget_wallet(&seed_hash)?;
+        self.wallets.write().unwrap().remove(&seed_hash);
+        if self.wallets.read().unwrap().is_empty() {
+            self.has_wallet
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(())
+    }
+
     pub fn identity_token_balances(&self) -> Result<Vec<IdentityTokenBalance>> {
         self.db.get_identity_token_balances(self)
     }

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -162,7 +162,7 @@ impl AddNewWalletScreen {
                 eprintln!("Failed to acquire write lock on wallets");
             }
 
-            Ok(AppAction::GoToMainScreen) // Navigate back to the main screen after saving
+            Ok(AppAction::PopScreenAndRefresh) // Navigate back to the main screen after saving
         } else {
             Ok(AppAction::None) // No action if no seed phrase exists
         }


### PR DESCRIPTION
Add "Forget Wallet" button to Wallets Screen which, when clicked, shows a confirmation popup, and if the user confirms, the wallet is deleted from database and app context... essentially forgotten in DET... along with any associated identities, UTXOs, and wallet addresses.