### PR TITLE
feat: perform local dpns name validation with  feedback

### DIFF
--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -299,7 +299,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
                         if let Some(error_msg) = validation_result.error_message() {
                             ui.colored_label(
                                 egui::Color32::RED,
-                                format!("{}", error_msg),
+                                error_msg,
                             );
                         }
                     }


### PR DESCRIPTION
Summary

- Added client-side validation for DPNS names to prevent platform submission errors
- Added real-time validation feedback in the registration UI
- Disabled registration button when name format is invalid

Background

Previously, invalid DPNS names would only be caught by the platform after submission, resulting in unhelpful JsonSchemaError messages like `"SomeRandomNameThatIsn'tContested" does not match "^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$"`. This created a poor user experience where users had to guess what was wrong with their name.

Changes
- New validation function: validate_dpns_name() enforces all DPNS naming rules:
- 3-63 character length requirement
- Alphanumeric characters and hyphens only
- Cannot start or end with hyphens
- Enhanced UI feedback: Real-time validation messages show specific errors (e.g., "Invalid character '!' detected")
- Improved UX: Registration button is disabled until name passes validation
- Preserved existing features: Contested name detection and cost estimation still work for valid names

  🤖 Generated with https://claude.ai/code