### PR TITLE
debug: update platform version for testing

### DIFF
--- a/src/sdk_wrapper.rs
+++ b/src/sdk_wrapper.rs
@@ -21,7 +21,7 @@ pub fn initialize_sdk<P: ContextProvider + 'static>(
     };
 
     let sdk = SdkBuilder::new(address_list)
-        .with_version(PlatformVersion::latest())
+        .with_version(PlatformVersion::get(8).unwrap())
         .with_network(network)
         .with_context_provider(context_provider)
         .with_settings(request_settings)

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -264,7 +264,7 @@ impl RegisterDataContractScreen {
 
         match json_result {
             Ok(json_val) => {
-                let platform_version = PlatformVersion::latest();
+                let platform_version = PlatformVersion::get(8).unwrap();
                 match DataContract::from_json(json_val, true, platform_version) {
                     Ok(mut contract) => {
                         // ------------------------------------------


### PR DESCRIPTION
**For testing only**
This was done to create a v8 contract on the devnet prior to migration to v9.