### PR TITLE
fix: reset correct fields to close token remove popup successfully

### DIFF
--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -4461,8 +4461,8 @@ Emits tokens in fixed amounts for specific intervals.
 
         // If user closes the popup window (the [x] button), also reset state
         if !is_open {
-            self.confirm_remove_identity_token_balance_popup = false;
-            self.identity_token_balance_to_remove = None;
+            self.confirm_remove_token_popup = false;
+            self.token_to_remove = None;
         }
     }
 }


### PR DESCRIPTION
This PR addresses an issue where closing the "Remove Token" confirmation popup via the "X" button did not reset the appropriate state variables.

Related to #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where closing the "Remove Token" popup did not properly reset its state, ensuring the correct popup state is cleared when the window is closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->