### PR TITLE
chore: update .gitignore to exclude explorer.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test_db
 .DS_Store
 .idea/
 **/.DS_Store
+explorer.log


### PR DESCRIPTION
### Summary  
This pull request updates the `.gitignore` file to include `explorer.log` in the list of ignored files. This change ensures that any log files generated by the explorer tool are not tracked by Git, keeping the repository clean and free from unnecessary log files.

### Details  
- Added `explorer.log` to the `.gitignore` file.  
- This helps prevent clutter in the repository and avoids accidentally committing log files generated during development or testing.

### Why  
Ignoring log files is a common practice to maintain a clean codebase and to ensure that only relevant files are tracked in the version control system.