### PR TITLE
fix: replace token properly after config update

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -665,6 +665,10 @@ impl AppContext {
         Ok(())
     }
 
+    pub fn remove_token(&self, token_id: &Identifier) -> Result<()> {
+        self.db.remove_token(token_id, self)
+    }
+
     pub fn insert_token_identity_balance(
         &self,
         token_id: &Identifier,


### PR DESCRIPTION
We were replacing the contract from the local DB after config update, which used to replace tokens too, but not anymore, so now we replace the tokens too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to remove tokens from the local database.

- **Bug Fixes**
  - Improved synchronization of token information between the local database and the platform, ensuring updates are accurately reflected.

- **Other**
  - Enhanced error handling for database operations related to token updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->