### PR TITLE
fix(wallet): refresh utxos with no address in wallet gives invalid balance

### DIFF
--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -1,5 +1,6 @@
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
+use dash_sdk::dashcore_rpc::json::ListUnspentResultEntry;
 use dash_sdk::dashcore_rpc::{Client, RpcApi};
 use dash_sdk::dpp::dashcore::{Address, Network, OutPoint, TxOut};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -103,93 +104,99 @@ impl Wallet {
             }
         }
 
+        // Calling list_unspent with an empty addresses vector will return all UTXOs,
+        // which is not what we want here. Instead, we handle the empty case explicitly.
+        let utxos: Vec<ListUnspentResultEntry> = if addresses.is_empty() {
+            Vec::new()
+        } else {
+            core_client
+                .list_unspent(None, None, Some(&addresses), Some(false), None)
+                .map_err(|e| e.to_string())?
+        };
+
         // Use the RPC client to list unspent outputs.
-        match core_client.list_unspent(None, None, Some(&addresses), Some(false), None) {
-            Ok(utxos) => {
-                // Initialize the HashMap to store the new UTXOs.
-                let mut new_utxo_map = HashMap::new();
-                // Build a set of new OutPoints for easy comparison.
-                let mut new_outpoints = HashSet::new();
 
-                // Iterate over the retrieved UTXOs and populate the HashMaps.
-                for utxo in utxos {
-                    let outpoint = OutPoint::new(utxo.txid, utxo.vout);
-                    let tx_out = TxOut {
-                        value: utxo.amount.to_sat(),
-                        script_pubkey: utxo.script_pub_key.clone(),
-                    };
-                    new_utxo_map.insert(outpoint, tx_out);
-                    new_outpoints.insert(outpoint);
-                }
+        // Initialize the HashMap to store the new UTXOs.
+        let mut new_utxo_map = HashMap::new();
+        // Build a set of new OutPoints for easy comparison.
+        let mut new_outpoints = HashSet::new();
 
-                // Collect current UTXOs into a set for comparison
-                let mut old_outpoints = HashSet::new();
-                for (_address, utxos) in self.utxos.iter() {
-                    for (outpoint, _tx_out) in utxos.iter() {
-                        old_outpoints.insert(*outpoint);
-                    }
-                }
-
-                // Determine UTXOs to be removed and added
-                let removed_outpoints: HashSet<_> =
-                    old_outpoints.difference(&new_outpoints).cloned().collect();
-                let added_outpoints: HashSet<_> =
-                    new_outpoints.difference(&old_outpoints).cloned().collect();
-
-                // Now update self.utxos by removing UTXOs not present in new_outpoints
-                let current_utxos = &mut self.utxos;
-                // Remove UTXOs that are no longer unspent
-                for utxos in current_utxos.values_mut() {
-                    utxos.retain(|outpoint, _| new_outpoints.contains(outpoint));
-                }
-                // Remove addresses with no UTXOs
-                current_utxos.retain(|_, utxos| !utxos.is_empty());
-
-                // Add new UTXOs to self.utxos
-                let current_utxos = &mut self.utxos;
-                for (outpoint, tx_out) in &new_utxo_map {
-                    // Get the address from the script_pubkey
-                    let address = Address::from_script(&tx_out.script_pubkey, network)
-                        .map_err(|e| e.to_string())?;
-                    // Add or update the UTXO in the wallet
-                    current_utxos
-                        .entry(address.clone())
-                        .or_default()
-                        .insert(*outpoint, tx_out.clone());
-                }
-
-                // If save is Some, update the database
-                if let Some(app_context) = save {
-                    let db = &app_context.db;
-
-                    // Remove UTXOs that are no longer unspent
-                    for outpoint in removed_outpoints {
-                        db.drop_utxo(&outpoint, &network.to_string())
-                            .map_err(|e| e.to_string())?;
-                    }
-
-                    // Add new UTXOs
-                    for outpoint in added_outpoints {
-                        let tx_out = &new_utxo_map[&outpoint];
-                        let address = Address::from_script(&tx_out.script_pubkey, network)
-                            .map_err(|e| e.to_string())?;
-
-                        db.insert_utxo(
-                            outpoint.txid.as_ref(),
-                            outpoint.vout,
-                            &address,
-                            tx_out.value,
-                            tx_out.script_pubkey.as_bytes(),
-                            network,
-                        )
-                        .map_err(|e| e.to_string())?;
-                    }
-                }
-
-                // Return the new UTXO map
-                Ok(new_utxo_map)
-            }
-            Err(first_error) => Err(first_error.to_string()),
+        // Iterate over the retrieved UTXOs and populate the HashMaps.
+        for utxo in utxos {
+            let outpoint = OutPoint::new(utxo.txid, utxo.vout);
+            let tx_out = TxOut {
+                value: utxo.amount.to_sat(),
+                script_pubkey: utxo.script_pub_key.clone(),
+            };
+            new_utxo_map.insert(outpoint, tx_out);
+            new_outpoints.insert(outpoint);
         }
+
+        // Collect current UTXOs into a set for comparison
+        let mut old_outpoints = HashSet::new();
+        for (_address, utxos) in self.utxos.iter() {
+            for (outpoint, _tx_out) in utxos.iter() {
+                old_outpoints.insert(*outpoint);
+            }
+        }
+
+        // Determine UTXOs to be removed and added
+        let removed_outpoints: HashSet<_> =
+            old_outpoints.difference(&new_outpoints).cloned().collect();
+        let added_outpoints: HashSet<_> =
+            new_outpoints.difference(&old_outpoints).cloned().collect();
+
+        // Now update self.utxos by removing UTXOs not present in new_outpoints
+        let current_utxos = &mut self.utxos;
+        // Remove UTXOs that are no longer unspent
+        for utxos in current_utxos.values_mut() {
+            utxos.retain(|outpoint, _| new_outpoints.contains(outpoint));
+        }
+        // Remove addresses with no UTXOs
+        current_utxos.retain(|_, utxos| !utxos.is_empty());
+
+        // Add new UTXOs to self.utxos
+        let current_utxos = &mut self.utxos;
+        for (outpoint, tx_out) in &new_utxo_map {
+            // Get the address from the script_pubkey
+            let address =
+                Address::from_script(&tx_out.script_pubkey, network).map_err(|e| e.to_string())?;
+            // Add or update the UTXO in the wallet
+            current_utxos
+                .entry(address.clone())
+                .or_default()
+                .insert(*outpoint, tx_out.clone());
+        }
+
+        // If save is Some, update the database
+        if let Some(app_context) = save {
+            let db = &app_context.db;
+
+            // Remove UTXOs that are no longer unspent
+            for outpoint in removed_outpoints {
+                db.drop_utxo(&outpoint, &network.to_string())
+                    .map_err(|e| e.to_string())?;
+            }
+
+            // Add new UTXOs
+            for outpoint in added_outpoints {
+                let tx_out = &new_utxo_map[&outpoint];
+                let address = Address::from_script(&tx_out.script_pubkey, network)
+                    .map_err(|e| e.to_string())?;
+
+                db.insert_utxo(
+                    outpoint.txid.as_ref(),
+                    outpoint.vout,
+                    &address,
+                    tx_out.value,
+                    tx_out.script_pubkey.as_bytes(),
+                    network,
+                )
+                .map_err(|e| e.to_string())?;
+            }
+        }
+
+        // Return the new UTXO map
+        Ok(new_utxo_map)
     }
 }


### PR DESCRIPTION
When no core address is defined in a wallet, total balance is displayed as 0.
