### PR TITLE
feat: add context menu for contract actions in contract chooser panel

### DIFF
--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -14,9 +14,26 @@ use dash_sdk::dpp::data_contract::{
     accessors::v0::DataContractV0Getters, document_type::DocumentType,
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::dpp::serialization::PlatformSerializableWithPlatformVersion;
 use egui::{Color32, Context as EguiContext, Frame, Margin, RichText, SidePanel};
 use std::collections::HashMap;
 use std::sync::Arc;
+
+pub struct ContractChooserState {
+    pub right_click_contract_id: Option<String>,
+    pub show_context_menu: bool,
+    pub context_menu_position: egui::Pos2,
+}
+
+impl Default for ContractChooserState {
+    fn default() -> Self {
+        Self {
+            right_click_contract_id: None,
+            show_context_menu: false,
+            context_menu_position: egui::Pos2::ZERO,
+        }
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub fn add_contract_chooser_panel(
@@ -29,6 +46,7 @@ pub fn add_contract_chooser_panel(
     document_query: &mut String,
     pending_document_type: &mut DocumentType,
     pending_fields_selection: &mut HashMap<String, bool>,
+    chooser_state: &mut ContractChooserState,
 ) -> AppAction {
     let mut action = AppAction::None;
 
@@ -109,28 +127,30 @@ pub fn add_contract_chooser_panel(
                                             };
 
                                             // Expand/collapse the contract info
-                                            ui.collapsing(contract_header_text, |ui| {
-                                                //
-                                                // ===== Document Types Section =====
-                                                //
-                                                ui.collapsing("Document Types", |ui| {
-                                                    for (doc_name, doc_type) in
-                                                        contract.contract.document_types()
-                                                    {
-                                                        let is_selected_doc_type =
-                                                            *selected_document_type == *doc_type;
+                                            let collapsing_response =
+                                                ui.collapsing(contract_header_text, |ui| {
+                                                    //
+                                                    // ===== Document Types Section =====
+                                                    //
+                                                    ui.collapsing("Document Types", |ui| {
+                                                        for (doc_name, doc_type) in
+                                                            contract.contract.document_types()
+                                                        {
+                                                            let is_selected_doc_type =
+                                                                *selected_document_type
+                                                                    == *doc_type;
 
-                                                        let doc_type_header_text =
-                                                            if is_selected_doc_type {
-                                                                RichText::new(doc_name.clone())
-                                                                    .color(Color32::from_rgb(
-                                                                        21, 101, 192,
-                                                                    ))
-                                                            } else {
-                                                                RichText::new(doc_name.clone())
-                                                            };
+                                                            let doc_type_header_text =
+                                                                if is_selected_doc_type {
+                                                                    RichText::new(doc_name.clone())
+                                                                        .color(Color32::from_rgb(
+                                                                            21, 101, 192,
+                                                                        ))
+                                                                } else {
+                                                                    RichText::new(doc_name.clone())
+                                                                };
 
-                                                        let doc_resp =
+                                                            let doc_resp =
                                                 ui.collapsing(doc_type_header_text, |ui| {
                                                     // Show the indexes
                                                     if doc_type.indexes().is_empty() {
@@ -240,133 +260,140 @@ pub fn add_contract_chooser_panel(
                                                     }
                                                 });
 
-                                                        // Document Type clicked
-                                                        if doc_resp.header_response.clicked()
-                                                            && doc_resp.body_response.is_some()
-                                                        {
-                                                            // Expand doc type
-                                                            if let Ok(new_doc_type) = contract
-                                                                .contract
-                                                                .document_type_cloned_for_name(
-                                                                    doc_name,
-                                                                )
+                                                            // Document Type clicked
+                                                            if doc_resp.header_response.clicked()
+                                                                && doc_resp.body_response.is_some()
                                                             {
-                                                                *pending_document_type =
-                                                                    new_doc_type.clone();
-                                                                *selected_document_type =
-                                                                    new_doc_type.clone();
-                                                                *selected_data_contract =
-                                                                    contract.clone();
+                                                                // Expand doc type
+                                                                if let Ok(new_doc_type) = contract
+                                                                    .contract
+                                                                    .document_type_cloned_for_name(
+                                                                        doc_name,
+                                                                    )
+                                                                {
+                                                                    *pending_document_type =
+                                                                        new_doc_type.clone();
+                                                                    *selected_document_type =
+                                                                        new_doc_type.clone();
+                                                                    *selected_data_contract =
+                                                                        contract.clone();
+                                                                    *selected_index = None;
+                                                                    *document_query = format!(
+                                                                        "SELECT * FROM {}",
+                                                                        selected_document_type
+                                                                            .name()
+                                                                    );
+
+                                                                    // Reinitialize field selection
+                                                                    pending_fields_selection
+                                                                        .clear();
+
+                                                                    // Mark doc-defined fields
+                                                                    for (field_name, _schema) in
+                                                                        new_doc_type
+                                                                            .properties()
+                                                                            .iter()
+                                                                    {
+                                                                        pending_fields_selection
+                                                                            .insert(
+                                                                                field_name.clone(),
+                                                                                true,
+                                                                            );
+                                                                    }
+                                                                    // Show "internal" fields as unchecked by default,
+                                                                    // except for $ownerId and $id, which are checked
+                                                                    for dash_field in
+                                                                        DOCUMENT_PRIVATE_FIELDS
+                                                                    {
+                                                                        let checked = *dash_field
+                                                                            == "$ownerId"
+                                                                            || *dash_field == "$id";
+                                                                        pending_fields_selection
+                                                                            .insert(
+                                                                                dash_field
+                                                                                    .to_string(),
+                                                                                checked,
+                                                                            );
+                                                                    }
+                                                                }
+                                                            }
+                                                            // Document Type collapsed
+                                                            else if doc_resp
+                                                                .header_response
+                                                                .clicked()
+                                                                && doc_resp.body_response.is_none()
+                                                            {
                                                                 *selected_index = None;
                                                                 *document_query = format!(
                                                                     "SELECT * FROM {}",
                                                                     selected_document_type.name()
                                                                 );
-
-                                                                // Reinitialize field selection
-                                                                pending_fields_selection.clear();
-
-                                                                // Mark doc-defined fields
-                                                                for (field_name, _schema) in
-                                                                    new_doc_type.properties().iter()
-                                                                {
-                                                                    pending_fields_selection
-                                                                        .insert(
-                                                                            field_name.clone(),
-                                                                            true,
-                                                                        );
-                                                                }
-                                                                // Show "internal" fields as unchecked by default,
-                                                                // except for $ownerId and $id, which are checked
-                                                                for dash_field in
-                                                                    DOCUMENT_PRIVATE_FIELDS
-                                                                {
-                                                                    let checked = *dash_field
-                                                                        == "$ownerId"
-                                                                        || *dash_field == "$id";
-                                                                    pending_fields_selection
-                                                                        .insert(
-                                                                            dash_field.to_string(),
-                                                                            checked,
-                                                                        );
-                                                                }
                                                             }
                                                         }
-                                                        // Document Type collapsed
-                                                        else if doc_resp.header_response.clicked()
-                                                            && doc_resp.body_response.is_none()
-                                                        {
-                                                            *selected_index = None;
-                                                            *document_query = format!(
-                                                                "SELECT * FROM {}",
-                                                                selected_document_type.name()
-                                                            );
-                                                        }
-                                                    }
-                                                });
+                                                    });
 
-                                                //
-                                                // ===== Tokens Section =====
-                                                //
-                                                ui.collapsing("Tokens", |ui| {
-                                                    let tokens_map = contract.contract.tokens();
-                                                    if tokens_map.is_empty() {
-                                                        ui.label(
+                                                    //
+                                                    // ===== Tokens Section =====
+                                                    //
+                                                    ui.collapsing("Tokens", |ui| {
+                                                        let tokens_map = contract.contract.tokens();
+                                                        if tokens_map.is_empty() {
+                                                            ui.label(
                                                             "No tokens defined for this contract.",
                                                         );
-                                                    } else {
-                                                        for (token_name, token) in tokens_map {
-                                                            // Each token is its own collapsible
-                                                            ui.collapsing(
-                                                                token_name.to_string(),
-                                                                |ui| {
-                                                                    // Now you can display base supply, max supply, etc.
-                                                                    ui.label(format!(
-                                                                        "Base Supply: {}",
-                                                                        token.base_supply()
-                                                                    ));
-                                                                    if let Some(max_supply) =
-                                                                        token.max_supply()
-                                                                    {
+                                                        } else {
+                                                            for (token_name, token) in tokens_map {
+                                                                // Each token is its own collapsible
+                                                                ui.collapsing(
+                                                                    token_name.to_string(),
+                                                                    |ui| {
+                                                                        // Now you can display base supply, max supply, etc.
                                                                         ui.label(format!(
-                                                                            "Max Supply: {}",
-                                                                            max_supply
+                                                                            "Base Supply: {}",
+                                                                            token.base_supply()
                                                                         ));
-                                                                    } else {
-                                                                        ui.label(
-                                                                            "Max Supply: None",
-                                                                        );
-                                                                    }
+                                                                        if let Some(max_supply) =
+                                                                            token.max_supply()
+                                                                        {
+                                                                            ui.label(format!(
+                                                                                "Max Supply: {}",
+                                                                                max_supply
+                                                                            ));
+                                                                        } else {
+                                                                            ui.label(
+                                                                                "Max Supply: None",
+                                                                            );
+                                                                        }
 
-                                                                    // Add more details here
-                                                                },
-                                                            );
+                                                                        // Add more details here
+                                                                    },
+                                                                );
+                                                            }
                                                         }
-                                                    }
-                                                });
+                                                    });
 
-                                                //
-                                                // ===== Entire Contract JSON =====
-                                                //
-                                                ui.collapsing("Contract JSON", |ui| {
-                                                    match contract
-                                                        .contract
-                                                        .to_json(app_context.platform_version())
-                                                    {
-                                                        Ok(json_value) => {
-                                                            let pretty_str =
-                                                                serde_json::to_string_pretty(
-                                                                    &json_value,
-                                                                )
-                                                                .unwrap_or_else(|_| {
-                                                                    "Error formatting JSON"
-                                                                        .to_string()
-                                                                });
+                                                    //
+                                                    // ===== Entire Contract JSON =====
+                                                    //
+                                                    ui.collapsing("Contract JSON", |ui| {
+                                                        match contract
+                                                            .contract
+                                                            .to_json(app_context.platform_version())
+                                                        {
+                                                            Ok(json_value) => {
+                                                                let pretty_str =
+                                                                    serde_json::to_string_pretty(
+                                                                        &json_value,
+                                                                    )
+                                                                    .unwrap_or_else(|_| {
+                                                                        "Error formatting JSON"
+                                                                            .to_string()
+                                                                    });
 
-                                                            ui.add_space(2.0);
+                                                                ui.add_space(2.0);
 
-                                                            // A resizable region that the user can drag to expand/shrink
-                                                            egui::Resize::default()
+                                                                // A resizable region that the user can drag to expand/shrink
+                                                                egui::Resize::default()
                                                                 .id_salt(
                                                                     "json_resize_area_for_contract",
                                                                 )
@@ -381,16 +408,34 @@ pub fn add_contract_chooser_panel(
                                                                         });
                                                                 });
 
-                                                            ui.add_space(3.0);
-                                                        }
-                                                        Err(e) => {
-                                                            ui.label(format!(
+                                                                ui.add_space(3.0);
+                                                            }
+                                                            Err(e) => {
+                                                                ui.label(format!(
                                                     "Error converting contract to JSON: {e}"
                                                 ));
+                                                            }
                                                         }
-                                                    }
+                                                    });
                                                 });
-                                            });
+
+                                            // Check for right-click on the contract header
+                                            if collapsing_response
+                                                .header_response
+                                                .secondary_clicked()
+                                            {
+                                                let contract_id = contract
+                                                    .contract
+                                                    .id()
+                                                    .to_string(Encoding::Base58);
+                                                chooser_state.right_click_contract_id =
+                                                    Some(contract_id);
+                                                chooser_state.show_context_menu = true;
+                                                chooser_state.context_menu_position = ui
+                                                    .ctx()
+                                                    .pointer_interact_pos()
+                                                    .unwrap_or(egui::Pos2::ZERO);
+                                            }
 
                                             // Right‐aligned Remove button
                                             ui.with_layout(
@@ -432,6 +477,69 @@ pub fn add_contract_chooser_panel(
                     });
                 }); // Close the island frame
         });
+
+    // Show context menu if right-clicked
+    if chooser_state.show_context_menu {
+        if let Some(ref contract_id_str) = chooser_state.right_click_contract_id {
+            // Find the contract that was right-clicked
+            let contract_opt = contracts
+                .iter()
+                .find(|c| c.contract.id().to_string(Encoding::Base58) == *contract_id_str);
+
+            if let Some(contract) = contract_opt {
+                egui::Window::new("Contract Menu")
+                    .id(egui::Id::new("contract_context_menu"))
+                    .title_bar(false)
+                    .resizable(false)
+                    .collapsible(false)
+                    .fixed_pos(chooser_state.context_menu_position)
+                    .show(ctx, |ui| {
+                        ui.set_min_width(150.0);
+
+                        // Copy Hex option
+                        if ui.button("Copy (Hex)").clicked() {
+                            // Serialize contract to bytes
+                            if let Ok(bytes) =
+                                contract.contract.serialize_to_bytes_with_platform_version(
+                                    app_context.platform_version(),
+                                )
+                            {
+                                let hex_string = hex::encode(&bytes);
+                                ui.ctx().copy_text(hex_string);
+                            }
+                            chooser_state.show_context_menu = false;
+                        }
+
+                        // Copy JSON option
+                        if ui.button("Copy (JSON)").clicked() {
+                            // Convert contract to JSON
+                            if let Ok(json_value) =
+                                contract.contract.to_json(app_context.platform_version())
+                            {
+                                if let Ok(json_string) = serde_json::to_string_pretty(&json_value) {
+                                    ui.ctx().copy_text(json_string);
+                                }
+                            }
+                            chooser_state.show_context_menu = false;
+                        }
+                    });
+
+                // Close menu if clicked elsewhere
+                if ctx.input(|i| i.pointer.any_click()) {
+                    // Check if click was outside the menu
+                    let menu_rect = egui::Rect::from_min_size(
+                        chooser_state.context_menu_position,
+                        egui::vec2(150.0, 70.0), // Approximate size
+                    );
+                    if let Some(pointer_pos) = ctx.pointer_interact_pos() {
+                        if !menu_rect.contains(pointer_pos) {
+                            chooser_state.show_context_menu = false;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     action
 }

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -4,7 +4,9 @@ use crate::backend_task::document::DocumentTask::{self, FetchDocumentsPage}; // 
 use crate::backend_task::BackendTask;
 use crate::context::AppContext;
 use crate::model::qualified_contract::QualifiedContract;
-use crate::ui::components::contract_chooser_panel::add_contract_chooser_panel;
+use crate::ui::components::contract_chooser_panel::{
+    add_contract_chooser_panel, ContractChooserState,
+};
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::theme::{DashColors, Shadow, Shape};
@@ -64,6 +66,8 @@ pub struct DocumentQueryScreen {
     pub next_cursors: Vec<Start>,
     has_next_page: bool,
     previous_cursors: Vec<Start>,
+    // Contract chooser state
+    contract_chooser_state: ContractChooserState,
 }
 
 #[derive(PartialEq, Eq, Clone)]
@@ -127,6 +131,7 @@ impl DocumentQueryScreen {
             next_cursors: vec![],
             has_next_page: false,
             previous_cursors: Vec::new(),
+            contract_chooser_state: ContractChooserState::default(),
         }
     }
 
@@ -688,6 +693,7 @@ impl ScreenLike for DocumentQueryScreen {
             &mut self.document_query,
             &mut self.pending_document_type,
             &mut self.pending_fields_selection,
+            &mut self.contract_chooser_state,
         );
 
         if let AppAction::BackendTask(BackendTask::ContractTask(contract_task)) = &action {


### PR DESCRIPTION
Added a context menu for contract actions in the contract chooser panel. Users can now right-click on a contract header to access options for copying the contract in both Hex and JSON formats. The context menu appears at the position of the right-click and closes when the user clicks outside of it. This enhances user interaction by providing quick access to contract data. 

Changes include:
- Introduced `ContractChooserState` to manage the state of the context menu.
- Implemented right-click functionality to display the context menu.
- Added options to copy the contract as Hex or JSON.