### PR TITLE
Release SPV storage lock on shutdown

### DIFF
--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -796,6 +796,15 @@ impl SpvManager {
             let mut nm_guard = self.network_manager.write().await;
             *nm_guard = None;
         }
+        {
+            // Drop shared storage/request handles so the disk lock is released before restart.
+            if let Ok(mut storage_guard) = self.storage.lock() {
+                *storage_guard = None;
+            }
+            if let Ok(mut guard) = self.request_tx.lock() {
+                *guard = None;
+            }
+        }
 
         result
     }


### PR DESCRIPTION
## Summary
- clear cached SPV storage/request handles when the runtime exits
- ensures the data-dir lock is released before restart

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced resource cleanup during SPV restart to reduce lock contention and improve restart performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->