### PR TITLE
fix: settings are read from db multiple times a second

### DIFF
--- a/src/backend_task/system_task/mod.rs
+++ b/src/backend_task/system_task/mod.rs
@@ -48,6 +48,8 @@ impl AppContext {
         self: &Arc<Self>,
         theme_mode: ThemeMode,
     ) -> Result<BackendTaskSuccessResult, String> {
+        let _guard = self.invalidate_settings_cache();
+        
         self.db
             .update_theme_preference(theme_mode)
             .map_err(|e| e.to_string())?;

--- a/src/database/settings.rs
+++ b/src/database/settings.rs
@@ -9,6 +9,8 @@ use std::{path::PathBuf, str::FromStr};
 
 impl Database {
     /// Inserts or updates the settings in the database. This method ensures that only one row exists.
+    ///
+    /// Don't call this method directly, use `AppContext` methods instead to ensure proper caching behavior.
     pub fn insert_or_update_settings(
         &self,
         network: Network,
@@ -27,6 +29,9 @@ impl Database {
         Ok(())
     }
 
+    /// Updates the main password information in the settings table.
+    ///
+    /// Don't call this method directly, use `AppContext` methods instead to ensure proper caching behavior.
     pub fn update_main_password(
         &self,
         salt: &[u8],
@@ -45,7 +50,9 @@ impl Database {
 
         Ok(())
     }
-
+    /// Updates the Dash Core execution settings in the settings table.
+    ///
+    /// Don't call this method directly, use `AppContext` methods instead to ensure proper caching behavior.
     pub fn update_dash_core_execution_settings(
         &self,
         custom_dash_qt_path: Option<PathBuf>,
@@ -112,7 +119,9 @@ impl Database {
 
         Ok(())
     }
-
+    /// Updates the theme preference in the settings table.
+    ///
+    /// Don't call this method directly, use `AppContext` methods instead to ensure proper caching behavior.
     pub fn update_theme_preference(&self, theme_preference: ThemeMode) -> Result<()> {
         let theme_str = match theme_preference {
             ThemeMode::Light => "Light",
@@ -144,6 +153,8 @@ impl Database {
     }
 
     /// Retrieves the settings from the database.
+    ///
+    /// Don't call this method directly, use `AppContext` methods instead to ensure proper caching behavior.
     #[allow(clippy::type_complexity)]
     pub fn get_settings(
         &self,

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -159,9 +159,10 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
                     let resp = resp.on_hover_text(tip);
 
                     if resp.clicked() && !connected {
-                        let settings = app_context.db.get_settings().ok().flatten();
+                        let settings = app_context.get_settings().ok().flatten();
+
                         let (custom_path, overwrite) = settings
-                            .map(|(_, _, _, custom_path, overwrite, _)| (custom_path, overwrite))
+                            .map(|s| (s.dash_qt_path, s.overwrite_dash_conf))
                             .unwrap_or((None, true));
                         if let Some(dash_qt_path) = custom_path {
                             action |= AppAction::BackendTask(BackendTask::CoreTask(

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -120,7 +120,6 @@ impl NetworkChooserScreen {
     /// TODO: doesn't save local network settings like password yet.
     fn save(&self) -> Result<(), String> {
         self.current_app_context()
-            .db
             .update_dash_core_execution_settings(
                 self.custom_dash_qt_path.clone(),
                 self.overwrite_dash_conf,

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -99,7 +99,6 @@ impl AddNewWalletScreen {
                     let (encrypted_message, salt, nonce) =
                         encrypt_message(DASH_SECRET_MESSAGE, self.password.as_str())?;
                     self.app_context
-                        .db
                         .update_main_password(&salt, &nonce, &encrypted_message)
                         .map_err(|e| e.to_string())?;
                 }

--- a/src/ui/wallets/import_wallet_screen.rs
+++ b/src/ui/wallets/import_wallet_screen.rs
@@ -63,7 +63,6 @@ impl ImportWalletScreen {
                     let (encrypted_message, salt, nonce) =
                         encrypt_message(DASH_SECRET_MESSAGE, self.password.as_str())?;
                     self.app_context
-                        .db
                         .update_main_password(&salt, &nonce, &encrypted_message)
                         .map_err(|e| e.to_string())?;
                 }


### PR DESCRIPTION
## Problem statement

Settings are read from DB a few times with every repaint of UI.

## Solution

This pull request introduces a caching mechanism for application settings to improve performance and ensure atomic updates. The key changes include adding a settings cache to `AppContext`, implementing methods to manage the cache, and updating database interaction logic to integrate with the cache. Additionally, direct database calls in the UI layer have been replaced with `AppContext` methods to ensure proper cache handling.

### Caching Mechanism Enhancements:
* **Added a settings cache to `AppContext`:** Introduced a `RwLock`-protected `cached_settings` field to store settings and allow concurrent reads while ensuring exclusive writes during updates (`src/context.rs`, [[1]](diffhunk://#diff-d6346fd7d17270b1282142aeeda9c4bc2b7d8fd0f37b24a1c871a9257f0ed0aaR79-R81) [[2]](diffhunk://#diff-d6346fd7d17270b1282142aeeda9c4bc2b7d8fd0f37b24a1c871a9257f0ed0aaR188).
* **Implemented cache invalidation logic:** Added the `invalidate_settings_cache` method to clear the cache and return a guard to prevent race conditions during database updates (`src/context.rs`, [src/context.rsR485-R551](diffhunk://#diff-d6346fd7d17270b1282142aeeda9c4bc2b7d8fd0f37b24a1c871a9257f0ed0aaR485-R551)).
* **Integrated caching in settings retrieval:** Updated `get_settings` to first check the cache before querying the database, and to update the cache after a database read (`src/context.rs`, [src/context.rsR485-R551](diffhunk://#diff-d6346fd7d17270b1282142aeeda9c4bc2b7d8fd0f37b24a1c871a9257f0ed0aaR485-R551)).

### Database Interaction Updates:
* **Encouraged use of `AppContext` methods:** Added documentation to database methods (e.g., `update_main_password`, `update_dash_core_execution_settings`) to discourage direct calls and ensure proper caching behavior (`src/database/settings.rs`, [[1]](diffhunk://#diff-d59764489f4735795b811ce8f8b28d762a12e4934e663523d0d3d2071d255f3dR12-R13) [[2]](diffhunk://#diff-d59764489f4735795b811ce8f8b28d762a12e4934e663523d0d3d2071d255f3dR32-R34) [[3]](diffhunk://#diff-d59764489f4735795b811ce8f8b28d762a12e4934e663523d0d3d2071d255f3dL48-R55) [[4]](diffhunk://#diff-d59764489f4735795b811ce8f8b28d762a12e4934e663523d0d3d2071d255f3dL115-R124) [[5]](diffhunk://#diff-d59764489f4735795b811ce8f8b28d762a12e4934e663523d0d3d2071d255f3dR156-R157).

### UI Layer Improvements:
* **Replaced direct database calls with `AppContext` methods:** Updated UI components to use `AppContext` methods for settings updates and retrieval, ensuring cache consistency:
  - `add_connection_indicator` now uses `get_settings` instead of directly querying the database (`src/ui/components/top_panel.rs`, [src/ui/components/top_panel.rsL162-R165](diffhunk://#diff-cc1aed9ec6d33c70705a5720505d32bdddfa5865fd37039d073a155a3a5d40dcL162-R165)).
  - `update_dash_core_execution_settings` calls in `NetworkChooserScreen` now use `AppContext` (`src/ui/network_chooser_screen.rs`, [src/ui/network_chooser_screen.rsL123](diffhunk://#diff-47f7dd8ab886f6b5b200c0bcfc793c32374d1a63ece0e7a8c383d084f54e170bL123)).
  - Password updates in `AddNewWalletScreen` and `ImportWalletScreen` now use `AppContext` (`src/ui/wallets/add_new_wallet_screen.rs`, [[1]](diffhunk://#diff-91dbaf43431d2ebeeebe49f27a14ab114be0cc7bc686919eb8566023b7da2b39L102); `src/ui/wallets/import_wallet_screen.rs`, [[2]](diffhunk://#diff-3944112de3bb202e3bca54db0ac4cacfdc2ba13e9cc4e0e303ef3281b4058cf1L66).