### PR TITLE
build: optimize x86-64 builds for base x86-64 cpu

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "target-cpu=x86-64"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=-crt-static", "-C", "target-cpu=x86-64"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,6 @@ default-run = "dash-evo-tool"
 rust-version = "1.85"
 build = "build.rs"
 
-[build]
-rustflags = [
-    "-C", "target-feature=+avx,-avx2,-avx512f,-avx512cd,-avx512er,-avx512pf,-avx512bw,-avx512dq,-avx512vl"
-]
-
 [dependencies]
 bip39 = { version = "2.1.0", features = ["all-languages", "rand"] }
 derive_more = "2.0.1"
@@ -40,16 +35,18 @@ envy = "0.4.2"
 chrono = "0.4"
 chrono-humanize = "0.2.3"
 sha2 = "0.10.8"
-arboard = { version = "3.4.0", default-features = false, features = ["windows-sys"] }
+arboard = { version = "3.4.0", default-features = false, features = [
+    "windows-sys",
+] }
 directories = "5.0"
-rusqlite = { version = "0.32.1",  features = ["functions"]}
+rusqlite = { version = "0.32.1", features = ["functions"] }
 serde_yaml = "0.9.34+deprecated"
 image = { version = "0.25.2", default-features = false, features = ["png"] }
 bitflags = "2.6.0"
 rust-embed = "8.5.0"
 zeroize = "1.8.1"
 zxcvbn = "3.1.0"
-argon2 = "0.5"           # For Argon2 key derivation
+argon2 = "0.5" # For Argon2 key derivation
 aes-gcm = "0.10" # For AES-256-GCM encryption
 crossbeam-channel = "0.5.13"
 regex = "1.11"


### PR DESCRIPTION
Cargo.toml contained ineffective `[build]` settings.

I removed these settings and added config to optimize for `x86-64` CPU.

See also: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to manage compiler flags through a dedicated configuration file for improved consistency across platforms.
  - Reformatted dependency declarations for improved readability.
  - Removed redundant build settings from the main configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->