### PR TITLE
fix(startup): harden cookie parsing, config save, and logger init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,8 @@ crossbeam-channel = "0.5.15"
 regex = "1.11.1"
 humantime = "2.2.0"
 which = { version = "8.0.0" }
-
+tz-rs = { version = "0.7.0" }
+tempfile = "3.20.0"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 zmq = "0.10.0"
@@ -84,7 +85,6 @@ native-dialog = "0.9.0"
 raw-cpuid = "11.5.0"
 
 [dev-dependencies]
-tempfile = { version = "3.20.0" }
 egui_kittest = { version = "0.33.3", features = ["eframe"] }
 
 [build-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::io::Write;
 use std::str::FromStr;
 
@@ -7,6 +6,7 @@ use dash_sdk::dapi_client::AddressList;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::sdk::Uri;
 use serde::Deserialize;
+use tempfile::NamedTempFile;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
@@ -70,12 +70,16 @@ impl Config {
         let env_file_path =
             app_user_data_file_path(".env").map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
-        // Write to a temporary file in the same directory first, then rename
-        // atomically. This prevents corruption if the write fails partway through.
-        let tmp_file_path = env_file_path.with_file_name(".env.tmp");
-
+        // Write to a temporary file in the same directory first, then
+        // atomically replace. This prevents corruption if the write fails
+        // partway through. NamedTempFile::persist() closes the handle before
+        // renaming and uses MoveFileEx with MOVEFILE_REPLACE_EXISTING on
+        // Windows for atomic replacement.
+        let parent_dir = env_file_path.parent().ok_or_else(|| {
+            ConfigError::LoadError("Config file path has no parent directory".to_string())
+        })?;
         let mut env_file =
-            File::create(&tmp_file_path).map_err(|e| ConfigError::LoadError(e.to_string()))?;
+            NamedTempFile::new_in(parent_dir).map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
         // Helper function to write a single network config to the `.env` file
         let mut write_network_config = |prefix: &str, config: &NetworkConfig| {
@@ -174,28 +178,15 @@ impl Config {
 
         // Sync all data to disk before renaming to ensure crash-safety
         env_file
+            .as_file()
             .sync_all()
             .map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
-        // On Windows, rename fails if the target already exists, so remove it first.
-        #[cfg(target_os = "windows")]
-        {
-            if env_file_path.exists() {
-                std::fs::remove_file(&env_file_path).map_err(|e| {
-                    let _ = std::fs::remove_file(&tmp_file_path);
-                    ConfigError::LoadError(format!(
-                        "Failed to remove old config file before rename: {}",
-                        e
-                    ))
-                })?;
-            }
-        }
-
-        // Replace the old config with the new one
-        std::fs::rename(&tmp_file_path, &env_file_path).map_err(|e| {
-            // Clean up the temp file on rename failure
-            let _ = std::fs::remove_file(&tmp_file_path);
-            ConfigError::LoadError(format!("Failed to rename temp config file: {}", e))
+        // Atomically replace the old config with the new one.
+        // persist() closes the file handle and uses platform-safe rename
+        // (MoveFileEx with MOVEFILE_REPLACE_EXISTING on Windows).
+        env_file.persist(&env_file_path).map_err(|e| {
+            ConfigError::LoadError(format!("Failed to persist temp config file: {}", e))
         })?;
 
         tracing::info!("Successfully saved configuration to {:?}", env_file_path);

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,13 +63,19 @@ impl Config {
 
     /// Write the current configuration back to the `.env` file so that
     /// subsequent calls to `Config::load()` will reflect changes.
+    ///
+    /// Uses atomic write (write to temp file, then rename) to prevent
+    /// config corruption if a write fails partway through.
     pub fn save(&self) -> Result<(), ConfigError> {
         let env_file_path =
             app_user_data_file_path(".env").map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
-        // Create / truncate the `.env` file
+        // Write to a temporary file in the same directory first, then rename
+        // atomically. This prevents corruption if the write fails partway through.
+        let tmp_file_path = env_file_path.with_extension("env.tmp");
+
         let mut env_file =
-            File::create(&env_file_path).map_err(|e| ConfigError::LoadError(e.to_string()))?;
+            File::create(&tmp_file_path).map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
         // Helper function to write a single network config to the `.env` file
         let mut write_network_config = |prefix: &str, config: &NetworkConfig| {
@@ -165,6 +171,18 @@ impl Config {
             writeln!(env_file, "DEVELOPER_MODE={}", developer_mode)
                 .map_err(|e| ConfigError::LoadError(e.to_string()))?;
         }
+
+        // Flush all buffered data to disk before renaming
+        env_file
+            .flush()
+            .map_err(|e| ConfigError::LoadError(e.to_string()))?;
+
+        // Atomically replace the old config with the new one
+        std::fs::rename(&tmp_file_path, &env_file_path).map_err(|e| {
+            // Clean up the temp file on rename failure
+            let _ = std::fs::remove_file(&tmp_file_path);
+            ConfigError::LoadError(format!("Failed to rename temp config file: {}", e))
+        })?;
 
         tracing::info!("Successfully saved configuration to {:?}", env_file_path);
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,7 @@ impl Config {
 
         // Write to a temporary file in the same directory first, then rename
         // atomically. This prevents corruption if the write fails partway through.
-        let tmp_file_path = env_file_path.with_extension("env.tmp");
+        let tmp_file_path = env_file_path.with_file_name(".env.tmp");
 
         let mut env_file =
             File::create(&tmp_file_path).map_err(|e| ConfigError::LoadError(e.to_string()))?;
@@ -172,12 +172,26 @@ impl Config {
                 .map_err(|e| ConfigError::LoadError(e.to_string()))?;
         }
 
-        // Flush all buffered data to disk before renaming
+        // Sync all data to disk before renaming to ensure crash-safety
         env_file
-            .flush()
+            .sync_all()
             .map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
-        // Atomically replace the old config with the new one
+        // On Windows, rename fails if the target already exists, so remove it first.
+        #[cfg(target_os = "windows")]
+        {
+            if env_file_path.exists() {
+                std::fs::remove_file(&env_file_path).map_err(|e| {
+                    let _ = std::fs::remove_file(&tmp_file_path);
+                    ConfigError::LoadError(format!(
+                        "Failed to remove old config file before rename: {}",
+                        e
+                    ))
+                })?;
+            }
+        }
+
+        // Replace the old config with the new one
         std::fs::rename(&tmp_file_path, &env_file_path).map_err(|e| {
             // Clean up the temp file on rename failure
             let _ = std::fs::remove_file(&tmp_file_path);

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -27,17 +27,22 @@ impl Provider {
         network: Network,
         config: &NetworkConfig,
     ) -> Result<Self, String> {
-        let cookie_path =
-            core_cookie_path(network, &config.devnet_name).expect("Failed to get core cookie path");
+        let cookie_path = core_cookie_path(network, &config.devnet_name)
+            .map_err(|e| format!("Failed to get core cookie path: {}", e))?;
 
         // Read the cookie from disk
         let cookie = std::fs::read_to_string(cookie_path);
         let (user, pass) = if let Ok(cookie) = cookie {
+            let cookie = cookie.trim();
             // split the cookie at ":", first part is user (__cookie__), second part is password
-            let cookie_parts: Vec<&str> = cookie.split(':').collect();
-            let user = cookie_parts[0];
-            let password = cookie_parts[1];
-            (user.to_string(), password.to_string())
+            if let Some((user, password)) = cookie.split_once(':') {
+                (user.to_string(), password.to_string())
+            } else {
+                return Err(format!(
+                    "Malformed cookie file: expected 'user:password' format, got '{}'",
+                    cookie
+                ));
+            }
         } else {
             // Fall back to the pre-set user / pass if needed
             (

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -38,9 +38,7 @@ impl Provider {
             if let Some((user, password)) = cookie.split_once(':') {
                 (user.to_string(), password.to_string())
             } else {
-                return Err(
-                    "Malformed cookie file: expected 'user:password' format".to_string(),
-                );
+                return Err("Malformed cookie file: expected 'user:password' format".to_string());
             }
         } else {
             // Fall back to the pre-set user / pass if needed

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -38,10 +38,9 @@ impl Provider {
             if let Some((user, password)) = cookie.split_once(':') {
                 (user.to_string(), password.to_string())
             } else {
-                return Err(format!(
-                    "Malformed cookie file: expected 'user:password' format, got '{}'",
-                    cookie
-                ));
+                return Err(
+                    "Malformed cookie file: expected 'user:password' format".to_string(),
+                );
             }
         } else {
             // Fall back to the pre-set user / pass if needed

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -13,27 +13,46 @@ pub fn initialize_logger() {
 }
 
 fn initialize_logger_internal() {
-    // Initialize log file, with improved error handling
-    let log_file_path = app_user_data_file_path("det.log").expect("should create log file path");
-    let log_file = match std::fs::File::create(&log_file_path) {
-        Ok(file) => file,
-        Err(e) => panic!("Failed to create log file: {:?}", e),
-    };
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::try_new(
             "info,dash_evo_tool=trace,dash_sdk=debug,dash_sdk::platform::transition=trace,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn,dash_spv=debug",
         )
-        .unwrap_or_else(|e| panic!("Failed to create EnvFilter: {:?}", e))
+        .unwrap_or_else(|_| EnvFilter::new("info"))
     });
 
-    let subscriber = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(log_file)
-        .with_ansi(false)
-        .finish();
+    // Try to create a log file; fall back to stderr if it fails
+    let log_file_result =
+        app_user_data_file_path("det.log").and_then(std::fs::File::create);
 
-    // Set global subscriber - ignore error if already set (can happen in tests)
-    if let Err(_e) = tracing::subscriber::set_global_default(subscriber) {
+    let (subscriber_set, log_file_path_for_msg) = match log_file_result {
+        Ok(log_file) => {
+            let subscriber = tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(log_file)
+                .with_ansi(false)
+                .finish();
+            let set = tracing::subscriber::set_global_default(subscriber).is_ok();
+            (set, Some(app_user_data_file_path("det.log").ok()))
+        }
+        Err(e) => {
+            // Fall back to stderr logging
+            let subscriber = tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_writer(std::io::stderr)
+                .with_ansi(true)
+                .finish();
+            let set = tracing::subscriber::set_global_default(subscriber).is_ok();
+            if set {
+                eprintln!(
+                    "Warning: Could not create log file, logging to stderr: {}",
+                    e
+                );
+            }
+            (set, None)
+        }
+    };
+
+    if !subscriber_set {
         // Logger already initialized, this is fine
         return;
     }
@@ -59,9 +78,16 @@ fn initialize_logger_internal() {
         default_panic_hook(panic_info);
     }));
 
-    info!(
-        version = VERSION,
-        log_file = ?log_file_path,
-        "Dash-Evo-Tool logging initialized successfully"
-    );
+    if let Some(Some(path)) = log_file_path_for_msg {
+        info!(
+            version = VERSION,
+            log_file = ?path,
+            "Dash-Evo-Tool logging initialized successfully"
+        );
+    } else {
+        info!(
+            version = VERSION,
+            "Dash-Evo-Tool logging initialized (stderr fallback)"
+        );
+    }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -21,8 +21,7 @@ fn initialize_logger_internal() {
     });
 
     // Try to create a log file; fall back to stderr if it fails
-    let log_file_result =
-        app_user_data_file_path("det.log").and_then(std::fs::File::create);
+    let log_file_result = app_user_data_file_path("det.log").and_then(std::fs::File::create);
 
     let (subscriber_set, log_file_path_for_msg) = match log_file_result {
         Ok(log_file) => {


### PR DESCRIPTION
## Summary
- Harden Core RPC cookie parsing with trim and format validation.
- Make config save atomic via temp-file write and rename.
- Fall back to stderr logging when file logger initialization fails.

## Testing
- Not run in this branch worktree (cherry-picked from commits that previously passed project checks).

This pull request was created by Codex (GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration saves are now atomic and crash-safe, reducing risk of corruption during writes and providing clearer errors when persisting fails.
  * Cookie parsing trims input and returns a clear error for malformed cookie files instead of crashing; fallback to config credentials is preserved.
  * Logging initialization now prefers file logging but gracefully falls back to stderr, emits a warning on fallback, and reports which target is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->