### PR TITLE
fix: reserve fees when using max button for platform address identity funding

### DIFF
--- a/src/model/fee_estimation.rs
+++ b/src/model/fee_estimation.rs
@@ -288,7 +288,7 @@ impl PlatformFeeEstimator {
 
     /// Estimate fee for identity creation from addresses (asset lock).
     /// This includes base cost, asset lock cost, input/output costs, per-key costs,
-    /// storage-based fees, and a 10% safety buffer to account for fee variability.
+    /// storage-based fees, and a 20% safety buffer to account for fee variability.
     pub fn estimate_identity_create_from_addresses(
         &self,
         input_count: usize,
@@ -355,7 +355,7 @@ impl PlatformFeeEstimator {
 
     /// Estimate fee for identity top-up from platform addresses.
     /// This includes base cost, asset lock cost, input costs, storage-based fees,
-    /// and a 10% safety buffer to account for fee variability.
+    /// and a 20% safety buffer to account for fee variability.
     pub fn estimate_identity_topup_from_addresses(&self, input_count: usize) -> u64 {
         // Estimated serialized bytes per input (address + signature/witness data)
         const ESTIMATED_BYTES_PER_INPUT: usize = 225;

--- a/src/model/fee_estimation.rs
+++ b/src/model/fee_estimation.rs
@@ -287,22 +287,36 @@ impl PlatformFeeEstimator {
     }
 
     /// Estimate fee for identity creation from addresses (asset lock).
-    /// This includes base cost, asset lock cost, input/output costs, and per-key costs.
+    /// This includes base cost, asset lock cost, input/output costs, per-key costs,
+    /// storage-based fees, and a 10% safety buffer to account for fee variability.
     pub fn estimate_identity_create_from_addresses(
         &self,
         input_count: usize,
         has_output: bool,
         key_count: usize,
     ) -> u64 {
+        // Estimated serialized bytes per input (address + signature/witness data)
+        const ESTIMATED_BYTES_PER_INPUT: usize = 225;
+        // Estimated bytes for identity structure + keys
+        const ESTIMATED_IDENTITY_BASE_BYTES: usize = 100;
+        const ESTIMATED_BYTES_PER_KEY: usize = 50;
+        // Estimated seek operations for tree traversal
+        const ESTIMATED_SEEKS_BASE: usize = 10;
+
         let output_count = if has_output { 1 } else { 0 };
+        let inputs = input_count.max(1);
+
+        // Base fee from min fee structure
+        // Note: identity creation requires the full identity_create_asset_lock_cost,
+        // not the smaller address_funding_asset_lock_cost used for simple transfers
         let base_fee = self
             .min_fees
             .identity_create_base_cost
-            .saturating_add(self.min_fees.address_funding_asset_lock_cost)
+            .saturating_add(self.min_fees.identity_create_asset_lock_cost)
             .saturating_add(
                 self.min_fees
                     .address_funds_transfer_input_cost
-                    .saturating_mul(input_count as u64),
+                    .saturating_mul(inputs as u64),
             )
             .saturating_add(
                 self.min_fees
@@ -314,7 +328,19 @@ impl PlatformFeeEstimator {
                     .identity_key_in_creation_cost
                     .saturating_mul(key_count as u64),
             );
-        self.apply_multiplier(base_fee)
+
+        // Add storage-based fees for serialized transaction data
+        let estimated_bytes = inputs * ESTIMATED_BYTES_PER_INPUT
+            + ESTIMATED_IDENTITY_BASE_BYTES
+            + key_count * ESTIMATED_BYTES_PER_KEY;
+        let estimated_seeks = ESTIMATED_SEEKS_BASE + inputs;
+        let storage_fee = self.calculate_storage_based_fee(estimated_bytes, estimated_seeks);
+
+        // Total with fee multiplier
+        let total = self.apply_multiplier(base_fee.saturating_add(storage_fee));
+
+        // Add 20% safety buffer to account for fee variability
+        total.saturating_add(total / 5)
     }
 
     /// Estimate fee for identity top-up.
@@ -325,6 +351,42 @@ impl PlatformFeeEstimator {
             .identity_topup_base_cost
             .saturating_add(self.min_fees.identity_topup_asset_lock_cost);
         self.apply_multiplier(base_fee)
+    }
+
+    /// Estimate fee for identity top-up from platform addresses.
+    /// This includes base cost, asset lock cost, input costs, storage-based fees,
+    /// and a 10% safety buffer to account for fee variability.
+    pub fn estimate_identity_topup_from_addresses(&self, input_count: usize) -> u64 {
+        // Estimated serialized bytes per input (address + signature/witness data)
+        const ESTIMATED_BYTES_PER_INPUT: usize = 225;
+        // Estimated bytes for top-up transaction structure
+        const ESTIMATED_TOPUP_BASE_BYTES: usize = 100;
+        // Estimated seek operations for tree traversal
+        const ESTIMATED_SEEKS_BASE: usize = 8;
+
+        let inputs = input_count.max(1);
+
+        // Base fee from min fee structure
+        let base_fee = self
+            .min_fees
+            .identity_topup_base_cost
+            .saturating_add(self.min_fees.address_funding_asset_lock_cost)
+            .saturating_add(
+                self.min_fees
+                    .address_funds_transfer_input_cost
+                    .saturating_mul(inputs as u64),
+            );
+
+        // Add storage-based fees for serialized transaction data
+        let estimated_bytes = inputs * ESTIMATED_BYTES_PER_INPUT + ESTIMATED_TOPUP_BASE_BYTES;
+        let estimated_seeks = ESTIMATED_SEEKS_BASE + inputs;
+        let storage_fee = self.calculate_storage_based_fee(estimated_bytes, estimated_seeks);
+
+        // Total with fee multiplier
+        let total = self.apply_multiplier(base_fee.saturating_add(storage_fee));
+
+        // Add 20% safety buffer to account for fee variability
+        total.saturating_add(total / 5)
     }
 
     /// Estimate fee for document batch transition

--- a/src/ui/identities/add_new_identity_screen/by_platform_address.rs
+++ b/src/ui/identities/add_new_identity_screen/by_platform_address.rs
@@ -150,6 +150,22 @@ impl AddNewIdentityScreen {
                     .map(|(_, _, balance)| *balance)
             });
 
+        // Calculate estimated fee for identity creation (needed for max amount calculation)
+        let key_count = self.identity_keys.keys_input.len() + 1; // +1 for master key
+        let input_count = if self.selected_platform_address_for_funding.is_some() {
+            1
+        } else {
+            0
+        };
+        let estimated_fee = self
+            .app_context
+            .fee_estimator()
+            .estimate_identity_create_from_addresses(input_count, false, key_count);
+
+        // Calculate max amount with fee reserved
+        let max_amount_with_fee_reserved =
+            max_balance_credits.map(|balance| balance.saturating_sub(estimated_fee));
+
         // Amount input using AmountInput component
         let amount_input = self.platform_funding_amount_input.get_or_insert_with(|| {
             AmountInput::new(Amount::new_dash(0.0))
@@ -159,8 +175,12 @@ impl AddNewIdentityScreen {
                 .with_desired_width(150.0)
         });
 
-        // Update max amount dynamically based on selected platform address
-        amount_input.set_max_amount(max_balance_credits);
+        // Update max amount dynamically based on selected platform address (with fee reserved)
+        amount_input.set_max_amount(max_amount_with_fee_reserved);
+        amount_input.set_max_exceeded_hint(Some(format!(
+            "~{} reserved for fees",
+            format_credits_as_dash(estimated_fee)
+        )));
 
         let response = amount_input.show(ui);
         response.inner.update(&mut self.platform_funding_amount);
@@ -190,17 +210,7 @@ impl AddNewIdentityScreen {
         // Extract the step from the RwLock to minimize borrow scope
         let step = *self.step.read().unwrap();
 
-        // Display estimated fee before action button
-        let key_count = self.identity_keys.keys_input.len() + 1; // +1 for master key
-        let input_count = if self.selected_platform_address_for_funding.is_some() {
-            1
-        } else {
-            0
-        };
-        let estimated_fee = self
-            .app_context
-            .fee_estimator()
-            .estimate_identity_create_from_addresses(input_count, false, key_count);
+        // Display estimated fee before action button (reuse already calculated value)
         let dark_mode = ui.ctx().style().visuals.dark_mode;
         egui::Frame::new()
             .fill(crate::ui::theme::DashColors::surface(dark_mode))

--- a/src/ui/identities/top_up_identity_screen/by_platform_address.rs
+++ b/src/ui/identities/top_up_identity_screen/by_platform_address.rs
@@ -96,6 +96,14 @@ impl TopUpIdentityScreen {
             .as_ref()
             .map(|(_, _, balance)| *balance);
 
+        // Calculate estimated fee for top-up from platform address (needed for max amount calculation)
+        let fee_estimator = self.app_context.fee_estimator();
+        let estimated_fee = fee_estimator.estimate_identity_topup_from_addresses(1);
+
+        // Calculate max amount with fee reserved
+        let max_amount_with_fee_reserved =
+            max_balance_credits.map(|balance| balance.saturating_sub(estimated_fee));
+
         Frame::group(ui.style())
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(12, 10))
@@ -111,8 +119,12 @@ impl TopUpIdentityScreen {
                             .with_desired_width(150.0)
                     });
 
-                    // Update max amount dynamically based on selected platform address
-                    amount_input.set_max_amount(max_balance_credits);
+                    // Update max amount dynamically based on selected platform address (with fee reserved)
+                    amount_input.set_max_amount(max_amount_with_fee_reserved);
+                    amount_input.set_max_exceeded_hint(Some(format!(
+                        "~{} reserved for fees",
+                        format_credits_as_dash(estimated_fee)
+                    )));
 
                     let response = amount_input.show(ui);
                     response.inner.update(&mut self.platform_top_up_amount);
@@ -130,10 +142,7 @@ impl TopUpIdentityScreen {
 
         ui.add_space(10.0);
 
-        // Fee estimation display
-        let fee_estimator = self.app_context.fee_estimator();
-        let estimated_fee = fee_estimator.estimate_identity_topup();
-
+        // Fee estimation display (reuse already calculated value)
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))


### PR DESCRIPTION

When clicking the max button to fund identity creation or top-up from a platform address, the full balance was used without reserving room for transaction fees, causing "Insufficient combined address balances" errors.

Changes:
- Subtract estimated fee from max amount in identity creation screen
- Subtract estimated fee from max amount in identity top-up screen
- Fix fee estimation to use identity_create_asset_lock_cost (200M credits) instead of address_funding_asset_lock_cost (50M credits)
- Add storage-based fees to identity creation/top-up fee estimates
- Add new estimate_identity_topup_from_addresses() for platform address top-ups
- Add 20% safety buffer to account for fee variability
- Show hint explaining fee reservation when max is used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fee estimation display for identity creation and top-up operations from platform addresses. The maximum transferable amount now automatically reserves funds for transaction fees, with clear UI indicators showing the amount set aside.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->