### PR TITLE
feat: autodetect dash-qt binary location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which 7.0.3",
  "zeroize",
  "zeromq",
  "zmq",
@@ -2385,6 +2386,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -4053,7 +4060,7 @@ dependencies = [
  "thiserror 1.0.69",
  "versions",
  "wfd",
- "which",
+ "which 4.4.2",
  "winapi",
 ]
 
@@ -7498,6 +7505,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8018,6 +8037,12 @@ checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ aes-gcm = "0.10" # For AES-256-GCM encryption
 crossbeam-channel = "0.5.13"
 regex = "1.11"
 humantime = "2.2.0"
+which = { version = "7.0.3" }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 zmq = "0.10"

--- a/src/app.rs
+++ b/src/app.rs
@@ -188,12 +188,16 @@ impl AppState {
             TokensScreen::new(&mainnet_app_context, TokensSubscreen::TokenCreator);
 
         let (custom_dash_qt_path, overwrite_dash_conf) = match settings.clone() {
-            Some((.., db_custom_dash_qt_path, db_overwrite_dash_qt)) => {
-                (db_custom_dash_qt_path, db_overwrite_dash_qt)
+            Some((.., Some(db_custom_dash_qt_path), db_overwrite_dash_qt)) => {
+                (Some(db_custom_dash_qt_path), db_overwrite_dash_qt)
             }
             _ => {
-                // Default values: Use system default path and overwrite conf
-                (None, true)
+                // Find `dash-qt` executable in the system PATH as default, and overwrite dash.conf
+                let dash_qt = which::which("dash-qt")
+                    .map(|path| path.to_string_lossy().to_string())
+                    .inspect_err(|e| tracing::warn!("failed to find dash-qt: {}", e))
+                    .ok();
+                (dash_qt, true)
             }
         };
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -88,6 +88,18 @@ impl NetworkChooserScreen {
         self.context_for_network(self.current_network)
     }
 
+    /// Save the current settings to the database
+    ///
+    /// TODO: doesn't save local network settings like password yet.
+    fn save(&self) -> Result<(), String> {
+        self.current_app_context()
+            .db
+            .update_dash_core_execution_settings(
+                self.custom_dash_qt_path.clone(),
+                self.overwrite_dash_conf,
+            )
+            .map_err(|e| e.to_string())
+    }
     /// Render the network selection table
     fn render_network_table(&mut self, ui: &mut Ui) -> AppAction {
         let mut app_action = AppAction::None;
@@ -149,7 +161,7 @@ impl NetworkChooserScreen {
                                         if file_name.ends_with(required_file_name.as_str()) {
                                             self.custom_dash_qt_path = Some(path.display().to_string());
                                             self.custom_dash_qt_error_message = None;
-                                            self.current_app_context().db.update_dash_core_execution_settings(self.custom_dash_qt_path.clone(), self.overwrite_dash_conf).expect("Expected to save db settings");
+                                            self.save().expect("Expected to save db settings");
                                         } else {
                                             self.custom_dash_qt_error_message = Some(format!("Invalid file: Please select a valid '{}'.", required_file_name));
                                         }
@@ -169,12 +181,13 @@ impl NetworkChooserScreen {
                             if ui.button("clear").clicked() {
                                 self.custom_dash_qt_path = None;
                                 self.custom_dash_qt_error_message = None;
+                                self.save().expect("Expected to save db settings");                                
                             }
                         }
                         ui.end_row();
 
                         if ui.checkbox(&mut self.overwrite_dash_conf, "Overwrite dash.conf").clicked() {
-                            self.current_app_context().db.update_dash_core_execution_settings(self.custom_dash_qt_path.clone(), self.overwrite_dash_conf).expect("Expected to save db settings");
+                            self.save().expect("Expected to save db settings");
                         }
                         if !self.overwrite_dash_conf {
                             ui.end_row();


### PR DESCRIPTION
This pull request introduces several enhancements to improve the handling of `dash-qt` executable paths and database settings, as well as refactoring for better code maintainability. The most important changes include adding the `which` crate for locating executables, modifying the logic for determining default `dash-qt` paths, and refactoring repeated database update calls into a new `save` method.

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R55): Added the `which` crate (`version = "7.0.3"`) to enable system PATH searches for executables.

### Enhancements to `dash-qt` Path Handling:
* [`src/app.rs`](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L191-R200): Updated the logic to use the `which` crate for locating the `dash-qt` executable in the system PATH as a default value when no custom path is provided. This includes error handling with logging for failed searches.

### Code Refactoring for Database Updates:
* [`src/ui/network_chooser_screen.rs`](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bR91-R102): Introduced a new `save` method in `NetworkChooserScreen` to encapsulate database update logic for `dash-core` execution settings. This method improves code reuse and readability.
* [`src/ui/network_chooser_screen.rs`](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL152-R164): Replaced direct database update calls with the new `save` method in multiple places, including file selection validation, clearing the custom path, and toggling the `overwrite dash.conf` checkbox. [[1]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL152-R164) [[2]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bR184-R190)