### PR TITLE
chore: remove .env and dash_core_configs from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,6 @@ jobs:
       - name: Setup prerequisites
         run: |
           mkdir -p dash-evo-tool/
-          cp .env.example dash-evo-tool/.env
-          cp -r dash_core_configs/ dash-evo-tool/dash_core_configs
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
# Issue
Environment file and dash core configs are now embedded in the binary https://github.com/dashpay/dash-evo-tool/pull/331, and now they can be safely removed from the release distributions.

# Changes
Removed copying of .env and dash_core_configs inside build dir in CI release workflow

# Tests
Last v0.9-Developer-Preview-3 release is working well without .env and dash_core_configs folder in the current working directory
