### PR TITLE
feat: skip processing of empty optional fields in document actions

### DIFF
--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -1103,6 +1103,11 @@ impl DocumentActionScreen {
                 .get(name)
                 .ok_or_else(|| format!("Unknown property {}", name))?;
 
+            // Skip empty optional fields
+            if !schema.required && input_str.trim().is_empty() {
+                continue;
+            }
+
             let value = match &schema.property_type {
                 DocumentPropertyType::U128 => {
                     let n = input_str
@@ -1273,6 +1278,11 @@ impl DocumentActionScreen {
                 .properties()
                 .get(name)
                 .ok_or_else(|| format!("Unknown property {}", name))?;
+
+            // Skip empty optional fields
+            if !schema.required && input_str.trim().is_empty() {
+                continue;
+            }
 
             let value = match &schema.property_type {
                 DocumentPropertyType::U128 => {


### PR DESCRIPTION
This update modifies the `DocumentActionScreen` to skip processing of empty optional fields when the schema indicates that the field is not required. This change prevents unnecessary processing of empty inputs, improving the efficiency of the document action handling. The logic was added in two places within the `DocumentActionScreen` implementation where input values are processed.