### PR TITLE
chore: bump version to 1.0.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "dash-evo-tool"
-version = "0.9.0"
+version = "1.0.0-dev"
 dependencies = [
  "aes-gcm",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-evo-tool"
-version = "0.9.0"
+version = "1.0.0-dev"
 license = "MIT"
 edition = "2024"
 default-run = "dash-evo-tool"


### PR DESCRIPTION
The 1.0-dev branch builds were still reporting as 0.9.0