### PR TITLE
fix(tokens): restore token reorder assignment and distribution field checks

### DIFF
--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -1795,8 +1795,15 @@ impl TokensScreen {
             }
         }
 
+        // Append any tokens not present in the saved order (e.g., newly added tokens)
+        for (key, value) in &self.my_tokens {
+            if !reordered.contains_key(key) {
+                reordered.insert(*key, value.clone());
+            }
+        }
+
         // Replace the original with the reordered map
-        //self.my_tokens = reordered;
+        self.my_tokens = reordered;
     }
 
     /// Save the current map's order of token IDs to the DB
@@ -2041,7 +2048,7 @@ impl TokensScreen {
                         .step_decreasing_initial_emission_input
                         .parse::<u64>()
                         .unwrap_or(0),
-                    min_value: if self.step_decreasing_start_period_offset_input.is_empty() {
+                    min_value: if self.step_decreasing_min_value_input.is_empty() {
                         None
                     } else {
                         match self.step_decreasing_min_value_input.parse::<u64>() {
@@ -2055,7 +2062,7 @@ impl TokensScreen {
                             }
                         }
                     },
-                    max_interval_count: if self.step_decreasing_start_period_offset_input.is_empty()
+                    max_interval_count: if self.step_decreasing_max_interval_count_input.is_empty()
                     {
                         None
                     } else {


### PR DESCRIPTION
## Summary
- Fix token reorder persistence by assigning reordered map back to `self.my_tokens`.
- Preserve tokens not present in saved order when rebuilding the token map.
- Correct distribution rule field checks for `min_value` and `max_interval_count`.

## Testing
- Not run in this branch worktree (cherry-picked from commits that previously passed project checks).

This pull request was created by Codex (GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Token reordering now properly includes newly added tokens that were previously being discarded.
  * Distribution input validation improved by referencing more specific input fields for step-decreasing amount configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->