### PR TITLE
Fix dark mode text colors

### DIFF
--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -1227,9 +1227,10 @@ impl ScreenLike for IdentitiesScreen {
                 });
                 ui.add_space(2.0); // Space below
             } else if let Some((message, message_type, timestamp)) = self.backend_message.clone() {
+                let dark_mode = ui.ctx().style().visuals.dark_mode;
                 let message_color = match message_type {
                     MessageType::Error => egui::Color32::DARK_RED,
-                    MessageType::Info => egui::Color32::BLACK,
+                    MessageType::Info => DashColors::text_primary(dark_mode),
                     MessageType::Success => egui::Color32::DARK_GREEN,
                 };
 

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -10,10 +10,10 @@ use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::theme::DashColors;
 use crate::ui::components::wallet_unlock_popup::{
     WalletUnlockPopup, WalletUnlockResult, try_open_wallet_no_password, wallet_needs_unlock,
 };
+use crate::ui::theme::DashColors;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
 use dash_sdk::dashcore_rpc::dashcore::PrivateKey as RPCPrivateKey;
@@ -106,8 +106,7 @@ impl ScreenLike for KeyInfoScreen {
                         // Purpose
                         ui.label(RichText::new("Purpose:").strong().color(text_primary));
                         ui.label(
-                            RichText::new(format!("{:?}", self.key.purpose()))
-                                .color(text_primary),
+                            RichText::new(format!("{:?}", self.key.purpose())).color(text_primary),
                         );
                         ui.end_row();
 
@@ -126,16 +125,14 @@ impl ScreenLike for KeyInfoScreen {
                         // Type
                         ui.label(RichText::new("Type:").strong().color(text_primary));
                         ui.label(
-                            RichText::new(format!("{:?}", self.key.key_type()))
-                                .color(text_primary),
+                            RichText::new(format!("{:?}", self.key.key_type())).color(text_primary),
                         );
                         ui.end_row();
 
                         // Read Only
                         ui.label(RichText::new("Read Only:").strong().color(text_primary));
                         ui.label(
-                            RichText::new(format!("{}", self.key.read_only()))
-                                .color(text_primary),
+                            RichText::new(format!("{}", self.key.read_only())).color(text_primary),
                         );
                         ui.end_row();
 

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -10,6 +10,7 @@ use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
+use crate::ui::theme::DashColors;
 use crate::ui::components::wallet_unlock_popup::{
     WalletUnlockPopup, WalletUnlockResult, try_open_wallet_no_password, wallet_needs_unlock,
 };
@@ -88,7 +89,8 @@ impl ScreenLike for KeyInfoScreen {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
-                ui.heading(RichText::new("Key Information").color(Color32::BLACK));
+                let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+                ui.heading(RichText::new("Key Information").color(text_primary));
                 ui.add_space(10.0);
 
                 egui::Grid::new("key_info_grid")
@@ -97,15 +99,15 @@ impl ScreenLike for KeyInfoScreen {
                     .striped(false)
                     .show(ui, |ui| {
                         // Key ID
-                        ui.label(RichText::new("Key ID:").strong().color(Color32::BLACK));
-                        ui.label(RichText::new(format!("{}", self.key.id())).color(Color32::BLACK));
+                        ui.label(RichText::new("Key ID:").strong().color(text_primary));
+                        ui.label(RichText::new(format!("{}", self.key.id())).color(text_primary));
                         ui.end_row();
 
                         // Purpose
-                        ui.label(RichText::new("Purpose:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Purpose:").strong().color(text_primary));
                         ui.label(
                             RichText::new(format!("{:?}", self.key.purpose()))
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         ui.end_row();
 
@@ -113,27 +115,27 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Security Level:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         ui.label(
                             RichText::new(format!("{:?}", self.key.security_level()))
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         ui.end_row();
 
                         // Type
-                        ui.label(RichText::new("Type:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Type:").strong().color(text_primary));
                         ui.label(
                             RichText::new(format!("{:?}", self.key.key_type()))
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         ui.end_row();
 
                         // Read Only
-                        ui.label(RichText::new("Read Only:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Read Only:").strong().color(text_primary));
                         ui.label(
                             RichText::new(format!("{}", self.key.read_only()))
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         ui.end_row();
 
@@ -141,12 +143,12 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Active/Disabled:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         if !self.key.is_disabled() {
-                            ui.label(RichText::new("Active").color(Color32::BLACK));
+                            ui.label(RichText::new("Active").color(text_primary));
                         } else {
-                            ui.label(RichText::new("Disabled").color(Color32::BLACK));
+                            ui.label(RichText::new("Disabled").color(text_primary));
                         }
                         ui.end_row();
 
@@ -157,7 +159,7 @@ impl ScreenLike for KeyInfoScreen {
                             ui.label(
                                 RichText::new("In local Wallet")
                                     .strong()
-                                    .color(Color32::BLACK),
+                                    .color(text_primary),
                             );
                             ui.label(
                                 RichText::new(format!(
@@ -165,7 +167,7 @@ impl ScreenLike for KeyInfoScreen {
                                     wallet_derivation_path.derivation_path
                                 ))
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                             );
                             ui.end_row();
                         }
@@ -175,13 +177,13 @@ impl ScreenLike for KeyInfoScreen {
                             ui.label(
                                 RichText::new("Contract Bounds:")
                                     .strong()
-                                    .color(Color32::BLACK),
+                                    .color(text_primary),
                             );
                             match contract_bounds {
                                 ContractBounds::SingleContract { id } => {
                                     ui.label(
                                         RichText::new(format!("Contract ID: {}", id))
-                                            .color(Color32::BLACK),
+                                            .color(text_primary),
                                     );
                                 }
                                 ContractBounds::SingleContractDocumentType {
@@ -193,7 +195,7 @@ impl ScreenLike for KeyInfoScreen {
                                             "Contract ID: {}\nDocument Type: {}",
                                             id, document_type_name
                                         ))
-                                        .color(Color32::BLACK),
+                                        .color(text_primary),
                                     );
                                 }
                             }
@@ -208,7 +210,7 @@ impl ScreenLike for KeyInfoScreen {
                 ui.add_space(10.0);
 
                 // Display the public key information
-                ui.heading(RichText::new("Public Key Information").color(Color32::BLACK));
+                ui.heading(RichText::new("Public Key Information").color(text_primary));
                 ui.add_space(10.0);
 
                 egui::Grid::new("public_key_info_grid")
@@ -222,11 +224,11 @@ impl ScreenLike for KeyInfoScreen {
                                 ui.label(
                                     RichText::new("Public Key (Hex):")
                                         .strong()
-                                        .color(Color32::BLACK),
+                                        .color(text_primary),
                                 );
                                 ui.label(
                                     RichText::new(self.key.data().to_string(Encoding::Hex))
-                                        .color(Color32::BLACK),
+                                        .color(text_primary),
                                 );
                                 ui.end_row();
 
@@ -234,11 +236,11 @@ impl ScreenLike for KeyInfoScreen {
                                 ui.label(
                                     RichText::new("Public Key (Base64):")
                                         .strong()
-                                        .color(Color32::BLACK),
+                                        .color(text_primary),
                                 );
                                 ui.label(
                                     RichText::new(self.key.data().to_string(Encoding::Base64))
-                                        .color(Color32::BLACK),
+                                        .color(text_primary),
                                 );
                                 ui.end_row();
                             }
@@ -249,12 +251,12 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Public Key Hash:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_primary),
                         );
                         match self.key.public_key_hash() {
                             Ok(hash) => {
                                 let hash_hex = hex::encode(hash);
-                                ui.label(RichText::new(hash_hex).color(Color32::BLACK));
+                                ui.label(RichText::new(hash_hex).color(text_primary));
                             }
                             Err(e) => {
                                 ui.colored_label(egui::Color32::RED, format!("Error: {}", e));
@@ -263,7 +265,7 @@ impl ScreenLike for KeyInfoScreen {
 
                         if self.key.key_type().is_core_address_key_type() {
                             // Public Key Hash
-                            ui.label(RichText::new("Address:").strong().color(Color32::BLACK));
+                            ui.label(RichText::new("Address:").strong().color(text_primary));
                             match self.key.public_key_hash() {
                                 Ok(hash) => {
                                     let address = if self.key.key_type() == BIP13_SCRIPT_HASH {
@@ -278,7 +280,7 @@ impl ScreenLike for KeyInfoScreen {
                                         )
                                     };
                                     ui.label(
-                                        RichText::new(address.to_string()).color(Color32::BLACK),
+                                        RichText::new(address.to_string()).color(text_primary),
                                     );
                                 }
                                 Err(e) => {
@@ -296,7 +298,7 @@ impl ScreenLike for KeyInfoScreen {
 
                 // Display the private key if available
                 if let Some((private_key, _)) = self.private_key_data.as_mut() {
-                    ui.heading(RichText::new("Private Key").color(Color32::BLACK));
+                    ui.heading(RichText::new("Private Key").color(text_primary));
                     ui.add_space(10.0);
 
                     match private_key {
@@ -339,7 +341,7 @@ impl ScreenLike for KeyInfoScreen {
                             self.render_sign_input(ui);
                         }
                         PrivateKeyData::Encrypted(_) => {
-                            ui.label(RichText::new("Key is encrypted").color(Color32::BLACK));
+                            ui.label(RichText::new("Key is encrypted").color(text_primary));
                             ui.add_space(10.0);
 
                             //todo decrypt key
@@ -499,7 +501,7 @@ impl ScreenLike for KeyInfoScreen {
                         }
                     }
                 } else {
-                    ui.label(RichText::new("Enter Private Key:").color(Color32::BLACK));
+                    ui.label(RichText::new("Enter Private Key:").color(text_primary));
                     ui.text_edit_singleline(&mut self.private_key_input);
 
                     if ui.button("Add Private Key").clicked() {
@@ -675,12 +677,13 @@ impl KeyInfoScreen {
     }
 
     fn render_sign_input(&mut self, ui: &mut egui::Ui) {
+        let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
         ui.add_space(10.0);
         ui.separator();
         ui.add_space(10.0);
 
         ui.horizontal(|ui| {
-            ui.heading(RichText::new("Sign").color(Color32::BLACK));
+            ui.heading(RichText::new("Sign").color(text_primary));
 
             // Create an info icon button
             let response = crate::ui::helpers::info_icon_button(ui, "Enter a message and click Sign to encrypt it with your private key. You can send the encrypted message to someone and they can decrypt it using your public key. This is useful for proving you own the private key.");
@@ -692,7 +695,7 @@ impl KeyInfoScreen {
         });
         ui.add_space(5.0);
 
-        ui.label(RichText::new("Enter message to sign:").color(Color32::BLACK));
+        ui.label(RichText::new("Enter message to sign:").color(text_primary));
         ui.add_space(5.0);
         ui.add(
             egui::TextEdit::multiline(&mut self.message_input)
@@ -731,7 +734,7 @@ impl KeyInfoScreen {
             ui.separator();
             ui.add_space(10.0);
 
-            ui.label(RichText::new("Signed Message (Base64):").color(Color32::BLACK));
+            ui.label(RichText::new("Signed Message (Base64):").color(text_primary));
             ui.add_space(5.0);
             ui.add(
                 egui::TextEdit::multiline(&mut signed_message.as_str().to_owned())
@@ -789,13 +792,14 @@ impl KeyInfoScreen {
     }
 
     fn render_remove_private_key_confirm(&mut self, ui: &mut egui::Ui) {
+        let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
         egui::Window::new("Remove Private Key")
             .collapsible(false) // Prevent collapsing
             .resizable(false) // Prevent resizing
             .show(ui.ctx(), |ui| {
                 ui.label(
                     RichText::new("Are you sure you want to remove the private key?")
-                        .color(Color32::BLACK),
+                        .color(text_primary),
                 );
                 ui.add_space(10.0);
 

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -408,6 +408,8 @@ impl SetTokenPriceScreen {
                 }
             }
             PricingType::TieredPricing => {
+                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let text_primary = DashColors::text_primary(dark_mode);
                 ui.label("Add pricing tiers to offer volume discounts");
                 ui.add_space(10.0);
 
@@ -429,7 +431,7 @@ impl SetTokenPriceScreen {
                         header.col(|ui| {
                             ui.label(
                                 RichText::new("Minimum Amount")
-                                    .color(Color32::BLACK)
+                                    .color(text_primary)
                                     .strong()
                                     .underline(),
                             );
@@ -437,7 +439,7 @@ impl SetTokenPriceScreen {
                         header.col(|ui| {
                             ui.label(
                                 RichText::new("Price per Token")
-                                    .color(Color32::BLACK)
+                                    .color(text_primary)
                                     .strong()
                                     .underline(),
                             );
@@ -445,7 +447,7 @@ impl SetTokenPriceScreen {
                         header.col(|ui| {
                             ui.label(
                                 RichText::new("Remove")
-                                    .color(Color32::BLACK)
+                                    .color(text_primary)
                                     .strong()
                                     .underline(),
                             );

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -2758,9 +2758,10 @@ impl ScreenLike for TokensScreen {
                         ui.add_space(2.0); // Space below
                     } else if let Some((msg, msg_type, timestamp)) = self.backend_message.clone() {
                         ui.add_space(25.0); // Same space as refreshing indicator
+                        let dark_mode = ui.ctx().style().visuals.dark_mode;
                         let color = match msg_type {
                             MessageType::Error => Color32::DARK_RED,
-                            MessageType::Info => Color32::BLACK,
+                            MessageType::Info => DashColors::text_primary(dark_mode),
                             MessageType::Success => Color32::DARK_GREEN,
                         };
                         ui.horizontal(|ui| {

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -8,6 +8,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
+use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dashcore_rpc::RpcApi;
 use dash_sdk::dashcore_rpc::json::QuorumType;
@@ -2464,13 +2465,15 @@ impl MasternodeListDiffScreen {
 
     /// Render the details for the selected quorum
     fn render_quorum_details(&mut self, ui: &mut Ui) {
+        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let border = DashColors::border(dark_mode);
         ui.heading("Quorum Details");
         if let Some(dml_key) = self.selected_dml_diff_key {
             if let Some(dml) = self.mnlist_diffs.get(&dml_key) {
                 if let Some(q_index) = self.selected_quorum_in_diff_index {
                     if let Some(quorum) = dml.new_quorums.get(q_index) {
                         Frame::NONE
-                            .stroke(Stroke::new(1.0, Color32::BLACK))
+                            .stroke(Stroke::new(1.0, border))
                             .show(ui, |ui| {
                                 ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
                                 let height = self.get_height(&quorum.quorum_hash).ok();
@@ -2630,7 +2633,7 @@ impl MasternodeListDiffScreen {
                         };
 
                         Frame::NONE
-                            .stroke(Stroke::new(1.0, Color32::BLACK))
+                            .stroke(Stroke::new(1.0, border))
                             .show(ui, |ui| {
                                 ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
                                 ScrollArea::vertical().id_salt("render_quorum_details_2").show(ui, |ui| {
@@ -2663,6 +2666,8 @@ impl MasternodeListDiffScreen {
 
     /// Render the details for the selected Masternode
     fn render_mn_details(&mut self, ui: &mut Ui) {
+        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let border = DashColors::border(dark_mode);
         ui.heading("Masternode Details");
 
         if let Some(dml_key) = self.selected_dml_diff_key {
@@ -2670,7 +2675,7 @@ impl MasternodeListDiffScreen {
                 if let Some(mn_index) = self.selected_masternode_in_diff_index {
                     if let Some(masternode) = dml.new_masternodes.get(mn_index) {
                         Frame::NONE
-                            .stroke(Stroke::new(1.0, Color32::BLACK))
+                            .stroke(Stroke::new(1.0, border))
                             .show(ui, |ui| {
                                 ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
                                 ScrollArea::vertical().id_salt("render_mn_details").show(
@@ -2729,7 +2734,7 @@ impl MasternodeListDiffScreen {
             {
                 let masternode = &qualified_masternode.masternode_list_entry;
                 Frame::NONE
-                    .stroke(Stroke::new(1.0, Color32::BLACK))
+                    .stroke(Stroke::new(1.0, border))
                     .show(ui, |ui| {
                         ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
                         ScrollArea::vertical()
@@ -4384,7 +4389,8 @@ impl ScreenLike for MasternodeListDiffScreen {
                         PendingTask::QrInfoWithDmls => "Fetching QR info + DMLs…",
                         PendingTask::ChainLocks => "Fetching chain locks…",
                     };
-                    ui.colored_label(Color32::BLACK, label);
+                    let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+                    ui.colored_label(text_primary, label);
                 });
                 ui.add_space(6.0);
             }

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -2674,15 +2674,13 @@ impl MasternodeListDiffScreen {
             if let Some(dml) = self.mnlist_diffs.get(&dml_key) {
                 if let Some(mn_index) = self.selected_masternode_in_diff_index {
                     if let Some(masternode) = dml.new_masternodes.get(mn_index) {
-                        Frame::NONE
-                            .stroke(Stroke::new(1.0, border))
-                            .show(ui, |ui| {
-                                ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
-                                ScrollArea::vertical().id_salt("render_mn_details").show(
-                                    ui,
-                                    |ui| {
-                                        ui.label(format!(
-                                            "Version: {}\n\
+                        Frame::NONE.stroke(Stroke::new(1.0, border)).show(ui, |ui| {
+                            ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
+                            ScrollArea::vertical()
+                                .id_salt("render_mn_details")
+                                .show(ui, |ui| {
+                                    ui.label(format!(
+                                        "Version: {}\n\
                                      ProRegTxHash: {}\n\
                                      Confirmed Hash: {}\n\
                                      Service Address: {}:{}\n\
@@ -2690,35 +2688,33 @@ impl MasternodeListDiffScreen {
                                      Voting Key ID: {}\n\
                                      Is Valid: {}\n\
                                      Masternode Type: {}",
-                                            masternode.version,
-                                            masternode.pro_reg_tx_hash.reverse(),
-                                            match masternode.confirmed_hash {
-                                                None => "No confirmed hash".to_string(),
-                                                Some(confirmed_hash) =>
-                                                    confirmed_hash.reverse().to_string(),
-                                            },
-                                            masternode.service_address.ip(),
-                                            masternode.service_address.port(),
-                                            masternode.operator_public_key,
-                                            masternode.key_id_voting,
-                                            masternode.is_valid,
-                                            match masternode.mn_type {
-                                                EntryMasternodeType::Regular =>
-                                                    "Regular".to_string(),
-                                                EntryMasternodeType::HighPerformance {
-                                                    platform_http_port,
-                                                    platform_node_id,
-                                                } => {
-                                                    format!(
-                                                        "High Performance (Port: {}, Node ID: {})",
-                                                        platform_http_port, platform_node_id
-                                                    )
-                                                }
+                                        masternode.version,
+                                        masternode.pro_reg_tx_hash.reverse(),
+                                        match masternode.confirmed_hash {
+                                            None => "No confirmed hash".to_string(),
+                                            Some(confirmed_hash) =>
+                                                confirmed_hash.reverse().to_string(),
+                                        },
+                                        masternode.service_address.ip(),
+                                        masternode.service_address.port(),
+                                        masternode.operator_public_key,
+                                        masternode.key_id_voting,
+                                        masternode.is_valid,
+                                        match masternode.mn_type {
+                                            EntryMasternodeType::Regular => "Regular".to_string(),
+                                            EntryMasternodeType::HighPerformance {
+                                                platform_http_port,
+                                                platform_node_id,
+                                            } => {
+                                                format!(
+                                                    "High Performance (Port: {}, Node ID: {})",
+                                                    platform_http_port, platform_node_id
+                                                )
                                             }
-                                        ));
-                                    },
-                                );
-                            });
+                                        }
+                                    ));
+                                });
+                        });
                     }
                 } else {
                     ui.label("Select a Masternode to view details.");
@@ -2733,15 +2729,13 @@ impl MasternodeListDiffScreen {
                 && let Some(qualified_masternode) = mn_list.masternodes.get(&selected_pro_tx_hash)
             {
                 let masternode = &qualified_masternode.masternode_list_entry;
-                Frame::NONE
-                    .stroke(Stroke::new(1.0, border))
-                    .show(ui, |ui| {
-                        ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
-                        ScrollArea::vertical()
-                            .id_salt("render_mn_details_2")
-                            .show(ui, |ui| {
-                                ui.label(format!(
-                                    "Version: {}\n\
+                Frame::NONE.stroke(Stroke::new(1.0, border)).show(ui, |ui| {
+                    ui.set_min_size(Vec2::new(ui.available_width(), 300.0));
+                    ScrollArea::vertical()
+                        .id_salt("render_mn_details_2")
+                        .show(ui, |ui| {
+                            ui.label(format!(
+                                "Version: {}\n\
                                      ProRegTxHash: {}\n\
                                      Confirmed Hash: {}\n\
                                      Service Address: {}:{}\n\
@@ -2751,41 +2745,40 @@ impl MasternodeListDiffScreen {
                                      Masternode Type: {}\n\
                                      Entry Hash: {}\n\
                                      Confirmed Hash hashed with ProRegTx: {}\n",
-                                    masternode.version,
-                                    masternode.pro_reg_tx_hash.reverse(),
-                                    match masternode.confirmed_hash {
-                                        None => "No confirmed hash".to_string(),
-                                        Some(confirmed_hash) =>
-                                            confirmed_hash.reverse().to_string(),
-                                    },
-                                    masternode.service_address.ip(),
-                                    masternode.service_address.port(),
-                                    masternode.operator_public_key,
-                                    masternode.key_id_voting,
-                                    masternode.is_valid,
-                                    match masternode.mn_type {
-                                        EntryMasternodeType::Regular => "Regular".to_string(),
-                                        EntryMasternodeType::HighPerformance {
-                                            platform_http_port,
-                                            platform_node_id,
-                                        } => {
-                                            format!(
-                                                "High Performance (Port: {}, Node ID: {})",
-                                                platform_http_port, platform_node_id
-                                            )
-                                        }
-                                    },
-                                    hex::encode(qualified_masternode.entry_hash),
-                                    if let Some(hash) =
-                                        qualified_masternode.confirmed_hash_hashed_with_pro_reg_tx
-                                    {
-                                        hash.reverse().to_string()
-                                    } else {
-                                        "None".to_string()
-                                    },
-                                ));
-                            });
-                    });
+                                masternode.version,
+                                masternode.pro_reg_tx_hash.reverse(),
+                                match masternode.confirmed_hash {
+                                    None => "No confirmed hash".to_string(),
+                                    Some(confirmed_hash) => confirmed_hash.reverse().to_string(),
+                                },
+                                masternode.service_address.ip(),
+                                masternode.service_address.port(),
+                                masternode.operator_public_key,
+                                masternode.key_id_voting,
+                                masternode.is_valid,
+                                match masternode.mn_type {
+                                    EntryMasternodeType::Regular => "Regular".to_string(),
+                                    EntryMasternodeType::HighPerformance {
+                                        platform_http_port,
+                                        platform_node_id,
+                                    } => {
+                                        format!(
+                                            "High Performance (Port: {}, Node ID: {})",
+                                            platform_http_port, platform_node_id
+                                        )
+                                    }
+                                },
+                                hex::encode(qualified_masternode.entry_hash),
+                                if let Some(hash) =
+                                    qualified_masternode.confirmed_hash_hashed_with_pro_reg_tx
+                                {
+                                    hash.reverse().to_string()
+                                } else {
+                                    "None".to_string()
+                                },
+                            ));
+                        });
+                });
             }
         } else {
             ui.label("Select a block height and Masternode.");

--- a/src/ui/tools/proof_log_screen.rs
+++ b/src/ui/tools/proof_log_screen.rs
@@ -5,6 +5,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
+use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::drive::grovedb::operations::proof::GroveDBProof;
 use dash_sdk::drive::query::PathQuery;
@@ -210,7 +211,12 @@ impl ProofLogScreen {
         });
     }
 
-    fn highlight_proof_text(proof_text: &str, hashes: &[String], font_id: FontId) -> LayoutJob {
+    fn highlight_proof_text(
+        proof_text: &str,
+        hashes: &[String],
+        font_id: FontId,
+        text_color: Color32,
+    ) -> LayoutJob {
         let mut job = LayoutJob::default();
         let mut remaining_text = proof_text;
 
@@ -231,7 +237,7 @@ impl ProofLogScreen {
                     0.0,
                     TextFormat {
                         font_id: font_id.clone(),
-                        color: Color32::BLACK,
+                        color: text_color,
                         ..Default::default()
                     },
                 );
@@ -329,10 +335,14 @@ impl ProofLogScreen {
 
                 // Create the layout job with highlighted hashes
                 let font_id = TextStyle::Monospace.resolve(ui.style());
-                let layout_job = Self::highlight_proof_text(&proof_display, &hashes, font_id);
+                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let text_primary = DashColors::text_primary(dark_mode);
+                let border = DashColors::border(dark_mode);
+                let layout_job =
+                    Self::highlight_proof_text(&proof_display, &hashes, font_id, text_primary);
 
                 let frame = Frame::new()
-                    .stroke(Stroke::new(1.0, Color32::BLACK))
+                    .stroke(Stroke::new(1.0, border))
                     .fill(Color32::TRANSPARENT)
                     .corner_radius(2.0); // Set margins to zero
 

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -11,6 +11,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::identities::funding_common::generate_qr_code_image;
+use crate::ui::theme::DashColors;
 use crate::ui::{RootScreenType, Screen, ScreenLike};
 use bip39::{Language, Mnemonic};
 use dash_sdk::dashcore_rpc::dashcore::key::Secp256k1;
@@ -538,6 +539,12 @@ impl AddNewWalletScreen {
     }
 
     fn render_seed_phrase_input(&mut self, ui: &mut Ui) {
+        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let surface = DashColors::surface(dark_mode);
+        let border = DashColors::border(dark_mode);
+        let text_primary = DashColors::text_primary(dark_mode);
+        let text_secondary = DashColors::text_secondary(dark_mode);
+
         ui.add_space(15.0); // Add spacing from the top
         ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
             ui.add_space(-6.0);
@@ -657,8 +664,8 @@ impl AddNewWalletScreen {
                     egui::Layout::top_down(egui::Align::Center),
                     |ui| {
                         Frame::new()
-                            .fill(Color32::WHITE)
-                            .stroke(Stroke::new(1.0, Color32::BLACK))
+                            .fill(surface)
+                            .stroke(Stroke::new(1.0, border))
                             .corner_radius(5.0)
                             .inner_margin(Margin::same(10))
                             .show(ui, |ui| {
@@ -675,11 +682,11 @@ impl AddNewWalletScreen {
                                         for (i, word) in mnemonic.words().enumerate() {
                                             let number_text = RichText::new(format!("{} ", i + 1))
                                                 .size(row_height * 0.3)
-                                                .color(Color32::GRAY);
+                                                .color(text_secondary);
 
                                             let word_text = RichText::new(word)
                                                 .size(row_height * 0.5)
-                                                .color(Color32::BLACK);
+                                                .color(text_primary);
 
                                             ui.with_layout(
                                                 Layout::left_to_right(Align::Min),


### PR DESCRIPTION
## Summary
- replace hardcoded black text/strokes with theme-aware colors across several screens
- ensure dark-mode labels, table headers, and frames use Dash theme colors

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark mode theming across the app: text, labels, borders, frames, and message/info colors now adapt to the active theme instead of using fixed black/white. Updates affect identities, key/info screens, token pricing headers, masternode tools, proof log displays, and wallet seed phrase input for a more consistent dark/light appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->