### PR TITLE
feat: allow setting zmq uri in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ MAINNET_core_rpc_port=9998
 MAINNET_core_rpc_user=dashrpc
 MAINNET_core_rpc_password=password
 MAINNET_insight_api_url=https://insight.dash.org/insight-api
+MAINNET_zmq_endpoint=tcp://127.0.0.1:23708
 MAINNET_show_in_ui=true
 MAINNET_developer_mode=true
 
@@ -13,6 +14,7 @@ TESTNET_core_rpc_port=19998
 TESTNET_core_rpc_user=dashrpc
 TESTNET_core_rpc_password=password
 TESTNET_insight_api_url=https://testnet-insight.dash.org/insight-api
+TESTNET_zmq_endpoint=tcp://127.0.0.1:23709
 TESTNET_show_in_ui=true
 TESTNET_developer_mode=false
 
@@ -22,6 +24,7 @@ DEVNET_core_rpc_port=29998
 DEVNET_core_rpc_user=dashrpc
 DEVNET_core_rpc_password=password
 DEVNET_insight_api_url=
+DEVNET_zmq_endpoint=tcp://127.0.0.1:23710
 DEVNET_show_in_ui=true
 DEVNET_developer_mode=false
 
@@ -31,4 +34,5 @@ LOCAL_core_rpc_port=20302
 LOCAL_core_rpc_user=dashmate
 LOCAL_core_rpc_password=password
 LOCAL_insight_api_url=http://localhost:3001/insight-api
+LOCAL_zmq_endpoint=tcp://127.0.0.1:20302
 LOCAL_show_in_ui=true

--- a/src/app.rs
+++ b/src/app.rs
@@ -319,9 +319,16 @@ impl AppState {
         let (core_message_sender, core_message_receiver) =
             mpsc::channel().with_egui_ctx(ctx.clone());
 
+        let mainnet_zmq_endpoint = mainnet_app_context
+            .config
+            .read()
+            .unwrap()
+            .zmq_endpoint
+            .clone()
+            .unwrap_or_else(|| "tcp://127.0.0.1:23708".to_string());
         let mainnet_core_zmq_listener = CoreZMQListener::spawn_listener(
             Network::Dash,
-            "tcp://127.0.0.1:23708",
+            &mainnet_zmq_endpoint,
             core_message_sender.clone(), // Clone the sender for each listener
             Some(mainnet_app_context.sx_zmq_status.clone()),
         )
@@ -331,9 +338,13 @@ impl AppState {
             .as_ref()
             .map(|context| context.sx_zmq_status.clone());
 
+        let testnet_zmq_endpoint = testnet_app_context
+            .as_ref()
+            .and_then(|ctx| ctx.config.read().unwrap().zmq_endpoint.clone())
+            .unwrap_or_else(|| "tcp://127.0.0.1:23709".to_string());
         let testnet_core_zmq_listener = CoreZMQListener::spawn_listener(
             Network::Testnet,
-            "tcp://127.0.0.1:23709",
+            &testnet_zmq_endpoint,
             core_message_sender.clone(), // Use the original sender or create a new one if needed
             testnet_tx_zmq_status_option,
         )
@@ -343,9 +354,13 @@ impl AppState {
             .as_ref()
             .map(|context| context.sx_zmq_status.clone());
 
+        let devnet_zmq_endpoint = devnet_app_context
+            .as_ref()
+            .and_then(|ctx| ctx.config.read().unwrap().zmq_endpoint.clone())
+            .unwrap_or_else(|| "tcp://127.0.0.1:23710".to_string());
         let devnet_core_zmq_listener = CoreZMQListener::spawn_listener(
             Network::Devnet,
-            "tcp://127.0.0.1:23710",
+            &devnet_zmq_endpoint,
             core_message_sender.clone(),
             devnet_tx_zmq_status_option,
         )
@@ -355,9 +370,13 @@ impl AppState {
             .as_ref()
             .map(|context| context.sx_zmq_status.clone());
 
+        let local_zmq_endpoint = local_app_context
+            .as_ref()
+            .and_then(|ctx| ctx.config.read().unwrap().zmq_endpoint.clone())
+            .unwrap_or_else(|| "tcp://127.0.0.1:20302".to_string());
         let local_core_zmq_listener = CoreZMQListener::spawn_listener(
             Network::Regtest,
-            "tcp://127.0.0.1:20302",
+            &local_zmq_endpoint,
             core_message_sender,
             local_tx_zmq_status_option,
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,8 @@ pub struct NetworkConfig {
     pub core_rpc_password: String,
     /// URL of the Insight API
     pub insight_api_url: String,
+    /// ZMQ endpoint for Core blockchain events (e.g., tcp://127.0.0.1:23708)
+    pub zmq_endpoint: Option<String>,
     /// Devnet network name if one exists
     pub devnet_name: Option<String>,
     /// Optional wallet private key to instantiate the wallet
@@ -102,6 +104,11 @@ impl Config {
                 prefix, config.insight_api_url
             )
             .map_err(|e| ConfigError::LoadError(e.to_string()))?;
+
+            if let Some(zmq_endpoint) = &config.zmq_endpoint {
+                writeln!(env_file, "{}zmq_endpoint={}", prefix, zmq_endpoint)
+                    .map_err(|e| ConfigError::LoadError(e.to_string()))?;
+            }
 
             if let Some(devnet_name) = &config.devnet_name {
                 // Only write devnet name if it exists


### PR DESCRIPTION
## Problem statement


I need to change ZMQ URI for local development, from 127.0.0.1 to custom one.

# Solution

This pull request adds support for configuring the ZMQ endpoint for each network environment via the `.env.example` file and updates the application logic to use these configuration values. This makes the ZMQ endpoint configurable rather than hardcoded, improving flexibility for different deployment scenarios.

Configuration changes:

* Added `*_zmq_endpoint` variables to the `.env.example` file for `MAINNET`, `TESTNET`, `DEVNET`, and `LOCAL`, allowing users to specify custom ZMQ endpoints for each network. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR7) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR17) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR27) [[4]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR37)
* Updated the `NetworkConfig` struct in `src/config.rs` to include an optional `zmq_endpoint` field for storing the ZMQ endpoint configuration.
* Modified the config file writing logic to persist the `zmq_endpoint` value when present.

Application logic changes:

* Updated ZMQ listener initialization in `src/app.rs` to use the configured ZMQ endpoint for each network, falling back to the default value if not set. This applies to Mainnet, Testnet, Devnet, and Local network listeners. [[1]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R322-R331) [[2]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R341-R347) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R357-R363) [[4]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R373-R379)