### PR TITLE
feat: add network field to identity structures

### DIFF
--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -304,6 +304,7 @@ impl AppContext {
             wallet_index: None, //todo
             top_ups: Default::default(),
             status: IdentityStatus::Active,
+            network: self.network,
         };
         let wallet_info = qualified_identity.determine_wallet_info()?;
 

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -142,6 +142,7 @@ impl AppContext {
             wallet_index: Some(identity_index),
             top_ups: Default::default(),
             status: IdentityStatus::Active,
+            network: self.network,
         };
 
         // Insert qualified identity into the database

--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -348,6 +348,7 @@ impl AppContext {
             wallet_index: Some(wallet_identity_index),
             top_ups: Default::default(),
             status: IdentityStatus::PendingCreation,
+            network: self.network,
         };
 
         if !alias_input.is_empty() {

--- a/src/backend_task/system_task/mod.rs
+++ b/src/backend_task/system_task/mod.rs
@@ -49,7 +49,7 @@ impl AppContext {
         theme_mode: ThemeMode,
     ) -> Result<BackendTaskSuccessResult, String> {
         let _guard = self.invalidate_settings_cache();
-        
+
         self.db
             .update_theme_preference(theme_mode)
             .map_err(|e| e.to_string())?;

--- a/src/database/identities.rs
+++ b/src/database/identities.rs
@@ -177,6 +177,7 @@ impl Database {
             identity.wallet_index = wallet_index;
 
             identity.status = IdentityStatus::from_u8(status);
+            identity.network = app_context.network;
 
             // Associate wallets
             identity.associated_wallets = wallets.clone(); //todo: use less wallets
@@ -232,6 +233,7 @@ impl Database {
             let mut identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
             identity.alias = alias;
             identity.wallet_index = wallet_index;
+            identity.network = app_context.network;
 
             // Associate wallets
             identity.associated_wallets = wallets.clone(); //todo: use less wallets
@@ -287,6 +289,7 @@ impl Database {
             let mut identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
             identity.alias = alias;
             identity.wallet_index = wallet_index;
+            identity.network = app_context.network;
 
             // Associate wallets
             identity.associated_wallets = wallets.clone(); //todo: use less wallets
@@ -326,7 +329,8 @@ impl Database {
         )?;
         let identity_iter = stmt.query_map(params![network], |row| {
             let data: Vec<u8> = row.get(0)?;
-            let identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
+            let mut identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
+            identity.network = app_context.network;
 
             Ok(identity)
         })?;
@@ -353,7 +357,8 @@ impl Database {
             stmt.query_map(params![network], |row| {
                 let data: Vec<u8> = row.get(0)?;
                 let wallet_id: Option<WalletSeedHash> = row.get(1)?;
-                let identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
+                let mut identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&data);
+                identity.network = app_context.network;
 
                 Ok((identity, wallet_id))
             })?

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -467,6 +467,7 @@ impl Database {
             if let Some(wallet) = wallets_map.get_mut(&wallet_seed_hash_array) {
                 let mut identity: QualifiedIdentity = QualifiedIdentity::from_bytes(&identity_data);
                 identity.wallet_index = Some(wallet_index);
+                identity.network = *network;
 
                 tracing::trace!(
                     wallet_seed = ?wallet_seed_hash_array,

--- a/src/model/qualified_identity/encrypted_key_storage.rs
+++ b/src/model/qualified_identity/encrypted_key_storage.rs
@@ -5,6 +5,7 @@ use bincode::de::{BorrowDecoder, Decoder};
 use bincode::enc::Encoder;
 use bincode::error::{DecodeError, EncodeError};
 use bincode::{BorrowDecode, Decode, Encode};
+use dash_sdk::dashcore_rpc::dashcore::Network;
 use dash_sdk::dashcore_rpc::dashcore::bip32::DerivationPath;
 use dash_sdk::dpp::dashcore::bip32::ChildNumber;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
@@ -277,6 +278,7 @@ impl KeyStorage {
         &self,
         key: &(PrivateKeyTarget, KeyID),
         wallets: &[Arc<RwLock<Wallet>>],
+        network: Network,
     ) -> Result<Option<(QualifiedIdentityPublicKey, [u8; 32])>, String> {
         self.private_keys
             .get(key)
@@ -296,6 +298,7 @@ impl KeyStorage {
                             wallets,
                             *wallet_seed_hash,
                             derivation_path,
+                            network,
                         )?
                         .ok_or(format!(
                             "Wallet for key at derivation path {} not present, we have {} wallets",

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -223,6 +223,7 @@ pub struct QualifiedIdentity {
     pub wallet_index: Option<u32>,
     pub top_ups: BTreeMap<u32, u64>,
     pub status: IdentityStatus,
+    pub network: Network,
 }
 
 impl AsRef<QualifiedIdentity> for QualifiedIdentity {
@@ -286,6 +287,7 @@ impl Decode for QualifiedIdentity {
             wallet_index: None,
             top_ups: Default::default(),
             status: IdentityStatus::Unknown, // Loaded from the database, not encoded
+            network: Network::Dash,          // Loaded from the database, not encoded
         })
     }
 }
@@ -308,6 +310,7 @@ impl Signer for QualifiedIdentity {
                     .cloned()
                     .collect::<Vec<_>>()
                     .as_slice(),
+                self.network,
             )
             .map_err(ProtocolError::Generic)?
             .ok_or(ProtocolError::Generic(format!(
@@ -614,23 +617,5 @@ impl QualifiedIdentity {
             .next();
 
         Ok(wallet_info)
-    }
-}
-impl From<Identity> for QualifiedIdentity {
-    fn from(value: Identity) -> Self {
-        QualifiedIdentity {
-            identity: value,
-            associated_voter_identity: None,
-            associated_operator_identity: None,
-            associated_owner_key_id: None,
-            identity_type: IdentityType::User,
-            alias: None,
-            private_keys: Default::default(),
-            dpns_names: vec![],
-            associated_wallets: BTreeMap::new(),
-            wallet_index: None,
-            top_ups: Default::default(),
-            status: IdentityStatus::Unknown,
-        }
     }
 }

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -336,6 +336,7 @@ impl Wallet {
         slice: &[Arc<RwLock<Wallet>>],
         wallet_seed_hash: WalletSeedHash,
         derivation_path: &DerivationPath,
+        network: Network,
     ) -> Result<Option<[u8; 32]>, String> {
         for wallet in slice {
             // Attempt to read the wallet from the RwLock
@@ -344,7 +345,7 @@ impl Wallet {
             if wallet_ref.seed_hash() == wallet_seed_hash {
                 // Attempt to derive the private key using the provided derivation path
                 let extended_private_key = derivation_path
-                    .derive_priv_ecdsa_for_master_seed(wallet_ref.seed_bytes()?, Network::Dash)
+                    .derive_priv_ecdsa_for_master_seed(wallet_ref.seed_bytes()?, network)
                     .map_err(|e| e.to_string())?;
                 return Ok(Some(extended_private_key.private_key.secret_bytes()));
             }
@@ -356,9 +357,10 @@ impl Wallet {
     pub fn private_key_at_derivation_path(
         &self,
         derivation_path: &DerivationPath,
+        network: Network,
     ) -> Result<PrivateKey, String> {
         let extended_private_key = derivation_path
-            .derive_priv_ecdsa_for_master_seed(self.seed_bytes()?, Network::Dash)
+            .derive_priv_ecdsa_for_master_seed(self.seed_bytes()?, network)
             .map_err(|e| e.to_string())?;
         Ok(extended_private_key.to_priv())
     }

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -334,6 +334,7 @@ impl ScreenLike for KeyInfoScreen {
                                         self.selected_wallet.as_ref().unwrap().read().unwrap();
                                     match wallet.private_key_at_derivation_path(
                                         &derivation_path.derivation_path,
+                                        self.app_context.network,
                                     ) {
                                         Ok(private_key) => {
                                             let private_key_wif = private_key.to_wif();
@@ -365,6 +366,7 @@ impl ScreenLike for KeyInfoScreen {
                                         self.selected_wallet.as_ref().unwrap().read().unwrap();
                                     match wallet.private_key_at_derivation_path(
                                         &derivation_path.derivation_path,
+                                        self.app_context.network,
                                     ) {
                                         Ok(private_key) => {
                                             let private_key_wif = private_key.to_wif();

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -2922,6 +2922,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
+            network: Network::Dash,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3224,6 +3225,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
+            network: Network::Dash,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3339,6 +3341,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
+            network: Network::Dash,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);

--- a/src/ui/tokens/tokens_screen/my_tokens.rs
+++ b/src/ui/tokens/tokens_screen/my_tokens.rs
@@ -523,10 +523,9 @@ impl TokensScreen {
                                 .token_configuration
                                 .conventions()
                                 .plural_form_by_language_code_or_default("en");
-                            let reward_amount = Amount::new(
-                                explanation.total_amount,
-                                decimal_places,
-                            ).with_unit_name(unit_name);
+                            let reward_amount =
+                                Amount::new(explanation.total_amount, decimal_places)
+                                    .with_unit_name(unit_name);
 
                             ui.label(format!("Total Estimated Rewards: {}", reward_amount));
                             ui.separator();


### PR DESCRIPTION
The main reason for this was that private keys were all exporting as if for mainnet.

Added a `network` field to various identity-related structures and methods to support network-specific operations. This change ensures that the network context is consistently passed through the application, enhancing the handling of identities across different networks. The updates include modifications to the `QualifiedIdentity`, database interactions, and wallet operations to accommodate the new field.