### PR TITLE
feat: enable vertical scrolling on network chooser screen

### DIFF
--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -642,7 +642,12 @@ impl ScreenLike for NetworkChooserScreen {
             RootScreenType::RootScreenNetworkChooser,
         );
 
-        action |= island_central_panel(ctx, |ui| self.render_network_table(ui));
+        action |= island_central_panel(ctx, |ui| {
+            egui::ScrollArea::vertical()
+                .auto_shrink([false; 2])
+                .show(ui, |ui| self.render_network_table(ui))
+                .inner
+        });
 
         // Recheck both network status every 3 seconds
         let recheck_time = Duration::from_secs(3);


### PR DESCRIPTION
**Note:** I think there are other screens that have the same issue of sometimes displaying unreachable content. Probably all screens should be reviewed for that.

Previously, if the content did not fit on the screen there was no way to view it unless the application window could be made larger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added vertical scrolling to the network table in the central panel, allowing users to view more content within the Network Chooser screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->