### PR TITLE
feat: add multiple Linux build variants for GLIBC compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release Dash Evo Tool
 on:
   push:
     tags:
-      - 'v*'
-      - 'v*-dev.*'
+      - "v*"
+      - "v*-dev.*"
   release:
     types:
       - published
@@ -13,6 +13,11 @@ on:
       tag:
         description: "Version (i.e. v0.1.0)"
         required: true
+      create_release:
+        description: "Create GitHub Release (check to publish release)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   id-token: write
@@ -31,35 +36,35 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
             platform: "x86_64-linux"
             build-type: "modern"
-          
+
           # Linux x86_64 - Compatible build (Ubuntu 20.04, GLIBC 2.31)
           - name: "linux-x86_64-compat"
             runs-on: "ubuntu-20.04"
             target: "x86_64-unknown-linux-gnu"
             platform: "x86_64-linux-compat"
             build-type: "compat"
-          
+
           # Linux ARM64 - Modern build
           - name: "linux-arm64"
             runs-on: "ubuntu-22.04-arm"
             target: "aarch64-unknown-linux-gnu"
             platform: "arm64-linux"
             build-type: "modern"
-          
+
           # Linux ARM64 - Compatible build
           - name: "linux-arm64-compat"
             runs-on: "ubuntu-20.04-arm"
             target: "aarch64-unknown-linux-gnu"
             platform: "arm64-linux-compat"
             build-type: "compat"
-          
+
           # AppImage x86_64 build
           - name: "linux-x86_64-appimage"
             runs-on: "ubuntu-20.04"
             target: "x86_64-unknown-linux-gnu"
             platform: "x86_64-linux-appimage"
             build-type: "appimage"
-          
+
           # macOS builds
           - name: "macos-x86_64"
             runs-on: "macos-13"
@@ -69,7 +74,7 @@ jobs:
             runs-on: "macos-latest"
             target: "aarch64-apple-darwin"
             platform: "arm64-mac"
-          
+
           # Windows build
           - name: "Windows"
             runs-on: "ubuntu-24.04"
@@ -181,12 +186,12 @@ jobs:
           mkdir -p AppDir/usr/bin
           mkdir -p AppDir/usr/share/applications
           mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-          
+
           # Copy binary and resources
           cp dash-evo-tool/dash-evo-tool AppDir/usr/bin/
           cp -r dash-evo-tool/dash_core_configs AppDir/usr/bin/
           cp dash-evo-tool/.env AppDir/usr/bin/
-          
+
           # Create desktop file
           cat > AppDir/usr/share/applications/dash-evo-tool.desktop << EOF
           [Desktop Entry]
@@ -197,10 +202,10 @@ jobs:
           Categories=Utility;
           X-AppImage-Version=${{ github.ref_name }}
           EOF
-          
+
           # Copy the app icon
           cp mac_os/AppIcons/Assets.xcassets/AppIcon.appiconset/256.png AppDir/usr/share/icons/hicolor/256x256/apps/dash-evo-tool.png
-          
+
           # Create AppRun script
           cat > AppDir/AppRun << 'EOF'
           #!/bin/bash
@@ -212,10 +217,10 @@ jobs:
           exec "${HERE}/usr/bin/dash-evo-tool" "$@"
           EOF
           chmod +x AppDir/AppRun
-          
+
           # Use linuxdeploy to create AppImage
           linuxdeploy --appdir AppDir --output appimage
-          
+
           # Move the generated AppImage
           mv Dash_Evo_Tool*.AppImage dash-evo-tool.AppImage
 
@@ -233,7 +238,7 @@ jobs:
       - name: Attest
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: 'dash-evo-tool-${{ matrix.platform }}.zip'
+          subject-path: "dash-evo-tool-${{ matrix.platform }}.zip"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -245,6 +250,9 @@ jobs:
     name: Create GitHub Release
     needs: build-and-release
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'true')
     steps:
       # Download all Linux variants
       - name: Download Linux AMD64 Modern
@@ -267,7 +275,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dash-evo-tool-arm64-linux-compat.zip
-      
+
       # Download macOS and Windows
       - name: Download MacOS AMD64 Artifact
         uses: actions/download-artifact@v4
@@ -301,17 +309,17 @@ jobs:
           prerelease: true
           body: |
             ## Linux Build Variants
-            
+
             This release includes multiple Linux build variants to ensure compatibility:
-            
+
             ### Standard Builds
             - **x86_64-linux**: Built on Ubuntu 24.04 (requires GLIBC 2.39+)
             - **arm64-linux**: Built on Ubuntu 22.04 ARM
-            
+
             ### Compatible Builds (Recommended for older systems)
             - **x86_64-linux-compat**: Built on Ubuntu 20.04 (requires GLIBC 2.31+, compatible with most distributions from 2020+)
             - **arm64-linux-compat**: Built on Ubuntu 20.04 ARM
-            
+
             ### AppImage (Most Compatible)
             - **x86_64-linux-appimage**: Self-contained AppImage with all dependencies bundled. Works on most Linux distributions.
               

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,42 @@ jobs:
     strategy:
       matrix:
         include:
+          # Linux x86_64 - Modern build (Ubuntu 24.04, GLIBC 2.39)
           - name: "linux-x86_64"
             runs-on: "ubuntu-24.04"
             target: "x86_64-unknown-linux-gnu"
             platform: "x86_64-linux"
+            build-type: "modern"
+          
+          # Linux x86_64 - Compatible build (Ubuntu 20.04, GLIBC 2.31)
+          - name: "linux-x86_64-compat"
+            runs-on: "ubuntu-20.04"
+            target: "x86_64-unknown-linux-gnu"
+            platform: "x86_64-linux-compat"
+            build-type: "compat"
+          
+          # Linux ARM64 - Modern build
           - name: "linux-arm64"
             runs-on: "ubuntu-22.04-arm"
             target: "aarch64-unknown-linux-gnu"
             platform: "arm64-linux"
+            build-type: "modern"
+          
+          # Linux ARM64 - Compatible build
+          - name: "linux-arm64-compat"
+            runs-on: "ubuntu-20.04-arm"
+            target: "aarch64-unknown-linux-gnu"
+            platform: "arm64-linux-compat"
+            build-type: "compat"
+          
+          # AppImage x86_64 build
+          - name: "linux-x86_64-appimage"
+            runs-on: "ubuntu-20.04"
+            target: "x86_64-unknown-linux-gnu"
+            platform: "x86_64-linux-appimage"
+            build-type: "appimage"
+          
+          # macOS builds
           - name: "macos-x86_64"
             runs-on: "macos-13"
             target: "x86_64-apple-darwin"
