### PR TITLE
feat: dev mode toggle and disable screens for mainnet

### DIFF
--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -4,6 +4,7 @@ use crate::ui::RootScreenType;
 use eframe::epaint::{Color32, Margin};
 use egui::{Context, Frame, ImageButton, SidePanel, TextureHandle};
 use rust_embed::RustEmbed;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 #[derive(RustEmbed)]
@@ -112,9 +113,13 @@ pub fn add_left_panel(
 
                 // Push content to the top and dev label to the bottom
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-                    if app_context.developer_mode {
+                    if app_context.developer_mode.load(Ordering::Relaxed) {
                         ui.add_space(10.0);
-                        ui.label("Dev mode");
+                        if ui.label("Dev mode").clicked() {
+                            action = AppAction::SetMainScreenThenGoToMainScreen(
+                                RootScreenType::RootScreenNetworkChooser,
+                            );
+                        };
                     }
                 });
             });

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -10,6 +10,7 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{BackendTaskSuccessResult, MessageType, RootScreenType, ScreenLike, ScreenType};
 use crate::utils::parsers::{DocumentQueryTextInputParser, TextInputParser};
 use chrono::{DateTime, Utc};
+use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dash_sdk::dpp::data_contract::document_type::{DocumentType, Index};
@@ -612,23 +613,43 @@ impl ScreenLike for DocumentQueryScreen {
             "Group Actions",
             DesiredAppAction::AddScreenType(ScreenType::GroupActions),
         );
