### PR TITLE
fix: correct format of open seed in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,8 +1443,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "dapi-grpc-macros",
  "futures-core",
@@ -1461,8 +1461,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc-macros"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "heck",
  "quote",
@@ -1580,8 +1580,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1692,8 +1692,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1703,8 +1703,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1992,8 +1992,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2003,8 +2003,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2046,8 +2046,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2071,8 +2071,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "dapi-grpc",
@@ -2597,8 +2597,8 @@ dependencies = [
 
 [[package]]
 name = "feature-flags-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3065,7 +3065,8 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611077565b279965fa34897787ae52f79471f0476db785116cceb92077f237ad"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3086,7 +3087,8 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab159c3f82b0387f6a27a54930b18aa594b507013de947c8e909cf61abb75fe"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3096,7 +3098,8 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dce2f34c6bfddb3a26696b42e6169f986330513e0e9f4c5d7ba290d09867a5e"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -3108,7 +3111,8 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4580e54da0031d2f36e50312f3361005099bceeb8adb0f6ccbf87a0880cd1b08"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -3128,7 +3132,8 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d61e09bb3055358974ceb65b91752064979450092014d91a6bc4a52d77887ea"
 dependencies = [
  "hex",
 ]
@@ -3136,7 +3141,8 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d61d27c76d49758b365a9e4a9da7f995f976b9525626bf645aef258024defd2"
 dependencies = [
  "thiserror 2.0.12",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3145,7 +3151,8 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8#221ca6ec6b8d2b192d334192bd5a7b2cab5b0aa8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaebfe3c1e5f263f14fd25ab060543b31eb4b9d6bdc44fe220e88df6be7ddf59"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -3828,8 +3835,8 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3975,8 +3982,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5080,8 +5087,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "platform-version",
@@ -5089,8 +5096,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5100,8 +5107,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -5120,8 +5127,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "bincode",
  "grovedb-version",
@@ -5132,8 +5139,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5668,8 +5675,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "backon",
  "chrono",
@@ -6698,8 +6705,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -7291,8 +7298,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8242,8 +8249,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "2.0.0-rc.16"
-source = "git+https://github.com/dashpay/platform?rev=5b8b29df2d0f58f52ae75b8d0672378df4b9e154#5b8b29df2d0f58f52ae75b8d0672378df4b9e154"
+version = "2.0.1"
+source = "git+https://github.com/dashpay/platform?rev=5f93c70720a1ea09f91c9142668e17f314986f03#5f93c70720a1ea09f91c9142668e17f314986f03"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.30.1", features = ["signal"] }
 eframe = { version = "0.31.1", features = ["persistence"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "5b8b29df2d0f58f52ae75b8d0672378df4b9e154" }
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "5f93c70720a1ea09f91c9142668e17f314986f03" }
 thiserror = "2.0.12"
 serde = "1.0.219"
 serde_json = "1.0.140"

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -9,6 +9,7 @@ use dash_sdk::dpp::dashcore::{
     Address, InstantLock, Network, OutPoint, PrivateKey, PublicKey, Transaction, TxOut,
 };
 use std::collections::{BTreeMap, HashMap};
+use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::{Arc, RwLock};
 
@@ -148,10 +149,19 @@ pub enum WalletSeed {
     Open(OpenWalletSeed),
     Closed(ClosedWalletSeed),
 }
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct OpenKeyItem<const N: usize> {
     pub seed: [u8; N],
     pub wallet_info: ClosedKeyItem,
+}
+
+impl<const N: usize> Debug for OpenKeyItem<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hash = ClosedKeyItem::compute_seed_hash(&self.seed);
+        f.debug_struct("OpenKeyItem")
+            .field("seed_hash", &hex::encode(hash))
+            .finish()
+    }
 }
 
 // Type alias for OpenWalletSeed with a fixed seed size of 64 bytes


### PR DESCRIPTION
This pull request implements correct debug logging of wallet seeds.

### Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L21-R21): Updated the `dash-sdk` dependency to a newer Git revision (`5f93c70720a1ea09f91c9142668e17f314986f03`) for compatibility with the latest platform changes.

### Code improvements:

* [`src/model/wallet/mod.rs`](diffhunk://#diff-d267e65e0ac1c0008842ec1436746440180f41162845a0e8f14b9019187b2471L151-R166): Added a custom `Debug` implementation for `OpenKeyItem` to display a hashed representation of the seed, enhancing debugging clarity.
* [`src/model/wallet/mod.rs`](diffhunk://#diff-d267e65e0ac1c0008842ec1436746440180f41162845a0e8f14b9019187b2471L151-R166): Removed the `#[derive(Debug)]` attribute from `OpenKeyItem` and manually implemented the `Debug` trait.
* [`src/model/wallet/mod.rs`](diffhunk://#diff-d267e65e0ac1c0008842ec1436746440180f41162845a0e8f14b9019187b2471R12): Added `use std::fmt::Debug` to support the custom `Debug` implementation.