### PR TITLE
chore: improve "no authentication key" error message

### DIFF
--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -368,7 +368,7 @@ impl ScreenLike for ClaimTokensScreen {
                 ui.colored_label(
                     Color32::RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -517,7 +517,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                 ui.colored_label(
                     Color32::DARK_RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -347,7 +347,7 @@ impl ScreenLike for PurchaseTokenScreen {
                 ui.colored_label(
                     Color32::DARK_RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity_token_info.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -496,7 +496,7 @@ impl ScreenLike for FreezeTokensScreen {
                 ui.colored_label(
                     Color32::RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -538,7 +538,7 @@ impl ScreenLike for MintTokensScreen {
                 ui.colored_label(
                     Color32::DARK_RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity_token_info.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -457,7 +457,7 @@ impl ScreenLike for PauseTokensScreen {
                 ui.colored_label(
                     Color32::RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -456,7 +456,7 @@ impl ScreenLike for ResumeTokensScreen {
                 ui.colored_label(
                     Color32::RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -533,7 +533,7 @@ impl ScreenLike for SetTokenPriceScreen {
                 ui.colored_label(
                     Color32::DARK_RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity_token_info.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -422,7 +422,7 @@ impl ScreenLike for TransferTokensScreen {
                 ui.colored_label(
                     egui::Color32::DARK_RED,
                     format!(
-                        "You do not have any authentication keys loaded for this {} identity.",
+                        "You do not have any authentication keys with CRITICAL security level loaded for this {} identity.",
                         self.identity.identity_type
                     ),
                 );

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -493,7 +493,7 @@ impl ScreenLike for UnfreezeTokensScreen {
                 ui.colored_label(
                     Color32::RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -992,7 +992,7 @@ impl ScreenLike for UpdateTokenConfigScreen {
                 ui.colored_label(
                     Color32::DARK_RED,
                     format!(
-                        "No authentication keys found for this {} identity.",
+                        "No authentication keys with CRITICAL security level found for this {} identity.",
                         self.identity.identity_type,
                     ),
                 );


### PR DESCRIPTION
Made a few messages more clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated error messages throughout the token-related screens to clarify that missing authentication keys must have a CRITICAL security level. This provides clearer feedback to users when required keys are not present for specific actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->