@@ -41,6 +69,8 @@ jobs:
             runs-on: "macos-latest"
             target: "aarch64-apple-darwin"
             platform: "arm64-mac"
+          
+          # Windows build
           - name: "Windows"
             runs-on: "ubuntu-24.04"
             target: "x86_64-pc-windows-gnu"
@@ -64,7 +94,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-
       - name: Setup prerequisites
         run: |
           mkdir -p dash-evo-tool/
@@ -80,16 +109,35 @@ jobs:
 
       - name: Install essentials
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config clang cmake unzip libsqlite3-dev gcc-mingw-w64 mingw-w64 libsqlite3-dev mingw-w64-x86-64-dev gcc-aarch64-linux-gnu zip && uname -a && cargo clean
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential pkg-config clang cmake unzip libsqlite3-dev zip
+          if [ "${{ matrix.target }}" = "x86_64-pc-windows-gnu" ]; then
+            sudo apt-get install -y gcc-mingw-w64 mingw-w64 mingw-w64-x86-64-dev
+          fi
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ] && [ "${{ runner.arch }}" != "ARM64" ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu
+          fi
+          uname -a && cargo clean
+
+      # Install AppImage tools for AppImage builds
+      - name: Install AppImage tools
+        if: ${{ matrix.build-type == 'appimage' }}
+        run: |
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          sudo mv linuxdeploy-x86_64.AppImage /usr/local/bin/linuxdeploy
+          # Install additional dependencies that might be needed at runtime
+          sudo apt-get install -y libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-xkb-dev libxkbcommon-x11-dev
 
       - name: Install protoc (ARM)
-        if: ${{ matrix.platform == 'arm64-linux' }}
+        if: ${{ matrix.platform == 'arm64-linux' || matrix.platform == 'arm64-linux-compat' }}
         run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-aarch_64.zip && sudo unzip -o protoc-25.2-linux-aarch_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-aarch_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-aarch_64.zip
         env:
           PROTOC: /usr/local/bin/protoc
 
-      - name: Install protoc (AMD)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
+      - name: Install protoc (AMD/AppImage)
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.build-type == 'appimage' }}
         run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip
         env:
           PROTOC: /usr/local/bin/protoc
@@ -125,9 +173,62 @@ jobs:
           AR_x86_64_pc_windows_gnu: x86_64-w64-mingw32-ar
           CFLAGS_x86_64_pc_windows_gnu: "-O2"
 