-        let mut action = add_top_panel(
-            ctx,
-            &self.app_context,
-            vec![("Contracts", AppAction::None)],
-            vec![
-                load_contract_button,
-                register_contract_button,
-                update_contract_button,
-                add_document_button,
-                delete_document_button,
-                replace_document_button,
-                transfer_document_button,
-                purchase_document_button,
-                set_document_price_button,
-                group_actions_button,
-            ],
-        );
+        let mut action = AppAction::None;
+        if self.app_context.network == Network::Dash {
+            action |= add_top_panel(
+                ctx,
+                &self.app_context,
+                vec![("Contracts", AppAction::None)],
+                vec![
+                    load_contract_button,
+                    register_contract_button,
+                    update_contract_button,
+                    add_document_button,
+                    delete_document_button,
+                    replace_document_button,
+                    transfer_document_button,
+                    purchase_document_button,
+                    set_document_price_button,
+                ],
+            );
+        } else {
+            action |= add_top_panel(
+                ctx,
+                &self.app_context,
+                vec![("Contracts", AppAction::None)],
+                vec![
+                    load_contract_button,
+                    register_contract_button,
+                    update_contract_button,
+                    add_document_button,
+                    delete_document_button,
+                    replace_document_button,
+                    transfer_document_button,
+                    purchase_document_button,
+                    set_document_price_button,
+                    group_actions_button,
+                ],
+            );
+        }
 
         action |= add_left_panel(
             ctx,

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -18,6 +18,7 @@ use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, TextEdit};
 use egui::{RichText, ScrollArea, Ui};
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -179,8 +180,8 @@ impl RegisterDataContractScreen {
 
         // Key selection
         if let Some(ref qid) = self.selected_qualified_identity {
-            // Attempt to list available keys (only auth keys in normal mode)
-            let keys = if self.app_context.developer_mode {
+            // Attempt to self.app_context.developer_mode.load(Ordering::Relaxed) eys in normal mode)
+            let keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 qid.0
                     .identity
                     .public_keys()

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -180,7 +180,7 @@ impl RegisterDataContractScreen {
 
         // Key selection
         if let Some(ref qid) = self.selected_qualified_identity {
-            // Attempt to self.app_context.developer_mode.load(Ordering::Relaxed) eys in normal mode)
+            // Attempt to list available keys (only auth keys in normal mode)
             let keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 qid.0
                     .identity

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -18,6 +18,7 @@ use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, TextEdit};
+use std::sync::atomic::Ordering;
 use egui::{RichText, ScrollArea, Ui};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -210,7 +211,7 @@ impl UpdateDataContractScreen {
         // Key selection
         if let Some(ref qid) = self.selected_qualified_identity {
             // Attempt to list available keys (only auth keys in normal mode)
-            let keys = if self.app_context.developer_mode {
+            let keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 qid.0
                     .identity
                     .public_keys()

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -17,6 +17,7 @@ use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Context, Ui};
 use egui::{Color32, RichText};
 use std::sync::{Arc, RwLock};
+use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
@@ -86,7 +87,7 @@ impl TransferScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         for key in self.identity.identity.public_keys().values() {
                             let label =
                                 format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
@@ -292,7 +293,7 @@ impl ScreenLike for TransferScreen {
             ui.heading("Transfer Funds");
             ui.add_space(10.0);
 
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self.identity.available_transfer_keys().is_empty()

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -18,6 +18,7 @@ use dash_sdk::dpp::prelude::TimestampMillis;
 use dash_sdk::platform::IdentityPublicKey;
 use eframe::egui::{self, Context, Ui};
 use egui::{Color32, RichText};
+use std::sync::atomic::Ordering;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -88,7 +89,7 @@ impl WithdrawalScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         for key in self.identity.identity.public_keys().values() {
                             let label =
                                 format!("Key ID: {} (Purpose: {:?})", key.id(), key.purpose());
@@ -136,7 +137,7 @@ impl WithdrawalScreen {
         } else {
             true
         };
-        if can_have_withdrawal_address || self.app_context.developer_mode {
+        if can_have_withdrawal_address || self.app_context.developer_mode.load(Ordering::Relaxed) {
             ui.horizontal(|ui| {
                 ui.label("Address:");
 
@@ -185,7 +186,7 @@ impl WithdrawalScreen {
                     .masternode_payout_address(self.app_context.network)
                 {
                     format!("masternode payout address {}", payout_address)
-                } else if !self.app_context.developer_mode {
+                } else if !self.app_context.developer_mode.load(Ordering::Relaxed) {
                     self.withdraw_from_identity_status = WithdrawFromIdentityStatus::ErrorMessage(
                         "No masternode payout address".to_string(),
                     );
@@ -324,7 +325,7 @@ impl ScreenLike for WithdrawalScreen {
             ui.heading("Withdraw Funds");
             ui.add_space(10.0);
 
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self.identity.available_withdrawal_keys().is_empty()

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -1,7 +1,7 @@
-use std::collections::HashSet;
-use std::sync::{Arc, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-
+use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
+use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
+use crate::ui::helpers::render_group_action_text;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
@@ -10,18 +10,17 @@ use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
 use dash_sdk::dpp::data_contract::group::Group;
 use dash_sdk::dpp::data_contract::GroupContractPosition;
 use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoStatus};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
-use egui::RichText;
-
-use crate::ui::components::left_panel::add_left_panel;
-use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
-use crate::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
-use crate::ui::helpers::render_group_action_text;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
+use eframe::egui::{self, Color32, Context, Ui};
+use egui::RichText;
+use std::collections::HashSet;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::tokens::TokenTask;
@@ -203,7 +202,7 @@ impl BurnTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self
                             .identity_token_info
@@ -490,7 +489,7 @@ impl ScreenLike for BurnTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self
                     .identity_token_info
                     .identity
@@ -640,7 +639,7 @@ impl ScreenLike for BurnTokensScreen {
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Burn", &self.group_action_id);
 
                 // Burn button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -2,6 +2,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
+use std::sync::atomic::Ordering;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -129,7 +130,7 @@ impl ClaimTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -358,7 +359,7 @@ impl ScreenLike for ClaimTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self.identity.available_authentication_keys_with_critical_security_level().is_empty()

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -212,7 +213,7 @@ impl DestroyFrozenFundsScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -504,7 +505,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self
@@ -640,7 +641,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                 );
 
                 // Destroy button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
+use std::sync::atomic::Ordering;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use dash_sdk::dpp::fee::Credits;
@@ -105,7 +106,7 @@ impl PurchaseTokenScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self
                             .identity_token_info
@@ -328,7 +329,7 @@ impl ScreenLike for PurchaseTokenScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self
                     .identity_token_info
                     .identity

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -204,7 +205,7 @@ impl FreezeTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -483,7 +484,7 @@ impl ScreenLike for FreezeTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self
@@ -615,7 +616,7 @@ impl ScreenLike for FreezeTokensScreen {
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Freeze", &self.group_action_id);
 
                 // Freeze button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -202,7 +203,7 @@ impl MintTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self
                             .identity_token_info
@@ -523,7 +524,7 @@ impl ScreenLike for MintTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self
                     .identity_token_info
                     .identity
@@ -629,7 +630,7 @@ impl ScreenLike for MintTokensScreen {
                     .token_config
                     .distribution_rules()
                     .minting_allow_choosing_destination()
-                    || self.app_context.developer_mode
+                    || self.app_context.developer_mode.load(Ordering::Relaxed)
                 {
                     ui.add_space(10.0);
                     ui.separator();
@@ -691,7 +692,7 @@ impl ScreenLike for MintTokensScreen {
                     render_group_action_text(ui, &self.group, &self.identity_token_info, "Mint", &self.group_action_id);
 
                 // Mint button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::Identifier;
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -198,7 +199,7 @@ impl PauseTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -444,7 +445,7 @@ impl ScreenLike for PauseTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self
@@ -559,7 +560,7 @@ impl ScreenLike for PauseTokensScreen {
                 );
 
                 // Pause button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::Identifier;
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -197,7 +198,7 @@ impl ResumeTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -443,7 +444,7 @@ impl ScreenLike for ResumeTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self
@@ -558,7 +559,7 @@ impl ScreenLike for ResumeTokensScreen {
                 );
 
                 // Resume button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -31,6 +31,7 @@ use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Color32, Context, Ui};
 use egui::RichText;
 use std::collections::HashSet;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -201,7 +202,7 @@ impl SetTokenPriceScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self
                             .identity_token_info
@@ -523,7 +524,7 @@ impl ScreenLike for SetTokenPriceScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity_token_info.identity.identity.public_keys().is_empty()
             } else {
                 !self.identity_token_info.identity.available_authentication_keys_with_critical_security_level().is_empty()

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -18,6 +18,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::TimestampMillis;
+use std::sync::atomic::Ordering;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Context, Ui};
 use egui::{Color32, RichText};
@@ -130,7 +131,7 @@ impl TransferTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -409,7 +410,7 @@ impl ScreenLike for TransferTokensScreen {
             ));
             ui.add_space(10.0);
 
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -18,6 +18,7 @@ use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
+use std::sync::atomic::Ordering;
 use dash_sdk::dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
 use dash_sdk::dpp::data_contract::group::accessors::v0::GroupV0Getters;
 use dash_sdk::dpp::data_contract::group::Group;
@@ -204,7 +205,7 @@ impl UnfreezeTokensScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -480,7 +481,7 @@ impl ScreenLike for UnfreezeTokensScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self
@@ -617,7 +618,7 @@ impl ScreenLike for UnfreezeTokensScreen {
                 );
 
                 // Unfreeze button
-                if self.app_context.developer_mode || !button_text.contains("Test") {
+                if self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test") {
                     ui.add_space(10.0);
                     let button =
                         egui::Button::new(RichText::new(button_text).color(Color32::WHITE))

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -18,6 +18,7 @@ use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
 use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 use chrono::{DateTime, Utc};
 use dash_sdk::dpp::balances::credits::TokenAmount;
+use std::sync::atomic::Ordering;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
 use dash_sdk::dpp::data_contract::associated_token::token_configuration::accessors::v0::TokenConfigurationV0Getters;
@@ -790,7 +791,7 @@ impl UpdateTokenConfigScreen {
             .frame(true)
             .corner_radius(3.0);
 
-        if (self.app_context.developer_mode || !button_text.contains("Test"))
+        if (self.app_context.developer_mode.load(Ordering::Relaxed) || !button_text.contains("Test"))
             && self.change_item != TokenConfigurationChangeItem::TokenConfigurationNoChange
         {
             ui.add_space(20.0);
@@ -1002,7 +1003,7 @@ impl UpdateTokenConfigScreen {
                     None => "Select a key".to_string(),
                 })
                 .show_ui(ui, |ui| {
-                    if self.app_context.developer_mode {
+                    if self.app_context.developer_mode.load(Ordering::Relaxed) {
                         // Show all loaded public keys
                         for key in self.identity.identity.public_keys().values() {
                             let is_valid = key.purpose() == Purpose::AUTHENTICATION
@@ -1122,7 +1123,7 @@ impl ScreenLike for UpdateTokenConfigScreen {
             ui.add_space(10.0);
 
             // Check if user has any auth keys
-            let has_keys = if self.app_context.developer_mode {
+            let has_keys = if self.app_context.developer_mode.load(Ordering::Relaxed) {
                 !self.identity.identity.public_keys().is_empty()
             } else {
                 !self


### PR DESCRIPTION
Add a toggle in settings screen to enable disable dev mode. Dev mode text at bottom left is clickable when dev mode is on. 

Disable token screens and group actions screens if network == mainnet (temporary while we are on testnet)