### PR TITLE
feat: view claims screen improvements

### DIFF
--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -52,17 +52,19 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
                         // Handle navigation based on which subscreen is selected
                         match subscreen {
                             TokensSubscreen::MyTokens => {
-                                action = AppAction::SetMainScreen(
+                                action = AppAction::SetMainScreenThenGoToMainScreen(
                                     RootScreenType::RootScreenMyTokenBalances,
                                 )
                             }
                             TokensSubscreen::SearchTokens => {
-                                action =
-                                    AppAction::SetMainScreen(RootScreenType::RootScreenTokenSearch)
+                                action = AppAction::SetMainScreenThenGoToMainScreen(
+                                    RootScreenType::RootScreenTokenSearch,
+                                )
                             }
                             TokensSubscreen::TokenCreator => {
-                                action =
-                                    AppAction::SetMainScreen(RootScreenType::RootScreenTokenCreator)
+                                action = AppAction::SetMainScreenThenGoToMainScreen(
+                                    RootScreenType::RootScreenTokenCreator,
+                                )
                             }
                         }
                     }

--- a/src/ui/tokens/add_token_by_id_screen.rs
+++ b/src/ui/tokens/add_token_by_id_screen.rs
@@ -12,6 +12,8 @@ use eframe::egui::{self, Color32, Context, RichText, Ui};
 use crate::backend_task::contract::ContractTask;
 use crate::backend_task::BackendTaskSuccessResult;
 use crate::database::contracts::InsertTokensToo;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::tokens::tokens_screen::TokenInfo;
 use crate::{
     app::AppAction,
@@ -216,6 +218,16 @@ impl ScreenLike for AddTokenByIdScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Add Token");

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -7,6 +7,8 @@ use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
@@ -279,6 +281,16 @@ impl ScreenLike for BurnTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -1,3 +1,5 @@
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -314,6 +316,16 @@ impl ScreenLike for ClaimTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == ClaimTokensStatus::Complete {

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -7,6 +7,8 @@ use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
@@ -298,6 +300,16 @@ impl ScreenLike for DestroyFrozenFundsScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == DestroyFrozenFundsStatus::Complete {

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -18,6 +18,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
@@ -276,6 +278,16 @@ impl ScreenLike for FreezeTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == FreezeTokensStatus::Complete {

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -19,6 +19,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
@@ -324,6 +326,16 @@ impl ScreenLike for MintTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -17,6 +17,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
@@ -240,6 +242,16 @@ impl ScreenLike for PauseTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == PauseTokensStatus::Complete {

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -17,6 +17,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
@@ -236,6 +238,16 @@ impl ScreenLike for ResumeTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == ResumeTokensStatus::Complete {

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -4,6 +4,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
@@ -320,6 +322,16 @@ impl ScreenLike for TransferTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             // Show the success screen if the transfer was successful

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -18,6 +18,8 @@ use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
@@ -272,6 +274,16 @@ impl ScreenLike for UnfreezeTokensScreen {
             ],
             vec![],
         );
+
+        // Left panel
+        action |= add_left_panel(
+            ctx,
+            &self.app_context,
+            crate::ui::RootScreenType::RootScreenMyTokenBalances,
+        );
+
+        // Subscreen chooser
+        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == UnfreezeTokensStatus::Complete {


### PR DESCRIPTION
 - Add the where clauses to the query for token id and recipient id
 - Format claims into a table
 - Show human readable timestamp
 - Add left panels to all token screens