### PR TITLE
fix: logging should interpret RUST_LOG env variable

### DIFF
--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -509,7 +509,7 @@ impl Database {
                 identity.network = *network;
 
                 tracing::trace!(
-                    wallet_seed = ?wallet_seed_hash_array,
+                    wallet_seed = hex::encode(wallet_seed_hash_array),
                     wallet_alias = ?wallet.alias,
                     identity = ?identity.identity.id().to_string(Encoding::Base58),
                     identity_alias = ?identity.alias,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -10,11 +10,12 @@ pub fn initialize_logger() {
         Ok(file) => file,
         Err(e) => panic!("Failed to create log file: {:?}", e),
     };
-
-    let filter = EnvFilter::try_new(
-        "info,dash_evo_tool=trace,dash_sdk=debug,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn",
-    )
-        .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::try_new(
+            "info,dash_evo_tool=trace,dash_sdk=debug,dash_sdk::platform::transition=trace,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn",
+        )
+        .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e))
+    });
 
     let subscriber = tracing_subscriber::fmt()
         .with_env_filter(filter)


### PR DESCRIPTION
This pull request contains two targeted improvements: one to the logging configuration and another to how wallet seed data is logged. The logging setup is now more flexible and includes more detailed trace information for platform transitions, while the wallet seed is now logged in a more readable format.

**Logging improvements:**
- Updated the logger initialization in `logging.rs` to use environment variables for log filtering if available, falling back to a default filter that now also includes `dash_sdk::platform::transition=trace` for more granular trace logs. This makes log configuration more flexible and adds deeper visibility into platform transitions.

**Wallet seed logging:**
- Changed the logging of `wallet_seed` in `wallet.rs` to use hexadecimal encoding, making the output more readable and consistent.