### PR TITLE
fix(build): allow uninlined format args in source code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,6 @@ raw-cpuid = "11.5.0"
 
 tempfile = { version = "3.20.0" }
 egui_kittest = { version = "0.31.1", features = ["eframe"] }
+
+[lints.clippy]
+uninlined_format_args = "allow"


### PR DESCRIPTION
Whole project formats format strings like that:

```format!("foo bar {} {}", a, b)```

In Rust 1.88, it is considered code style issue and causes CI/CD to fail; however, we  don't want to change it everywhere, so we disable this check.