### PR TITLE
chore: update bincode to 2.0.1, dash-sdk to v3.1-dev, and grovestark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
 dependencies = [
  "rustversion",
 ]
@@ -1120,9 +1120,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1152,9 +1152,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1382,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1392,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1404,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2991,9 +2991,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -3003,9 +3003,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -3615,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "grovestark"
 version = "0.1.0"
-source = "git+https://www.github.com/pauldelucia/grovestark?rev=a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da#a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da"
+source = "git+https://www.github.com/dashpay/grovestark?rev=a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da#a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da"
 dependencies = [
  "ark-ff",
  "base64 0.22.1",
@@ -3992,14 +3992,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -4008,7 +4007,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4018,9 +4017,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -4161,7 +4160,7 @@ dependencies = [
  "png 0.18.0",
  "tiff",
  "zune-core 0.5.1",
- "zune-jpeg 0.5.11",
+ "zune-jpeg 0.5.12",
 ]
 
 [[package]]
@@ -4527,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -4766,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -4844,9 +4843,9 @@ dependencies = [
 
 [[package]]
 name = "native-dialog"
-version = "0.9.4"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89853bb05334e192e6646290ea94ca31bcb80443f25ad40ebf478b6dafb08d6c"
+checksum = "3b2373fb763ea6962e8c586571c7f9c5d8c995f9777cbdebbe0180263691bd4b"
 dependencies = [
  "ascii",
  "block2 0.6.2",
@@ -5007,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -5454,9 +5453,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -5842,15 +5841,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
 ]
@@ -5916,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6038,9 +6037,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -6206,9 +6205,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6218,9 +6217,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6229,9 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "renderdoc-sys"
@@ -6534,7 +6533,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.0",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -6928,15 +6927,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -7037,9 +7036,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -7229,9 +7228,9 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
@@ -7422,9 +7421,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -7437,15 +7436,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7525,7 +7524,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -7672,9 +7671,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7689,7 +7688,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -7703,9 +7702,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -7715,9 +7714,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost",
@@ -7726,9 +7725,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -7932,9 +7931,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "tz-rs"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14eff19b8dc1ace5bf7e4d920b2628ae3837f422ff42210cb1567cbf68b5accf"
+checksum = "4fc6c929ffa10fb34f4a3c7e9a73620a83ef2e85e47f9ec3381b8289e6762f42"
 
 [[package]]
 name = "uds_windows"
@@ -8154,9 +8153,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -8535,9 +8534,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9731,18 +9730,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9863,9 +9862,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "7.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "268bf6f9ceb991e07155234071501490bb41fd1e39c6a588106dad10ae2a5804"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -9877,15 +9876,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zmq"
@@ -9954,9 +9953,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959ca473aae96a14ecedf501d20b3608d2825ba280d5adb57d651721885b0c2"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,15 +275,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,21 +808,22 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "bincode_derive",
  "serde",
+ "unty",
 ]
 
 [[package]]
 name = "bincode_derive"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
- "virtue 0.0.13",
+ "virtue 0.0.18",
 ]
 
 [[package]]
@@ -1731,8 +1723,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1799,8 +1791,8 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "dpp",
  "drive",