+      # Create AppImage
+      - name: Create AppImage
+        if: ${{ matrix.build-type == 'appimage' }}
+        run: |
+          # Create AppDir structure
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/share/applications
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+          
+          # Copy binary and resources
+          cp dash-evo-tool/dash-evo-tool AppDir/usr/bin/
+          cp -r dash-evo-tool/dash_core_configs AppDir/usr/bin/
+          cp dash-evo-tool/.env AppDir/usr/bin/
+          
+          # Create desktop file
+          cat > AppDir/usr/share/applications/dash-evo-tool.desktop << EOF
+          [Desktop Entry]
+          Name=Dash Evo Tool
+          Exec=dash-evo-tool
+          Icon=dash-evo-tool
+          Type=Application
+          Categories=Utility;
+          X-AppImage-Version=${{ github.ref_name }}
+          EOF
+          
+          # Copy the app icon
+          cp mac_os/AppIcons/Assets.xcassets/AppIcon.appiconset/256.png AppDir/usr/share/icons/hicolor/256x256/apps/dash-evo-tool.png
+          
+          # Create AppRun script
+          cat > AppDir/AppRun << 'EOF'
+          #!/bin/bash
+          SELF=$(readlink -f "$0")
+          HERE=${SELF%/*}
+          export PATH="${HERE}/usr/bin:${PATH}"
+          export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"
+          cd "${HERE}/usr/bin"
+          exec "${HERE}/usr/bin/dash-evo-tool" "$@"
+          EOF
+          chmod +x AppDir/AppRun
+          
+          # Use linuxdeploy to create AppImage
+          linuxdeploy --appdir AppDir --output appimage
+          
+          # Move the generated AppImage
+          mv Dash_Evo_Tool*.AppImage dash-evo-tool.AppImage
+
       - name: Package release
+        if: ${{ matrix.build-type != 'appimage' }}
         run: |
           zip -r dash-evo-tool-${{ matrix.platform }}.zip dash-evo-tool/
+
+      - name: Package AppImage
+        if: ${{ matrix.build-type == 'appimage' }}
+        run: |
+          # AppImage is already a single file, just create a zip for consistency
+          zip dash-evo-tool-${{ matrix.platform }}.zip dash-evo-tool.AppImage
 
       - name: Attest
         uses: actions/attest-build-provenance@v1
@@ -145,14 +246,29 @@ jobs:
     needs: build-and-release
     runs-on: ubuntu-latest
     steps:
-      - name: Download Linux AMD64 Artifact
+      # Download all Linux variants
+      - name: Download Linux AMD64 Modern
         uses: actions/download-artifact@v4
         with:
           name: dash-evo-tool-x86_64-linux.zip
-      - name: Download Linux Arm64 Artifact
+      - name: Download Linux AMD64 Compatible
+        uses: actions/download-artifact@v4
+        with:
+          name: dash-evo-tool-x86_64-linux-compat.zip
+      - name: Download Linux AMD64 AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: dash-evo-tool-x86_64-linux-appimage.zip
+      - name: Download Linux ARM64 Modern
         uses: actions/download-artifact@v4
         with:
           name: dash-evo-tool-arm64-linux.zip
+      - name: Download Linux ARM64 Compatible
+        uses: actions/download-artifact@v4
+        with:
+          name: dash-evo-tool-arm64-linux-compat.zip
+      
+      # Download macOS and Windows
       - name: Download MacOS AMD64 Artifact
         uses: actions/download-artifact@v4
         with:
@@ -174,9 +290,32 @@ jobs:
           tag_name: ${{ github.event.inputs.tag }}
           files: |
             ./dash-evo-tool-x86_64-linux.zip
+            ./dash-evo-tool-x86_64-linux-compat.zip
+            ./dash-evo-tool-x86_64-linux-appimage.zip
             ./dash-evo-tool-arm64-linux.zip
+            ./dash-evo-tool-arm64-linux-compat.zip
             ./dash-evo-tool-x86_64-mac.zip
             ./dash-evo-tool-arm64-mac.zip
             ./dash-evo-tool-windows.zip
           draft: false
           prerelease: true
+          body: |
+            ## Linux Build Variants
+            
+            This release includes multiple Linux build variants to ensure compatibility:
+            
+            ### Standard Builds
+            - **x86_64-linux**: Built on Ubuntu 24.04 (requires GLIBC 2.39+)
+            - **arm64-linux**: Built on Ubuntu 22.04 ARM
+            
+            ### Compatible Builds (Recommended for older systems)
+            - **x86_64-linux-compat**: Built on Ubuntu 20.04 (requires GLIBC 2.31+, compatible with most distributions from 2020+)
+            - **arm64-linux-compat**: Built on Ubuntu 20.04 ARM
+            
+            ### AppImage (Most Compatible)
+            - **x86_64-linux-appimage**: Self-contained AppImage with all dependencies bundled. Works on most Linux distributions.
+              
+            **Which version should I use?**
+            - Try the **-compat** version first if you're on an older Linux distribution
+            - Use the **AppImage** if you encounter any dependency issues
+            - The standard builds offer the best performance on modern systems

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
             build-type: "appimage"
 
           # AppImage ARM64
-          - name: "linux-arm64-compat"
+          - name: "linux-arm64-appimage"
             runs-on: "ubuntu-24.04-arm"
             target: "aarch64-unknown-linux-gnu"
             platform: "arm64-linux-appimage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,8 @@ jobs:
         if: ${{ matrix.build-type == 'appimage' && matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
           wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-aarch64.AppImage
-          chmod +x linuxdeploy-x86_64.AppImage
-          sudo mv linuxdeploy-x86_64.AppImage /usr/local/bin/linuxdeploy
+          chmod +x linuxdeploy-aarch64.AppImage
+          sudo mv linuxdeploy-aarch64.AppImage /usr/local/bin/linuxdeploy
           # Install additional dependencies that might be needed at runtime
           sudo apt-get install -y libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-xkb-dev libxkbcommon-x11-dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
           # AppImage x86_64 build
           - name: "linux-x86_64-appimage"
-            runs-on: "ubuntu-20.04"
+            runs-on: "ubuntu-24.04"
             target: "x86_64-unknown-linux-gnu"
             platform: "x86_64-linux-appimage"
             build-type: "appimage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,13 +143,13 @@ jobs:
           sudo apt-get install -y libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-xkb-dev libxkbcommon-x11-dev
 
       - name: Install protoc (ARM)
-        if: ${{ matrix.platform == 'arm64-linux' || matrix.platform == 'arm64-linux-compat' }}
+        if: ${{ matrix.platform == 'arm64-linux' || matrix.platform == 'arm64-linux-compat' || matrix.platform == 'arm64-linux-appimage' }}
         run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-aarch_64.zip && sudo unzip -o protoc-25.2-linux-aarch_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-aarch_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-aarch_64.zip
         env:
           PROTOC: /usr/local/bin/protoc
 
       - name: Install protoc (AMD/AppImage)
-        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' || matrix.build-type == 'appimage' }}
+        if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && sudo unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && rm -f protoc-25.2-linux-x86_64.zip
         env:
           PROTOC: /usr/local/bin/protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,13 @@ jobs:
             platform: "x86_64-linux-appimage"
             build-type: "appimage"
 
+          # AppImage ARM64
+          - name: "linux-arm64-compat"
+            runs-on: "ubuntu-24.04-arm"
+            target: "aarch64-unknown-linux-gnu"
+            platform: "arm64-linux-appimage"
+            build-type: "appimage"
+
           # macOS builds
           - name: "macos-x86_64"
             runs-on: "macos-13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,10 +133,20 @@ jobs:
           uname -a && cargo clean
 
       # Install AppImage tools for AppImage builds
-      - name: Install AppImage tools
-        if: ${{ matrix.build-type == 'appimage' }}
+      - name: Install x86 AppImage tools
+        if: ${{ matrix.build-type == 'appimage' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         run: |
           wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          sudo mv linuxdeploy-x86_64.AppImage /usr/local/bin/linuxdeploy
+          # Install additional dependencies that might be needed at runtime
+          sudo apt-get install -y libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-xkb-dev libxkbcommon-x11-dev
+
+      # Install AppImage tools for AppImage builds
+      - name: Install ARM AppImage tools
+        if: ${{ matrix.build-type == 'appimage' && matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-aarch64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
           sudo mv linuxdeploy-x86_64.AppImage /usr/local/bin/linuxdeploy
           # Install additional dependencies that might be needed at runtime

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ test_db
 **/.DS_Store
 explorer.log
 .gitaipconfig
+
+# Test build directories
+build-test/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,63 @@ system, unzip, and install:
 
 ## Installation
 
-To install Dash Evo Tool:
+### Download Pre-built Packages (Recommended)
+
+The easiest way to get started is to download a pre-built package from the [latest release](https://github.com/dashpay/dash-evo-tool/releases/latest).
+
+#### Linux
+
+We provide multiple Linux packages to ensure compatibility:
+
+- **Standard builds** (`x86_64-linux`, `arm64-linux`): For modern systems with GLIBC 2.39+
+- **Compatible builds** (`x86_64-linux-compat`, `arm64-linux-compat`): For older systems with GLIBC 2.31+ (Ubuntu 20.04+, Debian 11+, etc.)
+- **AppImage** (`x86_64-linux-appimage`): Self-contained package that works on most Linux distributions
+
+**Installation steps:**
+
+1. Download the appropriate `.zip` file for your system
+2. Extract the archive:
+   ```shell
+   unzip dash-evo-tool-*.zip
+   cd dash-evo-tool
+   ```
+3. Make the binary executable:
+   ```shell
+   chmod +x dash-evo-tool
+   ```
+4. Run the application:
+   ```shell
+   ./dash-evo-tool
+   ```
+
+For the AppImage version:
+```shell
+unzip dash-evo-tool-x86_64-linux-appimage.zip
+chmod +x dash-evo-tool.AppImage
+./dash-evo-tool.AppImage
+```
+
+#### macOS
+
+1. Download the appropriate package:
+   - `x86_64-mac` for Intel Macs
+   - `arm64-mac` for Apple Silicon
+2. Extract and run:
+   ```shell
+   unzip dash-evo-tool-*.zip
+   cd dash-evo-tool
+   ./dash-evo-tool
+   ```
+
+#### Windows
+
+1. Download `dash-evo-tool-windows.zip`
+2. Extract the archive
+3. Run `dash-evo-tool.exe`
+
+### Build from Source
+
+To build from source:
 
 1. **Clone the repository**:
 
@@ -95,14 +151,26 @@ To install Dash Evo Tool:
    cargo build --release
    ```
 
+4. **Run the application**:
+
+   ``` shell
+   cargo run --release
+   ```
+
 ## Getting Started
 
 ### Start the App
 
-Run the application using:
+If you downloaded a pre-built package:
 
 ``` shell
-cargo run
+./dash-evo-tool
+```
+
+If you built from source:
+
+``` shell
+cargo run --release
 ```
 
 ### Application directory

--- a/build-tests/README.md
+++ b/build-tests/README.md
@@ -1,0 +1,54 @@
+# Build Tests for Dash Evo Tool
+
+This directory contains test scripts and documentation for verifying the different Linux build variants of Dash Evo Tool.
+
+## Contents
+
+### Test Scripts
+
+- **`test-linux-builds.sh`** - Comprehensive automated test script that tests all build variants on multiple Linux distributions using Docker
+- **`test-single-build.sh`** - Quick script to test a single build on a specific distribution
+- **`test-build-locally.sh`** - Build and test all variants locally using Docker (simulates GitHub Actions environment)
+- **`test-glibc-compatibility.sh`** - Check GLIBC versions across different Linux distributions
+
+### Documentation
+
+- **`test-linux-builds-manual.md`** - Manual testing guide with Docker commands
+- **`quick-test-instructions.md`** - Quick reference for testing the workflow changes
+
+## Quick Start
+
+1. **Check GLIBC versions across distributions:**
+   ```bash
+   ./test-glibc-compatibility.sh
+   ```
+
+2. **Test pre-built releases:**
+   ```bash
+   # Download releases from GitHub first, then:
+   ./test-linux-builds.sh
+   ```
+
+3. **Build and test locally:**
+   ```bash
+   ./test-build-locally.sh
+   ```
+
+## Build Variants
+
+The project produces three types of Linux builds:
+
+1. **Standard Build** (`x86_64-linux`)
+   - Built on Ubuntu 24.04
+   - Requires GLIBC 2.39+
+   - Best performance on modern systems
+
+2. **Compatible Build** (`x86_64-linux-compat`)
+   - Built on Ubuntu 20.04
+   - Requires GLIBC 2.31+
+   - Works on most distributions from 2020 onwards
+
+3. **AppImage** (`x86_64-linux-appimage`)
+   - Self-contained with all dependencies
+   - Works on almost any Linux distribution
+   - No installation required

--- a/build-tests/quick-test-instructions.md
+++ b/build-tests/quick-test-instructions.md
@@ -1,0 +1,75 @@
+# Quick Test Instructions for Linux Build Variants
+
+Based on the GLIBC version check, here's what we've confirmed:
+
+## GLIBC Versions by Distribution:
+- Ubuntu 18.04: GLIBC 2.27
+- Ubuntu 20.04: GLIBC 2.31 ✓ (Compatible build target)
+- Ubuntu 22.04: GLIBC 2.35
+- Ubuntu 24.04: GLIBC 2.39 ✓ (Standard build target)
+- Debian 11: GLIBC 2.31
+- Debian 12: GLIBC 2.36
+
+## What the changes will do:
+
+1. **Standard Build** (built on Ubuntu 24.04):
+   - Will require GLIBC 2.39
+   - Only works on Ubuntu 24.04, Fedora 39+, and very recent distros
+   - This matches your current situation where users complain about GLIBC 2.39
+
+2. **Compatible Build** (built on Ubuntu 20.04):
+   - Will require GLIBC 2.31
+   - Works on Ubuntu 20.04, Debian 11, CentOS Stream 9, and most 2020+ distros
+   - This solves the compatibility issue for most users
+
+3. **AppImage**:
+   - Self-contained with all dependencies
+   - Works on almost any Linux distribution
+   - Best fallback option
+
+## To test the changes:
+
+1. **Commit and push the changes:**
+```bash
+git add .github/workflows/release.yml README.md
+git commit -m "feat: add multiple Linux build variants for GLIBC compatibility"
+git push origin v0.9-dev
+```
+
+2. **Create a test release:**
+```bash
+# Create a test tag to trigger the workflow
+git tag v0.9-dev.test1
+git push origin v0.9-dev.test1
+```
+
+3. **Monitor the build:**
+- Go to https://github.com/dashpay/dash-evo-tool/actions
+- Watch the "Release Dash Evo Tool" workflow
+- It should create 5 Linux packages instead of 2
+
+4. **Download and test:**
+Once complete, download the artifacts and test:
+
+```bash
+# Test compatible build on Ubuntu 20.04
+docker run --rm -it -v "$PWD:/test" ubuntu:20.04 bash -c "
+  apt-get update && apt-get install -y unzip
+  cd /test
+  unzip -q dash-evo-tool-x86_64-linux-compat.zip
+  cd dash-evo-tool
+  chmod +x dash-evo-tool
+  ./dash-evo-tool --version
+"
+```
+
+## Expected outcomes:
+
+✅ **Compatible build** should work on Ubuntu 20.04 (GLIBC 2.31)
+❌ **Standard build** should fail on Ubuntu 20.04 with GLIBC error
+✅ **AppImage** should work everywhere (might need --appimage-extract-and-run in containers)
+
+This approach gives users three options:
+- Modern systems: Use standard build for best performance
+- Older systems: Use compatible build
+- Any issues: Use AppImage as universal fallback

--- a/build-tests/test-build-locally.sh
+++ b/build-tests/test-build-locally.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+
+# Script to build and test Dash Evo Tool locally using Docker
+# This simulates the GitHub Actions build environment
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=== Building Dash Evo Tool Linux Variants Locally ==="
+
+# Create build directory
+mkdir -p build-test
+cd build-test
+
+# Function to build in a container
+build_in_container() {
+    local name=$1
+    local image=$2
+    local target=$3
+    
+    echo -e "${YELLOW}Building $name using $image...${NC}"
+    
+    # Create Dockerfile for building
+    cat > Dockerfile << EOF
+FROM $image
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    clang \
+    cmake \
+    unzip \
+    libsqlite3-dev \
+    zip \
+    curl \
+    git \
+    libssl-dev
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:\${PATH}"
+
+# Install protoc
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && \
+    unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && \
+    unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && \
+    rm -f protoc-25.2-linux-x86_64.zip
+
+WORKDIR /build
+COPY . .
+
+# Add target
+RUN rustup target add $target
+
+# Build
+RUN cargo build --release --target $target
+
+# Package
+RUN mkdir -p dash-evo-tool && \
+    cp target/$target/release/dash-evo-tool dash-evo-tool/ && \
+    cp .env.example dash-evo-tool/.env && \
+    cp -r dash_core_configs dash-evo-tool/ && \
+    zip -r dash-evo-tool-$name.zip dash-evo-tool/
+EOF
+
+    # Copy source code
+    echo "Copying source code..."
+    cp -r ../* . 2>/dev/null || true
+    
+    # Build in container
+    docker build -t dash-evo-tool-build-$name .
+    
+    # Extract the built artifact
+    docker run --rm -v "$PWD:/output" dash-evo-tool-build-$name \
+        cp /build/dash-evo-tool-$name.zip /output/
+    
+    echo -e "${GREEN}✓ Built $name${NC}"
+    echo ""
+}
+
+# Build standard version (Ubuntu 24.04)
+build_in_container "x86_64-linux" "ubuntu:24.04" "x86_64-unknown-linux-gnu"
+
+# Build compatible version (Ubuntu 20.04)
+build_in_container "x86_64-linux-compat" "ubuntu:20.04" "x86_64-unknown-linux-gnu"
+
+# Build AppImage
+echo -e "${YELLOW}Building AppImage...${NC}"
+cat > Dockerfile.appimage << 'EOF'
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    clang \
+    cmake \
+    unzip \
+    libsqlite3-dev \
+    zip \
+    curl \
+    git \
+    libssl-dev \
+    wget \
+    libxcb-xfixes0-dev \
+    libxcb-shape0-dev \
+    libxcb-randr0-dev \
+    libxcb-xkb-dev \
+    libxkbcommon-x11-dev \
+    file
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install protoc
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protoc-25.2-linux-x86_64.zip && \
+    unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local bin/protoc && \
+    unzip -o protoc-25.2-linux-x86_64.zip -d /usr/local 'include/*' && \
+    rm -f protoc-25.2-linux-x86_64.zip
+
+# Install linuxdeploy
+RUN wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage && \
+    chmod +x linuxdeploy-x86_64.AppImage && \
+    ./linuxdeploy-x86_64.AppImage --appimage-extract && \
+    mv squashfs-root/usr/bin/linuxdeploy /usr/local/bin/ && \
+    rm -rf squashfs-root linuxdeploy-x86_64.AppImage
+
+WORKDIR /build
+COPY . .
+
+# Build
+RUN cargo build --release --target x86_64-unknown-linux-gnu
+
+# Create AppImage structure
+RUN mkdir -p dash-evo-tool && \
+    cp target/x86_64-unknown-linux-gnu/release/dash-evo-tool dash-evo-tool/ && \
+    cp .env.example dash-evo-tool/.env && \
+    cp -r dash_core_configs dash-evo-tool/
+
+# Create AppDir
+RUN mkdir -p AppDir/usr/bin && \
+    mkdir -p AppDir/usr/share/applications && \
+    mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps && \
+    cp dash-evo-tool/dash-evo-tool AppDir/usr/bin/ && \
+    cp -r dash-evo-tool/dash_core_configs AppDir/usr/bin/ && \
+    cp dash-evo-tool/.env AppDir/usr/bin/
+
+# Create desktop file
+RUN echo '[Desktop Entry]' > AppDir/usr/share/applications/dash-evo-tool.desktop && \
+    echo 'Name=Dash Evo Tool' >> AppDir/usr/share/applications/dash-evo-tool.desktop && \
+    echo 'Exec=dash-evo-tool' >> AppDir/usr/share/applications/dash-evo-tool.desktop && \
+    echo 'Icon=dash-evo-tool' >> AppDir/usr/share/applications/dash-evo-tool.desktop && \
+    echo 'Type=Application' >> AppDir/usr/share/applications/dash-evo-tool.desktop && \
+    echo 'Categories=Utility;' >> AppDir/usr/share/applications/dash-evo-tool.desktop
+
+# Copy icon if exists, otherwise create placeholder
+RUN if [ -f mac_os/AppIcons/Assets.xcassets/AppIcon.appiconset/256.png ]; then \
+        cp mac_os/AppIcons/Assets.xcassets/AppIcon.appiconset/256.png AppDir/usr/share/icons/hicolor/256x256/apps/dash-evo-tool.png; \
+    else \
+        echo "No icon found, using placeholder"; \
+        touch AppDir/usr/share/icons/hicolor/256x256/apps/dash-evo-tool.png; \
+    fi
+
+# Create AppRun script
+RUN echo '#!/bin/bash' > AppDir/AppRun && \
+    echo 'SELF=$(readlink -f "$0")' >> AppDir/AppRun && \
+    echo 'HERE=${SELF%/*}' >> AppDir/AppRun && \
+    echo 'export PATH="${HERE}/usr/bin:${PATH}"' >> AppDir/AppRun && \
+    echo 'export LD_LIBRARY_PATH="${HERE}/usr/lib:${LD_LIBRARY_PATH}"' >> AppDir/AppRun && \
+    echo 'cd "${HERE}/usr/bin"' >> AppDir/AppRun && \
+    echo 'exec "${HERE}/usr/bin/dash-evo-tool" "$@"' >> AppDir/AppRun && \
+    chmod +x AppDir/AppRun
+
+# Create AppImage
+RUN linuxdeploy --appdir AppDir --output appimage && \
+    mv Dash_Evo_Tool*.AppImage dash-evo-tool.AppImage && \
+    zip dash-evo-tool-x86_64-linux-appimage.zip dash-evo-tool.AppImage
+EOF
+
+docker build -f Dockerfile.appimage -t dash-evo-tool-build-appimage .
+docker run --rm -v "$PWD:/output" dash-evo-tool-build-appimage \
+    cp /build/dash-evo-tool-x86_64-linux-appimage.zip /output/
+
+echo -e "${GREEN}✓ Built AppImage${NC}"
+echo ""
+
+# Now test the builds
+echo -e "${YELLOW}=== Testing Builds ===${NC}"
+
+# Test function
+test_build() {
+    local distro=$1
+    local image=$2
+    local build_file=$3
+    
+    echo -e "${YELLOW}Testing $build_file on $distro...${NC}"
+    
+    docker run --rm \
+        -v "$PWD/$build_file:/test.zip" \
+        "$image" \
+        bash -c "
+            apt-get update && apt-get install -y unzip > /dev/null 2>&1
+            cd /tmp
+            unzip -q /test.zip
+            cd dash-evo-tool
+            chmod +x dash-evo-tool
+            echo 'GLIBC version:'
+            ldd --version | head -n 1
+            echo 'Testing binary...'
+            if ./dash-evo-tool --version 2>&1; then
+                echo -e '\033[0;32m✓ SUCCESS: Binary runs!\033[0m'
+            else
+                echo -e '\033[0;31m✗ FAIL: Binary does not run\033[0m'
+                echo 'Dependencies:'
+                ldd ./dash-evo-tool 2>&1 | head -20
+            fi
+        "
+    echo ""
+}
+
+# Test AppImage
+test_appimage() {
+    local distro=$1
+    local image=$2
+    
+    echo -e "${YELLOW}Testing AppImage on $distro...${NC}"
+    
+    docker run --rm \
+        -v "$PWD/dash-evo-tool-x86_64-linux-appimage.zip:/test.zip" \
+        "$image" \
+        bash -c "
+            if command -v apt-get &> /dev/null; then
+                apt-get update && apt-get install -y unzip file > /dev/null 2>&1
+            fi
+            cd /tmp
+            unzip -q /test.zip
+            chmod +x dash-evo-tool.AppImage
+            echo 'Testing AppImage...'
+            if ./dash-evo-tool.AppImage --appimage-extract-and-run --version 2>&1; then
+                echo -e '\033[0;32m✓ SUCCESS: AppImage runs!\033[0m'
+            else
+                echo -e '\033[0;31m✗ FAIL: AppImage does not run\033[0m'
+            fi
+        "
+    echo ""
+}
+
+# Test builds
+echo -e "${YELLOW}Testing standard build (should only work on very recent systems)${NC}"
+test_build "Ubuntu 24.04" "ubuntu:24.04" "dash-evo-tool-x86_64-linux.zip"
+test_build "Ubuntu 20.04" "ubuntu:20.04" "dash-evo-tool-x86_64-linux.zip"
+
+echo -e "${YELLOW}Testing compatible build (should work on older systems)${NC}"
+test_build "Ubuntu 20.04" "ubuntu:20.04" "dash-evo-tool-x86_64-linux-compat.zip"
+test_build "Debian 11" "debian:11" "dash-evo-tool-x86_64-linux-compat.zip"
+
+echo -e "${YELLOW}Testing AppImage${NC}"
+test_appimage "Ubuntu 20.04" "ubuntu:20.04"
+test_appimage "Ubuntu 18.04" "ubuntu:18.04"
+
+echo -e "${GREEN}=== Build and Test Complete ===${NC}"
+echo "Built packages:"
+ls -la *.zip
+
+cd ..
+echo ""
+echo "Build artifacts are in the build-test/ directory"

--- a/build-tests/test-glibc-compatibility.sh
+++ b/build-tests/test-glibc-compatibility.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Simple script to test GLIBC compatibility without building
+# This helps understand what GLIBC versions different distributions have
+
+echo "=== GLIBC Version Check on Different Linux Distributions ==="
+echo ""
+
+# Function to check GLIBC version in a container
+check_glibc() {
+    local distro=$1
+    local image=$2
+    
+    echo -n "$distro: "
+    docker run --rm "$image" bash -c "ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+' | head -1" 2>/dev/null || echo "Failed to check"
+}
+
+echo "Checking GLIBC versions..."
+echo "=========================="
+
+# Ubuntu versions
+check_glibc "Ubuntu 18.04 LTS" "ubuntu:18.04"
+check_glibc "Ubuntu 20.04 LTS" "ubuntu:20.04"
+check_glibc "Ubuntu 22.04 LTS" "ubuntu:22.04"
+check_glibc "Ubuntu 24.04 LTS" "ubuntu:24.04"
+
+echo ""
+
+# Debian versions
+check_glibc "Debian 10 (Buster)" "debian:10"
+check_glibc "Debian 11 (Bullseye)" "debian:11"
+check_glibc "Debian 12 (Bookworm)" "debian:12"
+
+echo ""
+
+# Other distributions
+check_glibc "CentOS Stream 9" "quay.io/centos/centos:stream9"
+check_glibc "Fedora 38" "fedora:38"
+check_glibc "Fedora 39" "fedora:39"
+check_glibc "Alpine Linux" "alpine:latest"
+
+echo ""
+echo "Summary:"
+echo "========"
+echo "- GLIBC 2.31 (Ubuntu 20.04 compatible build) works on:"
+echo "  Ubuntu 20.04+, Debian 11+, CentOS Stream 9+, Fedora 34+"
+echo ""
+echo "- GLIBC 2.39 (Ubuntu 24.04 standard build) works on:"
+echo "  Ubuntu 24.04+, Fedora 39+, and very recent distributions"
+echo ""
+echo "- Alpine Linux uses musl libc instead of GLIBC (requires different build)"

--- a/build-tests/test-linux-builds-manual.md
+++ b/build-tests/test-linux-builds-manual.md
@@ -1,0 +1,127 @@
+# Testing Linux Builds for GLIBC Compatibility
+
+This guide helps you test the different Linux builds to ensure they work correctly across various distributions.
+
+## Quick Test with Docker
+
+### 1. First, trigger a test build
+
+You'll need to push your changes and create a test tag:
+
+```bash
+git add .github/workflows/release.yml README.md
+git commit -m "feat: add multiple Linux build variants for GLIBC compatibility"
+git push origin v0.9-dev
+
+# Create a test tag to trigger the workflow
+git tag v0.9-dev.test1
+git push origin v0.9-dev.test1
+```
+
+### 2. Download the artifacts
+
+Once the GitHub Actions workflow completes, download the Linux builds from the release page.
+
+### 3. Test with Docker
+
+Test each build variant on different distributions:
+
+#### Test Standard Build (should fail on older systems)
+```bash
+# Should work - Ubuntu 24.04 has GLIBC 2.39
+docker run --rm -it -v "$PWD:/test" ubuntu:24.04 bash -c "
+  cd /test && apt-get update && apt-get install -y unzip
+  unzip -q dash-evo-tool-x86_64-linux.zip
+  cd dash-evo-tool && chmod +x dash-evo-tool
+  ldd --version | head -n 1
+  ./dash-evo-tool --version
+"
+
+# Should fail - Ubuntu 20.04 has GLIBC 2.31
+docker run --rm -it -v "$PWD:/test" ubuntu:20.04 bash -c "
+  cd /test && apt-get update && apt-get install -y unzip
+  unzip -q dash-evo-tool-x86_64-linux.zip
+  cd dash-evo-tool && chmod +x dash-evo-tool
+  ldd --version | head -n 1
+  ./dash-evo-tool --version || echo 'Expected failure: GLIBC too old'
+"
+```
+
+#### Test Compatible Build (should work on older systems)
+```bash
+# Should work on Ubuntu 20.04 and newer
+docker run --rm -it -v "$PWD:/test" ubuntu:20.04 bash -c "
+  cd /test && apt-get update && apt-get install -y unzip
+  unzip -q dash-evo-tool-x86_64-linux-compat.zip
+  cd dash-evo-tool && chmod +x dash-evo-tool
+  ldd --version | head -n 1
+  ./dash-evo-tool --version
+"
+
+# Should also work on Debian 11
+docker run --rm -it -v "$PWD:/test" debian:11 bash -c "
+  cd /test && apt-get update && apt-get install -y unzip
+  unzip -q dash-evo-tool-x86_64-linux-compat.zip
+  cd dash-evo-tool && chmod +x dash-evo-tool
+  ldd --version | head -n 1
+  ./dash-evo-tool --version
+"
+```
+
+#### Test AppImage (should work almost everywhere)
+```bash
+# Test on various distributions
+for distro in ubuntu:20.04 ubuntu:18.04 debian:11 fedora:38; do
+  echo "Testing AppImage on $distro..."
+  docker run --rm -it -v "$PWD:/test" $distro bash -c "
+    cd /test
+    # Install unzip (commands vary by distro)
+    if command -v apt-get &> /dev/null; then
+      apt-get update && apt-get install -y unzip
+    elif command -v dnf &> /dev/null; then
+      dnf install -y unzip
+    fi
+    unzip -q dash-evo-tool-x86_64-linux-appimage.zip
+    chmod +x dash-evo-tool.AppImage
+    # AppImage might need --appimage-extract-and-run in containers
+    ./dash-evo-tool.AppImage --appimage-extract-and-run --version || ./dash-evo-tool.AppImage --version
+  "
+done
+```
+
+## Expected Results
+
+1. **Standard Build** (`x86_64-linux`):
+   - ✅ Works on Ubuntu 24.04, Fedora 39+, and other very recent distributions
+   - ❌ Fails on Ubuntu 22.04 and older with GLIBC version errors
+
+2. **Compatible Build** (`x86_64-linux-compat`):
+   - ✅ Works on Ubuntu 20.04, Debian 11, CentOS Stream 9, and most 2020+ distributions
+   - ✅ Also works on newer systems
+   - ❌ May fail on very old systems (Ubuntu 18.04 and older)
+
+3. **AppImage** (`x86_64-linux-appimage`):
+   - ✅ Works on almost all Linux distributions
+   - ✅ Self-contained with all dependencies
+   - ⚠️ May need `--appimage-extract-and-run` flag in Docker containers without FUSE
+
+## Checking GLIBC Dependencies
+
+To see what GLIBC version a binary requires:
+```bash
+# Check required GLIBC versions
+objdump -T dash-evo-tool | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -V | tail -1
+
+# Or use ldd to see all dependencies
+ldd dash-evo-tool
+```
+
+## Common GLIBC Versions
+
+- Ubuntu 18.04: GLIBC 2.27
+- Ubuntu 20.04: GLIBC 2.31
+- Ubuntu 22.04: GLIBC 2.35
+- Ubuntu 24.04: GLIBC 2.39
+- Debian 11: GLIBC 2.31
+- Debian 12: GLIBC 2.36
+- RHEL/CentOS 9: GLIBC 2.34

--- a/build-tests/test-linux-builds.sh
+++ b/build-tests/test-linux-builds.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+# Test script for Dash Evo Tool Linux builds
+# This script tests different Linux distributions to verify GLIBC compatibility
+
+set -e
+
+echo "=== Dash Evo Tool Linux Build Testing ==="
+echo "This script will test the different Linux builds using Docker containers"
+echo ""
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to test a build on a specific distribution
+test_build() {
+    local distro=$1
+    local image=$2
+    local build_file=$3
+    local expected_result=$4
+    
+    echo -e "${YELLOW}Testing $distro with $build_file...${NC}"
+    
+    # Create a test script that will run inside the container
+    cat > test_in_container.sh << 'EOF'
+#!/bin/bash
+cd /test
+unzip -q *.zip
+cd dash-evo-tool
+chmod +x dash-evo-tool
+
+# Check GLIBC version
+echo "GLIBC version in container:"
+ldd --version | head -n 1
+
+# Try to run the binary
+echo "Testing binary..."
+if timeout 5s ./dash-evo-tool --version 2>&1; then
+    echo "SUCCESS: Binary runs!"
+    exit 0
+else
+    echo "Checking dependencies..."
+    ldd ./dash-evo-tool || true
+    exit 1
+fi
+EOF
+    
+    chmod +x test_in_container.sh
+    
+    # Run the test in Docker
+    if docker run --rm \
+        -v "$PWD/test_in_container.sh:/test_in_container.sh" \
+        -v "$PWD/$build_file:/test/$build_file" \
+        "$image" \
+        /test_in_container.sh; then
+        
+        if [ "$expected_result" = "pass" ]; then
+            echo -e "${GREEN}✓ PASS: $distro works with $build_file as expected${NC}"
+        else
+            echo -e "${RED}✗ UNEXPECTED: $distro works with $build_file but was expected to fail${NC}"
+        fi
+    else
+        if [ "$expected_result" = "fail" ]; then
+            echo -e "${GREEN}✓ EXPECTED: $distro fails with $build_file as expected${NC}"
+        else
+            echo -e "${RED}✗ FAIL: $distro doesn't work with $build_file${NC}"
+        fi
+    fi
+    
+    echo ""
+    rm -f test_in_container.sh
+}
+
+# Test AppImage
+test_appimage() {
+    local distro=$1
+    local image=$2
+    
+    echo -e "${YELLOW}Testing AppImage on $distro...${NC}"
+    
+    cat > test_appimage.sh << 'EOF'
+#!/bin/bash
+cd /test
+unzip -q *.zip
+chmod +x dash-evo-tool.AppImage
+
+# Check GLIBC version
+echo "GLIBC version in container:"
+ldd --version | head -n 1
+
+# AppImages need FUSE or can be extracted
+echo "Testing AppImage..."
+if timeout 5s ./dash-evo-tool.AppImage --version 2>&1; then
+    echo "SUCCESS: AppImage runs!"
+    exit 0
+else
+    # Try extracting if FUSE is not available
+    echo "FUSE might not be available, trying --appimage-extract-and-run..."
+    if timeout 5s ./dash-evo-tool.AppImage --appimage-extract-and-run --version 2>&1; then
+        echo "SUCCESS: AppImage runs with extraction!"
+        exit 0
+    else
+        echo "FAIL: AppImage doesn't work"
+        exit 1
+    fi
+fi
+EOF
+    
+    chmod +x test_appimage.sh
+    
+    if docker run --rm \
+        -v "$PWD/test_appimage.sh:/test_appimage.sh" \
+        -v "$PWD/$3:/test/$3" \
+        --cap-add SYS_ADMIN \
+        --device /dev/fuse \
+        "$image" \
+        /test_appimage.sh; then
+        echo -e "${GREEN}✓ PASS: AppImage works on $distro${NC}"
+    else
+        echo -e "${RED}✗ FAIL: AppImage doesn't work on $distro${NC}"
+    fi
+    
+    echo ""
+    rm -f test_appimage.sh
+}
+
+# Check if we have the release files
+echo "Checking for release files..."
+echo "Please ensure you have built the releases or downloaded them to this directory:"
+echo "  - dash-evo-tool-x86_64-linux.zip (standard build)"
+echo "  - dash-evo-tool-x86_64-linux-compat.zip (compatible build)"
+echo "  - dash-evo-tool-x86_64-linux-appimage.zip (AppImage)"
+echo ""
+echo "Press Enter to continue or Ctrl+C to cancel..."
+read
+
+# Test matrix
+echo -e "${YELLOW}=== Testing Standard Build (GLIBC 2.39) ===${NC}"
+test_build "Ubuntu 24.04" "ubuntu:24.04" "dash-evo-tool-x86_64-linux.zip" "pass"
+test_build "Ubuntu 22.04" "ubuntu:22.04" "dash-evo-tool-x86_64-linux.zip" "fail"
+test_build "Ubuntu 20.04" "ubuntu:20.04" "dash-evo-tool-x86_64-linux.zip" "fail"
+test_build "Debian 12" "debian:12" "dash-evo-tool-x86_64-linux.zip" "fail"
+test_build "CentOS Stream 9" "quay.io/centos/centos:stream9" "dash-evo-tool-x86_64-linux.zip" "fail"
+
+echo -e "${YELLOW}=== Testing Compatible Build (GLIBC 2.31) ===${NC}"
+test_build "Ubuntu 24.04" "ubuntu:24.04" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "Ubuntu 22.04" "ubuntu:22.04" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "Ubuntu 20.04" "ubuntu:20.04" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "Debian 11" "debian:11" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "Debian 12" "debian:12" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "CentOS Stream 9" "quay.io/centos/centos:stream9" "dash-evo-tool-x86_64-linux-compat.zip" "pass"
+test_build "Ubuntu 18.04" "ubuntu:18.04" "dash-evo-tool-x86_64-linux-compat.zip" "fail"
+
+echo -e "${YELLOW}=== Testing AppImage ===${NC}"
+test_appimage "Ubuntu 24.04" "ubuntu:24.04" "dash-evo-tool-x86_64-linux-appimage.zip"
+test_appimage "Ubuntu 20.04" "ubuntu:20.04" "dash-evo-tool-x86_64-linux-appimage.zip"
+test_appimage "Ubuntu 18.04" "ubuntu:18.04" "dash-evo-tool-x86_64-linux-appimage.zip"
+test_appimage "Debian 11" "debian:11" "dash-evo-tool-x86_64-linux-appimage.zip"
+test_appimage "CentOS Stream 9" "quay.io/centos/centos:stream9" "dash-evo-tool-x86_64-linux-appimage.zip"
+
+echo -e "${GREEN}=== Testing Complete ===${NC}"
+echo "Summary:"
+echo "- Standard build should work on Ubuntu 24.04+ (GLIBC 2.39+)"
+echo "- Compatible build should work on Ubuntu 20.04+ and most 2020+ distributions (GLIBC 2.31+)"
+echo "- AppImage should work on most Linux distributions"

--- a/build-tests/test-single-build.sh
+++ b/build-tests/test-single-build.sh
@@ -20,7 +20,7 @@ docker run --rm -it \
     "$DISTRO" \
     /bin/bash -c "
         cd /test
-        apt-get update && apt-get install -y unzip ldd || yum install -y unzip
+        apt-get update && apt-get install -y unzip libc-bin || yum install -y unzip
         unzip -q $BUILD_FILE
         cd dash-evo-tool
         chmod +x dash-evo-tool

--- a/build-tests/test-single-build.sh
+++ b/build-tests/test-single-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Quick test script to verify a single build manually
+# Usage: ./test-single-build.sh <distro> <build-file>
+# Example: ./test-single-build.sh ubuntu:20.04 dash-evo-tool-x86_64-linux-compat.zip
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <docker-image> <build-file>"
+    echo "Example: $0 ubuntu:20.04 dash-evo-tool-x86_64-linux-compat.zip"
+    exit 1
+fi
+
+DISTRO=$1
+BUILD_FILE=$2
+
+echo "Testing $BUILD_FILE on $DISTRO..."
+
+docker run --rm -it \
+    -v "$PWD/$BUILD_FILE:/test/$BUILD_FILE" \
+    "$DISTRO" \
+    /bin/bash -c "
+        cd /test
+        apt-get update && apt-get install -y unzip ldd || yum install -y unzip
+        unzip -q $BUILD_FILE
+        cd dash-evo-tool
+        chmod +x dash-evo-tool
+        echo '=== GLIBC Version ==='
+        ldd --version | head -n 1
+        echo '=== Binary Dependencies ==='
+        ldd ./dash-evo-tool
+        echo '=== Testing Binary ==='
+        ./dash-evo-tool --version || echo 'Failed to run'
+    "


### PR DESCRIPTION
This update introduces multiple Linux build variants for the Dash Evo Tool to enhance compatibility across different systems. The new build types include:

- **Standard Builds**: 
  - `x86_64-linux`: Built on Ubuntu 24.04 (requires GLIBC 2.39+).
  - `arm64-linux`: Built on Ubuntu 22.04 ARM.

- **Compatible Builds**: 
  - `x86_64-linux-compat`: Built on Ubuntu 20.04 (requires GLIBC 2.31+, compatible with most distributions from 2020+).
  - `arm64-linux-compat`: Built on Ubuntu 20.04 ARM.

- **AppImage**: 
  - `x86_64-linux-appimage`: A self-contained AppImage that works on most Linux distributions.

Additionally, the GitHub Actions workflow has been updated to handle these new builds, and documentation has been added to clarify installation and compatibility details. This change aims to provide users with better options depending on their system requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multiple Linux build variants, including modern and compatible builds for x86_64 and ARM64, plus a self-contained AppImage for x86_64 Linux.
- **Documentation**
  - Expanded README with detailed installation and usage instructions for all platforms and build variants.
  - Added comprehensive guides and quick-start instructions for testing Linux builds and GLIBC compatibility.
  - Introduced documentation and scripts in the build-tests directory to assist with local and manual compatibility testing.
- **Chores**
  - Updated .gitignore to exclude test build directories.
  - Added new scripts for automated and manual build testing across various Linux distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->