### PR TITLE
fix: keyword search not working with token creator tokens

### DIFF
--- a/src/backend_task/tokens/mod.rs
+++ b/src/backend_task/tokens/mod.rs
@@ -481,7 +481,7 @@ impl AppContext {
             updated_at_block_height: None,
             created_at_epoch: None,
             updated_at_epoch: None,
-            description: None,
+            description: token_description.clone(),
         };
 
         // 2) Build a single TokenConfiguration in V0 format


### PR DESCRIPTION
Just copied the token description defined in the token creator over to the contract description as well.