### PR TITLE
fix: devnet contracts were not being cleared with clear data button

### DIFF
--- a/src/backend_task/system_task/mod.rs
+++ b/src/backend_task/system_task/mod.rs
@@ -33,6 +33,10 @@ impl AppContext {
             .remove_all_asset_locks_identity_id_for_devnet(self)
             .map_err(|e| e.to_string())?;
 
+        self.db
+            .remove_all_contracts_in_devnet(self)
+            .map_err(|e| e.to_string())?;
+
         Ok(BackendTaskSuccessResult::Refresh)
     }
 }


### PR DESCRIPTION
Added a function `remove_all_contracts_in_devnet()` and called it within `wipe_devnet()` which is executed upon clicking the "Clear local platform data" button.