### PR TITLE
chore: replace deprecated serde_yaml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,7 +1842,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
@@ -6936,10 +6936,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap 2.13.0",
  "itoa",
@@ -7757,9 +7757,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow 0.7.14",
 ]
@@ -8014,9 +8014,9 @@ dependencies = [
 
 [[package]]
 name = "typed-path"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3015e6ce46d5ad8751e4a772543a30c7511468070e98e64e20165f8f81155b64"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rayon = "1.8"
 thiserror = "2.0.18"
 serde = "1.0.219"
 serde_json = "1.0.140"
-serde_yaml = { version = "0.9.34-deprecated" }
+serde_yaml_ng = { version = "0.10.0" }
 tokio = { version = "1.46.1", features = ["full"] }
 bincode = { version = "=2.0.1", features = ["serde"] }
 hex = { version = "0.4.3" }

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -781,7 +781,7 @@ fn doc_to_filtered_string(
     // 3) Convert filtered_value to the chosen format
     let final_string = match display_mode {
         DocumentDisplayMode::Json => serde_json::to_string_pretty(&filtered_value).ok()?,
-        DocumentDisplayMode::Yaml => serde_yaml::to_string(&filtered_value).ok()?,
+        DocumentDisplayMode::Yaml => serde_yaml_ng::to_string(&filtered_value).ok()?,
     };
 
     Some(final_string)

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -56,7 +56,7 @@ struct TestnetNodes {
 
 fn load_testnet_nodes_from_yml(file_path: &str) -> Option<TestnetNodes> {
     let file_content = fs::read_to_string(file_path).ok()?;
-    serde_yaml::from_str(&file_content).expect("expected proper yaml")
+    serde_yaml_ng::from_str(&file_content).expect("expected proper yaml")
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- Replace `serde_yaml` (deprecated at version `0.9.34-deprecated`) with `serde_yaml_ng` `0.10.0`, the actively maintained community fork
- Update all 2 call sites (`contracts_documents_screen.rs`, `add_existing_identity_screen.rs`) to use the new crate name

## Test plan
- [ ] `cargo build` compiles successfully
- [ ] YAML document display in contracts/documents screen renders correctly
- [ ] YAML parsing in add existing identity screen works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated YAML handling library dependency to improve compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->