### PR TITLE
refactor: unified identity selector

### DIFF
--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -225,6 +225,12 @@ pub struct QualifiedIdentity {
     pub status: IdentityStatus,
 }
 
+impl AsRef<QualifiedIdentity> for QualifiedIdentity {
+    fn as_ref(&self) -> &QualifiedIdentity {
+        self
+    }
+}
+
 impl PartialEq for QualifiedIdentity {
     fn eq(&self, other: &Self) -> bool {
         self.identity == other.identity

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -23,9 +23,9 @@ use egui::{ComboBox, Response, Ui, Widget};
 ///
 /// // This example shows the API usage, but cannot be run in doctest
 /// // due to complex dependencies
-/// fn example_usage(ui: &mut egui::Ui, identities: &IndexMap<Identifier, QualifiedIdentity>) {
+/// fn example_usage(ui: &mut egui::Ui, identities: &[QualifiedIdentity]) {
 ///     let mut identity_str = String::new();
-///     let exclude_list = vec!["already_used_identity".to_string()];
+///     let exclude_list = vec![/* some identifiers */];
 ///
 ///     let response = ui.add(IdentitySelector::new(
 ///         "my_selector",
@@ -33,7 +33,7 @@ use egui::{ComboBox, Response, Ui, Widget};
 ///         identities
 ///     )
 ///     .width(250.0)
-///     .allow_duplicates(false)
+///     .label("Select Identity:")
 ///     .exclude(&exclude_list));
 ///
 ///     if response.changed() {
@@ -52,6 +52,8 @@ pub struct IdentitySelector<'a> {
     identities: BTreeMap<Identifier, &'a QualifiedIdentity>,
     /// Slice of identity strings to exclude from dropdown (can be empty)
     exclude_identities: &'a [Identifier],
+    /// Optional label to display before the selector
+    label: Option<String>,
 }
 
 impl<'a> IdentitySelector<'a> {
@@ -67,6 +69,7 @@ impl<'a> IdentitySelector<'a> {
             identity_str,
             identities: identities.iter().map(|q| (q.identity.id(), q)).collect(),
             exclude_identities: &[],
+            label: None,
         }
     }
 
@@ -81,11 +84,27 @@ impl<'a> IdentitySelector<'a> {
         self.exclude_identities = exclude_identities;
         self
     }
+
+    /// Set an optional label to display before the selector
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
 }
 
 impl<'a> Widget for IdentitySelector<'a> {
     fn ui(self, ui: &mut Ui) -> Response {
         ui.horizontal(|ui| {
+            // Display label if present, with centered vertical alignment
+
+            if let Some(label) = &self.label {
+                ui.vertical(|ui| {
+                    // FIXME we add space because vertical alignment is not working as expected
+                    ui.add_space(15.0);
+                    ui.label(label);
+                });
+            }
+
             // Check if current identity_str matches any existing identity
             let current_identity = if !self.identity_str.is_empty() {
                 Identifier::from_string(self.identity_str, Encoding::Base58).ok()

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -5,7 +5,7 @@ use dash_sdk::dpp::{
     identity::accessors::IdentityGettersV0, platform_value::string_encoding::Encoding,
 };
 use dash_sdk::platform::Identifier;
-use egui::{ComboBox, Response, Ui, Widget};
+use egui::{ComboBox, Response, TextEdit, Ui, Widget, WidgetText};
 
 /// A reusable identity selector widget that combines a ComboBox dropdown of available identities
 /// with a text edit field for manual entry. Implements the egui `Widget` trait for idiomatic usage.
@@ -15,11 +15,12 @@ use egui::{ComboBox, Response, Ui, Widget};
 /// identity is automatically selected in the dropdown.
 ///
 /// # Example
-/// ```rust,no_run
+/// ```rust
 /// use dash_evo_tool::ui::components::identity_selector::IdentitySelector;
 /// use dash_sdk::query_types::IndexMap;
 /// use dash_sdk::platform::Identifier;
 /// use dash_evo_tool::model::qualified_identity::QualifiedIdentity;
+/// use egui::{RichText, Color32};
 ///
 /// // This example shows the API usage, but cannot be run in doctest
 /// // due to complex dependencies
@@ -27,16 +28,27 @@ use egui::{ComboBox, Response, Ui, Widget};
 ///     let mut identity_str = String::new();
 ///     let exclude_list = vec![/* some identifiers */];
 ///
-///     let response = ui.add(IdentitySelector::new(
-///         "my_selector",
+///     // Basic usage with string label
+///     let response1 = ui.add(IdentitySelector::new(
+///         "my_selector1",
 ///         &mut identity_str,
 ///         identities
 ///     )
 ///     .width(250.0)
-///     .label("Select Identity:")
+///     .label("Select Identity:")               // accepts &str
 ///     .exclude(&exclude_list));
 ///
-///     if response.changed() {
+///     // Advanced usage with styled RichText label
+///     let response2 = ui.add(IdentitySelector::new(
+///         "my_selector2",
+///         &mut identity_str,
+///         identities
+///     )
+///     .width(300.0)
+///     .label(RichText::new("Styled Label").color(Color32::RED).strong()) // accepts RichText
+///     .exclude(&exclude_list));
+///
+///     if response1.changed() || response2.changed() {
 ///         // Identity was changed via dropdown selection, "Other" selection, or text input
 ///     }
 /// }
@@ -48,29 +60,64 @@ pub struct IdentitySelector<'a> {
     width: f32,
     /// Mutable reference to the current identity string
     identity_str: &'a mut String,
+    /// Selected identity, if any
+    identity: Option<&'a mut Option<QualifiedIdentity>>,
     /// Map of available identities to choose from
     identities: BTreeMap<Identifier, &'a QualifiedIdentity>,
     /// Slice of identity strings to exclude from dropdown (can be empty)
     exclude_identities: &'a [Identifier],
     /// Optional label to display before the selector
-    label: Option<String>,
+    label: Option<WidgetText>,
+    other_option: bool,
 }
 
 impl<'a> IdentitySelector<'a> {
     /// Create a new IdentitySelector with the given ID and required parameters
-    pub fn new(
+    pub fn new<I: AsRef<QualifiedIdentity>>(
         id: impl Into<String>,
         identity_str: &'a mut String,
-        identities: &'a [QualifiedIdentity],
+        identities: &'a [I],
     ) -> Self {
         Self {
             id: id.into(),
             width: 200.0,
             identity_str,
-            identities: identities.iter().map(|q| (q.identity.id(), q)).collect(),
+            identity: None,
+            identities: identities
+                .iter()
+                .map(|q| {
+                    let id = q.as_ref();
+                    (id.identity.id(), id)
+                })
+                .collect(),
             exclude_identities: &[],
             label: None,
+            other_option: true, // Default to showing "Other" option
         }
+    }
+
+    /// This method creates a selector that can update a mutable reference to the selected identity
+    /// based on user input. This is useful when you want to allow users to select from existing identities
+    /// or enter a new one, while keeping track of the selected identity in a mutable reference.
+    ///
+    /// `selected_identity` will be set to:
+    /// * `Some(qualified_identity)` if a known identity is selected from the dropdown
+    /// * `None` if the "Other" option is selected or the text input is empty or invalid
+    pub fn selected_identity(
+        mut self,
+        selected_identity: &'a mut Option<QualifiedIdentity>,
+    ) -> Result<Self, String> {
+        self.identity = Some(selected_identity);
+        // trigger change handling to initialize the state
+
+        Ok(self)
+    }
+
+    /// Enable or disable the "Other" option in the dropdown
+    pub fn other_option(mut self, other_option: bool) -> Self {
+        self.other_option = other_option;
+
+        self
     }
 
     /// Set the width of the ComboBox
@@ -86,52 +133,92 @@ impl<'a> IdentitySelector<'a> {
     }
 
     /// Set an optional label to display before the selector
-    pub fn label(mut self, label: impl Into<String>) -> Self {
+    pub fn label(mut self, label: impl Into<WidgetText>) -> Self {
         self.label = Some(label.into());
         self
+    }
+
+    /// Validate the given identity string and return the corresponding identity if valid.
+    fn get_identity(&self, identity_str: &str) -> Option<&'a QualifiedIdentity> {
+        let identifier = Identifier::from_string_unknown_encoding(identity_str).ok()?;
+
+        if self.exclude_identities.contains(&identifier) {
+            return None;
+        }
+
+        self.identities.get(&identifier).copied()
+    }
+
+    /// Handle changes to the identity selector
+    fn on_change(&mut self) {
+        let selected_identity = self.get_identity(self.identity_str);
+        if let Some(self_identity) = &mut self.identity {
+            if let Some(new_identity) = selected_identity {
+                self_identity.replace(new_identity.clone());
+                tracing::trace!(
+                    "updating selected identity: {:?} {:?}",
+                    new_identity,
+                    self.identity,
+                );
+            } else {
+                self_identity.take(); // Clear the existing identity reference if it was None
+            };
+        }
     }
 }
 
 impl<'a> Widget for IdentitySelector<'a> {
-    fn ui(self, ui: &mut Ui) -> Response {
+    /// Render the identity selector widget
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if there are no identities available to select from
+    /// and no "Other" option is enabled. It requires at least one identity to function
+    /// correctly, as it needs to provide a default selection.
+    fn ui(mut self, ui: &mut Ui) -> Response {
         ui.horizontal(|ui| {
             // Display label if present, with centered vertical alignment
-
             if let Some(label) = &self.label {
                 ui.vertical(|ui| {
                     // FIXME we add space because vertical alignment is not working as expected
                     ui.add_space(15.0);
-                    ui.label(label);
+                    ui.add(egui::Label::new(label.clone()));
                 });
             }
 
-            // Check if current identity_str matches any existing identity
-            let current_identity = if !self.identity_str.is_empty() {
-                Identifier::from_string(self.identity_str, Encoding::Base58).ok()
-            } else {
-                None
-            };
+            // If the "Other" option is disabled, we automatically select first identity
+            if !self.other_option && self.identity_str.is_empty() {
+                if let Some(first_identity) = self
+                    .identities
+                    .keys()
+                    .find(|id| !self.exclude_identities.contains(id))
+                {
+                    *self.identity_str = first_identity.to_string(Encoding::Base58);
+                    // trigger change handling to update the selected identity
+                    self.on_change();
+                }
+            }
 
-            let has_matching_identity = current_identity
-                .and_then(|id| self.identities.get(&id))
-                .is_some();
+            // Check if current identity_str matches any existing identity; current_identity = None means
+            // no identity is selected or the input is empty.
+            let current_identity = self.get_identity(self.identity_str);
+
+            let has_matching_identity = current_identity.is_some();
+
+            let current_identity_combo_label = current_identity
+                .map(|q| q.display_string())
+                .unwrap_or_else(|| {
+                    if self.other_option {
+                        "Other".to_string()
+                    } else {
+                        "No identities found".to_string()
+                    }
+                });
 
             // ComboBox for selecting existing identities
             let combo_response = ComboBox::from_id_salt(&self.id)
                 .width(self.width)
-                .selected_text(if has_matching_identity {
-                    // Show the display name of the matching identity
-                    current_identity
-                        .and_then(|id| self.identities.get(&id))
-                        .map(|q| q.display_string())
-                        .unwrap_or_else(|| "Other".to_string())
-                } else if self.identity_str.is_empty() {
-                    // Show "Other" when input is empty
-                    "Other".to_string()
-                } else {
-                    // Show "Other" when input doesn't match any known identity
-                    "Other".to_string()
-                })
+                .selected_text(current_identity_combo_label)
                 .show_ui(ui, |ui| {
                     let mut combo_changed = false;
 
@@ -142,23 +229,23 @@ impl<'a> Widget for IdentitySelector<'a> {
                             continue;
                         }
                         let id_str = identifier.to_string(Encoding::Base58);
+                        let checked = current_identity.is_some_and(|x| qualified_identity.eq(&x));
 
                         if ui
-                            .selectable_label(
-                                current_identity == Some(*identifier),
-                                qualified_identity.display_string(),
-                            )
+                            .selectable_label(checked, qualified_identity.display_string())
                             .clicked()
                         {
-                            *self.identity_str = id_str;
+                            // combo_changed = *self.identity_str != id_str;
                             combo_changed = true;
+                            *self.identity_str = id_str;
                         }
                     }
 
                     // Add "Other" option
-                    if ui
-                        .selectable_label(!has_matching_identity, "Other")
-                        .clicked()
+                    if self.other_option
+                        && ui
+                            .selectable_label(!has_matching_identity, "Other")
+                            .clicked()
                     {
                         self.identity_str.clear();
                         combo_changed = true;
@@ -168,16 +255,23 @@ impl<'a> Widget for IdentitySelector<'a> {
                 });
 
             // Text edit field for manual entry
-            let text_response = ui.text_edit_singleline(self.identity_str);
+            let text_response = TextEdit::singleline(self.identity_str)
+                .interactive(self.other_option)
+                .ui(ui);
+
+            // Handle identity selection updates after combo box and text input
+            let combo_changed = combo_response.inner.unwrap_or(false);
+            if combo_changed || text_response.changed() {
+                self.on_change();
+            }
 
             // Return a response that indicates if anything changed
-            let combo_changed = combo_response.inner.unwrap_or(false);
-
-            // Combine the responses, preferring the text edit response for interactions
             let mut response = text_response;
             if combo_changed {
+                // note: response inherits the changed state from text_response
                 response.mark_changed();
             }
+
             response
         })
         .inner

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -1,0 +1,174 @@
+use std::collections::BTreeMap;
+
+use crate::model::qualified_identity::QualifiedIdentity;
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::platform::Identifier;
+use egui::{ComboBox, Response, Ui, Widget};
+
+/// A reusable identity selector widget that combines a ComboBox dropdown of available identities
+/// with a text edit field for manual entry. Implements the egui `Widget` trait for idiomatic usage.
+///
+/// The widget includes an "Other" option in the dropdown that allows users to manually enter
+/// identity addresses. When a known identity ID is entered in the text field, the corresponding
+/// identity is automatically selected in the dropdown.
+///
+/// # Example
+/// ```rust,no_run
+/// use dash_evo_tool::ui::components::identity_selector::IdentitySelector;
+/// use dash_sdk::query_types::IndexMap;
+/// use dash_sdk::platform::Identifier;
+/// use dash_evo_tool::model::qualified_identity::QualifiedIdentity;
+///
+/// // This example shows the API usage, but cannot be run in doctest
+/// // due to complex dependencies
+/// fn example_usage(ui: &mut egui::Ui, identities: &IndexMap<Identifier, QualifiedIdentity>) {
+///     let mut identity_str = String::new();
+///     let exclude_list = vec!["already_used_identity".to_string()];
+///
+///     let response = ui.add(IdentitySelector::new(
+///         "my_selector",
+///         &mut identity_str,
+///         identities
+///     )
+///     .width(250.0)
+///     .allow_duplicates(false)
+///     .exclude(&exclude_list));
+///
+///     if response.changed() {
+///         // Identity was changed via dropdown selection, "Other" selection, or text input
+///     }
+/// }
+/// ```
+pub struct IdentitySelector<'a> {
+    /// A unique ID for this selector (used for egui's ID system)
+    id: String,
+    /// Width of the ComboBox
+    width: f32,
+    /// Whether to show duplicates or filter them out based on provided exclude_identities
+    allow_duplicates: bool,
+    /// Mutable reference to the current identity string
+    identity_str: &'a mut String,
+    /// Map of available identities to choose from
+    identities: &'a BTreeMap<Identifier, QualifiedIdentity>,
+    /// Slice of identity strings to exclude from dropdown (can be empty)
+    exclude_identities: &'a [Identifier],
+}
+
+impl<'a> IdentitySelector<'a> {
+    /// Create a new IdentitySelector with the given ID and required parameters
+    pub fn new(
+        id: impl Into<String>,
+        identity_str: &'a mut String,
+        identities: &'a BTreeMap<Identifier, QualifiedIdentity>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            width: 200.0,
+            allow_duplicates: true,
+            identity_str,
+            identities,
+            exclude_identities: &[],
+        }
+    }
+
+    /// Set the width of the ComboBox
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Set whether duplicates are allowed
+    pub fn allow_duplicates(mut self, allow_duplicates: bool) -> Self {
+        self.allow_duplicates = allow_duplicates;
+        self
+    }
+
+    /// Set the identities to exclude from the dropdown
+    pub fn exclude(mut self, exclude_identities: &'a [Identifier]) -> Self {
+        self.exclude_identities = exclude_identities;
+        self
+    }
+}
+
+impl<'a> Widget for IdentitySelector<'a> {
+    fn ui(self, ui: &mut Ui) -> Response {
+        ui.horizontal(|ui| {
+            // Check if current identity_str matches any existing identity
+            let current_identity = if !self.identity_str.is_empty() {
+                Identifier::from_string(self.identity_str, Encoding::Base58).ok()
+            } else {
+                None
+            };
+
+            let has_matching_identity = current_identity
+                .and_then(|id| self.identities.get(&id))
+                .is_some();
+
+            // ComboBox for selecting existing identities
+            let combo_response = ComboBox::from_id_salt(&self.id)
+                .width(self.width)
+                .selected_text(if has_matching_identity {
+                    // Show the display name of the matching identity
+                    current_identity
+                        .and_then(|id| self.identities.get(&id))
+                        .map(|q| q.display_string())
+                        .unwrap_or_else(|| "Other".to_string())
+                } else if self.identity_str.is_empty() {
+                    // Show "Other" when input is empty
+                    "Other".to_string()
+                } else {
+                    // Show "Other" when input doesn't match any known identity
+                    "Other".to_string()
+                })
+                .show_ui(ui, |ui| {
+                    let mut combo_changed = false;
+
+                    // Add existing identities to the dropdown
+                    for (identifier, qualified_identity) in self.identities.iter() {
+                        let id_str = identifier.to_string(Encoding::Base58);
+
+                        // Filter out excluded identities if duplicates are not allowed
+                        if !self.allow_duplicates && self.exclude_identities.contains(identifier) {
+                            continue;
+                        }
+
+                        if ui
+                            .selectable_label(
+                                current_identity == Some(*identifier),
+                                qualified_identity.display_string(),
+                            )
+                            .clicked()
+                        {
+                            *self.identity_str = id_str;
+                            combo_changed = true;
+                        }
+                    }
+
+                    // Add "Other" option
+                    if ui
+                        .selectable_label(!has_matching_identity, "Other")
+                        .clicked()
+                    {
+                        self.identity_str.clear();
+                        combo_changed = true;
+                    }
+
+                    combo_changed
+                });
+
+            // Text edit field for manual entry
+            let text_response = ui.text_edit_singleline(self.identity_str);
+
+            // Return a response that indicates if anything changed
+            let combo_changed = combo_response.inner.unwrap_or(false);
+
+            // Combine the responses, preferring the text edit response for interactions
+            let mut response = text_response;
+            if combo_changed {
+                response.mark_changed();
+            }
+            response
+        })
+        .inner
+    }
+}

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -235,7 +235,6 @@ impl<'a> Widget for IdentitySelector<'a> {
                             .selectable_label(checked, qualified_identity.display_string())
                             .clicked()
                         {
-                            // combo_changed = *self.identity_str != id_str;
                             combo_changed = true;
                             *self.identity_str = id_str;
                         }

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,6 +1,7 @@
 pub mod contract_chooser_panel;
 pub mod dpns_subscreen_chooser_panel;
 pub mod entropy_grid;
+pub mod identity_selector;
 pub mod left_panel;
 pub mod left_wallet_panel;
 pub mod styled;

--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -14,11 +14,11 @@ use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
 use crate::model::qualified_contract::QualifiedContract;
 use crate::model::qualified_identity::QualifiedIdentity;
+use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::helpers::add_contract_chooser_pre_filtered;
-use crate::ui::helpers::render_identity_selector;
 use crate::ui::tokens::burn_tokens_screen::BurnTokensScreen;
 use crate::ui::tokens::destroy_frozen_funds_screen::DestroyFrozenFundsScreen;
 use crate::ui::tokens::freeze_tokens_screen::FreezeTokensScreen;
@@ -78,6 +78,7 @@ pub struct GroupActionsScreen {
     qualified_identities: Vec<QualifiedIdentity>,
     identity_token_balances: IndexMap<IdentityTokenIdentifier, IdentityTokenBalance>,
     selected_identity: Option<QualifiedIdentity>,
+    selected_identity_str: String,
 
     // Backend task status
     fetch_group_actions_status: FetchGroupActionsStatus,
@@ -142,6 +143,7 @@ impl GroupActionsScreen {
             qualified_identities,
             identity_token_balances,
             selected_identity: None,
+            selected_identity_str: String::new(),
 
             // Backend task status
             fetch_group_actions_status: FetchGroupActionsStatus::NotStarted,
@@ -523,8 +525,19 @@ impl ScreenLike for GroupActionsScreen {
             ui.heading("2. Select an identity:");
 
             ui.add_space(10.0);
-            self.selected_identity =
-                render_identity_selector(ui, &self.qualified_identities, &self.selected_identity);
+
+            ui.add(
+                IdentitySelector::new(
+                    "group_actions_identity_selector",
+                    &mut self.selected_identity_str,
+                    &self.qualified_identities,
+                )
+                .selected_identity(&mut self.selected_identity)
+                .expect("Failed to create identity selector")
+                .other_option(false)
+                .width(250.0)
+                .label("Identity:"),
+            );
 
             let mut fetch_clicked = false;
             if self.selected_contract.is_some() && self.selected_identity.is_some() {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -54,49 +54,6 @@ pub fn info_icon_button(ui: &mut egui::Ui, hover_text: &str) -> Response {
     response.on_hover_text(hover_text)
 }
 
-/// Returns the newly selected identity (if changed), otherwise the existing one.
-pub fn render_identity_selector(
-    ui: &mut Ui,
-    qualified_identities: &[QualifiedIdentity],
-    selected_identity: &Option<QualifiedIdentity>,
-) -> Option<QualifiedIdentity> {
-    let mut new_selected_identity = selected_identity.clone();
-
-    ui.horizontal(|ui| {
-        ui.label("Identity:");
-        ComboBox::from_id_salt("identity_selector")
-            .selected_text(
-                selected_identity
-                    .as_ref()
-                    .map(|qi| {
-                        qi.alias
-                            .as_ref()
-                            .unwrap_or(&qi.identity.id().to_string(Encoding::Base58))
-                            .clone()
-                    })
-                    .unwrap_or_else(|| "Choose identity…".into()),
-            )
-            .show_ui(ui, |cb| {
-                for qi in qualified_identities {
-                    let label = qi
-                        .alias
-                        .as_ref()
-                        .unwrap_or(&qi.identity.id().to_string(Encoding::Base58))
-                        .clone();
-
-                    if cb
-                        .selectable_label(selected_identity.as_ref() == Some(qi), label)
-                        .clicked()
-                    {
-                        new_selected_identity = Some(qi.clone());
-                    }
-                }
-            });
-    });
-
-    new_selected_identity
-}
-
 /// Returns the newly selected key (if changed), otherwise the existing one.
 // Allow dead_code: This function provides UI for key selection within identities,
 // useful for identity-based operations and key management interfaces

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -112,20 +112,16 @@ impl TransferScreen {
     }
 
     fn render_to_identity_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Receiver Identity Id:");
-
-            // Use our reusable IdentitySelector widget
-            let _response = ui.add(
-                IdentitySelector::new(
-                    "transfer_recipient_selector",
-                    &mut self.receiver_identity_id,
-                    &self.known_identities,
-                )
-                .width(300.0)
-                .exclude(&[self.identity.identity.id()]),
-            );
-        });
+        ui.add(
+            IdentitySelector::new(
+                "transfer_recipient_selector",
+                &mut self.receiver_identity_id,
+                &self.known_identities,
+            )
+            .width(300.0)
+            .label("Receiver Identity ID:")
+            .exclude(&[self.identity.identity.id()]),
+        );
     }
 
     fn show_confirmation_popup(&mut self, ui: &mut Ui) -> AppAction {

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -214,14 +214,14 @@ impl DestroyFrozenFundsScreen {
 
     /// Renders the text input for specifying the “frozen identity”
     fn render_frozen_identity_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Frozen Identity ID:");
-            ui.add(IdentitySelector::new(
+        ui.add(
+            IdentitySelector::new(
                 "frozen_identity_selector",
                 &mut self.frozen_identity_id,
                 &self.frozen_identities,
-            ));
-        });
+            )
+            .label("Frozen Identity ID:"),
+        );
     }
 
     /// Confirmation popup

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -5,6 +5,7 @@ use crate::backend_task::tokens::TokenTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
@@ -64,6 +65,10 @@ pub struct DestroyFrozenFundsScreen {
     /// The user must specify the identity ID whose frozen funds are to be destroyed
     /// Typically some Identity that has been frozen by the system or a group
     pub frozen_identity_id: String,
+
+    /// All frozen identities that can be selected
+    /// TODO: We should filter them by frozen status, right now we just show all known identities
+    pub frozen_identities: Vec<QualifiedIdentity>,
 
     status: DestroyFrozenFundsStatus,
     error_message: Option<String>,
@@ -183,9 +188,14 @@ impl DestroyFrozenFundsScreen {
             &mut error_message,
         );
 
+        let all_identities = app_context
+            .load_local_qualified_identities()
+            .expect("Identities not loaded");
+
         Self {
             identity: identity_token_info.identity.clone(),
             frozen_identity_id: String::new(),
+            frozen_identities: all_identities,
             identity_token_info,
             selected_key: possible_key,
             group,
@@ -206,7 +216,11 @@ impl DestroyFrozenFundsScreen {
     fn render_frozen_identity_input(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             ui.label("Frozen Identity ID:");
-            ui.text_edit_singleline(&mut self.frozen_identity_id);
+            ui.add(IdentitySelector::new(
+                "frozen_identity_selector",
+                &mut self.frozen_identity_id,
+                &self.frozen_identities,
+            ));
         });
     }
 

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -202,19 +202,15 @@ impl FreezeTokensScreen {
 
     /// Renders text input for the identity to freeze
     fn render_freeze_identity_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Freeze Identity ID:");
-
-            // Use our reusable IdentitySelector widget
-            let _response = ui.add(
-                IdentitySelector::new(
-                    "freeze_identity_selector",
-                    &mut self.freeze_identity_id,
-                    &self.known_identities,
-                )
-                .width(300.0),
-            );
-        });
+        let _response = ui.add(
+            IdentitySelector::new(
+                "freeze_identity_selector",
+                &mut self.freeze_identity_id,
+                &self.known_identities,
+            )
+            .label("Freeze Identity ID:")
+            .width(300.0),
+        );
     }
 
     /// Confirmation popup

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -5,6 +5,7 @@ use crate::backend_task::tokens::TokenTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
@@ -52,6 +53,7 @@ pub struct FreezeTokensScreen {
     group: Option<(GroupContractPosition, Group)>,
     is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
+    known_identities: Vec<QualifiedIdentity>,
 
     /// The identity we want to freeze
     pub freeze_identity_id: String,
@@ -73,6 +75,10 @@ pub struct FreezeTokensScreen {
 
 impl FreezeTokensScreen {
     pub fn new(identity_token_info: IdentityTokenInfo, app_context: &Arc<AppContext>) -> Self {
+        let known_identities = app_context
+            .load_local_qualified_identities()
+            .expect("Identities not loaded");
+
         let possible_key = identity_token_info
             .identity
             .identity
@@ -190,6 +196,7 @@ impl FreezeTokensScreen {
             selected_wallet,
             wallet_password: String::new(),
             show_password: false,
+            known_identities,
         }
     }
 
@@ -197,7 +204,16 @@ impl FreezeTokensScreen {
     fn render_freeze_identity_input(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             ui.label("Freeze Identity ID:");
-            ui.text_edit_singleline(&mut self.freeze_identity_id);
+
+            // Use our reusable IdentitySelector widget
+            let _response = ui.add(
+                IdentitySelector::new(
+                    "freeze_identity_selector",
+                    &mut self.freeze_identity_id,
+                    &self.known_identities,
+                )
+                .width(300.0),
+            );
         });
     }
 

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -214,20 +214,16 @@ impl MintTokensScreen {
 
     /// Renders an optional text input for the user to specify a "Recipient Identity"
     fn render_recipient_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Recipient:");
-
-            // Use our reusable IdentitySelector widget
-            let _response = ui.add(
-                IdentitySelector::new(
-                    "mint_recipient_selector",
-                    &mut self.recipient_identity_id,
-                    &self.known_identities,
-                )
-                .width(300.0)
-                .exclude(&[self.identity_token_info.identity.identity.id()]),
-            );
-        });
+        let _response = ui.add(
+            IdentitySelector::new(
+                "mint_recipient_selector",
+                &mut self.recipient_identity_id,
+                &self.known_identities,
+            )
+            .width(300.0)
+            .label("Recipient:")
+            .exclude(&[self.identity_token_info.identity.identity.id()]),
+        );
 
         // If empty, minted tokens go to the 'issuer' identity (self.identity).
     }

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -3,7 +3,9 @@ use crate::app::AppAction;
 use crate::backend_task::BackendTask;
 use crate::backend_task::tokens::TokenTask;
 use crate::context::AppContext;
+use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
@@ -52,6 +54,7 @@ pub struct MintTokensScreen {
     group: Option<(GroupContractPosition, Group)>,
     is_unilateral_group_member: bool,
     pub group_action_id: Option<Identifier>,
+    known_identities: Vec<QualifiedIdentity>,
 
     pub recipient_identity_id: String,
 
@@ -73,6 +76,10 @@ pub struct MintTokensScreen {
 
 impl MintTokensScreen {
     pub fn new(identity_token_info: IdentityTokenInfo, app_context: &Arc<AppContext>) -> Self {
+        let known_identities = app_context
+            .load_local_qualified_identities()
+            .expect("Identities not loaded");
+
         let possible_key = identity_token_info
             .identity
             .identity
@@ -181,6 +188,7 @@ impl MintTokensScreen {
             group,
             is_unilateral_group_member,
             group_action_id: None,
+            known_identities,
             recipient_identity_id: "".to_string(),
             amount_to_mint: "".to_string(),
             status: MintTokensStatus::NotStarted,
@@ -208,7 +216,17 @@ impl MintTokensScreen {
     fn render_recipient_input(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             ui.label("Recipient:");
-            ui.text_edit_singleline(&mut self.recipient_identity_id);
+
+            // Use our reusable IdentitySelector widget
+            let _response = ui.add(
+                IdentitySelector::new(
+                    "mint_recipient_selector",
+                    &mut self.recipient_identity_id,
+                    &self.known_identities,
+                )
+                .width(300.0)
+                .exclude(&[self.identity_token_info.identity.identity.id()]),
+            );
         });
 
         // If empty, minted tokens go to the 'issuer' identity (self.identity).

--- a/src/ui/tokens/tokens_screen/groups.rs
+++ b/src/ui/tokens/tokens_screen/groups.rs
@@ -1,3 +1,4 @@
+use crate::model::qualified_identity::QualifiedIdentity;
 use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::tokens::tokens_screen::TokensScreen;
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -174,14 +175,14 @@ impl TokensScreen {
                                     Vec::new()
                                 };
 
+                                let identities = self.identities.values().cloned().collect::<Vec<QualifiedIdentity>>();
                                 // Use the reusable identity selector widget
                                 let _identity_response = ui.add(IdentitySelector::new(
                                     format!("member_identity_selector_{}", j),
                                     &mut member.identity_str,
-                                    &self.identities.clone().into_iter().collect::<BTreeMap<_, _>>(),
+                                    &identities,
                                 )
                                 .width(200.0)
-                                .allow_duplicates(self.app_context.is_developer_mode())
                                 .exclude(&exclude_identities));
 
                                 ui.label("Power (u32):");

--- a/src/ui/tokens/tokens_screen/groups.rs
+++ b/src/ui/tokens/tokens_screen/groups.rs
@@ -175,7 +175,7 @@ impl TokensScreen {
                                     Vec::new()
                                 };
 
-                                let identities = self.identities.values().cloned().collect::<Vec<QualifiedIdentity>>();
+                                let identities = self.identities.values().collect::<Vec<&QualifiedIdentity>>();
                                 // Use the reusable identity selector widget
                                 let _identity_response = ui.add(IdentitySelector::new(
                                     format!("member_identity_selector_{}", j),

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -158,18 +158,13 @@ impl TransferTokensScreen {
         let selected_wallet =
             get_selected_wallet(&identity, None, selected_key, &mut error_message);
 
-        let receiver_identity_id = known_identities
-            .first()
-            .map(|identity| identity.identity.id().to_string(Encoding::Base58))
-            .unwrap_or_default();
-
         Self {
             identity,
             identity_token_balance,
             known_identities,
             selected_key: selected_key.cloned(),
             public_note: None,
-            receiver_identity_id,
+            receiver_identity_id: String::new(),
             amount: String::new(),
             transfer_tokens_status: TransferTokensStatus::NotStarted,
             max_amount,

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -4,6 +4,7 @@ use crate::backend_task::tokens::TokenTask;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
+use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
@@ -21,7 +22,7 @@ use dash_sdk::dpp::prelude::TimestampMillis;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use eframe::egui::{self, Context, Ui};
 use egui::{Color32, RichText};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -117,8 +118,7 @@ pub enum TransferTokensStatus {
 pub struct TransferTokensScreen {
     pub identity: QualifiedIdentity,
     pub identity_token_balance: IdentityTokenBalance,
-    friend_identities: Vec<(String, Identifier)>,
-    selected_friend_index: Option<usize>,
+    friend_identities: BTreeMap<Identifier, QualifiedIdentity>,
     selected_key: Option<IdentityPublicKey>,
     pub public_note: Option<String>,
     pub receiver_identity_id: String,
@@ -141,16 +141,9 @@ impl TransferTokensScreen {
             .load_local_qualified_identities()
             .expect("Identities not loaded");
 
-        let friend_identities: Vec<(String, Identifier)> = all_identities
+        let friend_identities: BTreeMap<Identifier, QualifiedIdentity> = all_identities
             .iter()
-            .filter(|id| id.identity.id() != identity_token_balance.identity_id)
-            .map(|id| {
-                let alias = id
-                    .alias
-                    .clone()
-                    .unwrap_or_else(|| id.identity.id().to_string(Encoding::Base58));
-                (alias, id.identity.id())
-            })
+            .map(|id| (id.identity.id(), id.clone()))
             .collect();
 
         let identity = all_identities
@@ -170,17 +163,16 @@ impl TransferTokensScreen {
         let selected_wallet =
             get_selected_wallet(&identity, None, selected_key, &mut error_message);
 
-        let (selected_friend_index, receiver_identity_id) =
-            if let Some((_first, identifier)) = friend_identities.first() {
-                (Some(0), identifier.to_string(Encoding::Base58))
-            } else {
-                (None, String::new())
-            };
+        let receiver_identity_id = friend_identities
+            .iter()
+            .next()
+            .map(|x| x.0.to_string(Encoding::Base58))
+            .unwrap_or_default();
+
         Self {
             identity,
             identity_token_balance,
             friend_identities,
-            selected_friend_index,
             selected_key: selected_key.cloned(),
             public_note: None,
             receiver_identity_id,
@@ -214,39 +206,18 @@ impl TransferTokensScreen {
 
     fn render_to_identity_input(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            // Dropdown
-            egui::ComboBox::from_id_salt("friend_selector")
-                .selected_text(
-                    self.selected_friend_index
-                        .and_then(|i| self.friend_identities.get(i).map(|(name, _)| name.clone()))
-                        .unwrap_or_else(|| "Other".to_string()),
+            ui.label("To:");
+
+            // Use our reusable IdentitySelector widget
+            let _response = ui.add(
+                IdentitySelector::new(
+                    "transfer_recipient_selector",
+                    &mut self.receiver_identity_id,
+                    &self.friend_identities,
                 )
-                .show_ui(ui, |ui| {
-                    for (i, (alias, _)) in self.friend_identities.iter().enumerate() {
-                        if ui
-                            .selectable_value(&mut self.selected_friend_index, Some(i), alias)
-                            .clicked()
-                        {
-                            self.receiver_identity_id =
-                                self.friend_identities[i].1.to_string(Encoding::Base58);
-                        }
-                    }
-
-                    if ui
-                        .selectable_value(&mut self.selected_friend_index, None, "Other")
-                        .clicked()
-                    {
-                        // Clear the text box to avoid confusion
-                        self.receiver_identity_id.clear();
-                    }
-                });
-
-            // Text box
-            let prev_text = self.receiver_identity_id.clone();
-            ui.text_edit_singleline(&mut self.receiver_identity_id);
-            if self.receiver_identity_id != prev_text {
-                self.selected_friend_index = None;
-            }
+                .width(300.0)
+                .exclude(&[self.identity.identity.id()]),
+            );
         });
     }
 

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -199,20 +199,16 @@ impl TransferTokensScreen {
     }
 
     fn render_to_identity_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("To:");
-
-            // Use our reusable IdentitySelector widget
-            let _response = ui.add(
-                IdentitySelector::new(
-                    "transfer_recipient_selector",
-                    &mut self.receiver_identity_id,
-                    &self.known_identities,
-                )
-                .width(300.0)
-                .exclude(&[self.identity.identity.id()]),
-            );
-        });
+        let _response = ui.add(
+            IdentitySelector::new(
+                "transfer_recipient_selector",
+                &mut self.receiver_identity_id,
+                &self.known_identities,
+            )
+            .width(300.0)
+            .label("Recipient:")
+            .exclude(&[self.identity.identity.id()]),
+        );
     }
 
     fn show_confirmation_popup(&mut self, ui: &mut Ui) -> AppAction {

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -213,7 +213,7 @@ impl UnfreezeTokensScreen {
                 &self.frozen_identities,
             )
             .width(300.0)
-            .label("Unfreeze Identity ID to unfreeze:"),
+            .label("Identity ID to unfreeze:"),
         );
     }
 

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -206,19 +206,15 @@ impl UnfreezeTokensScreen {
     }
 
     fn render_unfreeze_identity_input(&mut self, ui: &mut Ui) {
-        ui.horizontal(|ui| {
-            ui.label("Identity to Unfreeze:");
-
-            // Use our reusable IdentitySelector widget
-            let _response = ui.add(
-                IdentitySelector::new(
-                    "unfreeze_identity_selector",
-                    &mut self.unfreeze_identity_id,
-                    &self.frozen_identities,
-                )
-                .width(300.0),
-            );
-        });
+        let _response = ui.add(
+            IdentitySelector::new(
+                "unfreeze_identity_selector",
+                &mut self.unfreeze_identity_id,
+                &self.frozen_identities,
+            )
+            .width(300.0)
+            .label("Unfreeze Identity ID to unfreeze:"),
+        );
     }
 
     fn show_confirmation_popup(&mut self, ui: &mut Ui) -> AppAction {


### PR DESCRIPTION
This pull request introduces a reusable `IdentitySelector` widget to simplify identity selection across multiple screens in the application. The widget combines a dropdown menu with a text input field, allowing users to select from known identities or manually input an identity ID. It is integrated into several screens, replacing previous manual text input fields for identity selection.

### New Feature: Reusable `IdentitySelector` Widget
* [`src/ui/components/identity_selector.rs`](diffhunk://#diff-65ed4efaf0a3f3898a4eece32ccf7192246a9c475360848c0267753ce6d3873fR1-R166): Added a new `IdentitySelector` widget that combines a dropdown of available identities with a text input field for manual entry. It supports customization such as width, exclusion of specific identities, and duplicate prevention.

### Integration of `IdentitySelector` Across Screens
#### Transfer Screen
* [`src/ui/identities/transfer_screen.rs`](diffhunk://#diff-9186d566ee97ff2052eaca6c6ef1465363a6cd795553ea886ecbb08e890dbce0L111-R127): Integrated the `IdentitySelector` widget for selecting the receiver identity ID. Added support for loading known identities from the application context. [[1]](diffhunk://#diff-9186d566ee97ff2052eaca6c6ef1465363a6cd795553ea886ecbb08e890dbce0L111-R127) [[2]](diffhunk://#diff-9186d566ee97ff2052eaca6c6ef1465363a6cd795553ea886ecbb08e890dbce0R57-R60) [[3]](diffhunk://#diff-9186d566ee97ff2052eaca6c6ef1465363a6cd795553ea886ecbb08e890dbce0R75)

#### Destroy Frozen Funds Screen
* [`src/ui/tokens/destroy_frozen_funds_screen.rs`](diffhunk://#diff-bb4684c85f64be5d80fd0ec9b613d7be5f2eea74321a97d2023c31cc70f26bd6L209-R223): Replaced manual text input for frozen identity ID with the `IdentitySelector` widget. Added functionality to load all identities from the application context. [[1]](diffhunk://#diff-bb4684c85f64be5d80fd0ec9b613d7be5f2eea74321a97d2023c31cc70f26bd6L209-R223) [[2]](diffhunk://#diff-bb4684c85f64be5d80fd0ec9b613d7be5f2eea74321a97d2023c31cc70f26bd6R191-R198)

#### Freeze Tokens Screen
* [`src/ui/tokens/freeze_tokens_screen.rs`](diffhunk://#diff-7cb6a4eb4dbeccf372cbcbb5a10914a7a8e10d84b5cd72c6f579603c1e206cc2R199-R216): Used the `IdentitySelector` widget for selecting the identity to freeze. Loaded known identities from the application context for dropdown options. [[1]](diffhunk://#diff-7cb6a4eb4dbeccf372cbcbb5a10914a7a8e10d84b5cd72c6f579603c1e206cc2R199-R216) [[2]](diffhunk://#diff-7cb6a4eb4dbeccf372cbcbb5a10914a7a8e10d84b5cd72c6f579603c1e206cc2R78-R81)

#### Mint Tokens Screen
* [`src/ui/tokens/mint_tokens_screen.rs`](diffhunk://#diff-7f8f8dee2ca90bb3cee26e2bacc0d83d06e5ea70758579c9bbaadb5d7685d0e2L211-R229): Replaced recipient identity ID input with the `IdentitySelector` widget. Added logic to exclude the issuer identity from the dropdown options. [[1]](diffhunk://#diff-7f8f8dee2ca90bb3cee26e2bacc0d83d06e5ea70758579c9bbaadb5d7685d0e2L211-R229) [[2]](diffhunk://#diff-7f8f8dee2ca90bb3cee26e2bacc0d83d06e5ea70758579c9bbaadb5d7685d0e2R79-R82)

### Supporting Changes
* Updated imports in files where the `IdentitySelector` widget is used, ensuring proper integration. [[1]](diffhunk://#diff-39fee2e00393629bdf343fd2cdb452c8d6dfd99fb5bd40976d0c4f59c556e532R4) [[2]](diffhunk://#diff-9186d566ee97ff2052eaca6c6ef1465363a6cd795553ea886ecbb08e890dbce0R7) [[3]](diffhunk://#diff-bb4684c85f64be5d80fd0ec9b613d7be5f2eea74321a97d2023c31cc70f26bd6R8) [[4]](diffhunk://#diff-7cb6a4eb4dbeccf372cbcbb5a10914a7a8e10d84b5cd72c6f579603c1e206cc2R8) [[5]](diffhunk://#diff-7f8f8dee2ca90bb3cee26e2bacc0d83d06e5ea70758579c9bbaadb5d7685d0e2R6-R8) [[6]](diffhunk://#diff-e32d14ecd9bd78c17d0a151ef8d3b838a432b1aaa3d1693fb93c8358e7cb9a5cR1-R2)
* Removed unused `ComboBox` import in `src/ui/tokens/tokens_screen/groups.rs`.Introduce a reusable identity selector component for consistent identity selection across various screens, enhancing user experience and code maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a reusable identity selector widget for choosing or entering identity addresses, now integrated across various screens.
  * Users can select from known identities or manually enter an identity, with options to exclude certain identities from selection.

* **Improvements**
  * Replaced manual text input fields and dropdowns for identity selection with a unified, user-friendly selector component in transfer, mint, freeze, unfreeze, and destroy frozen funds screens.
  * Enhanced consistency and usability when selecting identities throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->