### PR TITLE
Fix Key Info dark mode text colors

### DIFF
--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -88,7 +88,8 @@ impl ScreenLike for KeyInfoScreen {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
-                ui.heading(RichText::new("Key Information").color(Color32::BLACK));
+                let text_color = ui.visuals().text_color();
+                ui.heading(RichText::new("Key Information").color(text_color));
                 ui.add_space(10.0);
 
                 egui::Grid::new("key_info_grid")
@@ -97,15 +98,15 @@ impl ScreenLike for KeyInfoScreen {
                     .striped(false)
                     .show(ui, |ui| {
                         // Key ID
-                        ui.label(RichText::new("Key ID:").strong().color(Color32::BLACK));
-                        ui.label(RichText::new(format!("{}", self.key.id())).color(Color32::BLACK));
+                        ui.label(RichText::new("Key ID:").strong().color(text_color));
+                        ui.label(RichText::new(format!("{}", self.key.id())).color(text_color));
                         ui.end_row();
 
                         // Purpose
-                        ui.label(RichText::new("Purpose:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Purpose:").strong().color(text_color));
                         ui.label(
                             RichText::new(format!("{:?}", self.key.purpose()))
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         ui.end_row();
 
@@ -113,27 +114,27 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Security Level:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         ui.label(
                             RichText::new(format!("{:?}", self.key.security_level()))
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         ui.end_row();
 
                         // Type
-                        ui.label(RichText::new("Type:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Type:").strong().color(text_color));
                         ui.label(
                             RichText::new(format!("{:?}", self.key.key_type()))
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         ui.end_row();
 
                         // Read Only
-                        ui.label(RichText::new("Read Only:").strong().color(Color32::BLACK));
+                        ui.label(RichText::new("Read Only:").strong().color(text_color));
                         ui.label(
                             RichText::new(format!("{}", self.key.read_only()))
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         ui.end_row();
 
@@ -141,12 +142,12 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Active/Disabled:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         if !self.key.is_disabled() {
-                            ui.label(RichText::new("Active").color(Color32::BLACK));
+                            ui.label(RichText::new("Active").color(text_color));
                         } else {
-                            ui.label(RichText::new("Disabled").color(Color32::BLACK));
+                            ui.label(RichText::new("Disabled").color(text_color));
                         }
                         ui.end_row();
 
@@ -157,7 +158,7 @@ impl ScreenLike for KeyInfoScreen {
                             ui.label(
                                 RichText::new("In local Wallet")
                                     .strong()
-                                    .color(Color32::BLACK),
+                                    .color(text_color),
                             );
                             ui.label(
                                 RichText::new(format!(
@@ -165,7 +166,7 @@ impl ScreenLike for KeyInfoScreen {
                                     wallet_derivation_path.derivation_path
                                 ))
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_color),
                             );
                             ui.end_row();
                         }
@@ -175,13 +176,13 @@ impl ScreenLike for KeyInfoScreen {
                             ui.label(
                                 RichText::new("Contract Bounds:")
                                     .strong()
-                                    .color(Color32::BLACK),
+                                    .color(text_color),
                             );
                             match contract_bounds {
                                 ContractBounds::SingleContract { id } => {
                                     ui.label(
                                         RichText::new(format!("Contract ID: {}", id))
-                                            .color(Color32::BLACK),
+                                            .color(text_color),
                                     );
                                 }
                                 ContractBounds::SingleContractDocumentType {
@@ -193,7 +194,7 @@ impl ScreenLike for KeyInfoScreen {
                                             "Contract ID: {}\nDocument Type: {}",
                                             id, document_type_name
                                         ))
-                                        .color(Color32::BLACK),
+                                        .color(text_color),
                                     );
                                 }
                             }
@@ -208,7 +209,7 @@ impl ScreenLike for KeyInfoScreen {
                 ui.add_space(10.0);
 
                 // Display the public key information
-                ui.heading(RichText::new("Public Key Information").color(Color32::BLACK));
+                ui.heading(RichText::new("Public Key Information").color(text_color));
                 ui.add_space(10.0);
 
                 egui::Grid::new("public_key_info_grid")
@@ -222,11 +223,11 @@ impl ScreenLike for KeyInfoScreen {
                                 ui.label(
                                     RichText::new("Public Key (Hex):")
                                         .strong()
-                                        .color(Color32::BLACK),
+                                        .color(text_color),
                                 );
                                 ui.label(
                                     RichText::new(self.key.data().to_string(Encoding::Hex))
-                                        .color(Color32::BLACK),
+                                        .color(text_color),
                                 );
                                 ui.end_row();
 
@@ -234,11 +235,11 @@ impl ScreenLike for KeyInfoScreen {
                                 ui.label(
                                     RichText::new("Public Key (Base64):")
                                         .strong()
-                                        .color(Color32::BLACK),
+                                        .color(text_color),
                                 );
                                 ui.label(
                                     RichText::new(self.key.data().to_string(Encoding::Base64))
-                                        .color(Color32::BLACK),
+                                        .color(text_color),
                                 );
                                 ui.end_row();
                             }
@@ -249,12 +250,12 @@ impl ScreenLike for KeyInfoScreen {
                         ui.label(
                             RichText::new("Public Key Hash:")
                                 .strong()
-                                .color(Color32::BLACK),
+                                .color(text_color),
                         );
                         match self.key.public_key_hash() {
                             Ok(hash) => {
                                 let hash_hex = hex::encode(hash);
-                                ui.label(RichText::new(hash_hex).color(Color32::BLACK));
+                                ui.label(RichText::new(hash_hex).color(text_color));
                             }
                             Err(e) => {
                                 ui.colored_label(egui::Color32::RED, format!("Error: {}", e));
@@ -263,7 +264,7 @@ impl ScreenLike for KeyInfoScreen {
 
                         if self.key.key_type().is_core_address_key_type() {
                             // Public Key Hash
-                            ui.label(RichText::new("Address:").strong().color(Color32::BLACK));
+                            ui.label(RichText::new("Address:").strong().color(text_color));
                             match self.key.public_key_hash() {
                                 Ok(hash) => {
                                     let address = if self.key.key_type() == BIP13_SCRIPT_HASH {
@@ -278,7 +279,7 @@ impl ScreenLike for KeyInfoScreen {
                                         )
                                     };
                                     ui.label(
-                                        RichText::new(address.to_string()).color(Color32::BLACK),
+                                        RichText::new(address.to_string()).color(text_color),
                                     );
                                 }
                                 Err(e) => {
@@ -296,7 +297,7 @@ impl ScreenLike for KeyInfoScreen {
 
                 // Display the private key if available
                 if let Some((private_key, _)) = self.private_key_data.as_mut() {
-                    ui.heading(RichText::new("Private Key").color(Color32::BLACK));
+                    ui.heading(RichText::new("Private Key").color(text_color));
                     ui.add_space(10.0);
 
                     match private_key {
@@ -339,7 +340,7 @@ impl ScreenLike for KeyInfoScreen {
                             self.render_sign_input(ui);
                         }
                         PrivateKeyData::Encrypted(_) => {
-                            ui.label(RichText::new("Key is encrypted").color(Color32::BLACK));
+                            ui.label(RichText::new("Key is encrypted").color(text_color));
                             ui.add_space(10.0);
 
                             //todo decrypt key
@@ -499,7 +500,7 @@ impl ScreenLike for KeyInfoScreen {
                         }
                     }
                 } else {
-                    ui.label(RichText::new("Enter Private Key:").color(Color32::BLACK));
+                    ui.label(RichText::new("Enter Private Key:").color(text_color));
                     ui.text_edit_singleline(&mut self.private_key_input);
 
                     if ui.button("Add Private Key").clicked() {
@@ -675,12 +676,13 @@ impl KeyInfoScreen {
     }
 
     fn render_sign_input(&mut self, ui: &mut egui::Ui) {
+        let text_color = ui.visuals().text_color();
         ui.add_space(10.0);
         ui.separator();
         ui.add_space(10.0);
 
         ui.horizontal(|ui| {
-            ui.heading(RichText::new("Sign").color(Color32::BLACK));
+            ui.heading(RichText::new("Sign").color(text_color));
 
             // Create an info icon button
             let response = crate::ui::helpers::info_icon_button(ui, "Enter a message and click Sign to encrypt it with your private key. You can send the encrypted message to someone and they can decrypt it using your public key. This is useful for proving you own the private key.");
@@ -692,7 +694,7 @@ impl KeyInfoScreen {
         });
         ui.add_space(5.0);
 
-        ui.label(RichText::new("Enter message to sign:").color(Color32::BLACK));
+        ui.label(RichText::new("Enter message to sign:").color(text_color));
         ui.add_space(5.0);
         ui.add(
             egui::TextEdit::multiline(&mut self.message_input)
@@ -731,7 +733,7 @@ impl KeyInfoScreen {
             ui.separator();
             ui.add_space(10.0);
 
-            ui.label(RichText::new("Signed Message (Base64):").color(Color32::BLACK));
+            ui.label(RichText::new("Signed Message (Base64):").color(text_color));
             ui.add_space(5.0);
             ui.add(
                 egui::TextEdit::multiline(&mut signed_message.as_str().to_owned())
@@ -793,9 +795,10 @@ impl KeyInfoScreen {
             .collapsible(false) // Prevent collapsing
             .resizable(false) // Prevent resizing
             .show(ui.ctx(), |ui| {
+                let text_color = ui.visuals().text_color();
                 ui.label(
                     RichText::new("Are you sure you want to remove the private key?")
-                        .color(Color32::BLACK),
+                        .color(text_color),
                 );
                 ui.add_space(10.0);
 


### PR DESCRIPTION
## Summary
- use theme text color in Key Info screen instead of hardcoded black
- fix dark mode readability for headings/labels

## Testing
- not run (UI change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency by replacing hard-coded text colors with theme-based styling. Text colors throughout the key information display—including headings, labels, and key property values—now dynamically derive from the active UI theme. This ensures the interface respects user theme preferences and maintains a cohesive appearance across all text elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->