### PR TITLE
fix: some document actions were showing error when it was success

### DIFF
--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -1507,11 +1507,11 @@ impl ScreenLike for DocumentActionScreen {
     }
 
     fn display_message(&mut self, message: &str, _message_type: crate::ui::MessageType) {
-        if message.contains("Document deleted successfully")
-            || message.contains("Document replaced successfully")
-            || message.contains("Document transferred successfully")
-            || message.contains("Document purchased successfully")
-            || message.contains("Document price set successfully")
+        if message.contains("deleted successfully")
+            || message.contains("replaced successfully")
+            || message.contains("transferred successfully")
+            || message.contains("purchased successfully")
+            || message.contains("price set successfully")
         {
             self.broadcast_status = BroadcastStatus::Broadcasted;
         } else {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -623,6 +623,7 @@ pub fn show_success_screen(
                 action = button.1;
             }
         }
+        ui.add_space(100.0);
     });
     action
 }


### PR DESCRIPTION
Some document actions were showing error when it was success. They just weren't matching the message correctly.