### PR TITLE
feat: update group action headings for clarity and consistency

### DIFF
--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -372,7 +372,7 @@ impl BurnTokensScreen {
                 // This burn is already initiated by the group, we are just signing it
                 ui.heading("Group Burn Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
+                if !self.is_unilateral_group_member && self.group.is_some() {
                     ui.heading("Group Burn Initiated.");
                 } else {
                     ui.heading("Burn Successful.");

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -381,12 +381,12 @@ impl DestroyFrozenFundsScreen {
             ui.heading("🎉");
             if self.group_action_id.is_some() {
                 // This destroy is already initiated by the group, we are just signing it
-                ui.heading("Group Destroy Signing Successful.");
+                ui.heading("Group Destroy Frozen Funds Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
-                    ui.heading("Group Destroy Initiated.");
+                if !self.is_unilateral_group_member && self.group.is_some() {
+                    ui.heading("Group Action to Destroy Frozen Funds Initiated.");
                 } else {
-                    ui.heading("Destroy Successful.");
+                    ui.heading("Frozen Funds Destroyed Successfully.");
                 }
             }
 

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -365,12 +365,12 @@ impl FreezeTokensScreen {
             ui.heading("🎉");
             if self.group_action_id.is_some() {
                 // This freeze is already initiated by the group, we are just signing it
-                ui.heading("Group Freeze Signing Successful.");
+                ui.heading("Group Freeze of Identity Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
-                    ui.heading("Group Freeze Initiated.");
+                if !self.is_unilateral_group_member && self.group.is_some() {
+                    ui.heading("Group Freeze of Identity Initiated.");
                 } else {
-                    ui.heading("Freeze Successful.");
+                    ui.heading("Freeze of Identity Successful.");
                 }
             }
 

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -405,7 +405,7 @@ impl MintTokensScreen {
                 // This mint is already initiated by the group, we are just signing it
                 ui.heading("Group Mint Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
+                if !self.is_unilateral_group_member && self.group.is_some() {
                     ui.heading("Group Mint Initiated.");
                 } else {
                     ui.heading("Mint Successful.");

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -328,7 +328,7 @@ impl PauseTokensScreen {
                 // This Pause is already initiated by the group, we are just signing it
                 ui.heading("Group Pause Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
+                if !self.is_unilateral_group_member && self.group.is_some() {
                     ui.heading("Group Pause Initiated.");
                 } else {
                     ui.heading("Pause Successful.");

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -327,7 +327,7 @@ impl ResumeTokensScreen {
                 // This resume is already initiated by the group, we are just signing it
                 ui.heading("Group Resume Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
+                if !self.is_unilateral_group_member && self.group.is_some() {
                     ui.heading("Group Resume Initiated.");
                 } else {
                     ui.heading("Resume Successful.");

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -401,12 +401,12 @@ impl SetTokenPriceScreen {
             ui.heading("🎉");
             if self.group_action_id.is_some() {
                 // This is already initiated by the group, we are just signing it
-                ui.heading("Group SetPrice Signing Successful.");
+                ui.heading("Group Action to Set Price Signed Successfully.");
             } else {
-                if !self.is_unilateral_group_member {
-                    ui.heading("Group SetPrice Initiated.");
+                if !self.is_unilateral_group_member && self.group.is_some() {
+                    ui.heading("Group Action to Set Price Initiated.");
                 } else {
-                    ui.heading("SetPrice Successful.");
+                    ui.heading("Set Price of Token Successfully.");
                 }
             }
 

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -364,10 +364,10 @@ impl UnfreezeTokensScreen {
                 // This is already initiated by the group, we are just signing it
                 ui.heading("Group Unfreeze Signing Successful.");
             } else {
-                if !self.is_unilateral_group_member {
+                if !self.is_unilateral_group_member && self.group.is_some() {
                     ui.heading("Group Unfreeze Initiated.");
                 } else {
-                    ui.heading("Unfreeze Successful.");
+                    ui.heading("Unfroze Identity Successfully.");
                 }
             }
 


### PR DESCRIPTION
Updated UI headings across multiple screens to enhance clarity and consistency regarding group actions. The changes ensure that headings accurately reflect the specific action being performed, particularly when initiated by a group. This improves user understanding of the action's context and outcome. 

Key changes include:
- Updated headings for group actions in burn, destroy, freeze, mint, pause, resume, set price, and unfreeze screens to specify the nature of the action.
- Ensured consistent messaging regarding unilateral group membership and the presence of a group.