### PR TITLE
fix: don't auto-generate platform address when opening receive dialog

### DIFF
--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2898,15 +2898,18 @@ impl WalletsBalancesScreen {
         };
 
         // Collect Platform addresses with their balances (using DIP-18 Bech32m format)
+        // Use platform_addresses() which checks watched_addresses, not just platform_address_info
+        // This includes addresses that have been derived but may not have been synced yet
         let network = self.app_context.network;
         let platform_addresses: Vec<(String, u64)> = wallet_guard
-            .platform_address_info
-            .iter()
-            .filter_map(|(addr, info)| {
-                use dash_sdk::dpp::address_funds::PlatformAddress;
-                PlatformAddress::try_from(addr.clone())
-                    .ok()
-                    .map(|pa| (pa.to_bech32m_string(network), info.balance))
+            .platform_addresses(network)
+            .into_iter()
+            .map(|(core_addr, platform_addr)| {
+                let balance = wallet_guard
+                    .get_platform_address_info(&core_addr)
+                    .map(|info| info.balance)
+                    .unwrap_or(0);
+                (platform_addr.to_bech32m_string(network), balance)
             })
             .collect();
 


### PR DESCRIPTION
Use platform_addresses() which checks watched_addresses for derived Platform addresses, instead of only checking platform_address_info which only contains synced addresses with balances.

A new address is now only generated if there are truly no Platform addresses derived for the wallet, not just because they haven't been synced yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where derived and watched wallet addresses would not display until after their initial synchronization completed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->