### PR TITLE
fix: get critical key for token action screens

### DIFF
--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -79,11 +79,7 @@ impl BurnTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -77,11 +77,7 @@ impl ClaimTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -88,11 +88,7 @@ impl DestroyFrozenFundsScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -78,11 +78,7 @@ impl FreezeTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -76,11 +76,7 @@ impl PauseTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -73,11 +73,7 @@ impl ResumeTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -87,11 +87,7 @@ impl TransferTokensScreen {
         let identity_clone = identity.identity.clone();
         let selected_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -78,11 +78,7 @@ impl UnfreezeTokensScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -79,11 +79,7 @@ impl UpdateTokenConfigScreen {
         let identity_clone = identity.identity.clone();
         let possible_key = identity_clone.get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([
-                SecurityLevel::HIGH,
-                SecurityLevel::MEDIUM,
-                SecurityLevel::CRITICAL,
-            ]),
+            HashSet::from([SecurityLevel::CRITICAL]),
             KeyType::all_key_types().into(),
             false,
         );


### PR DESCRIPTION
On token action screens, we would select any authentication key High Medium or Critical, but only Critical can be used now on Platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated key selection criteria for token-related actions to require only the highest security level (CRITICAL) authentication keys, enhancing the security standard across all token management screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->