### PR TITLE
fix: panic when fetching withdrawals due to invalid destination address

### DIFF
--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -217,8 +217,9 @@ fn format_withdrawal_documents_with_daily_limit(
                 .get_bytes(OUTPUT_SCRIPT)
                 .expect("expected output script");
             let output_script = ScriptBuf::from_bytes(address_bytes);
-            let address =
-                Address::from_script(&output_script, network).expect("expected an address");
+            let address = Address::from_script(&output_script, network)
+                .map(|addr| addr.to_string())
+                .unwrap_or_else(|e| format!("Invalid Address: {}", e));
             format!(
                 "{}: {:.8} Dash for {} towards {} ({})",
                 local_datetime.format("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
This pull request modifies the `format_withdrawal_documents_with_daily_limit` function in `src/backend_task/platform_info.rs` to improve error handling when converting a script to an address.

Error handling improvement:

* Updated the `Address::from_script` call to handle errors gracefully by using `.map()` to convert the address to a string and `.unwrap_or_else()` to return a formatted error message if the address conversion fails.