### PR TITLE
fix: duplicate address error when registering identity or refreshing wallet

### DIFF
--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -7,11 +7,12 @@ use crate::model::wallet::{
 use dash_sdk::dashcore_rpc::dashcore::transaction::special_transaction::TransactionPayload;
 use dash_sdk::dashcore_rpc::dashcore::Address;
 use dash_sdk::dpp::balances::credits::Duffs;
+use dash_sdk::dpp::dashcore::address::{NetworkChecked, NetworkUnchecked};
 use dash_sdk::dpp::dashcore::bip32::{DerivationPath, ExtendedPubKey};
 use dash_sdk::dpp::dashcore::consensus::deserialize;
 use dash_sdk::dpp::dashcore::hashes::Hash;
 use dash_sdk::dpp::dashcore::{
-    InstantLock, Network, OutPoint, ScriptBuf, Transaction, TxOut, Txid,
+    self, InstantLock, Network, OutPoint, ScriptBuf, Transaction, TxOut, Txid,
 };
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
@@ -85,12 +86,16 @@ impl Database {
         &self,
         seed_hash: &[u8; 32],
         address: &Address,
+        network: &Network,
         derivation_path: &DerivationPath,
         path_reference: DerivationPathReference,
         path_type: DerivationPathType,
         balance: Option<u64>,
     ) -> rusqlite::Result<()> {
         let conn = self.conn.lock().unwrap();
+
+        let address = check_address_for_network(address.as_unchecked().clone(), network)
+            .expect("Expected address to be valid for network");
 
         // Step 1: Check if the address already exists for the given seed.
         let mut stmt = conn.prepare(
@@ -236,10 +241,10 @@ impl Database {
 
         // Step 2: Retrieve all addresses, balances, and derivation paths associated with the wallets.
         let mut address_stmt = conn.prepare(
-            "SELECT seed_hash, address, derivation_path, balance, path_reference, path_type FROM wallet_addresses",
+            "SELECT seed_hash, address, derivation_path, balance, path_reference, path_type FROM wallet_addresses WHERE seed_hash IN (SELECT seed_hash FROM wallet WHERE network = ?)",
         )?;
 
-        let address_rows = address_stmt.query_map([], |row| {
+        let address_rows = address_stmt.query_map([network_str.clone()], |row| {
             let seed_hash: Vec<u8> = row.get(0)?;
             let address: String = row.get(1)?;
             let derivation_path: String = row.get(2)?;
@@ -249,9 +254,9 @@ impl Database {
 
             let seed_hash_array: [u8; 32] =
                 seed_hash.try_into().expect("Seed hash should be 32 bytes");
-            let address = Address::from_str(&address)
-                .expect("Invalid address format")
-                .assume_checked();
+            let address_unchecked = Address::from_str(&address).expect("Invalid address format");
+            let address = check_address_for_network(address_unchecked, network)?;
+
             let derivation_path = DerivationPath::from_str(&derivation_path)
                 .expect("Expected to convert to derivation path");
 
@@ -280,7 +285,6 @@ impl Database {
         // Step 3: Add addresses, balances, and known addresses to the corresponding wallets.
         for row in address_rows {
             let (seed_array, address, derivation_path, balance, path_reference, path_type) = row?;
-
             if let Some(wallet) = wallets_map.get_mut(&seed_array) {
                 // Update the address balance if available.
                 if let Some(balance) = balance {
@@ -448,5 +452,56 @@ impl Database {
 
         // Convert the BTreeMap into a Vec of Wallets.
         Ok(wallets_map.into_values().collect())
+    }
+}
+
+/// Ensure the address is valid for the given network and
+/// update its network if necessary.
+///
+/// Consumes the adress and returns a new Address with the correct network.
+///
+
+fn check_address_for_network(
+    address_unchecked: Address<NetworkUnchecked>,
+    network: &Network,
+) -> Result<Address<NetworkChecked>, WalletError> {
+    if !address_unchecked.is_valid_for_network(*network) {
+        tracing::error!(
+            address = ?address_unchecked,
+            network = ?address_unchecked.network(),
+            expected_network = network.to_string(),
+            "address is not valid for the network",
+        );
+        return Err(WalletError::AddressError(
+            dashcore::address::Error::NetworkValidation {
+                found: *address_unchecked.network(),
+                required: *network,
+                address: address_unchecked,
+            },
+        ));
+    }
+
+    // For devnet (regtest) addresses, the address.network() can be set to Testnet; we need to
+    // overwrite this to match the network we are using.
+    if *network == Network::Regtest && address_unchecked.network() == &Network::Testnet {
+        Ok(Address::new(*network, address_unchecked.payload().clone()).assume_checked())
+    } else {
+        Ok(address_unchecked.clone().require_network(*network)?)
+    }
+    .inspect_err(|e| {
+        tracing::error!("address is not valid for the network: {}", e);
+    })
+}
+
+#[derive(thiserror::Error, Debug)]
+/// Error type for wallet operations.
+pub enum WalletError {
+    #[error("Error in address: {0}")]
+    AddressError(#[from] dashcore::address::Error),
+}
+
+impl From<WalletError> for rusqlite::Error {
+    fn from(err: WalletError) -> Self {
+        rusqlite::Error::UserFunctionError(Box::new(err))
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,7 @@ pub fn initialize_logger() {
     };
 
     let filter = EnvFilter::try_new(
-        "debug,dash_evo_tool=trace,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn",
+        "info,dash_evo_tool=trace,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn",
     )
         .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e));
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -12,7 +12,7 @@ pub fn initialize_logger() {
     };
 
     let filter = EnvFilter::try_new(
-        "error,debug,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug",
+        "debug,dash_evo_tool=trace,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn",
     )
         .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e));
 

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -609,8 +609,8 @@ impl Wallet {
                 &address,
                 &app_context.network,
                 derivation_path,
-                DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
-                DerivationPathType::CREDIT_FUNDING,
+                path_reference,
+                path_type,
                 None,
             )
             .map_err(|e| e.to_string())?;

--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -95,6 +95,12 @@ impl Wallet {
     ) -> Result<HashMap<OutPoint, TxOut>, String> {
         // Collect the addresses for which we want to load UTXOs.
         let addresses: Vec<_> = self.known_addresses.keys().collect();
+        if tracing::enabled!(tracing::Level::TRACE) {
+            for addr in addresses.iter() {
+                let (net, payload) = (*addr).clone().into_parts();
+                tracing::trace!(net=net.to_string(),payload=?payload , "Address to load UTXOs for");
+            }
+        }
 
         // Use the RPC client to list unspent outputs.
         match core_client.list_unspent(None, None, Some(&addresses), Some(false), None) {


### PR DESCRIPTION
## Issue

Address deserialization can lose information about the network type (devnet, testnet, mainnet, etc). 
This causes duplicate addresses to be registered, and errors like:

```
Error refreshing wallet: JSON-RPC error: RPC error response: RpcError { code: -8, message: "Invalid parameter, duplicated address: yMVVNedFcunEUMRXBNEsBeEbVWSP4W8cUu", data: None }
```

## What was done


Check addresses on load and replace network with correct one if needed.


Closes #228 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved address handling to ensure all wallet addresses are validated and consistent with the selected network, preventing network mismatches.
- **New Features**
	- Enhanced error handling for address-related issues during wallet storage and retrieval.
	- Securely erases sensitive wallet seed data when no longer needed.
- **Improvements**
	- Added detailed trace logging for address registration and UTXO loading to aid in troubleshooting and transparency.
	- Refined log levels for better visibility and control over application logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->