### PR TITLE
fix: add validation for contract keyword length

### DIFF
--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -3874,8 +3874,15 @@ Emits tokens in fixed amounts for specific intervals.
         } else {
             self.contract_keywords_input
                 .split(',')
-                .map(|s| s.trim().to_string())
-                .collect::<Vec<String>>()
+                .map(|s| {
+                    let trimmed = s.trim().to_string();
+                    if trimmed.len() < 3 || trimmed.len() > 50 {
+                        Err(format!("Invalid contract keyword {}, keyword must be between 3 and 50 characters", trimmed))
+                    } else {
+                        Ok(trimmed)
+                    }
+                })
+                .collect::<Result<Vec<String>, String>>()?
         };
         let token_description = if self.token_description_input.len() > 0 {
             Some(self.token_description_input.clone())


### PR DESCRIPTION
### What Changed
This update introduces a validation mechanism for contract keywords entered in the tokens screen. The keywords are now checked to ensure they are between 3 and 50 characters long.

### Why
Previously, there was no validation for the length of contract keywords, which could lead to issues with overly short or excessively long entries. This change ensures that only valid keywords are processed, improving the robustness and reliability of the application.

### Impact
- Users will receive an error message if they attempt to enter a keyword that does not meet the length requirements.
- This change ensures better data integrity and prevents potential issues related to invalid keyword lengths.