### PR TITLE
fix: invalid amount in identity create broke screen

### DIFF
--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -24,9 +24,7 @@ struct MasternodeInfo {
     #[serde(rename = "pro-tx-hash")]
     pro_tx_hash: String,
     owner: KeyInfo,
-    collateral: KeyInfo,
     voter: KeyInfo,
-    operator: OperatorInfo,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -34,32 +32,12 @@ struct HPMasternodeInfo {
     #[serde(rename = "protx-tx-hash")]
     protx_tx_hash: String,
     owner: KeyInfo,
-    collateral: KeyInfo,
     voter: KeyInfo,
     payout: KeyInfo,
-    operator: OperatorInfo,
-    #[serde(rename = "node_key")]
-    node_key: Option<NodeKeyInfo>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 struct KeyInfo {
-    address: String,
-    #[serde(rename = "private_key")]
-    private_key: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct OperatorInfo {
-    #[serde(rename = "public_key")]
-    public_key: String,
-    #[serde(rename = "private_key")]
-    private_key: String,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct NodeKeyInfo {
-    id: String,
     #[serde(rename = "private_key")]
     private_key: String,
 }
@@ -81,12 +59,6 @@ pub enum AddIdentityStatus {
     WaitingForResult(TimestampMillis),
     ErrorMessage(String),
     Complete,
-}
-
-#[derive(Clone, PartialEq)]
-pub enum IdentityLoadMethod {
-    ByIdentifier,
-    FromWallet,
 }
 
 pub struct AddExistingIdentityScreen {
@@ -286,7 +258,7 @@ impl AddExistingIdentityScreen {
         action
     }
 
-    fn render_wallet_selection(&mut self, ui: &mut Ui) {
+    fn _render_wallet_selection(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             if self.app_context.has_wallet.load(Ordering::Relaxed) {
                 let wallets = &self.app_context.wallets.read().unwrap();
@@ -337,12 +309,12 @@ impl AddExistingIdentityScreen {
         });
     }
 
-    fn render_from_wallet(&mut self, ui: &mut egui::Ui, wallets_len: usize) -> AppAction {
+    fn _render_from_wallet(&mut self, ui: &mut egui::Ui, wallets_len: usize) -> AppAction {
         let mut action = AppAction::None;
 
         // Wallet selection
         if wallets_len > 1 {
-            self.render_wallet_selection(ui);
+            self._render_wallet_selection(ui);
         }
 
         if self.selected_wallet.is_none() {

--- a/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
@@ -122,10 +122,6 @@ impl AddNewIdentityScreen {
         // Extract the step from the RwLock to minimize borrow scope
         let step = self.step.read().unwrap().clone();
 
-        let Ok(amount_dash) = self.funding_amount.parse::<f64>() else {
-            return AppAction::None;
-        };
-
         ui.add_space(10.0);
 
         ui.heading(
@@ -139,6 +135,14 @@ impl AddNewIdentityScreen {
         ui.add_space(8.0);
 
         self.render_funding_amount_input(ui);
+
+        let Ok(amount_dash) = self.funding_amount.parse::<f64>() else {
+            return AppAction::None;
+        };
+
+        if amount_dash <= 0.0 {
+            return AppAction::None;
+        }
 
         ui.with_layout(
             egui::Layout::top_down(egui::Align::Min).with_cross_align(egui::Align::Center),

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -124,7 +124,7 @@ impl TopUpIdentityScreen {
             return;
         };
         let funding_method_arc = self.funding_method.clone();
-        let mut funding_method = funding_method_arc.write().unwrap(); // Write lock on funding_method
+        let mut funding_method = funding_method_arc.write().unwrap();
 
         ComboBox::from_id_salt("funding_method")
             .selected_text(format!("{}", *funding_method))
@@ -153,6 +153,7 @@ impl TopUpIdentityScreen {
                         *step = WalletFundedScreenStep::ReadyToCreate;
                     }
                 }
+
                 if has_balance {
                     if ui
                         .selectable_value(
@@ -163,16 +164,17 @@ impl TopUpIdentityScreen {
                         .changed()
                     {
                         if let Some(wallet) = &self.wallet {
-                            let wallet = wallet.read().unwrap(); // Read lock on the wallet
+                            let wallet = wallet.read().unwrap();
                             let max_amount = wallet.max_balance();
                             self.funding_amount = format!("{:.4}", max_amount as f64 * 1e-8);
                             self.funding_amount_exact =
                                 Some(self.funding_amount.parse::<f64>().unwrap() as u64);
                         }
-                        let mut step = self.step.write().unwrap(); // Write lock on step
+                        let mut step = self.step.write().unwrap();
                         *step = WalletFundedScreenStep::ReadyToCreate;
                     }
                 }
+
                 if ui
                     .selectable_value(
                         &mut *funding_method,
@@ -181,18 +183,12 @@ impl TopUpIdentityScreen {
                     )
                     .changed()
                 {
-                    let mut step = self.step.write().unwrap(); // Write lock on step
+                    let mut step = self.step.write().unwrap();
                     *step = WalletFundedScreenStep::WaitingOnFunds;
                 }
-
-                // Uncomment this if AttachedCoreWallet is available in the future
-                // ui.selectable_value(
-                //     &mut *funding_method,
-                //     FundingMethod::AttachedCoreWallet,
-                //     "Attached Core Wallet",
-                // );
             });
     }
+
     fn top_up_identity_clicked(&mut self, funding_method: FundingMethod) -> AppAction {
         let Some(selected_wallet) = &self.wallet else {
             return AppAction::None;
@@ -202,7 +198,7 @@ impl TopUpIdentityScreen {
                 if let Some((tx, funding_asset_lock, address)) = self.funding_asset_lock.clone() {
                     let identity_input = IdentityTopUpInfo {
                         qualified_identity: self.identity.clone(),
-                        wallet: Arc::clone(selected_wallet), // Clone the Arc reference
+                        wallet: Arc::clone(selected_wallet),
                         identity_funding_method: TopUpIdentityFundingMethod::UseAssetLock(
                             address,
                             funding_asset_lock,
@@ -483,7 +479,6 @@ impl ScreenLike for TopUpIdentityScreen {
                     FundingMethod::AddressWithQRCode => {
                         action |= self.render_ui_by_wallet_qr_code(ui, step_number)
                     }
-                    FundingMethod::AttachedCoreWallet => return,
                 }
             });
         });


### PR DESCRIPTION
If a user entered an invalid amount in the Identity Create screen, it would break and the only way out was to exit the screen and reopen it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure the funding amount is a positive number when creating a new identity.

- **Bug Fixes**
  - Prevented QR code generation and further UI actions if the funding amount is invalid or non-positive.

- **Refactor**
  - Simplified identity and masternode information by removing unused fields and obsolete options.
  - Removed deprecated funding method options and related balance checking logic.
  - Improved UI responsiveness by resetting funding amount and step when changing funding methods.

- **Style**
  - Cleaned up comments and improved code readability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->