### PR TITLE
fix: display WIF format for manually added private keys

### DIFF
--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -305,6 +305,21 @@ impl ScreenLike for KeyInfoScreen {
                                 .num_columns(2)
                                 .spacing([10.0, 10.0])
                                 .show(ui, |ui| {
+                                    if let Ok(secret_key) = SecretKey::from_slice(clear) {
+                                        let private_key =
+                                            PrivateKey::new(secret_key, self.app_context.network);
+                                        ui.label(
+                                            RichText::new("Private Key (WIF):")
+                                                .strong()
+                                                .color(ui.visuals().text_color()),
+                                        );
+                                        ui.label(
+                                            RichText::new(private_key.to_wif())
+                                                .color(ui.visuals().text_color()),
+                                        );
+                                        ui.end_row();
+                                    }
+
                                     ui.label(
                                         RichText::new("Private Key (Hex):")
                                             .strong()

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -171,8 +171,8 @@ impl WithdrawalScreen {
             });
 
             // In dev mode with OWNER key, show hint about auto-selected payout address
-            if self.app_context.is_developer_mode() && is_owner_key {
-                if let Some(payout_address) = self
+            if self.app_context.is_developer_mode() && is_owner_key
+                && let Some(payout_address) = self
                     .identity
                     .masternode_payout_address(self.app_context.network)
                 {
@@ -185,7 +185,6 @@ impl WithdrawalScreen {
                         .color(Color32::GRAY),
                     );
                 }
-            }
         } else {
             ui.label(format!(
                 "Masternode payout address: {}",

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -171,20 +171,21 @@ impl WithdrawalScreen {
             });
 
             // In dev mode with OWNER key, show hint about auto-selected payout address
-            if self.app_context.is_developer_mode() && is_owner_key
+            if self.app_context.is_developer_mode()
+                && is_owner_key
                 && let Some(payout_address) = self
                     .identity
                     .masternode_payout_address(self.app_context.network)
-                {
-                    ui.label(
-                        RichText::new(format!(
-                            "Leave empty to use masternode payout address: {}",
-                            payout_address
-                        ))
-                        .italics()
-                        .color(Color32::GRAY),
-                    );
-                }
+            {
+                ui.label(
+                    RichText::new(format!(
+                        "Leave empty to use masternode payout address: {}",
+                        payout_address
+                    ))
+                    .italics()
+                    .color(Color32::GRAY),
+                );
+            }
         } else {
             ui.label(format!(
                 "Masternode payout address: {}",


### PR DESCRIPTION
## Summary

Fixes #495

When viewing private keys for externally loaded identities with manually added keys, only the hex format was displayed. This PR adds WIF format display to match the behavior of wallet-derived keys, providing consistency across all identity types.

## Changes

- Added WIF format display for `PrivateKeyData::Clear` and `PrivateKeyData::AlwaysClear` private keys in the Key Info screen
- WIF is now shown alongside hex format, matching the display for wallet-derived keys

## Test Plan

- [x] Load an external identity by ID
- [x] Add a private key manually (hex or WIF input)
- [x] View the key info and verify both WIF and Hex formats are displayed

---

🤖 Generated with [Claude Code](https://claude.ai/code)