### PR TITLE
fix: display keyword search results even if optional description not present

### DIFF
--- a/src/backend_task/tokens/query_tokens.rs
+++ b/src/backend_task/tokens/query_tokens.rs
@@ -82,19 +82,25 @@ impl AppContext {
                 value: Value::Identifier(cid.to_owned().into()),
             });
 
-            if let Some((_, Some(desc_doc))) = Document::fetch_many(sdk, desc_query)
+            let description = if let Some((_, Some(desc_doc))) = Document::fetch_many(sdk, desc_query)
                 .await
                 .map_err(|e| format!("Error fetching description doc: {e}"))?
                 .into_iter()
                 .next()
             {
                 if let Some(Value::Text(desc_txt)) = desc_doc.get("description") {
-                    descriptions.push(ContractDescriptionInfo {
-                        data_contract_id: *cid,
-                        description: desc_txt.to_owned(),
-                    });
+                    desc_txt.to_owned()
+                } else {
+                    "".to_string()
                 }
-            }
+            } else {
+                "".to_string()
+            };
+
+            descriptions.push(ContractDescriptionInfo {
+                data_contract_id: *cid,
+                description,
+            });
         }
 
         // ── 3. return result ────────────────────────────────────────────────


### PR DESCRIPTION
Previously, the UI would indicate "No tokens match your keyword" if results were returned but the token didn't define a description. Since token descriptions are optional, this PR removes the DET-only requirement to have a description for the search to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of contract descriptions to ensure every contract ID is included in the results, even if the description is empty or missing. This change streamlines the display of contract information for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->