### PR TITLE
feat: deduplicate keywords automatically before trying to register token

### DIFF
--- a/src/backend_task/tokens/query_tokens.rs
+++ b/src/backend_task/tokens/query_tokens.rs
@@ -82,19 +82,25 @@ impl AppContext {
                 value: Value::Identifier(cid.to_owned().into()),
             });
 
-            if let Some((_, Some(desc_doc))) = Document::fetch_many(sdk, desc_query)
+            let description = if let Some((_, Some(desc_doc))) = Document::fetch_many(sdk, desc_query)
                 .await
                 .map_err(|e| format!("Error fetching description doc: {e}"))?
                 .into_iter()
                 .next()
             {
                 if let Some(Value::Text(desc_txt)) = desc_doc.get("description") {
-                    descriptions.push(ContractDescriptionInfo {
-                        data_contract_id: *cid,
-                        description: desc_txt.to_owned(),
-                    });
+                    desc_txt.to_owned()
+                } else {
+                    "".to_string()
                 }
-            }
+            } else {
+                "".to_string()
+            };
+
+            descriptions.push(ContractDescriptionInfo {
+                data_contract_id: *cid,
+                description,
+            });
         }
 
         // ── 3. return result ────────────────────────────────────────────────


### PR DESCRIPTION
Uses a hash set to make sure the token keyword list is unique (automatically excludes duplicates).

Closes #275