### PR TITLE
feat: token screens ui improvements around group actions

### DIFF
--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -24,6 +24,7 @@ use crate::ui::tokens::freeze_tokens_screen::FreezeTokensScreen;
 use crate::ui::tokens::mint_tokens_screen::MintTokensScreen;
 use crate::ui::tokens::pause_tokens_screen::PauseTokensScreen;
 use crate::ui::tokens::resume_tokens_screen::ResumeTokensScreen;
+use crate::ui::tokens::set_token_price_screen::SetTokenPriceScreen;
 use crate::ui::tokens::tokens_screen::{
     IdentityTokenBalance, IdentityTokenIdentifier, IdentityTokenInfo,
 };
@@ -298,8 +299,9 @@ impl GroupActionsScreen {
                                     });
                                 });
                                 row.col(|ui| {
+                                    let note_clone = note.clone();
                                     ui.horizontal(|ui| {
-                                        ui.label(note);
+                                        ui.label(note_clone);
                                         ui.add_space(30.0);
                                     });
                                 });
@@ -361,6 +363,11 @@ impl GroupActionsScreen {
                                                     .next()
                                                     .unwrap_or("0")
                                                     .to_string();
+                                                mint_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
 
                                                 action |= AppAction::AddScreen(
                                                     Screen::MintTokensScreen(mint_screen),
@@ -376,6 +383,11 @@ impl GroupActionsScreen {
                                                     .next()
                                                     .unwrap_or("0")
                                                     .to_string();
+                                                burn_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
 
                                                 action |= AppAction::AddScreen(
                                                     Screen::BurnTokensScreen(burn_screen),
@@ -391,6 +403,12 @@ impl GroupActionsScreen {
                                                     .next()
                                                     .unwrap_or("")
                                                     .to_string();
+                                                freeze_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
+
                                                 action |= AppAction::AddScreen(
                                                     Screen::FreezeTokensScreen(freeze_screen),
                                                 );
@@ -405,6 +423,12 @@ impl GroupActionsScreen {
                                                     .next()
                                                     .unwrap_or("")
                                                     .to_string();
+                                                unfreeze_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
+
                                                 action |= AppAction::AddScreen(
                                                     Screen::UnfreezeTokensScreen(unfreeze_screen),
                                                 );
@@ -420,6 +444,12 @@ impl GroupActionsScreen {
                                                     .nth(2)
                                                     .unwrap_or("")
                                                     .to_string();
+                                                destroy_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
+
                                                 action |= AppAction::AddScreen(
                                                     Screen::DestroyFrozenFundsScreen(
                                                         destroy_screen,
@@ -432,6 +462,11 @@ impl GroupActionsScreen {
                                                         identity_token_info, &self.app_context,
                                                     );
                                                     pause_screen.group_action_id = Some(*id);
+                                                    pause_screen.public_note = if note.len() > 0 {
+                                                        Some(note)
+                                                    } else {
+                                                        None
+                                                    };
                                                     action |= AppAction::AddScreen(
                                                         Screen::PauseTokensScreen(pause_screen),
                                                     );
@@ -441,6 +476,11 @@ impl GroupActionsScreen {
                                                         identity_token_info, &self.app_context,
                                                     );
                                                     resume_screen.group_action_id = Some(*id);
+                                                    resume_screen.public_note = if note.len() > 0 {
+                                                        Some(note)
+                                                    } else {
+                                                        None
+                                                    };
                                                     action |= AppAction::AddScreen(
                                                         Screen::ResumeTokensScreen(resume_screen),
                                                     );
@@ -453,12 +493,37 @@ impl GroupActionsScreen {
                                                         identity_token_info, &self.app_context,
                                                     );
                                                 update_screen.group_action_id = Some(*id);
+                                                update_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
                                                 action |= AppAction::AddScreen(
                                                     Screen::UpdateTokenConfigScreen(update_screen),
                                                 );
                                             }
-
-                                            // To do: Change price and direct purchase
+                                            "ChangePrice" => {
+                                                let mut change_price_screen =
+                                                    SetTokenPriceScreen::new(
+                                                        identity_token_info, &self.app_context,
+                                                    );
+                                                change_price_screen.group_action_id = Some(*id);
+                                                change_price_screen.token_pricing_schedule =
+                                                    info.split_whitespace()
+                                                        .next()
+                                                        .unwrap_or("")
+                                                        .to_string();
+                                                change_price_screen.public_note = if note.len() > 0 {
+                                                    Some(note)
+                                                } else {
+                                                    None
+                                                };
+                                                action |= AppAction::AddScreen(
+                                                    Screen::SetTokenPriceScreen(
+                                                        change_price_screen,
+                                                    ),
+                                                );
+                                            }
                                             _ => {
                                                 action |= AppAction::None;
                                             }

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -6,6 +6,7 @@ use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
 use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
 use dash_sdk::dpp::data_contract::group::Group;
 use dash_sdk::dpp::data_contract::GroupContractPosition;
 use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
@@ -15,6 +16,7 @@ use egui::RichText;
 
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
@@ -31,7 +33,7 @@ use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 
 use super::tokens_screen::IdentityTokenInfo;
 
@@ -48,11 +50,12 @@ pub struct BurnTokensScreen {
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<IdentityPublicKey>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     // The user chooses how many tokens to burn
     pub amount_to_burn: String,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
 
     status: BurnTokensStatus,
     error_message: Option<String>,
@@ -149,6 +152,21 @@ impl BurnTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -161,6 +179,7 @@ impl BurnTokensScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             amount_to_burn: String::new(),
             public_note: None,
@@ -346,22 +365,42 @@ impl BurnTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Burn Signing Successful.");
+                // This burn is already initiated by the group, we are just signing it
+                ui.heading("Group Burn Signing Successful.");
             } else {
-                ui.heading("Burn Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Burn Initiated.");
+                } else {
+                    ui.heading("Burn Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                // Pop this screen and refresh
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -439,7 +478,7 @@ impl ScreenLike for BurnTokensScreen {
         egui::CentralPanel::default().show(ctx, |ui| {
             // If we are in the "Complete" status, just show success screen
             if self.status == BurnTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -563,24 +602,35 @@ impl ScreenLike for BurnTokensScreen {
                 // Render text input for the public note
                 ui.heading("3. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 {
-                            Some(txt)
-                        } else {
-                            None
-                        };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Burn so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text =
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Burn", &self.group_action_id);

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -335,7 +335,11 @@ impl BurnTokensScreen {
                                 data_contract,
                                 token_position: self.identity_token_info.token_position,
                                 signing_key: self.selected_key.clone().expect("Expected a key"),
-                                public_note: self.public_note.clone(),
+                                public_note: if self.group_action_id.is_some() {
+                                    None
+                                } else {
+                                    self.public_note.clone()
+                                },
                                 amount: amount_ok.unwrap(),
                                 group_info,
                             }),

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -1,40 +1,38 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use crate::ui::components::left_panel::add_left_panel;
-use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
-use crate::ui::helpers::render_group_action_text;
-use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-use dash_sdk::platform::{Identifier, IdentityPublicKey};
-
+use super::tokens_screen::IdentityTokenInfo;
 use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
+use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-
-use super::tokens_screen::IdentityTokenInfo;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Represents possible states in the “destroy frozen funds” flow
 #[derive(PartialEq)]
@@ -57,6 +55,7 @@ pub struct DestroyFrozenFundsScreen {
     selected_key: Option<IdentityPublicKey>,
 
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     /// Optional public note
@@ -161,6 +160,21 @@ impl DestroyFrozenFundsScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -175,6 +189,7 @@ impl DestroyFrozenFundsScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             public_note: None,
             status: DestroyFrozenFundsStatus::NotStarted,
@@ -361,21 +376,42 @@ impl DestroyFrozenFundsScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Destroy Signing Successful.");
+                // This destroy is already initiated by the group, we are just signing it
+                ui.heading("Group Destroy Signing Successful.");
             } else {
-                ui.heading("Destroy Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Destroy Initiated.");
+                } else {
+                    ui.heading("Destroy Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -456,7 +492,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == DestroyFrozenFundsStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -561,24 +597,35 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                 // Render text input for the public note
                 ui.heading("3. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 {
-                            Some(txt)
-                        } else {
-                            None
-                        };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Destroy so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text = render_group_action_text(
                     ui,

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -346,7 +346,11 @@ impl DestroyFrozenFundsScreen {
                                 data_contract,
                                 token_position: self.identity_token_info.token_position,
                                 signing_key: self.selected_key.clone().expect("Expected a key"),
-                                public_note: self.public_note.clone(),
+                                public_note: if self.group_action_id.is_some() {
+                                    None
+                                } else {
+                                    self.public_note.clone()
+                                },
                                 frozen_identity: frozen_id,
                                 group_info,
                             }),

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -1,23 +1,4 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-use dash_sdk::platform::{Identifier, IdentityPublicKey};
-
+use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
@@ -28,13 +9,30 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-
-use super::tokens_screen::IdentityTokenInfo;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Internal states for the freeze operation
 #[derive(PartialEq)]
@@ -50,9 +48,10 @@ pub struct FreezeTokensScreen {
     pub identity: QualifiedIdentity,
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<IdentityPublicKey>,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
 
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     /// The identity we want to freeze
@@ -153,6 +152,21 @@ impl FreezeTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -166,6 +180,7 @@ impl FreezeTokensScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             public_note: None,
             freeze_identity_id: String::new(),
@@ -345,21 +360,42 @@ impl FreezeTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Freeze Signing Successful.");
+                // This freeze is already initiated by the group, we are just signing it
+                ui.heading("Group Freeze Signing Successful.");
             } else {
-                ui.heading("Freeze Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Freeze Initiated.");
+                } else {
+                    ui.heading("Freeze Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -435,7 +471,7 @@ impl ScreenLike for FreezeTokensScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == FreezeTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -541,24 +577,35 @@ impl ScreenLike for FreezeTokensScreen {
                 // Render text input for the public note
                 ui.heading("3. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 {
-                            Some(txt)
-                        } else {
-                            None
-                        };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Freeze so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text =
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Freeze", &self.group_action_id);

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -334,7 +334,11 @@ impl FreezeTokensScreen {
                             data_contract,
                             token_position: self.identity_token_info.token_position,
                             signing_key: self.selected_key.clone().expect("No key selected"),
-                            public_note: self.public_note.clone(),
+                            public_note: if self.group_action_id.is_some() {
+                                None
+                            } else {
+                                self.public_note.clone()
+                            },
                             freeze_identity: freeze_id,
                             group_info,
                         }));

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -1,17 +1,3 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
 use super::tokens_screen::IdentityTokenInfo;
 use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::tokens::TokenTask;
@@ -22,17 +8,31 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
 use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Internal states for the mint process.
 #[derive(PartialEq)]
@@ -47,8 +47,9 @@ pub enum MintTokensStatus {
 pub struct MintTokensScreen {
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<IdentityPublicKey>,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     pub recipient_identity_id: String,
@@ -149,6 +150,21 @@ impl MintTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -162,6 +178,7 @@ impl MintTokensScreen {
             selected_key: possible_key,
             public_note: None,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             recipient_identity_id: "".to_string(),
             amount_to_mint: "".to_string(),
@@ -381,22 +398,42 @@ impl MintTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Mint Signing Successful.");
+                // This mint is already initiated by the group, we are just signing it
+                ui.heading("Group Mint Signing Successful.");
             } else {
-                ui.heading("Mint Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Mint Initiated.");
+                } else {
+                    ui.heading("Mint Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                // Pop this screen and refresh
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -474,7 +511,7 @@ impl ScreenLike for MintTokensScreen {
         egui::CentralPanel::default().show(ctx, |ui| {
             // If we are in the "Complete" status, just show success screen
             if self.status == MintTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -616,24 +653,35 @@ impl ScreenLike for MintTokensScreen {
                 // Render text input for the public note
                 ui.heading("4. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 {
-                            Some(txt)
-                        } else {
-                            None
-                        };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Mint so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text =
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Mint", &self.group_action_id);

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -367,7 +367,11 @@ impl MintTokensScreen {
                                     .clone(),
                                 token_position: self.identity_token_info.token_position,
                                 signing_key: self.selected_key.clone().expect("Expected a key"),
-                                public_note: self.public_note.clone(),
+                                public_note: if self.group_action_id.is_some() {
+                                    None
+                                } else {
+                                    self.public_note.clone()
+                                },
                                 amount: amount_ok.unwrap(),
                                 recipient_id: maybe_identifier,
                                 group_info,

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -1,23 +1,4 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-
+use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
@@ -28,13 +9,30 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-
-use super::tokens_screen::IdentityTokenInfo;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::Identifier;
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Represents states for the pause flow
 #[derive(PartialEq)]
@@ -51,6 +49,7 @@ pub struct PauseTokensScreen {
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<dash_sdk::platform::IdentityPublicKey>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
     pub public_note: Option<String>,
 
@@ -149,6 +148,21 @@ impl PauseTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -162,6 +176,7 @@ impl PauseTokensScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             public_note: None,
             status: PauseTokensStatus::NotStarted,
@@ -306,21 +321,42 @@ impl PauseTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Pause Signing Successful.");
+                // This Pause is already initiated by the group, we are just signing it
+                ui.heading("Group Pause Signing Successful.");
             } else {
-                ui.heading("Pause Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Pause Initiated.");
+                } else {
+                    ui.heading("Pause Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -396,7 +432,7 @@ impl ScreenLike for PauseTokensScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == PauseTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -480,20 +516,35 @@ impl ScreenLike for PauseTokensScreen {
                 // Render text input for the public note
                 ui.heading("2. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 { Some(txt) } else { None };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Pause so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text = render_group_action_text(
                     ui,

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -298,7 +298,11 @@ impl PauseTokensScreen {
                             data_contract,
                             token_position: self.identity_token_info.token_position,
                             signing_key: self.selected_key.clone().expect("No key selected"),
-                            public_note: self.public_note.clone(),
+                            public_note: if self.group_action_id.is_some() {
+                                None
+                            } else {
+                                self.public_note.clone()
+                            },
                             group_info,
                         }));
                 }

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -1,23 +1,4 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-
+use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
@@ -28,13 +9,30 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-
-use super::tokens_screen::IdentityTokenInfo;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::Identifier;
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// States for the resume flow
 #[derive(PartialEq)]
@@ -50,6 +48,7 @@ pub struct ResumeTokensScreen {
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<dash_sdk::platform::IdentityPublicKey>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
     pub public_note: Option<String>,
 
@@ -148,6 +147,21 @@ impl ResumeTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -161,6 +175,7 @@ impl ResumeTokensScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             public_note: None,
             status: ResumeTokensStatus::NotStarted,
@@ -305,21 +320,42 @@ impl ResumeTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Resume Signing Successful.");
+                // This resume is already initiated by the group, we are just signing it
+                ui.heading("Group Resume Signing Successful.");
             } else {
-                ui.heading("Resume Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Resume Initiated.");
+                } else {
+                    ui.heading("Resume Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -395,7 +431,7 @@ impl ScreenLike for ResumeTokensScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == ResumeTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -479,20 +515,35 @@ impl ScreenLike for ResumeTokensScreen {
                 // Render text input for the public note
                 ui.heading("2. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 { Some(txt) } else { None };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Resume so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text = render_group_action_text(
                     ui,

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -297,7 +297,11 @@ impl ResumeTokensScreen {
                             data_contract,
                             token_position: self.identity_token_info.token_position,
                             signing_key: self.selected_key.clone().expect("No key selected"),
-                            public_note: self.public_note.clone(),
+                            public_note: if self.group_action_id.is_some() {
+                                None
+                            } else {
+                                self.public_note.clone()
+                            },
                             group_info,
                         }));
                 }

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -369,7 +369,11 @@ impl SetTokenPriceScreen {
                             data_contract: self.identity_token_info.data_contract.contract.clone(),
                             token_position: self.identity_token_info.token_position,
                             signing_key: self.selected_key.clone().expect("Expected a key"),
-                            public_note: self.public_note.clone(),
+                            public_note: if self.group_action_id.is_some() {
+                                None
+                            } else {
+                                self.public_note.clone()
+                            },
                             token_pricing_schedule: token_pricing_schedule_opt,
                             group_info,
                         },

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -1,19 +1,3 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
 use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
@@ -24,16 +8,31 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-use dash_sdk::dpp::group::GroupStateTransitionInfoStatus;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_distribution_rules::accessors::v0::TokenDistributionRulesV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use dash_sdk::platform::IdentityPublicKey;
+use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
+use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Internal states for the mint process.
 #[derive(PartialEq)]
@@ -48,10 +47,12 @@ pub enum SetTokenPriceStatus {
 pub struct SetTokenPriceScreen {
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<IdentityPublicKey>,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
+    pub group_action_id: Option<Identifier>,
 
-    token_pricing_schedule: String,
+    pub token_pricing_schedule: String,
     status: SetTokenPriceStatus,
     error_message: Option<String>,
 
@@ -149,6 +150,21 @@ impl SetTokenPriceScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -162,6 +178,8 @@ impl SetTokenPriceScreen {
             selected_key: possible_key.cloned(),
             public_note: None,
             group,
+            is_unilateral_group_member,
+            group_action_id: None,
             token_pricing_schedule: "".to_string(),
             status: SetTokenPriceStatus::NotStarted,
             error_message: None,
@@ -327,9 +345,22 @@ impl SetTokenPriceScreen {
                         .as_secs();
                     self.status = SetTokenPriceStatus::WaitingForResult(now);
 
-                    let group_info = self.group.as_ref().map(|(pos, _)| {
-                        GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(*pos)
-                    });
+                    let group_info;
+                    if self.group_action_id.is_some() {
+                        group_info = self.group.as_ref().map(|(pos, _)| {
+                            GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                                GroupStateTransitionInfo {
+                                    group_contract_position: *pos,
+                                    action_id: self.group_action_id.unwrap(),
+                                    action_is_proposer: false,
+                                },
+                            )
+                        });
+                    } else {
+                        group_info = self.group.as_ref().map(|(pos, _)| {
+                            GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(*pos)
+                        });
+                    }
 
                     // Dispatch the actual backend mint action
                     action = AppAction::BackendTask(BackendTask::TokenTask(
@@ -364,13 +395,43 @@ impl SetTokenPriceScreen {
             ui.add_space(50.0);
 
             ui.heading("🎉");
-            ui.heading("Set Token Pricing Schedule Successful!");
+            if self.group_action_id.is_some() {
+                // This is already initiated by the group, we are just signing it
+                ui.heading("Group SetPrice Signing Successful.");
+            } else {
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group SetPrice Initiated.");
+                } else {
+                    ui.heading("SetPrice Successful.");
+                }
+            }
 
             ui.add_space(20.0);
 
-            if ui.button("Back to Tokens").clicked() {
-                // Pop this screen and refresh
-                action = AppAction::PopScreenAndRefresh;
+            if self.group_action_id.is_some() {
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
+            } else {
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -410,17 +471,32 @@ impl ScreenLike for SetTokenPriceScreen {
     }
 
     fn ui(&mut self, ctx: &Context) -> AppAction {
+        let mut action;
+
         // Build a top panel
-        let mut action = add_top_panel(
-            ctx,
-            &self.app_context,
-            vec![
-                ("Tokens", AppAction::GoToMainScreen),
-                (&self.identity_token_info.token_alias, AppAction::PopScreen),
-                ("SetPrice", AppAction::None),
-            ],
-            vec![],
-        );
+        if self.group_action_id.is_some() {
+            action = add_top_panel(
+                ctx,
+                &self.app_context,
+                vec![
+                    ("Contracts", AppAction::GoToMainScreen),
+                    ("Group Actions", AppAction::PopScreen),
+                    ("SetPrice", AppAction::None),
+                ],
+                vec![],
+            );
+        } else {
+            action = add_top_panel(
+                ctx,
+                &self.app_context,
+                vec![
+                    ("Tokens", AppAction::GoToMainScreen),
+                    (&self.identity_token_info.token_alias, AppAction::PopScreen),
+                    ("SetPrice", AppAction::None),
+                ],
+                vec![],
+            );
+        }
 
         // Left panel
         action |= add_left_panel(
@@ -435,7 +511,7 @@ impl ScreenLike for SetTokenPriceScreen {
         egui::CentralPanel::default().show(ctx, |ui| {
             // If we are in the "Complete" status, just show success screen
             if self.status == SetTokenPriceStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -520,7 +596,18 @@ impl ScreenLike for SetTokenPriceScreen {
                 // 2) Pricing schedule
                 ui.heading("2. Pricing schedule");
                 ui.add_space(5.0);
-                self.render_pricing_input(ui);
+                                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group SetPrice so you are not allowed to choose the pricing schedule.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Schedule: {}",
+                        self.token_pricing_schedule
+                    ));
+                } else {
+                    self.render_pricing_input(ui);
+                }
 
                 ui.add_space(10.0);
                 ui.separator();
@@ -529,21 +616,35 @@ impl ScreenLike for SetTokenPriceScreen {
                 // Render text input for the public note
                 ui.heading("3. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = Some(txt);
-                    }
-                });
-                ui.add_space(10.0);
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group SetPrice so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let set_price_text = if let Some((_, group)) = self.group.as_ref() {
                     let your_power = group.members().get(&self.identity_token_info.identity.identity.id());

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -332,7 +332,11 @@ impl UnfreezeTokensScreen {
                             data_contract,
                             token_position: self.identity_token_info.token_position,
                             signing_key: self.selected_key.clone().expect("No key selected"),
-                            public_note: self.public_note.clone(),
+                            public_note: if self.group_action_id.is_some() {
+                                None
+                            } else {
+                                self.public_note.clone()
+                            },
                             unfreeze_identity: unfreeze_id,
                             group_info,
                         }));

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -1,24 +1,4 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
-use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
-use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
-use dash_sdk::dpp::data_contract::group::Group;
-use dash_sdk::dpp::data_contract::GroupContractPosition;
-use dash_sdk::dpp::group::GroupStateTransitionInfoStatus;
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use dash_sdk::dpp::group::GroupStateTransitionInfo;
-use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-use dash_sdk::platform::{Identifier, IdentityPublicKey};
-
+use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
@@ -29,13 +9,31 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
-
-use super::tokens_screen::IdentityTokenInfo;
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
+use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
+use dash_sdk::dpp::data_contract::group::Group;
+use dash_sdk::dpp::data_contract::GroupContractPosition;
+use dash_sdk::dpp::group::GroupStateTransitionInfo;
+use dash_sdk::dpp::group::GroupStateTransitionInfoStatus;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// The states for the unfreeze flow
 #[derive(PartialEq)]
@@ -51,9 +49,10 @@ pub struct UnfreezeTokensScreen {
     pub identity: QualifiedIdentity,
     pub identity_token_info: IdentityTokenInfo,
     selected_key: Option<IdentityPublicKey>,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
 
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     /// The identity we want to freeze
@@ -154,6 +153,21 @@ impl UnfreezeTokensScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -167,6 +181,7 @@ impl UnfreezeTokensScreen {
             identity_token_info,
             selected_key: possible_key,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
             public_note: None,
             unfreeze_identity_id: String::new(),
@@ -342,21 +357,42 @@ impl UnfreezeTokensScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Unfreeze Signing Successful.");
+                // This is already initiated by the group, we are just signing it
+                ui.heading("Group Unfreeze Signing Successful.");
             } else {
-                ui.heading("Unfreeze Successful.");
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group Unfreeze Initiated.");
+                } else {
+                    ui.heading("Unfreeze Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action
@@ -432,7 +468,7 @@ impl ScreenLike for UnfreezeTokensScreen {
 
         egui::CentralPanel::default().show(ctx, |ui| {
             if self.status == UnfreezeTokensStatus::Complete {
-                action = self.show_success_screen(ui);
+                action |= self.show_success_screen(ui);
                 return;
             }
 
@@ -538,24 +574,35 @@ impl ScreenLike for UnfreezeTokensScreen {
                 // Render text input for the public note
                 ui.heading("3. Public note (optional)");
                 ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
-                    ui.add_space(10.0);
-                    let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .on_hover_text(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
-                        self.public_note = if txt.len() > 0 {
-                            Some(txt)
-                        } else {
-                            None
-                        };
-                    }
-                });
+                if self.group_action_id.is_some() {
+                    ui.label(
+                        "You are signing an existing group Mint so you are not allowed to put a note.",
+                    );
+                    ui.add_space(5.0);
+                    ui.label(format!(
+                        "Note: {}",
+                        self.public_note.clone().unwrap_or("None".to_string())
+                    ));
+                } else {
+                    ui.horizontal(|ui| {
+                        ui.label("Public note (optional):");
+                        ui.add_space(10.0);
+                        let mut txt = self.public_note.clone().unwrap_or_default();
+                        if ui
+                            .text_edit_singleline(&mut txt)
+                            .on_hover_text(
+                                "A note about the transaction that can be seen by the public.",
+                            )
+                            .changed()
+                        {
+                            self.public_note = if txt.len() > 0 {
+                                Some(txt)
+                            } else {
+                                None
+                            };
+                        }
+                    });
+                }
 
                 let button_text = render_group_action_text(
                     ui,

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, RwLock};
-
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use chrono::{DateTime, Utc};
 use dash_sdk::dpp::balances::credits::TokenAmount;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -20,13 +20,13 @@ use dash_sdk::dpp::data_contract::GroupContractPosition;
 use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
-
 use super::tokens_screen::IdentityTokenInfo;
 use crate::app::AppAction;
 use crate::backend_task::tokens::TokenTask;
 use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_contract::QualifiedContract;
+use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
 use crate::ui::components::left_panel::add_left_panel;
@@ -37,7 +37,7 @@ use crate::ui::helpers::render_group_action_text;
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::{MessageType, Screen, ScreenLike};
+use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
@@ -59,8 +59,9 @@ pub struct UpdateTokenConfigScreen {
     pub change_item: TokenConfigurationChangeItem,
     signing_key: Option<IdentityPublicKey>,
     identity: QualifiedIdentity,
-    public_note: Option<String>,
+    pub public_note: Option<String>,
     group: Option<(GroupContractPosition, Group)>,
+    is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
 
     // Input state fields
@@ -153,6 +154,21 @@ impl UpdateTokenConfigScreen {
             }
         };
 
+        let mut is_unilateral_group_member = false;
+        if group.is_some() {
+            if let Some((_, group)) = group.clone() {
+                let your_power = group
+                    .members()
+                    .get(&identity_token_info.identity.identity.id());
+
+                if let Some(your_power) = your_power {
+                    if your_power >= &group.required_power() {
+                        is_unilateral_group_member = true;
+                    }
+                }
+            }
+        };
+
         // Attempt to get an unlocked wallet reference
         let selected_wallet = get_selected_wallet(
             &identity_token_info.identity,
@@ -185,6 +201,7 @@ impl UpdateTokenConfigScreen {
 
             identity: identity_token_info.identity,
             group,
+            is_unilateral_group_member,
             group_action_id: None,
         }
     }
@@ -579,21 +596,30 @@ impl UpdateTokenConfigScreen {
         ui.add_space(10.0);
 
         ui.heading("3. Public note (optional)");
-        ui.add_space(10.0);
-
-        // Render text input for the public note
-        ui.horizontal(|ui| {
-            ui.label("Public note (optional):");
-            ui.add_space(10.0);
-            let mut txt = self.public_note.clone().unwrap_or_default();
-            if ui
-                .text_edit_singleline(&mut txt)
-                .on_hover_text("A note about the transaction that can be seen by the public.")
-                .changed()
-            {
-                self.public_note = if txt.len() > 0 { Some(txt) } else { None };
-            }
-        });
+        ui.add_space(5.0);
+        if self.group_action_id.is_some() {
+            ui.label(
+                "You are signing an existing group ConfigUpdate so you are not allowed to put a note.",
+            );
+            ui.add_space(5.0);
+            ui.label(format!(
+                "Note: {}",
+                self.public_note.clone().unwrap_or("None".to_string())
+            ));
+        } else {
+            ui.horizontal(|ui| {
+                ui.label("Public note (optional):");
+                ui.add_space(10.0);
+                let mut txt = self.public_note.clone().unwrap_or_default();
+                if ui
+                    .text_edit_singleline(&mut txt)
+                    .on_hover_text("A note about the transaction that can be seen by the public.")
+                    .changed()
+                {
+                    self.public_note = if txt.len() > 0 { Some(txt) } else { None };
+                }
+            });
+        }
 
         let button_text = render_group_action_text(
             ui,
@@ -778,21 +804,42 @@ impl UpdateTokenConfigScreen {
 
             ui.heading("🎉");
             if self.group_action_id.is_some() {
-                ui.label("Group Update Signing Successful.");
+                // This ConfigUpdate is already initiated by the group, we are just signing it
+                ui.heading("Group ConfigUpdate Signing Successful.");
             } else {
-                ui.heading(format!("{}", self.backend_message.as_ref().unwrap().0));
+                if !self.is_unilateral_group_member {
+                    ui.heading("Group ConfigUpdate Initiated.");
+                } else {
+                    ui.heading("ConfigUpdate Successful.");
+                }
             }
 
             ui.add_space(20.0);
 
-            let button_text;
             if self.group_action_id.is_some() {
-                button_text = "Back to Group Actions";
+                if ui.button("Back to Group Actions").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::SetMainScreenThenGoToMainScreen(
+                        RootScreenType::RootScreenMyTokenBalances,
+                    );
+                }
             } else {
-                button_text = "Back to Tokens";
-            }
-            if ui.button(button_text).clicked() {
-                action = AppAction::PopScreenAndRefresh;
+                if ui.button("Back to Tokens").clicked() {
+                    action = AppAction::PopScreenAndRefresh;
+                }
+
+                if !self.is_unilateral_group_member {
+                    if ui.button("Go to Group Actions").clicked() {
+                        action = AppAction::PopThenAddScreenToMainScreen(
+                            RootScreenType::RootScreenDocumentQuery,
+                            Screen::GroupActionsScreen(GroupActionsScreen::new(
+                                &self.app_context.clone(),
+                            )),
+                        );
+                    }
+                }
             }
         });
         action

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -660,7 +660,11 @@ impl UpdateTokenConfigScreen {
                         identity_token_info: self.identity_token_info.clone(),
                         change_item: self.change_item.clone(),
                         signing_key: self.signing_key.clone().expect("Signing key must be set"),
-                        public_note: self.public_note.clone(),
+                        public_note: if self.group_action_id.is_some() {
+                            None
+                        } else {
+                            self.public_note.clone()
+                        },
                         group_info,
                     }));
             }


### PR DESCRIPTION
 - Things like saying "Group Mint Initiated" instead of "Mint Successful" when necessary
 - Allow navigation to Group Actions screen after initiating an Action, allow navigation to Tokens screen after signing a Group Action
 - Add ChangePrice to Group Actions Screen
 - Pass PublicNote from Group Actions Screen to Token Action Screen