### PR TITLE
feat: enhance key display in developer mode

### DIFF
--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -119,19 +119,45 @@ impl BurnTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -128,19 +128,45 @@ impl DestroyFrozenFundsScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -117,19 +117,45 @@ impl FreezeTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -120,19 +120,45 @@ impl MintTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -114,19 +114,45 @@ impl PauseTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -135,23 +135,45 @@ impl TransferTokensScreen {
                 })
                 .show_ui(ui, |ui| {
                     if self.app_context.developer_mode {
+                        // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
-                        }
-                    } else {
-                        for key in self.identity.available_authentication_keys() {
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
                             let label = format!(
-                                "Key ID: {} (Purpose: {:?})",
-                                key.identity_public_key.id(),
-                                key.identity_public_key.purpose()
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
                             );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
                             ui.selectable_value(
                                 &mut self.selected_key,
-                                Some(key.identity_public_key.clone()),
-                                label,
+                                Some(key.clone()),
+                                styled_label,
                             );
+                        }
+                    } else {
+                        // Show only "available" auth keys
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
+                            let key = &key_wrapper.identity_public_key;
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }
                 });

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -116,19 +116,45 @@ impl UnfreezeTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }


### PR DESCRIPTION
Updated the UI to display additional information about public keys in developer mode. The key display now includes the key ID, purpose, security level, and key type. Keys marked with critical security levels are highlighted, while others are displayed in red. The logic for displaying available authentication keys has also been modified to only show keys with critical security levels. This improves the usability and clarity of key selection for developers.