### PR TITLE
fix: update platform address prefix from dashevo to evo

### DIFF
--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -527,7 +527,7 @@ impl Database {
                     )
                 })?;
 
-            // Parse address - Platform addresses (DIP-17/18) use Bech32m encoding with dashevo/tdashevo prefix
+            // Parse address - Platform addresses (DIP-17/18) use Bech32m encoding with evo/tevo prefix
             // and need special handling when stored (we store as Core address format internally)
             let address = if path_reference == DerivationPathReference::PlatformPayment {
                 // Platform addresses are stored as Core P2PKH format for efficient internal lookup.

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -1223,7 +1223,7 @@ impl Wallet {
         Ok(())
     }
 
-    /// Bootstrap DIP-17 Platform payment addresses (dashevo/tdashevo Bech32m prefix per DIP-18)
+    /// Bootstrap DIP-17 Platform payment addresses (evo/tevo Bech32m prefix)
     /// These addresses are for receiving Dash Credits on Platform, independent of identities.
     fn bootstrap_platform_payment_addresses(
         &mut self,
@@ -2006,7 +2006,7 @@ impl Signer<PlatformAddress> for Wallet {
         // The Signer trait doesn't pass network info, so we try each network.
         // This is safe because:
         // 1. A wallet instance only stores keys for ONE network (set at creation)
-        // 2. Platform addresses encode their network in the bech32m prefix (dashevo/tdashevo)
+        // 2. Platform addresses encode their network in the bech32m prefix (evo/tevo)
         // 3. get_platform_address_private_key will only succeed for the correct network
         // 4. Only one network's derivation will match the wallet's seed
         let private_key = self

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -261,8 +261,8 @@ impl TransferScreen {
 
         let input = self.platform_address_input.trim();
 
-        // Try to parse as Bech32m Platform address first (DIP-18 format: dashevo1.../tdashevo1...)
-        if input.starts_with("dashevo1") || input.starts_with("tdashevo1") {
+        // Try to parse as Bech32m Platform address first (evo1.../tevo1...)
+        if input.starts_with("evo1") || input.starts_with("tevo1") {
             let (addr, _network) = PlatformAddress::from_bech32m_string(input)
                 .map_err(|e| format!("Invalid Bech32m address: {}", e))?;
             return Ok(addr);

--- a/src/ui/tools/address_balance_screen.rs
+++ b/src/ui/tools/address_balance_screen.rs
@@ -58,11 +58,11 @@ impl AddressBalanceScreen {
         ui.heading("Platform Address Balance Lookup");
         ui.add_space(10.0);
 
-        ui.label("Enter a Platform address (dashevo1... or tdashevo1...):");
+        ui.label("Enter a Platform address (evo1... or tevo1...):");
         ui.add_space(5.0);
 
         let text_edit = TextEdit::singleline(&mut self.address_input)
-            .hint_text("dashevo1... or tdashevo1...")
+            .hint_text("evo1... or tevo1...")
             .desired_width(500.0);
 
         let response = ui.add(text_edit);

--- a/src/ui/wallets/account_summary.rs
+++ b/src/ui/wallets/account_summary.rs
@@ -17,7 +17,7 @@ pub enum AccountCategory {
     ProviderOwner,
     ProviderOperator,
     ProviderPlatform,
-    /// DIP-17: Platform Payment Addresses (dashevo/tdashevo Bech32m prefix per DIP-18)
+    /// DIP-17: Platform Payment Addresses (evo/tevo Bech32m prefix per DIP-18)
     PlatformPayment,
     Other(DerivationPathReference),
 }
@@ -124,7 +124,7 @@ impl AccountCategory {
                 Some("Platform service key branch used by masternode platform nodes.")
             }
             AccountCategory::PlatformPayment => Some(
-                "DIP-17 Platform payment addresses (dashevo/tdashevo prefix). Hold Dash Credits on Platform, independent of identities.",
+                "DIP-17 Platform payment addresses (evo/tevo prefix). Hold Dash Credits on Platform, independent of identities.",
             ),
             AccountCategory::Other(_) => None,
         }

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -231,7 +231,7 @@ impl WalletSendScreen {
         }
 
         // Check for Platform address (Bech32m format)
-        if trimmed.starts_with("dashevo1") || trimmed.starts_with("tdashevo1") {
+        if trimmed.starts_with("evo1") || trimmed.starts_with("tevo1") {
             return AddressType::Platform;
         }
 
@@ -363,7 +363,7 @@ impl WalletSendScreen {
         let dest_type = self.detect_address_type(&self.destination_address);
         if dest_type == AddressType::Unknown {
             return Err(
-                "Invalid destination address. Use a Dash address (X.../y...) or Platform address (dashevo1.../tdashevo1...)"
+                "Invalid destination address. Use a Dash address (X.../y...) or Platform address (evo1.../tevo1...)"
                     .to_string(),
             );
         }
@@ -853,7 +853,7 @@ impl WalletSendScreen {
             .show(ui, |ui| {
                 ui.add(
                     egui::TextEdit::singleline(&mut self.destination_address)
-                        .hint_text("Enter address (X.../y.../dashevo1.../tdashevo1...)")
+                        .hint_text("Enter address (X.../y.../evo1.../tevo1...)")
                         .desired_width(f32::INFINITY),
                 );
             });
@@ -1479,7 +1479,7 @@ impl WalletSendScreen {
                             ui.label("To:");
                             ui.add(
                                 egui::TextEdit::singleline(&mut self.advanced_outputs[idx].address)
-                                    .hint_text("Enter address (X.../y.../dashevo1.../tdashevo1...)")
+                                    .hint_text("Enter address (X.../y.../evo1.../tevo1...)")
                                     .desired_width(350.0),
                             );
 
@@ -1550,7 +1550,7 @@ impl WalletSendScreen {
         }
 
         // Check for Platform address (Bech32m format)
-        if trimmed.starts_with("dashevo1") || trimmed.starts_with("tdashevo1") {
+        if trimmed.starts_with("evo1") || trimmed.starts_with("tevo1") {
             return AddressType::Platform;
         }
 

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2699,45 +2699,46 @@ impl WalletsBalancesScreen {
 
             // Parse the Platform address (Bech32m format: evo1.../tevo1...)
             use dash_sdk::dashcore_rpc::dashcore::address::NetworkUnchecked;
-            let platform_addr =
-                if selected_addr.starts_with("evo1") || selected_addr.starts_with("tevo1") {
-                    match PlatformAddress::from_bech32m_string(selected_addr) {
-                        Ok((addr, network)) => {
-                            // Validate that address network matches app network
-                            if network != self.app_context.network {
-                                self.fund_platform_dialog.status = Some(format!(
-                                    "Address network mismatch: address is for {:?} but app is on {:?}",
-                                    network, self.app_context.network
-                                ));
-                                self.fund_platform_dialog.status_is_error = true;
-                                return AppAction::None;
-                            }
-                            addr
-                        }
-                        Err(e) => {
-                            self.fund_platform_dialog.status =
-                                Some(format!("Invalid Bech32m address: {}", e));
+            let platform_addr = if selected_addr.starts_with("evo1")
+                || selected_addr.starts_with("tevo1")
+            {
+                match PlatformAddress::from_bech32m_string(selected_addr) {
+                    Ok((addr, network)) => {
+                        // Validate that address network matches app network
+                        if network != self.app_context.network {
+                            self.fund_platform_dialog.status = Some(format!(
+                                "Address network mismatch: address is for {:?} but app is on {:?}",
+                                network, self.app_context.network
+                            ));
                             self.fund_platform_dialog.status_is_error = true;
                             return AppAction::None;
                         }
+                        addr
                     }
-                } else {
-                    // Fall back to base58 parsing for backwards compatibility
-                    match selected_addr
-                        .parse::<Address<NetworkUnchecked>>()
-                        .map_err(|e| e.to_string())
-                        .and_then(|a| {
-                            PlatformAddress::try_from(a.assume_checked())
-                                .map_err(|e| format!("Invalid Platform address: {}", e))
-                        }) {
-                        Ok(addr) => addr,
-                        Err(e) => {
-                            self.fund_platform_dialog.status = Some(e);
-                            self.fund_platform_dialog.status_is_error = true;
-                            return AppAction::None;
-                        }
+                    Err(e) => {
+                        self.fund_platform_dialog.status =
+                            Some(format!("Invalid Bech32m address: {}", e));
+                        self.fund_platform_dialog.status_is_error = true;
+                        return AppAction::None;
                     }
-                };
+                }
+            } else {
+                // Fall back to base58 parsing for backwards compatibility
+                match selected_addr
+                    .parse::<Address<NetworkUnchecked>>()
+                    .map_err(|e| e.to_string())
+                    .and_then(|a| {
+                        PlatformAddress::try_from(a.assume_checked())
+                            .map_err(|e| format!("Invalid Platform address: {}", e))
+                    }) {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        self.fund_platform_dialog.status = Some(e);
+                        self.fund_platform_dialog.status_is_error = true;
+                        return AppAction::None;
+                    }
+                }
+            };
 
             (
                 wallet.seed_hash(),

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -148,7 +148,7 @@ struct AddressData {
 
 impl AddressData {
     /// Returns the address formatted for display.
-    /// Platform Payment addresses are shown in DIP-18 Bech32m format (e.g., tdashevo...).
+    /// Platform Payment addresses are shown in DIP-18 Bech32m format (e.g., tevo1...).
     fn display_address(&self, network: Network) -> String {
         if self.account_category == AccountCategory::PlatformPayment {
             use dash_sdk::dpp::address_funds::PlatformAddress;
@@ -2287,7 +2287,7 @@ impl WalletsBalancesScreen {
     }
 
     /// Generate a new Platform address for the wallet.
-    /// Returns the address in DIP-18 Bech32m format (e.g., tdashevo1... for testnet)
+    /// Returns the address in Bech32m format (e.g., tevo1... for testnet)
     fn generate_platform_address(&self, wallet: &Arc<RwLock<Wallet>>) -> Result<String, String> {
         use dash_sdk::dpp::address_funds::PlatformAddress;
         let mut wallet_guard = wallet.write().map_err(|e| e.to_string())?;
@@ -2697,37 +2697,36 @@ impl WalletsBalancesScreen {
                 return AppAction::None;
             };
 
-            // Parse the Platform address (Bech32m format: dashevo1.../tdashevo1...)
+            // Parse the Platform address (Bech32m format: evo1.../tevo1...)
             use dash_sdk::dashcore_rpc::dashcore::address::NetworkUnchecked;
-            let platform_addr = if selected_addr.starts_with("dashevo1")
-                || selected_addr.starts_with("tdashevo1")
-            {
-                match PlatformAddress::from_bech32m_string(selected_addr) {
-                    Ok((addr, _network)) => addr,
-                    Err(e) => {
-                        self.fund_platform_dialog.status =
-                            Some(format!("Invalid Bech32m address: {}", e));
-                        self.fund_platform_dialog.status_is_error = true;
-                        return AppAction::None;
+            let platform_addr =
+                if selected_addr.starts_with("evo1") || selected_addr.starts_with("tevo1") {
+                    match PlatformAddress::from_bech32m_string(selected_addr) {
+                        Ok((addr, _network)) => addr,
+                        Err(e) => {
+                            self.fund_platform_dialog.status =
+                                Some(format!("Invalid Bech32m address: {}", e));
+                            self.fund_platform_dialog.status_is_error = true;
+                            return AppAction::None;
+                        }
                     }
-                }
-            } else {
-                // Fall back to base58 parsing for backwards compatibility
-                match selected_addr
-                    .parse::<Address<NetworkUnchecked>>()
-                    .map_err(|e| e.to_string())
-                    .and_then(|a| {
-                        PlatformAddress::try_from(a.assume_checked())
-                            .map_err(|e| format!("Invalid Platform address: {}", e))
-                    }) {
-                    Ok(addr) => addr,
-                    Err(e) => {
-                        self.fund_platform_dialog.status = Some(e);
-                        self.fund_platform_dialog.status_is_error = true;
-                        return AppAction::None;
+                } else {
+                    // Fall back to base58 parsing for backwards compatibility
+                    match selected_addr
+                        .parse::<Address<NetworkUnchecked>>()
+                        .map_err(|e| e.to_string())
+                        .and_then(|a| {
+                            PlatformAddress::try_from(a.assume_checked())
+                                .map_err(|e| format!("Invalid Platform address: {}", e))
+                        }) {
+                        Ok(addr) => addr,
+                        Err(e) => {
+                            self.fund_platform_dialog.status = Some(e);
+                            self.fund_platform_dialog.status_is_error = true;
+                            return AppAction::None;
+                        }
                     }
-                }
-            };
+                };
 
             (
                 wallet.seed_hash(),

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2702,7 +2702,18 @@ impl WalletsBalancesScreen {
             let platform_addr =
                 if selected_addr.starts_with("evo1") || selected_addr.starts_with("tevo1") {
                     match PlatformAddress::from_bech32m_string(selected_addr) {
-                        Ok((addr, _network)) => addr,
+                        Ok((addr, network)) => {
+                            // Validate that address network matches app network
+                            if network != self.app_context.network {
+                                self.fund_platform_dialog.status = Some(format!(
+                                    "Address network mismatch: address is for {:?} but app is on {:?}",
+                                    network, self.app_context.network
+                                ));
+                                self.fund_platform_dialog.status_is_error = true;
+                                return AppAction::None;
+                            }
+                            addr
+                        }
                         Err(e) => {
                             self.fund_platform_dialog.status =
                                 Some(format!("Invalid Bech32m address: {}", e));


### PR DESCRIPTION
Update address detection and UI hints to use the new shorter platform address prefixes (evo1/tevo1) instead of the old format (dashevo1/tdashevo1) to match SDK v3.0.1 changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Features**
  * Updated platform address prefix recognition to use `evo1` and `tevo1` instead of legacy `dashevo1` and `tdashevo1`
  * Enhanced address validation across parsing and input screens

* **Documentation**
  * Updated address prefix references in UI prompts, hints, error messages, and comments throughout the application

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->