### PR TITLE
v0.9.2 to master

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.88
           components: clippy
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-evo-tool"
-version = "0.9.0"
+version = "0.9.2"
 license = "MIT"
 edition = "2024"
 default-run = "dash-evo-tool"

--- a/src/backend_task/tokens/mod.rs
+++ b/src/backend_task/tokens/mod.rs
@@ -782,7 +782,7 @@ impl AppContext {
             0 => TokenTradeMode::NotTradeable,
             _ => TokenTradeMode::NotTradeable, // Default to NotTradeable for any unknown value
         };
-        
+
         token_config_v0.marketplace_rules = TokenMarketplaceRules::V0(TokenMarketplaceRulesV0 {
             trade_mode,
             trade_mode_change_rules: marketplace_rules,

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,7 +30,6 @@ use dash_sdk::dpp::state_transition::StateTransitionSigningOptions;
 use dash_sdk::dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dash_sdk::dpp::system_data_contracts::{SystemDataContract, load_system_data_contract};
 use dash_sdk::dpp::version::PlatformVersion;
-use dash_sdk::dpp::version::v8::PLATFORM_V8;
 use dash_sdk::dpp::version::v9::PLATFORM_V9;
 use dash_sdk::platform::{DataContract, Identifier};
 use dash_sdk::query_types::IndexMap;
@@ -792,10 +791,11 @@ impl AppContext {
 }
 
 /// Returns the default platform version for the given network.
+///
+/// For certain releases like developer previews, we may want to only increment the platform version for non-mainnet.
 pub(crate) const fn default_platform_version(network: &Network) -> &'static PlatformVersion {
-    // TODO: Use self.sdk.read().unwrap().version() instead of hardcoding
     match network {
-        Network::Dash => &PLATFORM_V8,
+        Network::Dash => &PLATFORM_V9,
         Network::Testnet => &PLATFORM_V9,
         Network::Devnet => &PLATFORM_V9,
         Network::Regtest => &PLATFORM_V9,

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -59,7 +59,7 @@ use crate::context::AppContext;
 use crate::model::qualified_identity::{IdentityType, QualifiedIdentity};
 use crate::model::wallet::Wallet;
 use crate::ui::components::left_panel::add_left_panel;
-use crate::ui::components::styled::{island_central_panel, ClickableCollapsingHeader};
+use crate::ui::components::styled::{ClickableCollapsingHeader, island_central_panel};
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;

--- a/src/ui/tokens/tokens_screen/my_tokens.rs
+++ b/src/ui/tokens/tokens_screen/my_tokens.rs
@@ -2,7 +2,7 @@ use crate::app::AppAction;
 use crate::backend_task::BackendTask;
 use crate::backend_task::tokens::TokenTask;
 use crate::ui::Screen;
-use crate::ui::components::styled::{StyledButton, ClickableCollapsingHeader};
+use crate::ui::components::styled::{ClickableCollapsingHeader, StyledButton};
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
 use crate::ui::theme::DashColors;
 use crate::ui::tokens::burn_tokens_screen::BurnTokensScreen;
@@ -58,100 +58,100 @@ impl TokensScreen {
         ClickableCollapsingHeader::new("Basic Information")
             .id_salt("token_basic_info_header")
             .show(ui, |ui| {
-            egui::Grid::new("token_basic_info")
-                .num_columns(2)
-                .spacing([10.0, 5.0])
-                .show(ui, |ui| {
-                    ui.label("Description:");
-                    ui.label(
-                        token_info
-                            .token_configuration
-                            .description()
-                            .as_ref()
-                            .unwrap_or(&"No description".to_string()),
-                    );
-                    ui.end_row();
+                egui::Grid::new("token_basic_info")
+                    .num_columns(2)
+                    .spacing([10.0, 5.0])
+                    .show(ui, |ui| {
+                        ui.label("Description:");
+                        ui.label(
+                            token_info
+                                .token_configuration
+                                .description()
+                                .as_ref()
+                                .unwrap_or(&"No description".to_string()),
+                        );
+                        ui.end_row();
 
-                    // Base Supply
-                    ui.label("Base Supply:");
-                    ui.label(config.base_supply().to_string());
-                    ui.end_row();
+                        // Base Supply
+                        ui.label("Base Supply:");
+                        ui.label(config.base_supply().to_string());
+                        ui.end_row();
 
-                    // Max Supply
-                    ui.label("Max Supply:");
-                    if let Some(max_supply) = config.max_supply() {
-                        ui.label(max_supply.to_string());
-                    } else {
-                        ui.label("Unlimited");
-                    }
-                    ui.end_row();
-
-                    // Distribution info
-                    ui.label("Perpetual Distribution:");
-                    ui.label(
-                        if config
-                            .distribution_rules()
-                            .perpetual_distribution()
-                            .is_some()
-                        {
-                            "Yes"
+                        // Max Supply
+                        ui.label("Max Supply:");
+                        if let Some(max_supply) = config.max_supply() {
+                            ui.label(max_supply.to_string());
                         } else {
-                            "No"
-                        },
-                    );
-                    ui.end_row();
+                            ui.label("Unlimited");
+                        }
+                        ui.end_row();
 
-                    ui.label("Preprogrammed Distribution:");
-                    ui.label(
-                        if config
-                            .distribution_rules()
-                            .pre_programmed_distribution()
-                            .is_some()
-                        {
-                            "Yes"
-                        } else {
-                            "No"
-                        },
-                    );
-                    ui.end_row();
+                        // Distribution info
+                        ui.label("Perpetual Distribution:");
+                        ui.label(
+                            if config
+                                .distribution_rules()
+                                .perpetual_distribution()
+                                .is_some()
+                            {
+                                "Yes"
+                            } else {
+                                "No"
+                            },
+                        );
+                        ui.end_row();
 
-                    ui.label("Token ID:");
-                    ui.label(token_info.token_id.to_string(Encoding::Base58));
-                    ui.end_row();
+                        ui.label("Preprogrammed Distribution:");
+                        ui.label(
+                            if config
+                                .distribution_rules()
+                                .pre_programmed_distribution()
+                                .is_some()
+                            {
+                                "Yes"
+                            } else {
+                                "No"
+                            },
+                        );
+                        ui.end_row();
 
-                    ui.label("Contract ID:");
-                    ui.label(token_info.data_contract.id().to_string(Encoding::Base58));
-                    ui.end_row();
+                        ui.label("Token ID:");
+                        ui.label(token_info.token_id.to_string(Encoding::Base58));
+                        ui.end_row();
 
-                    ui.label("Contract Owner:");
-                    ui.label(
-                        token_info
-                            .data_contract
-                            .owner_id()
-                            .to_string(Encoding::Base58),
-                    );
-                    ui.end_row();
-                });
-        });
+                        ui.label("Contract ID:");
+                        ui.label(token_info.data_contract.id().to_string(Encoding::Base58));
+                        ui.end_row();
+
+                        ui.label("Contract Owner:");
+                        ui.label(
+                            token_info
+                                .data_contract
+                                .owner_id()
+                                .to_string(Encoding::Base58),
+                        );
+                        ui.end_row();
+                    });
+            });
 
         // Token Configuration Summary
         ClickableCollapsingHeader::new("Token Configuration")
             .id_salt("token_config_header")
             .show(ui, |ui| {
-            ui.label("This token has the following configuration:");
-            ui.add_space(5.0);
+                ui.label("This token has the following configuration:");
+                ui.add_space(5.0);
 
-            // Show raw configuration as JSON for now
-            if let Ok(json_str) = serde_json::to_string_pretty(&config) {
-                egui::ScrollArea::vertical()
-                    .max_height(300.0)
-                    .show(ui, |ui| {
-                        ui.code(&json_str);
-                    });
-            } else {
-                ui.label("Unable to display configuration details");
-            }
-        });
+                // Show raw configuration as JSON for now
+                if let Ok(json_str) = serde_json::to_string_pretty(&config) {
+                    egui::ScrollArea::vertical()
+                        .max_height(300.0)
+                        .show(ui, |ui| {
+                            ui.code(&json_str);
+                        });
+                } else {
+                    ui.label("Unable to display configuration details");
+                }
+            });
     }
 
     pub(super) fn render_my_tokens_subscreen(&mut self, ui: &mut Ui) -> AppAction {
@@ -527,41 +527,48 @@ impl TokensScreen {
                             ClickableCollapsingHeader::new("Basic Explanation")
                                 .id_salt("basic_explanation_header")
                                 .show(ui, |ui| {
-                                let local_time = Local::now();
-                                let timezone = local_time.format("%Z").to_string();
+                                    let local_time = Local::now();
+                                    let timezone = local_time.format("%Z").to_string();
 
-                                let short_explanation = explanation.short_explanation(
-                                    token_info.token_configuration.conventions().decimals(),
-                                    self.app_context.platform_version(),
-                                    &timezone,
-                                );
+                                    let short_explanation = explanation.short_explanation(
+                                        token_info.token_configuration.conventions().decimals(),
+                                        self.app_context.platform_version(),
+                                        &timezone,
+                                    );
 
-                                ui.label(short_explanation);
-                            });
+                                    ui.label(short_explanation);
+                                });
 
                             ClickableCollapsingHeader::new("Detailed Explanation")
                                 .id_salt("detailed_explanation_header")
                                 .show(ui, |ui| {
-                                ui.label(explanation.detailed_explanation());
-                            });
+                                    ui.label(explanation.detailed_explanation());
+                                });
 
                             if !explanation.evaluation_steps.is_empty() {
                                 ClickableCollapsingHeader::new("Step-by-Step Breakdown")
                                     .id_salt("step_by_step_header")
                                     .show(ui, |ui| {
-                                    for (i, step) in explanation.evaluation_steps.iter().enumerate()
-                                    {
-                                        ClickableCollapsingHeader::new(format!("Step {}", i + 1))
+                                        for (i, step) in
+                                            explanation.evaluation_steps.iter().enumerate()
+                                        {
+                                            ClickableCollapsingHeader::new(format!(
+                                                "Step {}",
+                                                i + 1
+                                            ))
                                             .id_salt(format!("step_{}_header", i))
-                                            .show(ui, |ui| {
-                                            if let Some(step_explanation) =
-                                                explanation.explanation_for_step(step.step_index)
-                                            {
-                                                ui.label(step_explanation);
-                                            }
-                                        });
-                                    }
-                                });
+                                            .show(
+                                                ui,
+                                                |ui| {
+                                                    if let Some(step_explanation) = explanation
+                                                        .explanation_for_step(step.step_index)
+                                                    {
+                                                        ui.label(step_explanation);
+                                                    }
+                                                },
+                                            );
+                                        }
+                                    });
                             }
 
                             ui.separator();


### PR DESCRIPTION
Mainnet was using Platform V8 instead of V9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped app version to 0.9.2.
  - Updated default platform version to V9 across Dash, Testnet, Devnet, and Regtest.
  - CI: Clippy now uses Rust toolchain 1.88.

- Documentation
  - Added note about platform version increments for non-mainnet developer previews.

- Style
  - Formatting cleanups and import order adjustments in tokens backend and UI modules.
  - UI: Reflowed My Tokens basic info grid and reformatted step-by-step sections without changing displayed content or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->