### PR TITLE
fix: critical wallet bugs (GH#522, GH#476, GH#478, GH#85)

### DIFF
--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -231,7 +231,11 @@ impl AppContext {
             // Fee NOT deducted from output: destination receives the exact requested
             // amount. We use a fresh wallet-controlled change address to absorb the
             // fee estimate surplus, keeping it spendable.
-            let amount_credits = amount.saturating_mul(CREDITS_PER_DUFF);
+            let amount_credits = amount.checked_mul(CREDITS_PER_DUFF).ok_or_else(|| {
+                format!(
+                    "Overflow converting {amount} duffs to credits (CREDITS_PER_DUFF = {CREDITS_PER_DUFF})"
+                )
+            })?;
 
             if let Some(change_address) = change_platform_address {
                 outputs.insert(destination, Some(amount_credits));

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -4,6 +4,7 @@ use crate::context::AppContext;
 use crate::model::fee_estimation::PlatformFeeEstimator;
 use crate::model::wallet::WalletSeedHash;
 use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
 use dash_sdk::dpp::prelude::AssetLockProof;
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,9 +32,11 @@ impl AppContext {
             // Fees deducted from output: use the requested amount, allow core fee to be taken from it
             (amount, true)
         } else {
-            // Fees paid from wallet: add estimated platform fee to asset lock amount
+            // Fees paid from wallet: add estimated platform fee to asset lock amount.
+            // We use 2 outputs: the destination (explicit amount) and a change address
+            // (remainder recipient that absorbs the fee).
             let estimated_platform_fee_duffs =
-                PlatformFeeEstimator::new().estimate_address_funding_from_asset_lock_duffs(1);
+                PlatformFeeEstimator::new().estimate_address_funding_from_asset_lock_duffs(2);
             let asset_lock_amount = amount.saturating_add(estimated_platform_fee_duffs);
             (asset_lock_amount, false)
         };
@@ -169,9 +172,39 @@ impl AppContext {
 
         // Step 8: Fund the destination platform address
         let mut outputs = std::collections::BTreeMap::new();
-        outputs.insert(destination, None); // None means use all available funds
 
-        let fee_strategy = vec![AddressFundsFeeStrategyStep::ReduceOutput(0)];
+        let fee_strategy = if fee_deduct_from_output {
+            // Fee deducted from output: destination is the remainder recipient (gets
+            // asset lock value minus fee). ReduceOutput(0) tells Platform to deduct
+            // the fee from the single output.
+            outputs.insert(destination, None);
+            vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]
+        } else {
+            // Fee NOT deducted from output: destination receives the exact requested
+            // amount. We use a separate "change" address derived from the asset lock
+            // key as the remainder recipient (absorbs the fee estimate surplus).
+            // The fee is deducted from the change output, not the destination.
+            let amount_credits = amount.saturating_mul(CREDITS_PER_DUFF);
+            let change_address = PlatformAddress::from(&asset_lock_private_key);
+
+            if change_address == destination {
+                // Extremely unlikely: random key collides with destination address.
+                // Fall back to single-output mode with remainder.
+                outputs.insert(destination, None);
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]
+            } else {
+                outputs.insert(destination, Some(amount_credits));
+                outputs.insert(change_address, None); // Remainder recipient
+
+                // Determine the BTreeMap index of the change address to target it
+                // with the fee strategy (BTreeMap iterates in key order).
+                let change_index = outputs
+                    .keys()
+                    .position(|k| *k == change_address)
+                    .unwrap_or(0) as u16;
+                vec![AddressFundsFeeStrategyStep::ReduceOutput(change_index)]
+            }
+        };
 
         outputs
             .top_up(

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -35,8 +35,9 @@ impl AppContext {
             // Fees paid from wallet: add estimated platform fee to asset lock amount.
             // We use 2 outputs: the destination (explicit amount) and a change address
             // (remainder recipient that absorbs the fee).
-            let estimated_platform_fee_duffs =
-                self.fee_estimator().estimate_address_funding_from_asset_lock_duffs(2);
+            let estimated_platform_fee_duffs = self
+                .fee_estimator()
+                .estimate_address_funding_from_asset_lock_duffs(2);
             let asset_lock_amount = amount.saturating_add(estimated_platform_fee_duffs);
             (asset_lock_amount, false)
         };

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -2,6 +2,7 @@ use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::wallet::PlatformSyncMode;
 use crate::context::AppContext;
 use crate::model::wallet::WalletSeedHash;
+use crate::spv::CoreBackendMode;
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
 use dash_sdk::dpp::prelude::AssetLockProof;
@@ -149,6 +150,23 @@ impl AppContext {
                     if let Ok(mut proofs) = self.transactions_waiting_for_finality.try_lock() {
                         proofs.remove(&tx_id);
                     }
+
+                    // Auto-refresh wallet UTXOs in RPC mode so the broadcast tx's
+                    // spent inputs are reconciled (the tx was already broadcast and
+                    // may confirm later). SPV handles its own reconciliation.
+                    if self.core_backend_mode() == CoreBackendMode::Rpc
+                        && let Some(wallet_arc) = self.wallets.read().ok()
+                            .and_then(|w| w.get(&seed_hash).cloned())
+                    {
+                        let ctx = Arc::clone(self);
+                        // Fire-and-forget — don't block the error return on refresh
+                        tokio::task::spawn_blocking(move || {
+                            if let Err(e) = ctx.refresh_wallet_info(wallet_arc) {
+                                tracing::warn!("Failed to auto-refresh wallet after timeout: {}", e);
+                            }
+                        });
+                    }
+
                     return Err("Timeout waiting for asset lock proof — no InstantLock or ChainLock received within 5 minutes".to_string());
                 }
                 _ = tokio::time::sleep(Duration::from_millis(200)) => {

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -137,17 +137,27 @@ impl AppContext {
             }
         }
 
-        // Step 5: Wait for asset lock proof (InstantLock or ChainLock)
+        // Step 5: Wait for asset lock proof (InstantLock or ChainLock) with timeout
         let asset_lock_proof: AssetLockProof;
+        let timeout = tokio::time::sleep(Duration::from_secs(300)); // 5 minute timeout
+        tokio::pin!(timeout);
+
         loop {
-            {
-                let proofs = self.transactions_waiting_for_finality.lock().unwrap();
-                if let Some(Some(proof)) = proofs.get(&tx_id) {
-                    asset_lock_proof = proof.clone();
-                    break;
+            tokio::select! {
+                _ = &mut timeout => {
+                    // Clean up the finality tracking entry before returning error
+                    let mut proofs = self.transactions_waiting_for_finality.lock().unwrap();
+                    proofs.remove(&tx_id);
+                    return Err("Timeout waiting for asset lock proof — no InstantLock or ChainLock received within 5 minutes".to_string());
+                }
+                _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                    let proofs = self.transactions_waiting_for_finality.lock().unwrap();
+                    if let Some(Some(proof)) = proofs.get(&tx_id) {
+                        asset_lock_proof = proof.clone();
+                        break;
+                    }
                 }
             }
-            tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
         // Step 6: Clean up the finality tracking

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -1,7 +1,6 @@
 use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::wallet::PlatformSyncMode;
 use crate::context::AppContext;
-use crate::model::fee_estimation::PlatformFeeEstimator;
 use crate::model::wallet::WalletSeedHash;
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
@@ -36,7 +35,7 @@ impl AppContext {
             // We use 2 outputs: the destination (explicit amount) and a change address
             // (remainder recipient that absorbs the fee).
             let estimated_platform_fee_duffs =
-                PlatformFeeEstimator::new().estimate_address_funding_from_asset_lock_duffs(2);
+                self.fee_estimator().estimate_address_funding_from_asset_lock_duffs(2);
             let asset_lock_amount = amount.saturating_add(estimated_platform_fee_duffs);
             (asset_lock_amount, false)
         };
@@ -166,8 +165,8 @@ impl AppContext {
             proofs.remove(&tx_id);
         }
 
-        // Step 7: Get wallet and SDK for the platform funding operation
-        let (wallet, sdk) = {
+        // Step 7: Get wallet, SDK, and derive a fresh change address if needed
+        let (wallet, sdk, change_platform_address) = {
             let wallet_arc = {
                 let wallets = self.wallets.read().unwrap();
                 wallets
@@ -175,9 +174,29 @@ impl AppContext {
                     .cloned()
                     .ok_or_else(|| "Wallet not found".to_string())?
             };
+
+            // Derive a fresh change address while we have write access (only
+            // needed when fees are NOT deducted from the output).
+            let change_platform_address = if !fee_deduct_from_output {
+                let mut wallet_w = wallet_arc.write().map_err(|e| e.to_string())?;
+                let addr = wallet_w.receive_address(self.network, true, Some(self))?;
+                match PlatformAddress::try_from(addr) {
+                    Ok(pa) if pa != destination => Some(pa),
+                    // First address matched destination or failed to convert;
+                    // derive another — two consecutive fresh addresses can't collide.
+                    _ => {
+                        let addr2 =
+                            wallet_w.receive_address(self.network, true, Some(self))?;
+                        PlatformAddress::try_from(addr2).ok()
+                    }
+                }
+            } else {
+                None
+            };
+
             let wallet = wallet_arc.read().map_err(|e| e.to_string())?.clone();
             let sdk = self.sdk.read().map_err(|e| e.to_string())?.clone();
-            (wallet, sdk)
+            (wallet, sdk, change_platform_address)
         };
 
         // Step 8: Fund the destination platform address
@@ -191,18 +210,11 @@ impl AppContext {
             vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]
         } else {
             // Fee NOT deducted from output: destination receives the exact requested
-            // amount. We use a separate "change" address derived from the asset lock
-            // key as the remainder recipient (absorbs the fee estimate surplus).
-            // The fee is deducted from the change output, not the destination.
+            // amount. We use a fresh wallet-controlled change address to absorb the
+            // fee estimate surplus, keeping it spendable.
             let amount_credits = amount.saturating_mul(CREDITS_PER_DUFF);
-            let change_address = PlatformAddress::from(&asset_lock_private_key);
 
-            if change_address == destination {
-                // Extremely unlikely: random key collides with destination address.
-                // Fall back to single-output mode with remainder.
-                outputs.insert(destination, None);
-                vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]
-            } else {
+            if let Some(change_address) = change_platform_address {
                 outputs.insert(destination, Some(amount_credits));
                 outputs.insert(change_address, None); // Remainder recipient
 
@@ -213,6 +225,8 @@ impl AppContext {
                     .position(|k| *k == change_address)
                     .unwrap_or(0) as u16;
                 vec![AddressFundsFeeStrategyStep::ReduceOutput(change_index)]
+            } else {
+                return Err("Failed to derive a change address for platform funding".to_string());
             }
         };
 

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -144,12 +144,16 @@ impl AppContext {
         loop {
             tokio::select! {
                 _ = &mut timeout => {
-                    // Clean up the finality tracking entry before returning error
-                    let mut proofs = self.transactions_waiting_for_finality.lock().unwrap();
-                    proofs.remove(&tx_id);
+                    // Best-effort cleanup: use try_lock to avoid blocking the
+                    // async runtime if another thread holds the mutex.
+                    if let Ok(mut proofs) = self.transactions_waiting_for_finality.try_lock() {
+                        proofs.remove(&tx_id);
+                    }
                     return Err("Timeout waiting for asset lock proof — no InstantLock or ChainLock received within 5 minutes".to_string());
                 }
                 _ = tokio::time::sleep(Duration::from_millis(200)) => {
+                    // Brief lock to check for proof — acquired and released quickly
+                    // so contention is minimal.
                     let proofs = self.transactions_waiting_for_finality.lock().unwrap();
                     if let Some(Some(proof)) = proofs.get(&tx_id) {
                         asset_lock_proof = proof.clone();
@@ -175,21 +179,17 @@ impl AppContext {
                     .ok_or_else(|| "Wallet not found".to_string())?
             };
 
-            // Derive a fresh change address while we have write access (only
-            // needed when fees are NOT deducted from the output).
+            // Derive a fresh change address from the BIP44 internal (change) path
+            // while we have write access (only needed when fees are NOT deducted
+            // from the output). Using change_address() ensures proper BIP44
+            // separation between receive and change addresses.
             let change_platform_address = if !fee_deduct_from_output {
                 let mut wallet_w = wallet_arc.write().map_err(|e| e.to_string())?;
-                let addr = wallet_w.receive_address(self.network, true, Some(self))?;
-                match PlatformAddress::try_from(addr) {
-                    Ok(pa) if pa != destination => Some(pa),
-                    // First address matched destination or failed to convert;
-                    // derive another — two consecutive fresh addresses can't collide.
-                    _ => {
-                        let addr2 =
-                            wallet_w.receive_address(self.network, true, Some(self))?;
-                        PlatformAddress::try_from(addr2).ok()
-                    }
-                }
+                let addr = wallet_w.change_address(self.network, Some(self))?;
+                Some(
+                    PlatformAddress::try_from(addr)
+                        .map_err(|e| format!("Failed to convert change address: {}", e))?,
+                )
             } else {
                 None
             };
@@ -223,7 +223,8 @@ impl AppContext {
                 let change_index = outputs
                     .keys()
                     .position(|k| *k == change_address)
-                    .unwrap_or(0) as u16;
+                    .ok_or("Change address not found in outputs map")?
+                    as u16;
                 vec![AddressFundsFeeStrategyStep::ReduceOutput(change_index)]
             } else {
                 return Err("Failed to derive a change address for platform funding".to_string());

--- a/src/backend_task/wallet/generate_receive_address.rs
+++ b/src/backend_task/wallet/generate_receive_address.rs
@@ -35,7 +35,7 @@ impl AppContext {
         } else {
             let mut wallet = wallet_arc.write().map_err(|e| e.to_string())?;
             wallet
-                .receive_address(self.network, false, Some(self))?
+                .receive_address(self.network, true, Some(self))?
                 .to_string()
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -464,8 +464,8 @@ impl AppContext {
     pub fn handle_wallet_unlocked(self: &Arc<Self>, wallet: &Arc<RwLock<Wallet>>) {
         if let Some((seed_hash, seed_bytes)) = Self::wallet_seed_snapshot(wallet) {
             self.queue_spv_wallet_load(seed_hash, seed_bytes);
-            // Note: Platform address sync and Core UTXO refresh are NOT done automatically on unlock.
-            // User must explicitly click Refresh to update balances.
+            // Note: Platform address sync is not done here.
+            // Core UTXO refresh is handled at startup in bootstrap_loaded_wallets.
         }
     }
 
@@ -541,9 +541,50 @@ impl AppContext {
             guard.values().cloned().collect()
         };
 
-        for wallet in wallets {
-            self.bootstrap_wallet_addresses(&wallet);
-            self.handle_wallet_unlocked(&wallet);
+        for wallet in wallets.iter() {
+            self.bootstrap_wallet_addresses(wallet);
+            self.handle_wallet_unlocked(wallet);
+        }
+
+        // Auto-refresh UTXOs from Core on startup so balances are current
+        // without requiring the user to manually click Refresh (fixes GH#522).
+        // Only in RPC mode — SPV mode handles UTXO loading via reconciliation.
+        if self.core_backend_mode() == CoreBackendMode::Rpc {
+            for wallet in wallets {
+                let ctx = Arc::clone(self);
+                self.subtasks.spawn_sync(async move {
+                    if let Err(e) =
+                        tokio::task::spawn_blocking(move || ctx.refresh_wallet_info(wallet))
+                            .await
+                            .map_err(|e| format!("Task join error: {}", e))
+                            .and_then(|r| r.map(|_| ()))
+                    {
+                        tracing::warn!("Failed to auto-refresh wallet UTXOs on startup: {}", e);
+                    }
+                });
+            }
+
+            let single_key_wallets: Vec<_> = {
+                let guard = self.single_key_wallets.read().unwrap();
+                guard.values().cloned().collect()
+            };
+            for wallet in single_key_wallets {
+                let ctx = Arc::clone(self);
+                self.subtasks.spawn_sync(async move {
+                    if let Err(e) = tokio::task::spawn_blocking(move || {
+                        ctx.refresh_single_key_wallet_info(wallet)
+                    })
+                    .await
+                    .map_err(|e| format!("Task join error: {}", e))
+                    .and_then(|r| r)
+                    {
+                        tracing::warn!(
+                            "Failed to auto-refresh single key wallet UTXOs on startup: {}",
+                            e
+                        );
+                    }
+                });
+            }
         }
     }
 

--- a/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
@@ -23,7 +23,7 @@ impl AddNewIdentityScreen {
                     let mut wallet = wallet_guard.write().unwrap();
                     let receive_address = wallet.receive_address(
                         self.app_context.network,
-                        false,
+                        true,
                         Some(&self.app_context),
                     )?;
 

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -17,7 +17,7 @@ impl TopUpIdentityScreen {
                     let mut wallet = wallet_guard.write().unwrap();
                     let receive_address = wallet.receive_address(
                         self.app_context.network,
-                        false,
+                        true,
                         Some(&self.app_context),
                     )?;
 

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -10,6 +10,7 @@ use crate::backend_task::identity::{IdentityTask, IdentityTopUpInfo, TopUpIdenti
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult, FeeResult};
 use crate::context::AppContext;
 use crate::model::amount::Amount;
+use crate::model::fee_estimation::format_credits_as_dash;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
 use crate::ui::components::amount_input::AmountInput;
@@ -371,17 +372,30 @@ impl TopUpIdentityScreen {
 
         // Only apply max amount restriction when using wallet balance
         // For QR code funding, funds come from external source so no max applies
-        let (max_amount, show_max_button) = if funding_method == FundingMethod::UseWalletBalance {
-            let max_amount_duffs = self
-                .wallet
-                .as_ref()
-                .map(|w| w.read().unwrap().total_balance_duffs())
-                .unwrap_or(0);
-            // Convert Duffs to Credits (1 Duff = 1000 Credits)
-            (Some(max_amount_duffs * 1000), true)
-        } else {
-            (None, false)
-        };
+        let (max_amount, show_max_button, fee_hint) =
+            if funding_method == FundingMethod::UseWalletBalance {
+                let max_amount_duffs = self
+                    .wallet
+                    .as_ref()
+                    .map(|w| w.read().unwrap().total_balance_duffs())
+                    .unwrap_or(0);
+                // Convert Duffs to Credits (1 Duff = 1000 Credits)
+                let total_credits = max_amount_duffs * 1000;
+                // Reserve estimated fees so "Max" doesn't exceed spendable amount
+                let fee_estimator = self.app_context.fee_estimator();
+                let estimated_fee = fee_estimator.estimate_identity_topup();
+                let max_with_fee_reserved = total_credits.saturating_sub(estimated_fee);
+                (
+                    Some(max_with_fee_reserved),
+                    true,
+                    Some(format!(
+                        "~{} reserved for fees",
+                        format_credits_as_dash(estimated_fee)
+                    )),
+                )
+            } else {
+                (None, false, None)
+            };
 
         // Lazy initialization of the AmountInput component
         let amount_input = self.funding_amount_input.get_or_insert_with(|| {
@@ -394,6 +408,7 @@ impl TopUpIdentityScreen {
         // Update max amount and button visibility in case funding method or wallet balance changed
         amount_input.set_max_amount(max_amount);
         amount_input.set_show_max_button(show_max_button);
+        amount_input.set_max_exceeded_hint(fee_hint);
 
         let response = amount_input.show(ui);
 

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -107,7 +107,7 @@ impl CreateAssetLockScreen {
 
         // Generate a new asset lock funding address
         let receive_address =
-            wallet.receive_address(self.app_context.network, false, Some(&self.app_context))?;
+            wallet.receive_address(self.app_context.network, true, Some(&self.app_context))?;
 
         // Import address to core if needed
         if let Some(has_address) = self.core_has_funding_address {


### PR DESCRIPTION
## Summary
- **GH#522:** Auto-refresh wallet UTXOs on app startup so balances are current without manual Refresh (RPC mode only)
- **GH#476:** Respect `fee_deduct_from_output` flag in platform address funding — when user selects "deduct from input", destination now receives the exact requested amount
- **GH#478:** Reserve estimated fees in wallet balance top-up max button so clicking Max doesn't produce an underfunded transaction
- **GH#85:** Prevent funding address reuse across identities by using fresh unused addresses in all 4 identity/asset-lock funding paths
- **wallet-008:** Add 5-minute timeout to asset lock proof wait loop to prevent indefinite hangs if proof never arrives

Fixes #522
Fixes #476
Fixes #478
Fixes #85

## Review Notes
- Cherry-picked from branch `ralph/improvements` (commits `ac393dc`, `4b86e4b`, `5537776`, `03e36b3`, `d804e98`)
- This PR was created via an automated process by Claude Code
- Please review carefully before merging
- Each commit is independent and can be reviewed separately

## Test Plan
- [ ] Start app with multiple wallets configured — verify UTXOs refresh automatically (check balances without clicking Refresh)
- [ ] Fund a platform address with "deduct from input" selected — verify destination receives exact amount
- [ ] Open identity top-up, select Wallet Balance method, click Max — verify amount leaves room for fees
- [ ] Create two identities back-to-back from same wallet — verify different funding addresses are generated
- [ ] (Hard to test) Simulate asset lock proof timeout — verify task fails after 5 minutes instead of hanging

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 5-minute timeout for asset-lock proofs to avoid indefinite waits.
  * Startup wallet auto-refresh (RPC mode).
  * Max spend now reserves estimated fees for identity top-ups and shows a fee-reservation hint.
  * Receive-address behavior updated to prefer fresh/change addresses when appropriate.

* **Bug Fixes**
  * Improved multi-output change handling and fee strategy for wallet funding.
  * Better cleanup on timeout and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->