### PR TITLE
fix: dash-qt path autodetection fails

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -478,28 +478,8 @@ impl AppContext {
 
     /// Retrieves the current settings
     pub fn get_settings(&self) -> Result<Option<Settings>> {
-        let settings_tuple = self.db.get_settings()?;
-
-        if let Some((
-            network,
-            root_screen_type,
-            password_info,
-            dash_qt_path,
-            developer_mode,
-            theme_mode,
-        )) = settings_tuple
-        {
-            Ok(Some(Settings::new(
-                network,
-                root_screen_type,
-                password_info,
-                dash_qt_path, // This will map to dash_qt_path in Settings::new
-                developer_mode,
-                theme_mode,
-            )))
-        } else {
-            Ok(None)
-        }
+        let settings = self.db.get_settings()?.map(Settings::from);
+        Ok(settings)
     }
 
     /// Retrieves all contracts from the database plus the system contracts from app context.

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,7 @@ use crate::model::contested_name::ContestedName;
 use crate::model::password_info::PasswordInfo;
 use crate::model::qualified_contract::QualifiedContract;
 use crate::model::qualified_identity::{DPNSNameInfo, QualifiedIdentity};
+use crate::model::settings::Settings;
 use crate::model::wallet::{Wallet, WalletSeedHash};
 use crate::sdk_wrapper::initialize_sdk;
 use crate::ui::RootScreenType;
@@ -37,7 +38,6 @@ use dash_sdk::query_types::IndexMap;
 use egui::Context;
 use rusqlite::Result;
 use std::collections::{BTreeMap, HashMap};
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -476,21 +476,30 @@ impl AppContext {
             .insert_or_update_settings(self.network, root_screen_type)
     }
 
-    /// Retrieves the current `RootScreenType` from the settings
-    #[allow(clippy::type_complexity)]
-    pub fn get_settings(
-        &self,
-    ) -> Result<
-        Option<(
-            Network,
-            RootScreenType,
-            Option<PasswordInfo>,
-            Option<PathBuf>,
-            bool,
-            crate::ui::theme::ThemeMode,
-        )>,
-    > {
-        self.db.get_settings()
+    /// Retrieves the current settings
+    pub fn get_settings(&self) -> Result<Option<Settings>> {
+        let settings_tuple = self.db.get_settings()?;
+
+        if let Some((
+            network,
+            root_screen_type,
+            password_info,
+            dash_qt_path,
+            developer_mode,
+            theme_mode,
+        )) = settings_tuple
+        {
+            Ok(Some(Settings::new(
+                network,
+                root_screen_type,
+                password_info,
+                dash_qt_path, // This will map to dash_qt_path in Settings::new
+                developer_mode,
+                theme_mode,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Retrieves all contracts from the database plus the system contracts from app context.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,4 +3,5 @@ pub mod password_info;
 pub mod proof_log_item;
 pub mod qualified_contract;
 pub mod qualified_identity;
+pub mod settings;
 pub mod wallet;

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -10,6 +10,7 @@ pub struct Settings {
     pub network: Network,
     pub root_screen_type: RootScreenType,
     pub password_info: Option<PasswordInfo>,
+    /// Path to the Dash-Qt binary, if set. None means autodetect. Empty string means no path set and no autodetect.
     pub dash_qt_path: Option<PathBuf>,
     pub overwrite_dash_conf: bool,
     pub theme_mode: ThemeMode,

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -10,7 +10,8 @@ pub struct Settings {
     pub network: Network,
     pub root_screen_type: RootScreenType,
     pub password_info: Option<PasswordInfo>,
-    /// Path to the Dash-Qt binary, if set. None means autodetect. Empty string means no path set and no autodetect.
+    /// Path to the Dash-Qt binary, if set. None means autodetect.
+    /// Empty value (`""`) means path deliberately not set, autodetect will not be performed.
     pub dash_qt_path: Option<PathBuf>,
     pub overwrite_dash_conf: bool,
     pub theme_mode: ThemeMode,

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -1,0 +1,107 @@
+use crate::model::password_info::PasswordInfo;
+use crate::ui::RootScreenType;
+use crate::ui::theme::ThemeMode;
+use dash_sdk::dpp::dashcore::Network;
+use std::path::PathBuf;
+
+/// Application settings structure
+#[derive(Debug, Clone)]
+pub struct Settings {
+    pub network: Network,
+    pub root_screen_type: RootScreenType,
+    pub password_info: Option<PasswordInfo>,
+    pub dash_qt_path: Option<PathBuf>,
+    pub overwrite_dash_conf: bool,
+    pub theme_mode: ThemeMode,
+}
+
+impl
+    From<(
+        Network,
+        RootScreenType,
+        Option<PasswordInfo>,
+        Option<PathBuf>,
+        bool,
+        ThemeMode,
+    )> for Settings
+{
+    /// Converts a tuple into a Settings instance
+    ///
+    /// Used mainly for database operations where settings are retrieved as a tuple.
+    fn from(
+        tuple: (
+            Network,
+            RootScreenType,
+            Option<PasswordInfo>,
+            Option<PathBuf>,
+            bool,
+            ThemeMode,
+        ),
+    ) -> Self {
+        Self::new(tuple.0, tuple.1, tuple.2, tuple.3, tuple.4, tuple.5)
+    }
+}
+
+impl Default for Settings {
+    /// Default settings for the application
+    fn default() -> Self {
+        Self::new(
+            Network::Dash,
+            RootScreenType::RootScreenIdentities,
+            None,
+            None, // autodetect
+            true,
+            ThemeMode::System,
+        )
+    }
+}
+
+impl Settings {
+    /// Creates a new Settings instance
+    pub fn new(
+        network: Network,
+        root_screen_type: RootScreenType,
+        password_info: Option<PasswordInfo>,
+        dash_qt_path: Option<PathBuf>,
+        overwrite_dash_conf: bool,
+        theme_mode: ThemeMode,
+    ) -> Self {
+        Self {
+            network,
+            root_screen_type,
+            password_info,
+            dash_qt_path: dash_qt_path.or_else(detect_dash_qt_path),
+            overwrite_dash_conf,
+            theme_mode,
+        }
+    }
+}
+
+/// Detects the path to the Dash-Qt binary on the system
+fn detect_dash_qt_path() -> Option<PathBuf> {
+    let path = which::which("dash-qt")
+        .map(|path| path.to_string_lossy().to_string())
+        .inspect_err(|e| tracing::warn!("failed to find dash-qt: {}", e))
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            // Fallback to default paths based on the operating system
+            if cfg!(target_os = "macos") {
+                PathBuf::from("/Applications/Dash-Qt.app/Contents/MacOS/Dash-Qt")
+            } else if cfg!(target_os = "windows") {
+                // Retrieve the PROGRAMFILES environment variable or default to "C:\\Program Files"
+                let program_files = std::env::var("PROGRAMFILES")
+                    .unwrap_or_else(|_| "C:\\Program Files".to_string());
+                PathBuf::from(program_files).join("DashCore\\dash-qt.exe")
+            } else {
+                PathBuf::from("/usr/local/bin/dash-qt") // Default Linux path
+            }
+        });
+
+    if path.is_file() {
+        Some(path)
+    } else {
+        tracing::warn!("Dash-Qt binary not found at: {:?}", path);
+        None
+    }
+}

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -17,7 +17,7 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
     ];
 
     let active_screen = match app_context.get_settings() {
-        Ok(Some(settings)) => match settings.1 {
+        Ok(Some(settings)) => match settings.root_screen_type {
             ui::RootScreenType::RootScreenDPNSActiveContests => DPNSSubscreen::Active,
             ui::RootScreenType::RootScreenDPNSPastContests => DPNSSubscreen::Past,
             ui::RootScreenType::RootScreenDPNSOwnedNames => DPNSSubscreen::Owned,

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -15,7 +15,7 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
     ];
 
     let active_screen = match app_context.get_settings() {
-        Ok(Some(settings)) => match settings.1 {
+        Ok(Some(settings)) => match settings.root_screen_type {
             ui::RootScreenType::RootScreenMyTokenBalances => TokensSubscreen::MyTokens,
             ui::RootScreenType::RootScreenTokenSearch => TokensSubscreen::SearchTokens,
             ui::RootScreenType::RootScreenTokenCreator => TokensSubscreen::TokenCreator,

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -41,7 +41,7 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
     ];
 
     let active_screen = match app_context.get_settings() {
-        Ok(Some(settings)) => match settings.1 {
+        Ok(Some(settings)) => match settings.root_screen_type {
             ui::RootScreenType::RootScreenToolsProofLogScreen => ToolsSubscreen::ProofLog,
             ui::RootScreenType::RootScreenToolsTransitionVisualizerScreen => {
                 ToolsSubscreen::TransactionViewer

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -13,6 +13,7 @@ use crate::utils::path::format_path_for_display;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::identity::TimestampMillis;
 use eframe::egui::{self, Context, Ui};
+use nix::NixPath;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -295,7 +296,7 @@ impl NetworkChooserScreen {
                                             )
                                             .clicked()
                                     {
-                                        self.custom_dash_qt_path = None;
+                                        self.custom_dash_qt_path = Some(PathBuf::new()); // Reset to empty to avoid auto-detection
                                         self.custom_dash_qt_error_message = None;
                                         self.save().expect("Expected to save db settings");
                                     }
@@ -570,12 +571,18 @@ impl NetworkChooserScreen {
         }
 
         // Add a button to start the network
+        let start_enabled = if let Some(path) = self.custom_dash_qt_path.as_ref() {
+            !path.is_empty() && path.is_file()
+        } else {
+            false
+        };
+
         if network != Network::Regtest {
-            ui.add_enabled_ui(self.custom_dash_qt_path.is_some(), |ui| {
+            ui.add_enabled_ui(start_enabled, |ui| {
                 if ui
                     .button("Start")
                     .on_disabled_hover_text(
-                        "Configure dash-qt binary using Advanced Settings below",
+                        "Please select path to dash-qt binary in Advanced Settings",
                     )
                     .clicked()
                 {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -13,7 +13,6 @@ use crate::utils::path::format_path_for_display;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::identity::TimestampMillis;
 use eframe::egui::{self, Context, Ui};
-use nix::NixPath;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -572,7 +571,7 @@ impl NetworkChooserScreen {
 
         // Add a button to start the network
         let start_enabled = if let Some(path) = self.custom_dash_qt_path.as_ref() {
-            !path.is_empty() && path.is_file()
+            !path.as_os_str().is_empty() && path.is_file()
         } else {
             false
         };

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -44,7 +44,6 @@ impl NetworkChooserScreen {
         devnet_app_context: Option<&Arc<AppContext>>,
         local_app_context: Option<&Arc<AppContext>>,
         current_network: Network,
-        custom_dash_qt_path: Option<PathBuf>,
         overwrite_dash_conf: bool,
     ) -> Self {
         let local_network_dashmate_password = if let Ok(config) = Config::load() {
@@ -66,13 +65,14 @@ impl NetworkChooserScreen {
         };
         let developer_mode = current_context.is_developer_mode();
 
-        // Load theme preference from settings
-        let theme_preference = current_context
+        // Load settings including theme preference and dash_qt_path
+        let settings = current_context
             .get_settings()
             .ok()
             .flatten()
-            .map(|(_, _, _, _, _, theme)| theme)
-            .unwrap_or(ThemeMode::System);
+            .unwrap_or_default();
+        let theme_preference = settings.theme_mode;
+        let custom_dash_qt_path = settings.dash_qt_path;
 
         Self {
             mainnet_app_context: mainnet_app_context.clone(),
@@ -672,12 +672,10 @@ impl ScreenLike for NetworkChooserScreen {
         self.should_reset_collapsing_states = true;
 
         // Reload settings from database to ensure we have the latest values
-        if let Ok(Some((_, _, _, custom_dash_qt_path, overwrite_dash_conf, theme_preference))) =
-            self.current_app_context().get_settings()
-        {
-            self.custom_dash_qt_path = custom_dash_qt_path;
-            self.overwrite_dash_conf = overwrite_dash_conf;
-            self.theme_preference = theme_preference;
+        if let Ok(Some(settings)) = self.current_app_context().get_settings() {
+            self.custom_dash_qt_path = settings.dash_qt_path;
+            self.overwrite_dash_conf = settings.overwrite_dash_conf;
+            self.theme_preference = settings.theme_mode;
         }
     }
 


### PR DESCRIPTION
## Issue 

dash-qt path is not correctly autodetected

## Solution

Refactored settings handling to make it easier to manage dash-qt path (and others).

## Details

This pull request refactors the handling of application settings by introducing a new `Settings` struct and centralizing its usage across the codebase. The changes simplify the code, improve readability, and enhance maintainability by replacing complex tuple-based settings with a structured approach. Additionally, redundant code for detecting the Dash-Qt binary path has been consolidated into the `Settings` struct.

### Refactoring and centralization of settings:

* Introduced a new `Settings` struct in `src/model/settings.rs` to encapsulate application settings, replacing tuple-based settings. Includes methods for creating, converting, and defaulting settings, along with logic for Dash-Qt path detection.
* Updated `AppContext::get_settings` in `src/context.rs` to return the new `Settings` struct instead of a tuple, simplifying database operations.
* Replaced tuple-based settings logic with structured `Settings` usage in `AppState` initialization in `src/app.rs`. This includes extracting individual settings like `password_info`, `theme_mode`, and `dash_qt_path` directly from the `Settings` struct. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L158-R165) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020L229-R250)

### Removal of redundant code:

* Removed the standalone `detect_dash_qt_path` function from `src/app.rs` and integrated its functionality into the `Settings` struct. This consolidates Dash-Qt path detection logic and eliminates duplication.

### Updates to UI components:

* Refactored the logic in various UI components (`dpns_subscreen_chooser_panel`, `tokens_subscreen_chooser_panel`, `tools_subscreen_chooser_panel`) to use `Settings::root_screen_type` instead of accessing tuple indices. [[1]](diffhunk://#diff-363da30faf03bec4ff5ba1d5fe1c7d2409937b24c956317ae63c25e6d4ff4aceL20-R20) [[2]](diffhunk://#diff-ba4100b53ed2d6cc0bf59bb59c7b750b6de2ccd1091d292b38cb16720157bdd1L18-R18) [[3]](diffhunk://#diff-24a88bb1190b18ccb74569dde2210db4ef283d257cd7c653df241ff1f1220215L44-R44)
* Enhanced `NetworkChooserScreen` in `src/ui/network_chooser_screen.rs` to utilize `Settings` for theme preference and Dash-Qt path, and added validation for Dash-Qt binary path before enabling the "Start" button. [[1]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL69-R76) [[2]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL298-R299) [[3]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bR574-R585) [[4]](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL675-R685)

These changes improve the codebase's clarity and modularity, making it easier to maintain and extend in the future.