### PR TITLE
fix: scrollable unused asset locks on identity creation

### DIFF
--- a/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
@@ -21,6 +21,7 @@ impl AddNewIdentityScreen {
         }
 
         ui.heading("Select an unused asset lock:");
+        ui.add_space(8.0);
 
         // Track the index of the currently selected asset lock (if any)
         let selected_index = self.funding_asset_lock.as_ref().and_then(|(_, proof, _)| {
@@ -31,45 +32,53 @@ impl AddNewIdentityScreen {
         });
 
         // Display the asset locks in a scrollable area
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            for (index, (tx, address, amount, islock, proof)) in
-                wallet.unused_asset_locks.iter().enumerate()
-            {
-                ui.horizontal(|ui| {
-                    let tx_id = tx.txid().to_string();
-                    let lock_amount = *amount as f64 * 1e-8; // Convert to DASH
-                    let is_locked = if islock.is_some() { "Yes" } else { "No" };
+        egui::ScrollArea::vertical()
+            .auto_shrink([false; 2])
+            .min_scrolled_height(180.0)
+            .show(ui, |ui| {
+                for (index, (tx, address, amount, islock, proof)) in
+                    wallet.unused_asset_locks.iter().enumerate()
+                {
+                    ui.group(|ui| {
+                        ui.vertical(|ui| {
+                            let tx_id = tx.txid().to_string();
+                            let lock_amount = *amount as f64 * 1e-8; // Convert to DASH
+                            let is_locked = if islock.is_some() { "Yes" } else { "No" };
 
-                    // Display asset lock information with "Selected" if this one is selected
-                    let selected_text = if Some(index) == selected_index {
-                        " (Selected)"
-                    } else {
-                        ""
-                    };
+                            // Display asset lock information with "Selected" if this one is selected
+                            if Some(index) == selected_index {
+                                ui.colored_label(
+                                    Color32::from_rgb(0, 130, 90),
+                                    "Selected asset lock",
+                                );
+                            }
 
-                    ui.label(format!(
-                        "TxID: {}, Address: {}, Amount: {:.8} DASH, InstantLock: {}{}",
-                        tx_id, address, lock_amount, is_locked, selected_text
-                    ));
+                            ui.label(format!("TxID: {}", tx_id));
+                            ui.label(format!("Address: {}", address));
+                            ui.label(format!("Amount: {:.8} DASH", lock_amount));
+                            ui.label(format!("InstantLock: {}", is_locked));
 
-                    // Button to select this asset lock
-                    if ui.button("Select").clicked() {
-                        // Update the selected asset lock
-                        self.funding_asset_lock = Some((
-                            tx.clone(),
-                            proof.clone().expect("Asset lock proof is required"),
-                            address.clone(),
-                        ));
+                            ui.add_space(6.0);
 
-                        // Update the step to ready to create identity
-                        let mut step = self.step.write().unwrap();
-                        *step = WalletFundedScreenStep::ReadyToCreate;
-                    }
-                });
+                            // Button to select this asset lock stays visible regardless of wrapping
+                            if ui.button("Select").clicked() {
+                                // Update the selected asset lock
+                                self.funding_asset_lock = Some((
+                                    tx.clone(),
+                                    proof.clone().expect("Asset lock proof is required"),
+                                    address.clone(),
+                                ));
 
-                ui.add_space(5.0); // Add space between each entry
-            }
-        });
+                                // Update the step to ready to create identity
+                                let mut step = self.step.write().unwrap();
+                                *step = WalletFundedScreenStep::ReadyToCreate;
+                            }
+                        });
+                    });
+
+                    ui.add_space(6.0); // Add space between each entry
+                }
+            });
     }
 
     pub fn render_ui_by_using_unused_asset_lock(

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -167,10 +167,11 @@ impl WalletsBalancesScreen {
         };
 
         if let Some(seed_hash) = selected_seed
-            && let Some(wallet) = wallets.get(&seed_hash) {
-                self.selected_wallet = Some(wallet.clone());
-                return;
-            }
+            && let Some(wallet) = wallets.get(&seed_hash)
+        {
+            self.selected_wallet = Some(wallet.clone());
+            return;
+        }
 
         self.selected_wallet = wallets.values().next().cloned();
     }


### PR DESCRIPTION
Unused asset locks for creating identity were going off the window in some instances, so we reformatted.

Addresses #397 