### PR TITLE
feat: improve identity handling and registration cost estimation

### DIFF
--- a/src/backend_task/identity/refresh_identity.rs
+++ b/src/backend_task/identity/refresh_identity.rs
@@ -52,7 +52,7 @@ impl AppContext {
         qualified_identity_to_update.identity = refreshed_identity;
 
         // Insert the updated identity into local state
-        self.insert_local_qualified_identity(&qualified_identity_to_update, None)
+        self.update_local_qualified_identity(&qualified_identity_to_update)
             .map_err(|e| e.to_string())?;
 
         // Send refresh message to refresh the Identities Screen

--- a/src/model/qualified_identity/qualified_identity_public_key.rs
+++ b/src/model/qualified_identity/qualified_identity_public_key.rs
@@ -1,7 +1,10 @@
 use crate::model::qualified_identity::encrypted_key_storage::WalletDerivationPath;
 use crate::model::wallet::Wallet;
 use bincode::{Decode, Encode};
-use dash_sdk::dpp::dashcore::{Address, PublicKey};
+use dash_sdk::dpp::dashcore::address::Payload;
+use dash_sdk::dpp::dashcore::hashes::Hash;
+use dash_sdk::dpp::dashcore::{Address, PubkeyHash, PublicKey};
+use dash_sdk::dpp::identity::KeyType;
 use dash_sdk::dpp::{
     dashcore::Network, identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0,
 };
@@ -41,35 +44,101 @@ impl QualifiedIdentityPublicKey {
         // Initialize `in_wallet_at_derivation_path` as `None`
         let mut in_wallet_at_derivation_path = None;
 
-        if value.data().len() > 20 {
-            let pubkey =
-                PublicKey::from_slice(value.data().as_slice()).expect("Expected valid public key");
+        match value.key_type() {
+            KeyType::ECDSA_SECP256K1 => {
+                let pubkey = PublicKey::from_slice(value.data().as_slice())
+                    .expect("Expected valid public key");
 
-            let address = Address::p2pkh(&pubkey, network);
+                let address = Address::p2pkh(&pubkey, network);
 
-            // Iterate over each wallet to check for matching derivation paths
-            for locked_wallet in wallets {
-                let wallet = locked_wallet.read().unwrap();
-                if let Some(derivation_path) = wallet.known_addresses.get(&address) {
-                    in_wallet_at_derivation_path = Some(WalletDerivationPath {
-                        wallet_seed_hash: wallet.seed_hash(),
-                        derivation_path: derivation_path.clone(),
-                    });
+                let testnet_address = if network != Network::Dash {
+                    Some(Address::p2pkh(&pubkey, Network::Testnet))
+                } else {
+                    None
+                };
+
+                // Iterate over each wallet to check for matching derivation paths
+                for locked_wallet in wallets {
+                    let wallet = locked_wallet.read().unwrap();
+                    if let Some(derivation_path) = wallet.known_addresses.get(&address) {
+                        in_wallet_at_derivation_path = Some(WalletDerivationPath {
+                            wallet_seed_hash: wallet.seed_hash(),
+                            derivation_path: derivation_path.clone(),
+                        });
+                    }
+                    if in_wallet_at_derivation_path.is_some() {
+                        break;
+                    }
+
+                    if let Some(testnet_address) = testnet_address.as_ref() {
+                        if let Some(derivation_path) = wallet.known_addresses.get(testnet_address) {
+                            in_wallet_at_derivation_path = Some(WalletDerivationPath {
+                                wallet_seed_hash: wallet.seed_hash(),
+                                derivation_path: derivation_path.clone(),
+                            });
+                        }
+                        if in_wallet_at_derivation_path.is_some() {
+                            break;
+                        }
+                    }
                 }
-                if in_wallet_at_derivation_path.is_some() {
-                    break;
+
+                Self {
+                    identity_public_key: value,
+                    in_wallet_at_derivation_path,
                 }
             }
+            KeyType::ECDSA_HASH160 => {
+                let hash160_data = value.data().as_slice();
+                let pubkey_hash = PubkeyHash::from_slice(hash160_data)
+                    .expect("Expected valid 20-byte pubkey hash for ECDSA_HASH160");
 
-            Self {
-                identity_public_key: value,
-                in_wallet_at_derivation_path,
+                let address = Address::new(network, Payload::PubkeyHash(pubkey_hash));
+
+                let testnet_address = if network != Network::Dash {
+                    Some(Address::new(
+                        Network::Testnet,
+                        Payload::PubkeyHash(pubkey_hash),
+                    ))
+                } else {
+                    None
+                };
+
+                // Iterate over each wallet to check for matching derivation paths
+                for locked_wallet in wallets {
+                    let wallet = locked_wallet.read().unwrap();
+                    if let Some(derivation_path) = wallet.known_addresses.get(&address) {
+                        in_wallet_at_derivation_path = Some(WalletDerivationPath {
+                            wallet_seed_hash: wallet.seed_hash(),
+                            derivation_path: derivation_path.clone(),
+                        });
+                    }
+                    if in_wallet_at_derivation_path.is_some() {
+                        break;
+                    }
+
+                    if let Some(testnet_address) = testnet_address.as_ref() {
+                        if let Some(derivation_path) = wallet.known_addresses.get(testnet_address) {
+                            in_wallet_at_derivation_path = Some(WalletDerivationPath {
+                                wallet_seed_hash: wallet.seed_hash(),
+                                derivation_path: derivation_path.clone(),
+                            });
+                        }
+                        if in_wallet_at_derivation_path.is_some() {
+                            break;
+                        }
+                    }
+                }
+
+                Self {
+                    identity_public_key: value,
+                    in_wallet_at_derivation_path,
+                }
             }
-        } else {
-            Self {
+            _ => Self {
                 identity_public_key: value,
                 in_wallet_at_derivation_path: None,
-            }
+            },
         }
     }
 }

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -99,7 +99,6 @@ pub struct AddExistingIdentityScreen {
     keys_input: Vec<String>,
     add_identity_status: AddIdentityStatus,
     testnet_loaded_nodes: Option<TestnetNodes>,
-    pub identity_load_method: IdentityLoadMethod,
     selected_wallet: Option<Arc<RwLock<Wallet>>>,
     show_password: bool,
     wallet_password: String,
@@ -127,7 +126,6 @@ impl AddExistingIdentityScreen {
             keys_input: vec![String::new(), String::new(), String::new()],
             add_identity_status: AddIdentityStatus::NotStarted,
             testnet_loaded_nodes,
-            identity_load_method: IdentityLoadMethod::ByIdentifier,
             selected_wallet,
             show_password: false,
             wallet_password: "".to_string(),
@@ -138,7 +136,7 @@ impl AddExistingIdentityScreen {
         }
     }
 
-    fn render_by_identity(&mut self, ui: &mut egui::Ui) -> AppAction {
+    fn render_by_identity(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
 
         if self.app_context.network == Network::Testnet && self.testnet_loaded_nodes.is_some() {
@@ -543,40 +541,8 @@ impl ScreenLike for AddExistingIdentityScreen {
                 return;
             }
 
-            // ui.heading(format!("1. Select a method to load the identity:"));
-            // ui.add_space(10.0);
-            // // Prepare tabs
-            // let tabs = vec![("By Identifier", IdentityLoadMethod::ByIdentifier)];
-            // // let wallets_len = {
-            // //     // Check if there are wallets
-            // //     let wallets = self.app_context.wallets.read().unwrap();
-            // //     let has_wallet = !wallets.is_empty();
-            // //     if has_wallet {
-            // //         tabs.push(("From Wallet", IdentityLoadMethod::FromWallet));
-            // //     }
-            // //     wallets.len()
-            // // };
+            action |= self.render_by_identity(ui);
 
-            // // Render tabs
-            // ui.horizontal(|ui| {
-            //     for (tab_name, tab_method) in &tabs {
-            //         let selected = self.identity_load_method == *tab_method;
-            //         if ui.selectable_label(selected, *tab_name).clicked() {
-            //             self.identity_load_method = tab_method.clone();
-            //         }
-            //     }
-            // });
-
-            // ui.add_space(10.0);
-            // ui.separator();
-            // ui.add_space(10.0);
-
-            match self.identity_load_method {
-                IdentityLoadMethod::ByIdentifier => action |= self.render_by_identity(ui),
-                IdentityLoadMethod::FromWallet => {
-                    // action |= self.render_from_wallet(ui, wallets_len)
-                }
-            }
             ui.add_space(10.0);
 
             match &self.add_identity_status {

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -136,22 +136,42 @@ impl ClaimTokensScreen {
                     if self.app_context.developer_mode {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
-                            ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
+                            let is_valid = key.purpose() == Purpose::AUTHENTICATION
+                                && key.security_level() == SecurityLevel::CRITICAL;
+
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
+                            let styled_label = if is_valid {
+                                RichText::new(label.clone())
+                            } else {
+                                RichText::new(label.clone()).color(Color32::RED)
+                            };
+
+                            ui.selectable_value(
+                                &mut self.selected_key,
+                                Some(key.clone()),
+                                styled_label,
+                            );
                         }
                     } else {
                         // Show only "available" auth keys
-                        for key_wrapper in self.identity.available_authentication_keys() {
-                            if key_wrapper.identity_public_key.security_level()
-                                == SecurityLevel::MASTER
-                            {
-                                // Master keys can't sign claims
-                                continue;
-                            }
+                        for key_wrapper in self
+                            .identity
+                            .available_authentication_keys_with_critical_security_level()
+                        {
                             let key = &key_wrapper.identity_public_key;
-                            let label =
-                                format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
+                            let label = format!(
+                                "Key ID: {} (Info: {}/{}/{})",
+                                key.id(),
+                                key.purpose(),
+                                key.security_level(),
+                                key.key_type()
+                            );
                             ui.selectable_value(&mut self.selected_key, Some(key.clone()), label);
                         }
                     }


### PR DESCRIPTION
- Updated the identity refresh logic to use `update_local_qualified_identity` instead of `insert_local_qualified_identity`.
- Enhanced `QualifiedIdentityPublicKey` to support both `ECDSA_SECP256K1` and `ECDSA_HASH160` key types, including testnet address handling.
- Removed unused `identity_load_method` from `AddExistingIdentityScreen`.
- Simplified identity loading in `TokensScreen` to filter out identities without private keys.
- Added `estimate_registration_cost` method to calculate the fees for token registration based on various parameters.
- Included user feedback for estimated registration costs in the token creation confirmation popup.
- Added validation for token name lengths to ensure they meet specified criteria.