### PR TITLE
feat: use deterministic derivation path for platform address funding

### DIFF
--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -50,11 +50,16 @@ impl AppContext {
 
             let mut wallet = wallet_arc.write().map_err(|e| e.to_string())?;
 
+            // Get the next available funding index for deterministic key derivation
+            // Path: m/9'/coin_type'/17'/0'/2'/index (DIP-17 with key_class=2)
+            let funding_index = wallet.next_platform_address_funding_index(self.network);
+
             // Try to create the asset lock transaction, reload UTXOs if needed
             match wallet.generic_asset_lock_transaction(
                 self.network,
                 asset_lock_amount,
                 allow_take_fee_from_amount,
+                funding_index,
                 Some(self),
             ) {
                 Ok((tx, private_key, address, _change, utxos)) => (tx, private_key, address, utxos),
@@ -76,6 +81,7 @@ impl AppContext {
                             self.network,
                             asset_lock_amount,
                             allow_take_fee_from_amount,
+                            funding_index,
                             Some(self),
                         )?;
                     (tx, private_key, address, utxos)

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -76,14 +76,16 @@ impl Wallet {
         )
     }
 
-    /// Create an asset lock transaction with a randomly generated one-time key.
+    /// Create an asset lock transaction with a key derived from the wallet seed.
     /// This is used for generic platform address funding (not identity-specific).
+    /// Path: m/9'/coin_type'/17'/0'/2'/index (DIP-17 with key_class=2 for funding)
     #[allow(clippy::type_complexity)]
     pub fn generic_asset_lock_transaction(
         &mut self,
         network: Network,
         amount: u64,
         allow_take_fee_from_amount: bool,
+        funding_index: u32,
         register_addresses: Option<&AppContext>,
     ) -> Result<
         (
@@ -95,12 +97,14 @@ impl Wallet {
         ),
         String,
     > {
-        use rand::rngs::OsRng;
+        // Get the private key from the platform address funding derivation path
+        let private_key = self.platform_address_funding_ecdsa_private_key(
+            network,
+            funding_index,
+            register_addresses,
+        )?;
 
-        // Generate a random private key for the asset lock
         let secp = Secp256k1::new();
-        let (secret_key, _) = secp.generate_keypair(&mut OsRng);
-        let private_key = PrivateKey::new(secret_key, network);
         let public_key = private_key.public_key(&secp);
 
         // The asset lock address is where the proof will be tied to

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -58,8 +58,10 @@ pub enum DerivationPathReference {
     BlockchainIdentityCreditInvitationFunding = 13,
     ProviderPlatformNodeKeys = 14,
     CoinJoin = 15,
-    /// DIP-17: Platform Payment Addresses
+    /// DIP-17: Platform Payment Addresses (key_class 0')
     PlatformPayment = 16,
+    /// DIP-17: Platform Address Funding (key_class 2')
+    PlatformAddressFunding = 17,
     Root = 255,
 }
 
@@ -85,6 +87,7 @@ impl TryFrom<u32> for DerivationPathReference {
             14 => Ok(DerivationPathReference::ProviderPlatformNodeKeys),
             15 => Ok(DerivationPathReference::CoinJoin),
             16 => Ok(DerivationPathReference::PlatformPayment),
+            17 => Ok(DerivationPathReference::PlatformAddressFunding),
             255 => Ok(DerivationPathReference::Root),
             value => Err(format!(
                 "value {} not convertable to a DerivationPathReference",
@@ -226,6 +229,17 @@ const BOOTSTRAP_IDENTITY_TOPUP_NOT_BOUND_COUNT: u32 = 8;
 const BOOTSTRAP_PROVIDER_ADDRESS_COUNT: u32 = 4;
 /// DIP-17: Number of Platform payment addresses to bootstrap per key class
 const BOOTSTRAP_PLATFORM_PAYMENT_ADDRESS_COUNT: u32 = 20;
+
+/// DIP-17 key_class values for path: m/9'/coin_type'/17'/account'/key_class'/index
+/// These constants are defined here for documentation and future use until
+/// dash-sdk adds native support for platform address funding paths.
+#[allow(dead_code)]
+const PLATFORM_KEY_CLASS_PAYMENT: u32 = 0;
+/// Key class reserved for wallet internal and change operations
+#[allow(dead_code)]
+const PLATFORM_KEY_CLASS_INTERNAL: u32 = 1;
+/// Key class for platform address funding (asset lock keys)
+const PLATFORM_KEY_CLASS_FUNDING: u32 = 2;
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -1363,6 +1377,83 @@ impl Wallet {
             )?;
         }
         Ok(private_key)
+    }
+
+    /// Generate key for platform address funding (asset locks)
+    /// Path: m/9'/coin_type'/17'/0'/2'/index (DIP-17 with key_class=2)
+    pub fn platform_address_funding_ecdsa_private_key(
+        &mut self,
+        network: Network,
+        index: u32,
+        register_addresses: Option<&AppContext>,
+    ) -> Result<PrivateKey, String> {
+        let account = 0u32;
+        let derivation_path = DerivationPath::platform_payment_path(
+            network,
+            account,
+            PLATFORM_KEY_CLASS_FUNDING,
+            index,
+        );
+        let extended_private_key = derivation_path
+            .derive_priv_ecdsa_for_master_seed(self.seed_bytes()?, network)
+            .expect("derivation should not be able to fail");
+        let private_key = extended_private_key.to_priv();
+
+        if let Some(app_context) = register_addresses {
+            self.register_address_from_private_key(
+                &private_key,
+                &derivation_path,
+                DerivationPathType::CREDIT_FUNDING,
+                DerivationPathReference::PlatformAddressFunding,
+                app_context,
+            )?;
+        }
+        Ok(private_key)
+    }
+
+    /// Get the next available index for platform address funding.
+    /// This scans watched addresses for existing funding paths (key_class=2)
+    /// and returns the next unused index.
+    pub fn next_platform_address_funding_index(&self, network: Network) -> u32 {
+        let coin_type = match network {
+            Network::Dash => 5,
+            _ => 1,
+        };
+
+        let max_existing = self
+            .watched_addresses
+            .iter()
+            .filter(|(_, info)| {
+                info.path_reference == DerivationPathReference::PlatformAddressFunding
+            })
+            .filter_map(|(path, _)| {
+                let components = path.as_ref();
+                // Check this is a DIP-17 path with key_class=2
+                // m/9'/coin_type'/17'/account'/key_class'/index
+                if components.len() != 6 {
+                    return None;
+                }
+                let is_valid_path = matches!(
+                    (&components[0], &components[1], &components[2], &components[4]),
+                    (
+                        ChildNumber::Hardened { index: 9 },
+                        ChildNumber::Hardened { index: ct },
+                        ChildNumber::Hardened { index: 17 },
+                        ChildNumber::Hardened { index: kc },
+                    ) if *ct == coin_type && *kc == PLATFORM_KEY_CLASS_FUNDING
+                );
+                if !is_valid_path {
+                    return None;
+                }
+                // Extract index (last component, non-hardened)
+                match components[5] {
+                    ChildNumber::Normal { index } => Some(index),
+                    _ => None,
+                }
+            })
+            .max();
+
+        max_existing.map(|m| m + 1).unwrap_or(0)
     }
 
     pub fn receive_address(


### PR DESCRIPTION
Replace random one-time keys with deterministic keys derived from wallet seed for platform address funding asset locks.

Uses DIP-17 path structure with key_class=2 for funding: m/9'/coin_type'/17'/0'/2'/index

This is a local workaround until dash-sdk adds native support for platform_address_funding_path().

Changes:
- Add DerivationPathReference::PlatformAddressFunding variant
- Add PLATFORM_KEY_CLASS_FUNDING constant (key_class=2)
- Add platform_address_funding_ecdsa_private_key() method
- Add next_platform_address_funding_index() to track used indices
- Update generic_asset_lock_transaction() to use derived keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Wallet now uses deterministic key derivation from the seed for asset lock transactions, replacing random key generation for enhanced security and recoverability.

* **Infrastructure Updates**
  * Introduced platform address funding support with deterministic index tracking to improve wallet functionality and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->