### PR TITLE
fix: document actions were auto selecting master keys but shouldnt

### DIFF
--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -248,12 +248,14 @@ impl DocumentActionScreen {
         if response.changed() {
             if let Some(identity) = &self.selected_identity {
                 // Auto-select a suitable key for document actions
+                // Note: MASTER keys cannot be used for document operations,
+                // only MEDIUM, HIGH, or CRITICAL security levels are allowed
                 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
                 self.selected_key = identity
                     .identity
                     .get_first_public_key_matching(
                         Purpose::AUTHENTICATION,
-                        SecurityLevel::full_range().into(),
+                        [SecurityLevel::CRITICAL, SecurityLevel::HIGH, SecurityLevel::MEDIUM].into(),
                         KeyType::all_key_types().into(),
                         false,
                     )

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -77,13 +77,15 @@ impl RegisterDpnsNameScreen {
         };
 
         // Auto-select a suitable key for DPNS registration
+        // Note: MASTER keys cannot be used for document operations,
+        // only MEDIUM, HIGH, or CRITICAL security levels are allowed
         let selected_key = selected_qualified_identity.as_ref().and_then(|identity| {
-            use dash_sdk::dpp::identity::KeyType;
+            use dash_sdk::dpp::identity::{KeyType, SecurityLevel};
             identity
                 .identity
                 .get_first_public_key_matching(
                     Purpose::AUTHENTICATION,
-                    dash_sdk::dpp::identity::SecurityLevel::full_range().into(),
+                    [SecurityLevel::CRITICAL, SecurityLevel::HIGH, SecurityLevel::MEDIUM].into(),
                     KeyType::all_key_types().into(),
                     false,
                 )
@@ -133,12 +135,14 @@ impl RegisterDpnsNameScreen {
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
             // Auto-select a suitable key for DPNS registration
-            use dash_sdk::dpp::identity::KeyType;
+            // Note: MASTER keys cannot be used for document operations,
+            // only MEDIUM, HIGH, or CRITICAL security levels are allowed
+            use dash_sdk::dpp::identity::{KeyType, SecurityLevel};
             self.selected_key = qi
                 .identity
                 .get_first_public_key_matching(
                     Purpose::AUTHENTICATION,
-                    dash_sdk::dpp::identity::SecurityLevel::full_range().into(),
+                    [SecurityLevel::CRITICAL, SecurityLevel::HIGH, SecurityLevel::MEDIUM].into(),
                     KeyType::all_key_types().into(),
                     false,
                 )
@@ -178,12 +182,14 @@ impl RegisterDpnsNameScreen {
         if response.changed() {
             if let Some(identity) = &self.selected_qualified_identity {
                 // Auto-select a suitable key for DPNS registration
-                use dash_sdk::dpp::identity::KeyType;
+                // Note: MASTER keys cannot be used for document operations,
+                // only MEDIUM, HIGH, or CRITICAL security levels are allowed
+                use dash_sdk::dpp::identity::{KeyType, SecurityLevel};
                 self.selected_key = identity
                     .identity
                     .get_first_public_key_matching(
                         Purpose::AUTHENTICATION,
-                        dash_sdk::dpp::identity::SecurityLevel::full_range().into(),
+                        [SecurityLevel::CRITICAL, SecurityLevel::HIGH, SecurityLevel::MEDIUM].into(),
                         KeyType::all_key_types().into(),
                         false,
                     )

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -171,8 +171,8 @@ impl WithdrawalScreen {
             });
 
             // In dev mode with OWNER key, show hint about auto-selected payout address
-            if self.app_context.is_developer_mode() && is_owner_key {
-                if let Some(payout_address) = self
+            if self.app_context.is_developer_mode() && is_owner_key
+                && let Some(payout_address) = self
                     .identity
                     .masternode_payout_address(self.app_context.network)
                 {
@@ -185,7 +185,6 @@ impl WithdrawalScreen {
                         .color(Color32::GRAY),
                     );
                 }
-            }
         } else {
             ui.label(format!(
                 "Masternode payout address: {}",


### PR DESCRIPTION
Document Action screens like Document Create and Delete were auto-selecting Master keys but Master keys don't work. Needs to be Critical, High, or Medium Authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication keys for document actions now exclude MASTER security level keys; only MEDIUM, HIGH, and CRITICAL levels are available.
  * Authentication keys for DPNS name registration now exclude MASTER security level keys; only MEDIUM, HIGH, and CRITICAL levels are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->