### PR TITLE
feat: add method to retrieve unqualified contract by ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+build-test/
 
 # Dot env file
 .env

--- a/src/context.rs
+++ b/src/context.rs
@@ -490,15 +490,15 @@ impl AppContext {
         contract_id: &Identifier,
     ) -> Result<Option<QualifiedContract>> {
         // Get the contract from the database
-        let contract = self.db.get_contract_by_id(*contract_id, self)?;
+        self.db.get_contract_by_id(*contract_id, self)
+    }
 
-        // If the contract is not found in the database, return None
-        if contract.is_none() {
-            return Ok(None);
-        }
-
-        // If the contract is found, return it
-        Ok(Some(contract.unwrap()))
+    pub fn get_unqualified_contract_by_id(
+        &self,
+        contract_id: &Identifier,
+    ) -> Result<Option<DataContract>> {
+        // Get the contract from the database
+        self.db.get_unqualified_contract_by_id(*contract_id, self)
     }
 
     // Remove contract from the database by ID

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -217,16 +217,11 @@ impl TransferTokensScreen {
                     self.transfer_tokens_status = TransferTokensStatus::WaitingForResult(now);
                     let data_contract = Arc::new(
                         self.app_context
-                            .get_contracts(None, None)
+                            .get_unqualified_contract_by_id(
+                                &self.identity_token_balance.data_contract_id,
+                            )
                             .expect("Contracts not loaded")
-                            .iter()
-                            .find(|contract| {
-                                contract.contract.id()
-                                    == self.identity_token_balance.data_contract_id
-                            })
-                            .expect("Data contract not found")
-                            .contract
-                            .clone(),
+                            .expect("Data contract not found"),
                     );
                     app_action |= AppAction::BackendTasks(
                         vec![

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -13,7 +13,6 @@ use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::balances::credits::TokenAmount;
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;


### PR DESCRIPTION
- Added a new method `get_unqualified_contract_by_id` in the `Database` struct to fetch a `DataContract` based on its ID and network.
- Updated the `AppContext` to include a new method that calls the database method.
- Modified the `TransferTokensScreen` to use the new method for retrieving the data contract, simplifying the logic by directly fetching the contract instead of filtering a list. 
- Updated `.gitignore` to include `build-test/` directory.