@@ -1817,7 +1809,7 @@ dependencies = [
  "arboard",
  "argon2",
  "base64 0.22.1",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bip39",
  "bitflags 2.10.0",
  "cbc",
@@ -1878,9 +1870,9 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
  "hex",
  "serde",
@@ -1888,8 +1880,8 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "heck",
  "quote",
@@ -1898,8 +1890,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1933,11 +1925,11 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
  "anyhow",
  "async-trait",
- "bincode 1.3.3",
+ "bincode 2.0.1",
  "blsful",
  "chrono",
  "clap",
@@ -1964,12 +1956,12 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
  "anyhow",
  "base64-compat",
  "bech32 0.9.1",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
  "bitvec",
  "blake3",
@@ -1990,12 +1982,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2008,9 +2000,9 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "dashcore",
  "hex",
  "key-wallet",
@@ -2023,9 +2015,9 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "dashcore-private",
  "rs-x11-hash",
  "secp256k1",
@@ -2047,8 +2039,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2058,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2116,17 +2108,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2322,8 +2303,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2333,15 +2314,14 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
  "bech32 0.11.1",
- "bincode 2.0.0-rc.3",
- "bincode_derive",
+ "bincode 2.0.1",
  "bs58",
  "byteorder",
  "chrono",
@@ -2382,18 +2362,18 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "byteorder",
  "derive_more 1.0.0",
  "dpp",
- "grovedb 4.0.0",
- "grovedb-costs 4.0.0",
+ "grovedb",
+ "grovedb-costs",
  "grovedb-epoch-based-storage-flags",
- "grovedb-path 4.0.0",
- "grovedb-version 4.0.0",
+ "grovedb-path",
+ "grovedb-version",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -2407,10 +2387,10 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "dapi-grpc",
  "dash-context-provider",
  "derive_more 1.0.0",
@@ -2983,8 +2963,8 @@ dependencies = [
 
 [[package]]
 name = "feature-flags-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3500,21 +3480,21 @@ dependencies = [
 
 [[package]]
 name = "grovedb"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12b2378c5eda5b7cadceb34fc6e0a8fd87fe03fc04841a7d32a74ff73ccef71"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
  "blake3",
- "grovedb-costs 3.1.0",
- "grovedb-merk 3.1.0",
- "grovedb-path 3.1.0",
+ "grovedb-costs",
+ "grovedb-element",
+ "grovedb-merk",
+ "grovedb-path",
  "grovedb-storage",
- "grovedb-version 3.1.0",
- "grovedb-visualize 3.1.0",
+ "grovedb-version",
+ "grovedb-visualize",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "indexmap 2.13.0",
  "integer-encoding",
  "intmap",
@@ -3526,42 +3506,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "grovedb"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
-dependencies = [
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "blake3",
- "grovedb-costs 4.0.0",
- "grovedb-element",
- "grovedb-merk 4.0.0",
- "grovedb-path 4.0.0",
- "grovedb-version 4.0.0",
- "hex",
- "hex-literal 1.1.0",
- "indexmap 2.13.0",
- "integer-encoding",
- "reqwest",
- "sha2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grovedb-costs"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74fafe53bf5ae27128799856e557ef5cb2d7109f1f7bc7f4440bbd0f97c7072"
-dependencies = [
- "integer-encoding",
- "intmap",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3571,12 +3518,13 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
- "grovedb-path 4.0.0",
- "grovedb-version 4.0.0",
+ "grovedb-path",
+ "grovedb-version",
+ "grovedb-visualize",
  "hex",
  "integer-encoding",
  "thiserror 2.0.18",
@@ -3585,9 +3533,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
- "grovedb-costs 4.0.0",
+ "grovedb-costs",
  "hex",
  "integer-encoding",
  "intmap",
@@ -3596,21 +3544,21 @@ dependencies = [
 
 [[package]]
 name = "grovedb-merk"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dd6f733e9d5c15c98e05b68a2028e00b7f177baa51e8d8c1541102942a72b7"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
  "blake3",
  "byteorder",
  "colored",
  "ed",
- "grovedb-costs 3.1.0",
- "grovedb-path 3.1.0",
+ "grovedb-costs",
+ "grovedb-element",
+ "grovedb-path",
  "grovedb-storage",
- "grovedb-version 3.1.0",
- "grovedb-visualize 3.1.0",
+ "grovedb-version",
+ "grovedb-visualize",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -3620,53 +3568,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "grovedb-merk"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
-dependencies = [
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "blake3",
- "byteorder",
- "ed",
- "grovedb-costs 4.0.0",
- "grovedb-element",
- "grovedb-path 4.0.0",
- "grovedb-version 4.0.0",
- "grovedb-visualize 4.0.0",
- "hex",
- "indexmap 2.13.0",
- "integer-encoding",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grovedb-path"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f716520d6c6b0f25dc4a68bc7dded645826ed57d38a06a80716a487c09d23c"
-dependencies = [
- "hex",
-]
-
-[[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "grovedb-storage"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d04f3831fe210543a7246f2a60ae068f23eac5f9d53200d5a82785750f68fd"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
  "blake3",
- "grovedb-costs 3.1.0",
- "grovedb-path 3.1.0",
- "grovedb-visualize 3.1.0",
+ "grovedb-costs",
+ "grovedb-path",
+ "grovedb-visualize",
  "hex",
  "integer-encoding",
  "lazy_static",
@@ -3679,18 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-version"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc855662f05f41b10dd022226cb78e345a33f35c390e25338d21dedd45966ae"
-dependencies = [
- "thiserror 2.0.18",
- "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3698,18 +3605,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-visualize"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fa6f41c110d1d141bf912175f187ef51ac5d2a8f163dfd229be007461a548f"
-dependencies = [
- "hex",
- "itertools 0.14.0",
-]
-
-[[package]]
-name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?tag=v4.1.0#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
+source = "git+https://github.com/dashpay/grovedb?rev=33dfd48a1718160cb333fa95424be491785f1897#33dfd48a1718160cb333fa95424be491785f1897"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -3718,20 +3615,20 @@ dependencies = [
 [[package]]
 name = "grovestark"
 version = "0.1.0"
-source = "git+https://www.github.com/pauldelucia/grovestark?rev=c5823c8239792f75f93f59f025aa335ab6d42c36#c5823c8239792f75f93f59f025aa335ab6d42c36"
+source = "git+https://www.github.com/pauldelucia/grovestark?rev=a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da#a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da"
 dependencies = [
  "ark-ff",
  "base64 0.22.1",
  "bincode 1.3.3",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "blake3",
  "bs58",
  "curve25519-dalek",
  "ed25519-dalek",
  "env_logger",
- "grovedb 3.1.0",
- "grovedb-costs 3.1.0",
- "grovedb-merk 3.1.0",
+ "grovedb",
+ "grovedb-costs",
+ "grovedb-merk",
  "hex",
  "log",
  "num-bigint",
@@ -3872,12 +3769,6 @@ checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex-literal"
@@ -4503,11 +4394,11 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
  "async-trait",
  "base58ck",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bincode_derive",
  "bip39",
  "bitflags 2.10.0",
@@ -4530,10 +4421,10 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.41.0"
-source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.41.0#c0da3509c695351e6dc300723ded35b4f0df16a3"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=53d699c9b551ac7d3644e11ca46dc3819277ff87#53d699c9b551ac7d3644e11ca46dc3819277ff87"
 dependencies = [
  "async-trait",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "dashcore",
  "dashcore_hashes",
  "key-wallet",
@@ -4543,8 +4434,8 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4653,9 +4544,8 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.3+10.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+version = "0.18.0+10.7.5"
+source = "git+https://github.com/QuantumExplorer/rust-rocksdb.git?rev=52772eea7bcd214d1d07d80aa538b1d24e5015b7#52772eea7bcd214d1d07d80aa538b1d24e5015b7"
 dependencies = [
  "bindgen 0.72.1",
  "bzip2-sys",
@@ -4760,8 +4650,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5832,17 +5722,17 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "platform-version",
 ]
 
 [[package]]
 name = "platform-serialization-derive"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5852,11 +5742,11 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "base64 0.22.1",
- "bincode 2.0.0-rc.3",
+ "bincode 2.0.1",
  "bs58",
  "ciborium",
  "hex",
@@ -5872,11 +5762,11 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
- "bincode 2.0.0-rc.3",
- "grovedb-version 4.0.0",
+ "bincode 2.0.1",
+ "grovedb-version",
  "once_cell",
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
@@ -5884,8 +5774,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6466,8 +6356,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+source = "git+https://github.com/QuantumExplorer/rust-rocksdb.git?rev=52772eea7bcd214d1d07d80aa538b1d24e5015b7#52772eea7bcd214d1d07d80aa538b1d24e5015b7"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -6494,8 +6383,8 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rs-dapi-client"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "backon",
  "chrono",
@@ -7405,8 +7294,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-abci"
-version = "1.5.0-dev.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0-dev.2#3f6ac716c42125a01caceb42cc5997efa41c88fc"
+version = "1.5.0"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
 dependencies = [
  "bytes",
  "hex",
@@ -7420,8 +7309,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto"
-version = "1.5.0-dev.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0-dev.2#3f6ac716c42125a01caceb42cc5997efa41c88fc"
+version = "1.5.0"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
 dependencies = [
  "bytes",
  "chrono",
@@ -7438,8 +7327,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto-compiler"
-version = "1.5.0-dev.2"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0-dev.2#3f6ac716c42125a01caceb42cc5997efa41c88fc"
+version = "1.5.0"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
 dependencies = [
  "fs_extra",
  "prost-build",
@@ -7615,8 +7504,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8030,6 +7919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3015e6ce46d5ad8751e4a772543a30c7511468070e98e64e20165f8f81155b64"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8157,6 +8052,12 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
@@ -8316,15 +8217,15 @@ dependencies = [
 
 [[package]]
 name = "virtue"
-version = "0.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
-
-[[package]]
-name = "virtue"
 version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7302ac74a033bf17b6e609ceec0f891ca9200d502d31f02dc7908d3d98767c9d"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vsss-rs"
@@ -8356,8 +8257,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9612,8 +9513,8 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "withdrawals-contract"
-version = "3.0.1-hotfix.1"
-source = "git+https://github.com/dashpay/platform?rev=07f7eb649bdc1485b3a43f384da7f96232fcfbba#07f7eb649bdc1485b3a43f384da7f96232fcfbba"
+version = "3.0.0"
+source = "git+https://github.com/dashpay/platform?rev=98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9#98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",
@@ -9962,15 +9863,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "5.1.1"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
- "arbitrary",
  "crc32fast",
  "flate2",
  "indexmap 2.13.0",
  "memchr",
+ "typed-path",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.30.1", features = ["signal"] }
 eframe = { version = "0.32.0", features = ["persistence"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "07f7eb649bdc1485b3a43f384da7f96232fcfbba", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "98a0ebeca4e6a9ae000d316c4c9c5b64f6fd3dd9", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -27,14 +27,14 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "07f7eb649bdc148
     "core_rpc_client",
     "core_spv",
 ] }
-grovestark = { git = "https://www.github.com/pauldelucia/grovestark", rev = "c5823c8239792f75f93f59f025aa335ab6d42c36" }
+grovestark = { git = "https://www.github.com/pauldelucia/grovestark", rev = "a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da" }
 rayon = "1.8"
 thiserror = "2.0.12"
 serde = "1.0.219"
 serde_json = "1.0.140"
 serde_yaml = { version = "0.9.34-deprecated" }
 tokio = { version = "1.46.1", features = ["full"] }
-bincode = { version = "=2.0.0-rc.3", features = ["serde"] }
+bincode = { version = "=2.0.1", features = ["serde"] }
 hex = { version = "0.4.3" }
 itertools = "0.14.0"
 enum-iterator = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "98a0ebeca4e6a9a
     "core_rpc_client",
     "core_spv",
 ] }
-grovestark = { git = "https://www.github.com/pauldelucia/grovestark", rev = "a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da" }
+grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "a70bdb1adac080d4f1dc10f2f4480d9dacd0f0da" }
 rayon = "1.8"
 thiserror = "2.0.12"
 serde = "1.0.219"

--- a/src/model/qualified_identity/encrypted_key_storage.rs
+++ b/src/model/qualified_identity/encrypted_key_storage.rs
@@ -54,7 +54,7 @@ impl Encode for WalletDerivationPath {
     }
 }
 
-impl Decode for WalletDerivationPath {
+impl<Context> Decode<Context> for WalletDerivationPath {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, DecodeError> {
         // Decode `wallet_seed_hash`
         let wallet_seed_hash = WalletSeedHash::decode(decoder)?;
@@ -92,7 +92,7 @@ impl Decode for WalletDerivationPath {
     }
 }
 
-impl<'de> BorrowDecode<'de> for WalletDerivationPath {
+impl<'de, Context> BorrowDecode<'de, Context> for WalletDerivationPath {
     fn borrow_decode<D: BorrowDecoder<'de>>(decoder: &mut D) -> Result<Self, DecodeError> {
         // Decode `wallet_seed_hash`
         let wallet_seed_hash = WalletSeedHash::decode(decoder)?;

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -270,7 +270,7 @@ impl Encode for QualifiedIdentity {
 }
 
 // Implement Decode manually for QualifiedIdentity, excluding decrypted_wallets
-impl Decode for QualifiedIdentity {
+impl<Context> Decode<Context> for QualifiedIdentity {
     fn decode<D: bincode::de::Decoder>(
         decoder: &mut D,
     ) -> Result<Self, bincode::error::DecodeError> {


### PR DESCRIPTION
- Update bincode from 2.0.0-rc.3 to 2.0.1
- Update dash-sdk to latest v3.1-dev (98a0ebec)
- Update grovestark to a70bdb1a
- Fix Decode/BorrowDecode implementations for bincode 2.0.1 API changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bincode dependency to version 2.0.1
  * Refreshed internal dependency revisions to latest versions

* **Refactor**
  * Enhanced internal code structure for improved extensibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->