### PR TITLE
fix: QR code not showing on top up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 
 [[package]]
 name = "dash-evo-tool"
-version = "0.9.0"
+version = "0.9.2"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -5,7 +5,7 @@ use crate::ui::identities::funding_common::{copy_to_clipboard, generate_qr_code_
 use crate::ui::identities::top_up_identity_screen::{TopUpIdentityScreen, WalletFundedScreenStep};
 use dash_sdk::dashcore_rpc::RpcApi;
 use eframe::epaint::TextureHandle;
-use egui::{Color32, Ui};
+use egui::Ui;
 use std::sync::Arc;
 
 impl TopUpIdentityScreen {
@@ -140,11 +140,6 @@ impl TopUpIdentityScreen {
             }
 
             ui.add_space(20.0);
-
-            if let Some(error_message) = self.error_message.as_ref() {
-                ui.colored_label(Color32::DARK_RED, error_message);
-                ui.add_space(20.0);
-            }
 
             match step {
                 WalletFundedScreenStep::ChooseFundingMethod => {}

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -111,7 +111,7 @@ impl TopUpIdentityScreen {
     pub fn render_ui_by_wallet_qr_code(&mut self, ui: &mut Ui, step_number: u32) -> AppAction {
         // Extract the step from the RwLock to minimize borrow scope
         let step = *self.step.read().unwrap();
-        
+
         ui.heading(
             format!(
                 "{}. Select how much you would like to transfer?",

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -83,8 +83,7 @@ impl TopUpIdentityScreen {
         } else {
             ui.label("Failed to generate QR code.");
         }
-
-        ui.add_space(15.0);
+        ui.add_space(10.0);
 
         ui.label(&pay_uri);
         ui.add_space(5.0);
@@ -112,11 +111,7 @@ impl TopUpIdentityScreen {
     pub fn render_ui_by_wallet_qr_code(&mut self, ui: &mut Ui, step_number: u32) -> AppAction {
         // Extract the step from the RwLock to minimize borrow scope
         let step = *self.step.read().unwrap();
-
-        let Ok(amount_dash) = self.funding_amount.parse::<f64>() else {
-            return AppAction::None;
-        };
-
+        
         ui.heading(
             format!(
                 "{}. Select how much you would like to transfer?",
@@ -129,7 +124,17 @@ impl TopUpIdentityScreen {
 
         self.top_up_funding_amount_input(ui);
 
-        let response = ui.vertical_centered(|ui| {
+        let Ok(amount_dash) = self.funding_amount.parse::<f64>() else {
+            return AppAction::None;
+        };
+
+        if amount_dash <= 0.0 {
+            return AppAction::None;
+        }
+
+        let response = ui.with_layout(
+            egui::Layout::top_down(egui::Align::Min).with_cross_align(egui::Align::Center),
+            |ui| {
             if let Err(e) = self.render_qr_code(ui, amount_dash) {
                 self.error_message = Some(e);
             }

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -490,6 +490,7 @@ impl ScreenLike for TopUpIdentityScreen {
 
                 if funding_method == FundingMethod::UseWalletBalance
                     || funding_method == FundingMethod::UseUnusedAssetLock
+                    || funding_method == FundingMethod::AddressWithQRCode
                 {
                     ui.heading(format!(
                         "{}. Choose the wallet to use to top up this identity.",

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -25,7 +25,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::AssetLockProof;
 use eframe::egui::Context;
-use egui::{ComboBox, ScrollArea, Ui};
+use egui::{Color32, ComboBox, ScrollArea, Ui};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 
@@ -143,11 +143,22 @@ impl TopUpIdentityScreen {
                         self.wallet = Some(wallet.clone());
                     }
                 }
+                ui.label(format!(
+                    "Using only loaded wallet: {}",
+                    self.wallet
+                        .as_ref()
+                        .and_then(|w| w.read().ok()?.alias.clone())
+                        .unwrap_or_else(|| "(unnamed wallet)".to_string())
+                ));
                 false
             } else {
                 false
             }
         } else {
+            ui.colored_label(
+                Color32::DARK_RED,
+                "No wallets available. Please create or import a wallet first.",
+            );
             false
         }
     }
@@ -298,22 +309,12 @@ impl TopUpIdentityScreen {
             ui.label("Amount (DASH):");
 
             // Render the text input field for the funding amount
-            let amount_input = ui
-                .add(egui::TextEdit::singleline(&mut self.funding_amount).desired_width(100.0))
+            ui.add(egui::TextEdit::singleline(&mut self.funding_amount).desired_width(100.0))
                 .lost_focus();
 
             self.funding_amount_exact = self.funding_amount.parse::<f64>().ok().map(|f| {
                 (f * 1e8) as u64 // Convert the amount to Duffs
             });
-
-            let enter_pressed = ui.input(|i| i.key_pressed(egui::Key::Enter));
-
-            if amount_input && enter_pressed {
-                // Optional: Validate the input when Enter is pressed
-                if self.funding_amount.parse::<f64>().is_err() {
-                    ui.label("Invalid amount. Please enter a valid number.");
-                }
-            }
         });
 
         ui.add_space(10.0);
@@ -530,6 +531,10 @@ impl ScreenLike for TopUpIdentityScreen {
                     }
                 }
             });
+
+            if let Some(error_message) = self.error_message.as_ref() {
+                ui.colored_label(Color32::DARK_RED, error_message);
+            }
 
             inner_action
         });


### PR DESCRIPTION
QR code was not showing up in the Top Up section because we tried to show it before we asked for the funding amount, making the entire screen "stuck"

This did not affect the QR code in the "New identity" screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet selection/unlock flow added for topping up via QR code; single-wallet hint and a clear "no wallets available" warning are shown.

* **Bug Fixes**
  * Funding amounts validated earlier and non‑positive values are blocked before QR rendering.

* **Style**
  * Cleaner QR area with improved layout, reduced spacing, centered QR, and in‑line red error labels for visible error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->