### PR TITLE
fix(core): handle dash-qt spawn and wallet DB update failures gracefully

### DIFF
--- a/src/backend_task/core/send_single_key_wallet_payment.rs
+++ b/src/backend_task/core/send_single_key_wallet_payment.rs
@@ -230,14 +230,26 @@ impl AppContext {
 
         // Remove spent UTXOs from database
         for (outpoint, _) in &selected_utxos {
-            let _ = self.db.drop_utxo(outpoint, &self.network.to_string());
+            if let Err(e) = self.db.drop_utxo(outpoint, &self.network.to_string()) {
+                tracing::warn!(
+                    "Failed to remove spent UTXO {:?} from database: {}",
+                    outpoint,
+                    e
+                );
+            }
         }
 
         // Persist new balance
         let balance = wallet.read().map_err(|e| e.to_string())?.total_balance;
-        let _ = self
+        if let Err(e) = self
             .db
-            .update_single_key_wallet_balances(&key_hash, balance, 0, balance);
+            .update_single_key_wallet_balances(&key_hash, balance, 0, balance)
+        {
+            tracing::warn!(
+                "Failed to update single key wallet balances in database: {}",
+                e
+            );
+        }
 
         let total_sent: u64 = request.recipients.iter().map(|r| r.amount_duffs).sum();
         let recipients_result: Vec<(String, u64)> = request

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -51,20 +51,23 @@ impl AppContext {
             command.arg("-local");
         }
         // Spawn the Dash-Qt process
+        let mut dash_qt = command.spawn().map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!(
+                    "Failed to start dash-qt binary at {}: {}",
+                    format_path_for_display(&dash_qt_path),
+                    e
+                ),
+            )
+        })?;
+
+        tracing::debug!(?command, pid = dash_qt.id(), "dash-qt started");
 
         // Spawn a task to wait for the Dash-Qt process to exit
         let cancel = self.subtasks.cancellation_token.clone();
         let db = Arc::clone(&self.db);
         self.subtasks.spawn_sync(async move {
-            let mut dash_qt = match command.spawn() {
-                Ok(child) => child,
-                Err(e) => {
-                    tracing::error!(error=?e, ?command, "failed to start dash-qt binary");
-                    return;
-                }
-            };
-
-            tracing::debug!(?command, pid = dash_qt.id(), "dash-qt started");
 
             // Wait for the process to exit or current task to be cancelled
             tokio::select! {

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -56,12 +56,13 @@ impl AppContext {
         let cancel = self.subtasks.cancellation_token.clone();
         let db = Arc::clone(&self.db);
         self.subtasks.spawn_sync(async move {
-            let mut dash_qt = command
-                .spawn()
-                .inspect_err(
-                    |e| tracing::error!(error=?e, ?command, "failed to start dash-qt binary"),
-                )
-                .expect("Failed to spawn dash-qt process");
+            let mut dash_qt = match command.spawn() {
+                Ok(child) => child,
+                Err(e) => {
+                    tracing::error!(error=?e, ?command, "failed to start dash-qt binary");
+                    return;
+                }
+            };
 
             tracing::debug!(?command, pid = dash_qt.id(), "dash-qt started");
 


### PR DESCRIPTION
## Summary
- Replace panic on `dash-qt` spawn failure with graceful error logging and early return.
- Log database failures when dropping spent UTXOs.
- Log database failures when persisting single-key wallet balances after send.

## Testing
- Not run in this branch worktree (cherry-picked from commits that previously passed project checks).

This pull request was created by Codex (GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for wallet payment operations to surface failures instead of silently ignoring them.
  * Replaced potential panics in background process startup with graceful error propagation, added logging of successful process starts (including PID) to aid diagnostics and increase stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->