### PR TITLE
feat: integrate enum-iterator to manage token name languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "egui",
  "egui_commonmark",
  "egui_extras",
+ "enum-iterator",
  "envy",
  "futures",
  "hex",
@@ -2288,6 +2289,26 @@ name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enum-iterator"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "enum-map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.44.2", features = ["full"] }
 bincode = { version = "=2.0.0-rc.3", features = ["serde"] }
 hex = { version = "0.4.3" }
 itertools = "0.14.0"
+enum-iterator = "2.1.0"
 futures = "0.3.30"
 rand = "0.8"
 tracing = "0.1.40"

--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -36,6 +36,7 @@ use eframe::egui::{self, CentralPanel, Color32, Context, Frame, Margin, Ui};
 use egui::{Align, Checkbox, ColorImage, Label, Response, RichText, Sense, TextureHandle};
 use egui_commonmark::{CommonMarkCache, CommonMarkViewer};
 use egui_extras::{Column, TableBuilder};
+use enum_iterator::Sequence;
 use image::ImageReader;
 use crate::app::BackendTasksExecutionMode;
 use crate::backend_task::contract::ContractTask;
@@ -907,7 +908,7 @@ pub struct DistributionEntry {
     pub amount_str: String,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum TokenNameLanguage {
     English,
     French,
@@ -2517,8 +2518,12 @@ impl TokensScreen {
                                     });
                                 ui.horizontal(|ui| {
                                     if ui.button("+").clicked() {
+                                        let used_languages: HashSet<_> = self.token_names_input.iter().map(|(_, lang)| *lang).collect();
+                                        let next_non_used_language = enum_iterator::all::<TokenNameLanguage>()
+                                            .find(|lang| !used_languages.contains(lang))
+                                            .unwrap_or(TokenNameLanguage::English); // fallback
                                         // Add a new token name input
-                                        self.token_names_input.push((String::new(), TokenNameLanguage::English));
+                                        self.token_names_input.push((String::new(), next_non_used_language));
                                     }
                                     if ui.button("-").clicked() {
                                         token_to_remove = Some(i.try_into().expect("Failed to convert index"));


### PR DESCRIPTION
### Summary
This pull request introduces the `enum-iterator` crate to the project, which simplifies the management of enumerations, specifically for the `TokenNameLanguage` enum.

### Changes
- Added `enum-iterator` and `enum-iterator-derive` to `Cargo.toml` and `Cargo.lock`.
- Implemented the `Sequence` trait from `enum-iterator` for the `TokenNameLanguage` enum.
- Updated the logic in `TokensScreen` to utilize `enum-iterator` for iterating over `TokenNameLanguage` values and selecting the next unused language.

### Reason
By using `enum-iterator`, we can easily iterate over all possible values of an enum, which is particularly useful for selecting the next available language in the token name input feature. This change enhances code readability and reduces the potential for errors when managing enum variants.