### PR TITLE
feat: add support for additional fonts and languages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,32 @@ fn main() -> eframe::Result<()> {
                         ..,
                         vec![
                             "Ubuntu-Light".into(),
+                            "emoji-icon-font".into(),
+                            "NotoEmoji-Regular".into(),
+                            "noto_sans".to_owned(),
+                            "noto_sans_sc".to_owned(), // Simplified Chinese
+                            "noto_sans_tc".to_owned(), // Traditional Chinese
+                            "noto_sans_jp".to_owned(), // Japanese
+                            "noto_sans_kr".to_owned(), // Korean
+                            "noto_sans_thai".to_owned(),
+                            "noto_sans_khmer".to_owned(),
+                            "noto_sans_arabic".to_owned(),
+                            "noto_sans_hebrew".to_owned(),
+                            "noto_sans_devanagari".to_owned(),
+                        ],
+                    );
+
+                fonts
+                    .families
+                    .entry(FontFamily::Monospace)
+                    .or_default()
+                    .splice(
+                        ..,
+                        vec![
+                            "Hack".into(),
+                            "Ubuntu-Light".into(),
+                            "emoji-icon-font".into(),
+                            "NotoEmoji-Regular".into(),
                             "noto_sans".to_owned(),
                             "noto_sans_sc".to_owned(), // Simplified Chinese
                             "noto_sans_tc".to_owned(), // Traditional Chinese


### PR DESCRIPTION
### Summary
This pull request adds support for a variety of new fonts and languages in the application. The changes include integrating additional fonts into both the default and monospace font families, enhancing the application's ability to render text in multiple languages and incorporate emojis.

### Changes
- Added new font entries such as `emoji-icon-font`, `NotoEmoji-Regular`, and various `noto_sans` fonts for different languages (e.g., Simplified Chinese, Traditional Chinese, Japanese, Korean, Thai, Khmer, Arabic, Hebrew, and Devanagari) to the default font family.
- Updated the monospace font family with the same set of fonts to ensure consistent rendering across different text styles.

### Why
These changes are intended to improve the user experience by supporting a wider range of languages and emojis, addressing user feedback regarding font rendering limitations. This update ensures that the application can handle diverse text content more effectively.