### PR TITLE
fix: estimate unclaimed rewards when no rewards available

### DIFF
--- a/src/backend_task/tokens/mod.rs
+++ b/src/backend_task/tokens/mod.rs
@@ -409,7 +409,7 @@ impl AppContext {
                     sdk,
                 )
                 .await
-                .map_err(|e| format!("Failed to claim tokens: {e}")),
+                .map_err(|e| format!("Failed to get estimated rewards: {e}")),
             TokenTask::QueryIdentityTokenBalance(identity_token_pair) => self
                 .query_token_balance(
                     sdk,

--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -1428,7 +1428,8 @@ impl TokensScreen {
                                                         action = AppAction::BackendTask(BackendTask::TokenTask(TokenTask::EstimatePerpetualTokenRewards {
                                                             identity_id: itb.identity_id,
                                                             token_id: itb.token_id,
-                                                        }))
+                                                        }));
+                                                        self.refreshing_status = RefreshingStatus::Refreshing(Utc::now().timestamp() as u64);
                                                     }
                                                 }
                                             }
@@ -4260,6 +4261,7 @@ impl ScreenLike for TokensScreen {
             .db
             .get_all_known_tokens(&self.app_context)
             .unwrap_or_default();
+
         self.identities = self
             .app_context
             .load_local_qualified_identities()
@@ -4267,6 +4269,7 @@ impl ScreenLike for TokensScreen {
             .into_iter()
             .map(|qi| (qi.identity.id(), qi))
             .collect();
+
         match self.app_context.db.load_token_order() {
             Ok(saved_ids) => {
                 self.reorder_vec_to(saved_ids);
@@ -4301,45 +4304,41 @@ impl ScreenLike for TokensScreen {
     }
 
     fn display_message(&mut self, msg: &str, msg_type: MessageType) {
-        if self.tokens_subscreen == TokensSubscreen::TokenCreator {
-            // Handle messages from Token Creator
-            if msg.contains("Successfully registered token contract") {
-                self.token_creator_status = TokenCreatorStatus::Complete;
-            } else if msg.contains("Failed to register token contract") {
-                self.token_creator_status = TokenCreatorStatus::ErrorMessage(msg.to_string());
-                self.token_creator_error_message = Some(msg.to_string());
-            } else if msg.contains("Error building contract V1") {
-                self.token_creator_status = TokenCreatorStatus::ErrorMessage(msg.to_string());
-                self.token_creator_error_message = Some(msg.to_string());
-            } else {
-                return;
+        match self.tokens_subscreen {
+            TokensSubscreen::TokenCreator => {
+                if msg.contains("Successfully registered token contract") {
+                    self.token_creator_status = TokenCreatorStatus::Complete;
+                } else if msg.contains("Failed to register token contract")
+                    | msg.contains("Error building contract V1")
+                {
+                    self.token_creator_status = TokenCreatorStatus::ErrorMessage(msg.to_string());
+                    self.token_creator_error_message = Some(msg.to_string());
+                } else {
+                    return;
+                }
             }
-        }
-
-        // Handle messages from querying My Token Balances
-        if self.tokens_subscreen == TokensSubscreen::MyTokens {
-            if msg.contains("Successfully fetched token balances")
-                | msg.contains("Failed to fetch token balances")
-            {
-                self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
+            TokensSubscreen::MyTokens => {
+                if msg.contains("Successfully fetched token balances")
+                    | msg.contains("Failed to fetch token balances")
+                    | msg.contains("Failed to get estimated rewards")
+                {
+                    self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
+                    self.refreshing_status = RefreshingStatus::NotRefreshing;
+                } else {
+                    return;
+                }
             }
-        }
-        if msg.contains("Successfully fetched token balances")
-            | msg.contains("Failed to fetch token balances")
-        {
-            self.refreshing_status = RefreshingStatus::NotRefreshing;
-        }
-
-        // Handle messages from Token Search
-        if msg.contains("Error fetching tokens") {
-            self.contract_search_status = ContractSearchStatus::ErrorMessage(msg.to_string());
-            self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
-        }
-        if msg.contains("Added token") {
-            self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
-        }
-        if msg.contains("Token already added") {
-            self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
+            TokensSubscreen::SearchTokens => {
+                if msg.contains("Error fetching tokens") {
+                    self.contract_search_status =
+                        ContractSearchStatus::ErrorMessage(msg.to_string());
+                    self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
+                } else if msg.contains("Added token") | msg.contains("Token already added") {
+                    self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
+                } else {
+                    return;
+                }
+            }
         }
     }
 
@@ -4396,7 +4395,7 @@ impl ScreenLike for TokensScreen {
                     )),
                 ),
             ],
-            TokensSubscreen::SearchTokens => vec![("Refresh", DesiredAppAction::Refresh)],
+            TokensSubscreen::SearchTokens => vec![],
             TokensSubscreen::TokenCreator => vec![],
         };
 


### PR DESCRIPTION
If there was some error when estimating unclaimed rewards, like if the token didn't have any distributions defined, no message was being shown.