### PR TITLE
feat: deduplicate keywords automatically before trying to register token

### DIFF
--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -4169,6 +4169,10 @@ Emits tokens in fixed amounts for specific intervals.
             }
         }
 
+        // ---- Deduplicate contract_keywords after adding token names ----
+        let mut seen = HashSet::new();
+        contract_keywords.retain(|kw| seen.insert(kw.clone()));
+
         let token_description = if self.token_description_input.len() > 0 {
             Some(self.token_description_input.clone())
         } else {


### PR DESCRIPTION
Uses a hash set to make sure the token keyword list is unique (automatically excludes duplicates).

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyword handling to remove duplicate entries from token search keywords, ensuring more accurate and efficient search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->