### PR TITLE
fix: handle RegisteredTokenContract result to clear token creation spinner

### DIFF
--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -2977,6 +2977,9 @@ impl ScreenLike for TokensScreen {
                 );
                 self.refreshing_status = RefreshingStatus::NotRefreshing;
             }
+            BackendTaskSuccessResult::RegisteredTokenContract => {
+                self.token_creator_status = TokenCreatorStatus::Complete;
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
The backend task returned RegisteredTokenContract on success but the tokens screen had no handler for it, causing the spinner to spin forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Token Creator UI state to properly reflect successful token contract registration, ensuring the status updates to completion when a token contract is registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->