### PR TITLE
feat: remove wallet

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -825,6 +825,35 @@ impl AppContext {
         self.db.remove_token(token_id, self)
     }
 
+    pub fn remove_wallet(&self, seed_hash: &WalletSeedHash) -> Result<(), String> {
+        {
+            let wallets = self
+                .wallets
+                .read()
+                .map_err(|_| "Failed to access wallets".to_string())?;
+            if !wallets.contains_key(seed_hash) {
+                return Err("Wallet not found".to_string());
+            }
+        }
+
+        self.db
+            .remove_wallet(seed_hash, &self.network)
+            .map_err(|e| e.to_string())?;
+
+        let mut wallets = self
+            .wallets
+            .write()
+            .map_err(|_| "Failed to update wallets".to_string())?;
+
+        wallets.remove(seed_hash);
+        let has_wallet = !wallets.is_empty();
+        drop(wallets);
+
+        self.has_wallet.store(has_wallet, Ordering::Relaxed);
+
+        Ok(())
+    }
+
     #[allow(dead_code)] // May be used for storing token balances
     pub fn insert_token_identity_balance(
         &self,

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -68,6 +68,45 @@ impl Database {
         Ok(())
     }
 
+    /// Remove a wallet and all associated records from the database.
+    ///
+    /// This clears dependent records (addresses, utxos, asset locks, identity links)
+    /// to keep the database consistent before deleting the wallet itself.
+    pub fn remove_wallet(&self, seed_hash: &[u8; 32], network: &Network) -> rusqlite::Result<()> {
+        let network_str = network.to_string();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+
+        let mut address_stmt =
+            tx.prepare("SELECT address FROM wallet_addresses WHERE seed_hash = ?")?;
+        let address_rows =
+            address_stmt.query_map(params![seed_hash], |row| row.get::<_, String>(0))?;
+        let mut addresses = Vec::new();
+        for address in address_rows {
+            addresses.push(address?);
+        }
+        drop(address_stmt);
+
+        for address in addresses {
+            tx.execute(
+                "DELETE FROM utxos WHERE address = ? AND network = ?",
+                params![address, &network_str],
+            )?;
+        }
+
+        tx.execute(
+            "UPDATE identity SET wallet = NULL, wallet_index = NULL WHERE wallet = ? AND network = ?",
+            params![seed_hash, &network_str],
+        )?;
+
+        tx.execute(
+            "DELETE FROM wallet WHERE seed_hash = ? AND network = ?",
+            params![seed_hash, &network_str],
+        )?;
+
+        tx.commit()
+    }
+
     /// Update only the alias and is_main fields of a wallet
     #[allow(dead_code)] // May be used for batch wallet metadata updates
     pub fn update_wallet_alias_and_main(

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -624,7 +624,7 @@ impl WalletsBalancesScreen {
                     self.pending_wallet_removal_alias = Some(alias.clone());
 
                     let message = format!(
-                        "Removing wallet \"{}\" will delete its local data, including addresses, balances, and asset locks stored on this device. Identities linked to it will remain but will no longer be connected to this wallet. Continue?",
+                        "Removing wallet \"{}\" will delete its local data, including addresses, balances, and asset locks stored on this device. Identities linked to it will remain but the keys derived from this wallet will no longer work unless the wallet is re-imported. Continue?",
                         alias
                     );
 

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2,7 +2,9 @@ use crate::app::{AppAction, DesiredAppAction};
 use crate::backend_task::BackendTask;
 use crate::backend_task::core::CoreTask;
 use crate::context::AppContext;
-use crate::model::wallet::Wallet;
+use crate::model::wallet::{Wallet, WalletSeedHash};
+use crate::ui::components::component_trait::Component;
+use crate::ui::components::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
@@ -49,6 +51,9 @@ pub struct WalletsBalancesScreen {
     wallet_password: String,
     show_password: bool,
     error_message: Option<String>,
+    remove_wallet_dialog: Option<ConfirmationDialog>,
+    pending_wallet_removal: Option<WalletSeedHash>,
+    pending_wallet_removal_alias: Option<String>,
 }
 
 pub trait DerivationPathHelpers {
@@ -141,6 +146,9 @@ impl WalletsBalancesScreen {
             wallet_password: String::new(),
             show_password: false,
             error_message: None,
+            remove_wallet_dialog: None,
+            pending_wallet_removal: None,
+            pending_wallet_removal_alias: None,
         }
     }
 
@@ -565,15 +573,13 @@ impl WalletsBalancesScreen {
     }
 
     fn render_bottom_options(&mut self, ui: &mut Ui) {
+        let wallet_is_open = self
+            .selected_wallet
+            .as_ref()
+            .is_some_and(|wallet_guard| wallet_guard.read().unwrap().is_open());
+
         if self.selected_filters.contains("Funds") {
             ui.add_space(10.0);
-
-            // Check if wallet is unlocked
-            let wallet_is_open = if let Some(wallet_guard) = &self.selected_wallet {
-                wallet_guard.read().unwrap().is_open()
-            } else {
-                false
-            };
 
             if wallet_is_open {
                 ui.horizontal(|ui| {
@@ -585,8 +591,113 @@ impl WalletsBalancesScreen {
                     }
                 });
             } else {
-                // Show wallet unlock UI
+                // Show wallet unlock UI for locked wallets when Funds filter is active
                 self.render_wallet_unlock_if_needed(ui);
+            }
+        }
+
+        if self.selected_wallet.is_some() {
+            ui.add_space(16.0);
+            let dark_mode = ui.ctx().style().visuals.dark_mode;
+
+            let remove_button = egui::Button::new(
+                RichText::new("🗑 Remove Wallet")
+                    .color(Color32::WHITE)
+                    .size(14.0),
+            )
+            .min_size(egui::vec2(0.0, 28.0))
+            .fill(DashColors::error_color(!dark_mode))
+            .stroke(egui::Stroke::NONE)
+            .corner_radius(4.0);
+
+            if ui.add(remove_button).clicked() {
+                if let Some(selected_wallet) = &self.selected_wallet {
+                    let wallet = selected_wallet.read().unwrap();
+                    let alias = wallet
+                        .alias
+                        .clone()
+                        .unwrap_or_else(|| "Unnamed Wallet".to_string());
+                    let seed_hash = wallet.seed_hash();
+                    drop(wallet);
+
+                    self.pending_wallet_removal = Some(seed_hash);
+                    self.pending_wallet_removal_alias = Some(alias.clone());
+
+                    let message = format!(
+                        "Removing wallet \"{}\" will delete its local data, including addresses, balances, and asset locks stored on this device. Identities linked to it will remain but will no longer be connected to this wallet. Continue?",
+                        alias
+                    );
+
+                    self.remove_wallet_dialog = Some(
+                        ConfirmationDialog::new("Remove Wallet", message)
+                            .confirm_text(Some("Remove"))
+                            .cancel_text(Some("Cancel"))
+                            .danger_mode(true),
+                    );
+                }
+            }
+
+            if let Some(dialog) = self.remove_wallet_dialog.as_mut() {
+                let response = dialog.show(ui);
+                if let Some(status) = response.inner.dialog_response {
+                    match status {
+                        ConfirmationStatus::Confirmed => {
+                            self.remove_wallet_dialog = None;
+                            if let Some(seed_hash) = self.pending_wallet_removal.take() {
+                                let alias = self
+                                    .pending_wallet_removal_alias
+                                    .take()
+                                    .unwrap_or_else(|| "Unnamed Wallet".to_string());
+                                self.handle_wallet_removal(seed_hash, alias);
+                            } else {
+                                self.pending_wallet_removal_alias = None;
+                            }
+                        }
+                        ConfirmationStatus::Canceled => {
+                            self.remove_wallet_dialog = None;
+                            self.pending_wallet_removal = None;
+                            self.pending_wallet_removal_alias = None;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_wallet_removal(&mut self, seed_hash: WalletSeedHash, alias: String) {
+        match self.app_context.remove_wallet(&seed_hash) {
+            Ok(()) => {
+                let next_wallet = self
+                    .app_context
+                    .wallets
+                    .read()
+                    .ok()
+                    .and_then(|wallets| wallets.values().next().cloned());
+
+                self.selected_wallet = next_wallet;
+
+                if self.selected_wallet.is_none() {
+                    self.selected_filters.clear();
+                    self.selected_filters.insert("Funds".to_string());
+                }
+
+                self.show_rename_dialog = false;
+                self.rename_input.clear();
+                self.wallet_password.clear();
+                self.show_password = false;
+                self.error_message = None;
+                self.refreshing = false;
+
+                self.display_message(
+                    &format!("Removed wallet \"{}\" successfully", alias),
+                    MessageType::Success,
+                );
+            }
+            Err(err) => {
+                self.display_message(
+                    &format!("Failed to remove wallet: {}", err),
+                    MessageType::Error,
+                );
             }
         }
     }

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -610,8 +610,8 @@ impl WalletsBalancesScreen {
             .stroke(egui::Stroke::NONE)
             .corner_radius(4.0);
 
-            if ui.add(remove_button).clicked() {
-                if let Some(selected_wallet) = &self.selected_wallet {
+            if ui.add(remove_button).clicked()
+                && let Some(selected_wallet) = &self.selected_wallet {
                     let wallet = selected_wallet.read().unwrap();
                     let alias = wallet
                         .alias
@@ -635,7 +635,6 @@ impl WalletsBalancesScreen {
                             .danger_mode(true),
                     );
                 }
-            }
 
             if let Some(dialog) = self.remove_wallet_dialog.as_mut() {
                 let response = dialog.show(ui);


### PR DESCRIPTION
Add ability to remove wallets. Associated identities are not removed with the wallets. The links are broken, but they can be re-established via the new Add Existing Identity by loaded wallet + identity index feature in #444 