### PR TITLE
fix(tokens): refresh takes forever when no identity defined

### DIFF
--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -37,6 +37,9 @@ pub mod system_task;
 pub mod tokens;
 pub mod update_data_contract;
 
+// TODO: Refactor how we handle errors and messages, and remove it from here
+pub(crate) const NO_IDENTITIES_FOUND: &str = "No identities found";
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum BackendTask {
     IdentityTask(IdentityTask),

--- a/src/backend_task/tokens/query_my_token_balances.rs
+++ b/src/backend_task/tokens/query_my_token_balances.rs
@@ -1,6 +1,6 @@
 //! Query token balances from Platform
 
-use crate::backend_task::BackendTaskSuccessResult;
+use crate::backend_task::{BackendTaskSuccessResult, NO_IDENTITIES_FOUND};
 use crate::context::AppContext;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::platform::tokens::identity_token_balances::{
@@ -11,6 +11,7 @@ use dash_sdk::{dpp::balances::credits::TokenAmount, Sdk};
 use tokio::sync::mpsc;
 
 use crate::app::TaskResult;
+
 impl AppContext {
     pub async fn query_my_token_balances(
         &self,
@@ -22,9 +23,7 @@ impl AppContext {
             .map_err(|e| format!("Failed to load identities: {e}"))?;
 
         if identities.is_empty() {
-            return Ok(BackendTaskSuccessResult::Message(
-                "No identities found".to_string(),
-            ));
+            return Err(NO_IDENTITIES_FOUND.to_string());
         }
 
         for identity in identities {

--- a/src/ui/tokens/tokens_screen.rs
+++ b/src/ui/tokens/tokens_screen.rs
@@ -42,8 +42,8 @@ use enum_iterator::Sequence;
 use image::ImageReader;
 use crate::app::BackendTasksExecutionMode;
 use crate::backend_task::contract::ContractTask;
-use crate::backend_task::tokens::TokenTask;
-use crate::backend_task::BackendTask;
+use crate::backend_task::tokens::{TokenTask};
+use crate::backend_task::{BackendTask, NO_IDENTITIES_FOUND};
 
 use crate::app::{AppAction, DesiredAppAction};
 use crate::context::AppContext;
@@ -5521,10 +5521,16 @@ impl ScreenLike for TokensScreen {
                 if msg.contains("Successfully fetched token balances")
                     | msg.contains("Failed to fetch token balances")
                     | msg.contains("Failed to get estimated rewards")
+                    | msg.eq(NO_IDENTITIES_FOUND)
                 {
                     self.backend_message = Some((msg.to_string(), msg_type, Utc::now()));
                     self.refreshing_status = RefreshingStatus::NotRefreshing;
                 } else {
+                    tracing::debug!(
+                        ?msg,
+                        ?msg_type,
+                        "unsupported message received in token screen"
+                    );
                     return;
                 }
             }
@@ -5796,7 +5802,10 @@ impl ScreenLike for TokensScreen {
             AppAction::Custom(ref s) if s == "Back to tokens from contract" => {
                 self.selected_contract_id = None;
             }
-            _ => {}
+            AppAction::None => {}
+            ref a => {
+                tracing::trace!(action=?a, "tokens screen unsupported action");
+            }
         }
 
         if action == AppAction::None {


### PR DESCRIPTION
Refreshing tokens takes forever when no identity is loaded.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for token balance queries by displaying an explicit error message when no identities are found.
- **Refactor**
	- Updated internal message handling to better distinguish between supported and unsupported messages or actions in the tokens screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->