### PR TITLE
feat: change top-up amount type from u32 to u64

### DIFF
--- a/src/database/identities.rs
+++ b/src/database/identities.rs
@@ -190,7 +190,7 @@ impl Database {
 
             while let Some(top_up_row) = rows.next()? {
                 let top_up_index: u32 = top_up_row.get(0)?;
-                let amount: u32 = top_up_row.get(1)?;
+                let amount: u64 = top_up_row.get(1)?;
                 top_ups.insert(top_up_index, amount);
             }
 
@@ -245,7 +245,7 @@ impl Database {
 
             while let Some(top_up_row) = rows.next()? {
                 let top_up_index: u32 = top_up_row.get(0)?;
-                let amount: u32 = top_up_row.get(1)?;
+                let amount: u64 = top_up_row.get(1)?;
                 top_ups.insert(top_up_index, amount);
             }
 
@@ -300,7 +300,7 @@ impl Database {
 
             while let Some(top_up_row) = rows.next()? {
                 let top_up_index: u32 = top_up_row.get(0)?;
-                let amount: u32 = top_up_row.get(1)?;
+                let amount: u64 = top_up_row.get(1)?;
                 top_ups.insert(top_up_index, amount);
             }
 

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -220,7 +220,7 @@ pub struct QualifiedIdentity {
     pub associated_wallets: BTreeMap<WalletSeedHash, Arc<RwLock<Wallet>>>,
     /// The index used to register the identity
     pub wallet_index: Option<u32>,
-    pub top_ups: BTreeMap<u32, u32>,
+    pub top_ups: BTreeMap<u32, u64>,
     pub status: IdentityStatus,
 }
 


### PR DESCRIPTION
Updated the data type for top-up amounts from `u32` to `u64` in the `Database` and `QualifiedIdentity` structs. This change accommodates larger top-up values, ensuring that the application can handle a wider range of financial transactions without overflow issues.