### PR TITLE
fix: security level validation for add key screen

### DIFF
--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -473,7 +473,7 @@ impl ScreenLike for AddKeyScreen {
                     ui.label("Security Level:");
                     // Only AUTHENTICATION has multiple security level options
                     let has_multiple_security_levels =
-                        self.purpose == Purpose::AUTHENTICATION && !self.enable_contract_bounds;
+                        self.purpose == Purpose::AUTHENTICATION;
                     let inner_response = ui.add_enabled_ui(has_multiple_security_levels, |ui| {
                         egui::ComboBox::from_id_salt("security_level_selector")
                             .selected_text(format!("{:?}", self.security_level))

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -404,6 +404,7 @@ impl ScreenLike for AddKeyScreen {
                 .show(ui, |ui| {
                     // Purpose
                     ui.label("Purpose:");
+                    let prev_purpose = self.purpose;
                     egui::ComboBox::from_id_salt("purpose_selector")
                         .selected_text(format!("{:?}", self.purpose))
                         .show_ui(ui, |ui| {
@@ -443,6 +444,29 @@ impl ScreenLike for AddKeyScreen {
                                 );
                             }
                         });
+
+                    // Auto-set security level when purpose changes
+                    if self.purpose != prev_purpose {
+                        match self.purpose {
+                            Purpose::ENCRYPTION | Purpose::DECRYPTION => {
+                                self.security_level = SecurityLevel::MEDIUM;
+                            }
+                            Purpose::TRANSFER => {
+                                self.security_level = SecurityLevel::CRITICAL;
+                            }
+                            Purpose::AUTHENTICATION => {
+                                // AUTHENTICATION allows multiple levels, keep current if valid
+                                // otherwise default to CRITICAL
+                                if self.security_level != SecurityLevel::CRITICAL
+                                    && self.security_level != SecurityLevel::HIGH
+                                    && self.security_level != SecurityLevel::MEDIUM
+                                {
+                                    self.security_level = SecurityLevel::CRITICAL;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
                     ui.end_row();
 
                     // Security Level
@@ -473,7 +497,17 @@ impl ScreenLike for AddKeyScreen {
                                     SecurityLevel::MEDIUM,
                                     "MEDIUM",
                                 );
+                            } else if self.purpose == Purpose::ENCRYPTION
+                                || self.purpose == Purpose::DECRYPTION
+                            {
+                                // ENCRYPTION and DECRYPTION only allow MEDIUM
+                                ui.selectable_value(
+                                    &mut self.security_level,
+                                    SecurityLevel::MEDIUM,
+                                    "MEDIUM",
+                                );
                             } else {
+                                // TRANSFER only allows CRITICAL
                                 ui.selectable_value(
                                     &mut self.security_level,
                                     SecurityLevel::CRITICAL,

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -471,50 +471,67 @@ impl ScreenLike for AddKeyScreen {
 
                     // Security Level
                     ui.label("Security Level:");
-                    egui::ComboBox::from_id_salt("security_level_selector")
-                        .selected_text(format!("{:?}", self.security_level))
-                        .show_ui(ui, |ui| {
-                            if self.enable_contract_bounds {
-                                // When contract bounds are enabled, only allow MEDIUM
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::MEDIUM,
-                                    "MEDIUM",
-                                );
-                            } else if self.purpose == Purpose::AUTHENTICATION {
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::CRITICAL,
-                                    "CRITICAL",
-                                );
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::HIGH,
-                                    "HIGH",
-                                );
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::MEDIUM,
-                                    "MEDIUM",
-                                );
-                            } else if self.purpose == Purpose::ENCRYPTION
-                                || self.purpose == Purpose::DECRYPTION
-                            {
-                                // ENCRYPTION and DECRYPTION only allow MEDIUM
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::MEDIUM,
-                                    "MEDIUM",
-                                );
-                            } else {
-                                // TRANSFER only allows CRITICAL
-                                ui.selectable_value(
-                                    &mut self.security_level,
-                                    SecurityLevel::CRITICAL,
-                                    "CRITICAL",
-                                );
-                            }
-                        });
+                    // Only AUTHENTICATION has multiple security level options
+                    let has_multiple_security_levels =
+                        self.purpose == Purpose::AUTHENTICATION && !self.enable_contract_bounds;
+                    let inner_response = ui.add_enabled_ui(has_multiple_security_levels, |ui| {
+                        egui::ComboBox::from_id_salt("security_level_selector")
+                            .selected_text(format!("{:?}", self.security_level))
+                            .show_ui(ui, |ui| {
+                                if self.enable_contract_bounds {
+                                    // When contract bounds are enabled, only allow MEDIUM
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::MEDIUM,
+                                        "MEDIUM",
+                                    );
+                                } else if self.purpose == Purpose::AUTHENTICATION {
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::CRITICAL,
+                                        "CRITICAL",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::HIGH,
+                                        "HIGH",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::MEDIUM,
+                                        "MEDIUM",
+                                    );
+                                } else if self.purpose == Purpose::ENCRYPTION
+                                    || self.purpose == Purpose::DECRYPTION
+                                {
+                                    // ENCRYPTION and DECRYPTION only allow MEDIUM
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::MEDIUM,
+                                        "MEDIUM",
+                                    );
+                                } else {
+                                    // TRANSFER only allows CRITICAL
+                                    ui.selectable_value(
+                                        &mut self.security_level,
+                                        SecurityLevel::CRITICAL,
+                                        "CRITICAL",
+                                    );
+                                }
+                            })
+                    });
+                    if !has_multiple_security_levels {
+                        // Use interact with hover sense to detect hover on disabled widget
+                        let hover_response = ui.interact(
+                            inner_response.response.rect,
+                            egui::Id::new("security_level_tooltip"),
+                            egui::Sense::hover(),
+                        );
+                        hover_response.on_hover_text(format!(
+                            "{:?} purpose requires {:?} security level",
+                            self.purpose, self.security_level
+                        ));
+                    }
                     ui.end_row();
 
                     // Key Type

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -472,8 +472,7 @@ impl ScreenLike for AddKeyScreen {
                     // Security Level
                     ui.label("Security Level:");
                     // Only AUTHENTICATION has multiple security level options
-                    let has_multiple_security_levels =
-                        self.purpose == Purpose::AUTHENTICATION;
+                    let has_multiple_security_levels = self.purpose == Purpose::AUTHENTICATION;
                     let inner_response = ui.add_enabled_ui(has_multiple_security_levels, |ui| {
                         egui::ComboBox::from_id_salt("security_level_selector")
                             .selected_text(format!("{:?}", self.security_level))


### PR DESCRIPTION
Fixes the "Add New Key" screen to correctly enforce security level constraints based on the selected key purpose. Previously, selecting ENCRYPTION or DECRYPTION purpose would only show CRITICAL as an option, but the Dash Platform protocol requires MEDIUM for these purposes, causing a broadcast error.

## Changes
- Auto-set security level when purpose changes - Automatically selects the valid security level for the chosen purpose (MEDIUM for ENCRYPTION/DECRYPTION, CRITICAL for TRANSFER)
- Disable dropdown when only one option is valid - Grays out the Security Level dropdown for purposes with a fixed security level requirement, making it visually clear the value is protocol-enforced
- Add hover tooltip - Explains why the dropdown is disabled (e.g., "ENCRYPTION purpose requires MEDIUM security level")

## Testing
1. Navigate to Add New Key screen
2. Select Purpose = ENCRYPTION → Security Level should show MEDIUM and be disabled
3. Select Purpose = AUTHENTICATION → Security Level should be enabled with CRITICAL, HIGH, MEDIUM options
4. Add a key with ENCRYPTION purpose → Should succeed without protocol error

## Preview image:

<img width="1206" height="744" alt="image" src="https://github.com/user-attachments/assets/151a8ce0-37bd-403c-b1fe-d2effb524772" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational tooltips explaining security level requirements for key purposes.

* **Bug Fixes**
  * Security level now automatically adjusts based on the selected key purpose.
  * Different purposes enforce appropriate security level constraints with improved UI handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->