### PR TITLE
feat: enhance identity fetching with wallet associations and top-ups

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -290,16 +290,11 @@ impl AppContext {
         &self,
         identity_id: &Identifier,
     ) -> Result<Option<QualifiedIdentity>> {
+        let wallets = self.wallets.read().unwrap();
         // Get the identity from the database
-        let identity = self.db.get_identity_by_id(identity_id, self)?;
+        let result = self.db.get_identity_by_id(identity_id, self, &wallets)?;
 
-        // If the identity is not found in the database, return None
-        if identity.is_none() {
-            return Ok(None);
-        }
-
-        // If the identity is found, return it
-        Ok(Some(identity.unwrap()))
+        Ok(result)
     }
 
     /// Fetches all voting identities from the database

--- a/src/database/identities.rs
+++ b/src/database/identities.rs
@@ -230,15 +230,23 @@ impl Database {
         &self,
         identifier: &Identifier,
         app_context: &AppContext,
+        wallets: &BTreeMap<WalletSeedHash, Arc<RwLock<Wallet>>>,
     ) -> rusqlite::Result<Option<QualifiedIdentity>> {
-        let id = identifier.to_vec();
         let network = app_context.network_string();
 
         let conn = self.conn.lock().unwrap();
+
+        // Prepare the main statement to select identities, including wallet_index
         let mut stmt = conn.prepare(
-            "SELECT data, alias, wallet_index FROM identity WHERE id = ? AND network = ?",
+            "SELECT data, alias, wallet_index FROM identity WHERE id = ? AND is_local = 1 AND network = ? AND data IS NOT NULL",
         )?;
-        let identity_iter = stmt.query_map(params![id, network], |row| {
+
+        // Prepare the statement to select top-ups (will be used multiple times)
+        let mut top_up_stmt =
+            conn.prepare("SELECT top_up_index, amount FROM top_up WHERE identity_id = ?")?;
+
+        // Iterate over each identity
+        let identity_iter = stmt.query_map(params![identifier.to_buffer(), network], |row| {
             let data: Vec<u8> = row.get(0)?;
             let alias: Option<String> = row.get(1)?;
             let wallet_index: Option<u32> = row.get(2)?;
@@ -247,14 +255,30 @@ impl Database {
             identity.alias = alias;
             identity.wallet_index = wallet_index;
 
+            // Associate wallets
+            identity.associated_wallets = wallets.clone(); //todo: use less wallets
+
+            // Retrieve the identity_id as bytes
+            let identity_id = identity.identity.id().to_buffer();
+
+            // Query the top_up table for this identity_id
+            let mut top_ups = BTreeMap::new();
+            let mut rows = top_up_stmt.query(params![identity_id])?;
+
+            while let Some(top_up_row) = rows.next()? {
+                let top_up_index: u32 = top_up_row.get(0)?;
+                let amount: u32 = top_up_row.get(1)?;
+                top_ups.insert(top_up_index, amount);
+            }
+
+            // Assign the top_ups to the identity
+            identity.top_ups = top_ups;
+
             Ok(identity)
         })?;
 
-        // Collect the results
-        let identities: Vec<QualifiedIdentity> = identity_iter.collect::<rusqlite::Result<_>>()?;
-
-        // Return the first one if it exists
-        Ok(identities.into_iter().next())
+        let identities: rusqlite::Result<Vec<QualifiedIdentity>> = identity_iter.collect();
+        Ok(identities?.into_iter().next())
     }
 
     pub fn get_local_voting_identities(

--- a/src/model/qualified_identity/qualified_identity_public_key.rs
+++ b/src/model/qualified_identity/qualified_identity_public_key.rs
@@ -41,28 +41,35 @@ impl QualifiedIdentityPublicKey {
         // Initialize `in_wallet_at_derivation_path` as `None`
         let mut in_wallet_at_derivation_path = None;
 
-        let pubkey =
-            PublicKey::from_slice(value.data().as_slice()).expect("Expected valid public key");
+        if value.data().len() > 20 {
+            let pubkey =
+                PublicKey::from_slice(value.data().as_slice()).expect("Expected valid public key");
 
-        let address = Address::p2pkh(&pubkey, network);
+            let address = Address::p2pkh(&pubkey, network);
 
-        // Iterate over each wallet to check for matching derivation paths
-        for locked_wallet in wallets {
-            let wallet = locked_wallet.read().unwrap();
-            if let Some(derivation_path) = wallet.known_addresses.get(&address) {
-                in_wallet_at_derivation_path = Some(WalletDerivationPath {
-                    wallet_seed_hash: wallet.seed_hash(),
-                    derivation_path: derivation_path.clone(),
-                });
+            // Iterate over each wallet to check for matching derivation paths
+            for locked_wallet in wallets {
+                let wallet = locked_wallet.read().unwrap();
+                if let Some(derivation_path) = wallet.known_addresses.get(&address) {
+                    in_wallet_at_derivation_path = Some(WalletDerivationPath {
+                        wallet_seed_hash: wallet.seed_hash(),
+                        derivation_path: derivation_path.clone(),
+                    });
+                }
+                if in_wallet_at_derivation_path.is_some() {
+                    break;
+                }
             }
-            if in_wallet_at_derivation_path.is_some() {
-                break;
-            }
-        }
 
-        Self {
-            identity_public_key: value,
-            in_wallet_at_derivation_path,
+            Self {
+                identity_public_key: value,
+                in_wallet_at_derivation_path,
+            }
+        } else {
+            Self {
+                identity_public_key: value,
+                in_wallet_at_derivation_path: None,
+            }
         }
     }
 }


### PR DESCRIPTION
- Updated `get_identity_by_id` to accept a reference to wallets for improved identity fetching.
- Modified the SQL query to include a condition for local identities and non-null data.
- Added logic to associate wallets with identities and retrieve top-ups for each identity.
- Enhanced `QualifiedIdentityPublicKey` to check for valid public keys only if the data length exceeds 20 bytes. 

These changes improve the efficiency of fetching identities and ensure that wallet associations and top-ups are correctly handled.