### PR TITLE
fix: wallet screen not updating wallets after network change

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -510,7 +510,10 @@ impl Screen {
             Screen::AddNewWalletScreen(screen) => screen.app_context = app_context,
             Screen::TransferScreen(screen) => screen.app_context = app_context,
             Screen::TopUpIdentityScreen(screen) => screen.app_context = app_context,
-            Screen::WalletsBalancesScreen(screen) => screen.app_context = app_context,
+            Screen::WalletsBalancesScreen(screen) => {
+                screen.app_context = app_context;
+                screen.update_selected_wallet_for_network();
+            }
             Screen::ImportWalletScreen(screen) => screen.app_context = app_context,
             Screen::ProofLogScreen(screen) => screen.app_context = app_context,
             Screen::AddContractsScreen(screen) => screen.app_context = app_context,

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -4,6 +4,7 @@ use crate::ui::ScreenLike;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
+use crate::ui::theme::DashColors;
 use eframe::egui::Context;
 
 use crate::model::wallet::encryption::{DASH_SECRET_MESSAGE, encrypt_message};
@@ -433,7 +434,7 @@ impl ScreenLike for AddNewWalletScreen {
                     // Centered "Save Wallet" button at the bottom
                     ui.with_layout(Layout::centered_and_justified(Direction::TopDown), |ui| {
                         let save_button = egui::Button::new(
-                            RichText::new("Save Wallet").strong().size(30.0),
+                            RichText::new("Save Wallet").strong().size(30.0).color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode)),
                         )
                             .min_size(Vec2::new(300.0, 60.0))
                             .corner_radius(10.0)

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -152,6 +152,30 @@ impl WalletsBalancesScreen {
         }
     }
 
+    pub(crate) fn update_selected_wallet_for_network(&mut self) {
+        let selected_seed = self
+            .selected_wallet
+            .as_ref()
+            .and_then(|wallet| wallet.read().ok().map(|wallet| wallet.seed_hash()));
+
+        let wallets = match self.app_context.wallets.read() {
+            Ok(guard) => guard,
+            Err(_) => {
+                self.selected_wallet = None;
+                return;
+            }
+        };
+
+        if let Some(seed_hash) = selected_seed {
+            if let Some(wallet) = wallets.get(&seed_hash) {
+                self.selected_wallet = Some(wallet.clone());
+                return;
+            }
+        }
+
+        self.selected_wallet = wallets.values().next().cloned();
+    }
+
     fn add_receiving_address(&mut self) {
         if let Some(wallet) = &self.selected_wallet {
             let result = {

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -166,12 +166,11 @@ impl WalletsBalancesScreen {
             }
         };
 
-        if let Some(seed_hash) = selected_seed {
-            if let Some(wallet) = wallets.get(&seed_hash) {
+        if let Some(seed_hash) = selected_seed
+            && let Some(wallet) = wallets.get(&seed_hash) {
                 self.selected_wallet = Some(wallet.clone());
                 return;
             }
-        }
 
         self.selected_wallet = wallets.values().next().cloned();
     }


### PR DESCRIPTION
If you created a wallet on one network with some alias, then switch networks and create a new wallet with the same alias, the wallet screen would show the wallet from the old network because the screen was already created and holding the old wallet by alias