### PR TITLE
fix: change of wallet on top up does not update the address

### DIFF
--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -373,6 +373,17 @@ impl AddNewIdentityScreen {
                             if ui.selectable_label(is_selected, wallet_alias).clicked() {
                                 // Update the selected wallet
                                 selected_wallet = Some(wallet.clone());
+                                // Reset the funding address
+                                self.funding_address = None;
+                                // Reset the funding asset lock
+                                self.funding_asset_lock = None;
+                                // Reset the funding UTXO
+                                self.funding_utxo = None;
+                                // Reset the copied to clipboard state
+                                self.copied_to_clipboard = None;
+                                // Reset the step to choose funding method
+                                let mut step = self.step.write().unwrap();
+                                *step = WalletFundedScreenStep::ChooseFundingMethod;
                             }
                         }
                     });

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -117,6 +117,17 @@ impl TopUpIdentityScreen {
                                 if ui.selectable_label(is_selected, wallet_alias).clicked() {
                                     // Update the selected wallet from app_context
                                     self.wallet = Some(wallet.clone());
+                                    // Reset the funding address
+                                    self.funding_address = None;
+                                    // Reset the funding asset lock
+                                    self.funding_asset_lock = None;
+                                    // Reset the funding UTXO
+                                    self.funding_utxo = None;
+                                    // Reset the copied to clipboard state
+                                    self.copied_to_clipboard = None;
+                                    // Reset the step to choose funding method
+                                    let mut step = self.step.write().unwrap();
+                                    *step = WalletFundedScreenStep::ChooseFundingMethod;
                                 }
                             });
                         }


### PR DESCRIPTION
This pull request introduces changes to ensure proper state resets when switching wallets in the `AddNewIdentityScreen` and `TopUpIdentityScreen` components. The updates improve the user experience by resetting relevant fields and returning the interface to the initial step for selecting a funding method.

### State management updates:

* [`src/ui/identities/add_new_identity_screen/mod.rs`](diffhunk://#diff-5fa5172ab2569a44b5b55b181bcf49177efa56b0f9c985fe23d26baa4bdaae3dR376-R386): Updated the `AddNewIdentityScreen` to reset `funding_address`, `funding_asset_lock`, `funding_utxo`, `copied_to_clipboard`, and set the step to `ChooseFundingMethod` when a new wallet is selected.
* [`src/ui/identities/top_up_identity_screen/mod.rs`](diffhunk://#diff-653578740fdf30123b18359e605ce6322651124e2f04ff18a2b343a1eb0f025cR120-R130): Updated the `TopUpIdentityScreen` to reset `funding_address`, `funding_asset_lock`, `funding_utxo`, `copied_to_clipboard`, and set the step to `ChooseFundingMethod` when a new wallet is selected.