### PR TITLE
fix: error loading identities from local DB on token creation screen

### DIFF
--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -302,10 +302,14 @@ impl AppContext {
             wallet_index: None, //todo
             top_ups: Default::default(),
         };
+        let (wallet_seed_hash, identity_id) = qualified_identity.determine_wallet_info()?;
 
         // Insert qualified identity into the database
-        self.insert_local_qualified_identity(&qualified_identity, None)
-            .map_err(|e| format!("Database error: {}", e))?;
+        self.insert_local_qualified_identity(
+            &qualified_identity,
+            Some((&wallet_seed_hash, identity_id)),
+        )
+        .map_err(|e| format!("Database error: {}", e))?;
 
         Ok(BackendTaskSuccessResult::Message(
             "Successfully loaded identity".to_string(),

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -144,8 +144,11 @@ impl AppContext {
         };
 
         // Insert qualified identity into the database
-        self.insert_local_qualified_identity(&qualified_identity, None)
-            .map_err(|e| format!("Database error: {}", e))?;
+        self.insert_local_qualified_identity(
+            &qualified_identity,
+            Some((&wallet_seed_hash, identity_index)),
+        )
+        .map_err(|e| format!("Database error: {}", e))?;
 
         Ok(BackendTaskSuccessResult::Message(
             "Successfully loaded identity".to_string(),

--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -416,7 +416,7 @@ impl AppContext {
 
         self.insert_local_qualified_identity(
             &qualified_identity,
-            Some((wallet_id.as_slice(), wallet_identity_index)),
+            Some((&wallet_id, wallet_identity_index)),
         )
         .map_err(|e| e.to_string())?;
         {

--- a/src/context.rs
+++ b/src/context.rs
@@ -23,7 +23,6 @@ use dash_sdk::dpp::data_contract::TokenConfiguration;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
-use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::prelude::{AssetLockProof, CoreBlockHeight};
 use dash_sdk::dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dash_sdk::dpp::state_transition::StateTransitionSigningOptions;
@@ -226,12 +225,6 @@ impl AppContext {
         Ok(())
     }
 
-    #[allow(dead_code)] // May be used for storing identities
-    pub fn insert_local_identity(&self, identity: &Identity) -> Result<()> {
-        self.db
-            .insert_local_qualified_identity(&identity.clone().into(), None, self)
-    }
-
     /// Inserts a local qualified identity into the database
     pub fn insert_local_qualified_identity(
         &self,
@@ -325,27 +318,54 @@ impl AppContext {
     pub fn load_local_user_identities(&self) -> Result<Vec<QualifiedIdentity>> {
         let identities = self.db.get_local_user_identities(self)?;
 
-        let wallets = self.wallets.read().unwrap();
-        identities
+        Ok(identities
             .into_iter()
-            .map(|(mut identity, wallet_id)| {
-                if let Some(wallet_id) = wallet_id {
-                    // For each identity, we need to set the wallet information
-                    if let Some(wallet) = wallets.get(&wallet_id) {
-                        identity
-                            .associated_wallets
-                            .insert(wallet_id, wallet.clone());
-                    } else {
+            .map(|(mut identity, wallet_hash)| {
+                if let Some(wallet_id) = wallet_hash {
+                    // Load wallets for each identity
+                    self.load_wallet_for_identity(
+                        &mut identity,
+                        &[wallet_id],
+                    )
+                    .unwrap_or_else(|e| {
                         tracing::warn!(
-                            wallet = %hex::encode(wallet_id),
                             identity = %identity.identity.id(),
-                            "wallet not found for identity when loading local user identities",
-                        );
-                    }
+                            error = ?e,
+                            "cannot load wallet for identity when loading local user identities",
+                        )
+                    })
+                } else {
+                    tracing::debug!(
+                        identity = %identity.identity.id(),
+                        "no wallet hash found for identity when loading local user identities",
+                    );
                 }
-                Ok(identity)
+                identity
             })
-            .collect()
+            .collect())
+    }
+
+    fn load_wallet_for_identity(
+        &self,
+        identity: &mut QualifiedIdentity,
+        wallet_hashes: &[WalletSeedHash],
+    ) -> Result<()> {
+        let wallets = self.wallets.read().unwrap();
+        for wallet_hash in wallet_hashes {
+            if let Some(wallet) = wallets.get(wallet_hash) {
+                identity
+                    .associated_wallets
+                    .insert(wallet_hash.clone(), wallet.clone());
+            } else {
+                tracing::warn!(
+                    wallet = %hex::encode(wallet_hash),
+                    identity = %identity.identity.id(),
+                    "wallet not found for identity when loading local user identities",
+                );
+            }
+        }
+
+        Ok(())
     }
 
     /// Fetches all contested names from the database including past and active ones

--- a/src/database/identities.rs
+++ b/src/database/identities.rs
@@ -366,7 +366,7 @@ impl Database {
     pub fn get_local_user_identities(
         &self,
         app_context: &AppContext,
-    ) -> rusqlite::Result<Vec<(QualifiedIdentity, Option<[u8; 32]>)>> {
+    ) -> rusqlite::Result<Vec<(QualifiedIdentity, Option<WalletSeedHash>)>> {
         let network = app_context.network.to_string();
 
         let conn = self.conn.lock().unwrap();

--- a/src/ui/tokens/tokens_screen/token_creator.rs
+++ b/src/ui/tokens/tokens_screen/token_creator.rs
@@ -58,7 +58,8 @@ impl TokensScreen {
                         let all_identities = match self.app_context.load_local_user_identities() {
                             Ok(identities) => identities.into_iter().filter(|qi| !qi.private_keys.private_keys.is_empty()).collect::<Vec<_>>(),
                             Err(e) => {
-                                ui.colored_label(Color32::RED, format!("Error loading identities from local DB: {}", e));
+                                tracing::error!(err=?e, "error loading identities from local DB");
+                                ui.colored_label(Color32::RED,format!("Error loading identities from local DB: {}", e));
                                 return;
                             }
                         };


### PR DESCRIPTION
Importing an identity from the network causes NULL wallet in database identity table. This causes errors when loading identities.
