### PR TITLE
fix: timed message countdown freezes without user interaction

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -84,7 +84,8 @@ pub struct AppState {
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
-    pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
+    last_repaint_request: Instant,     // Throttle periodic repaint scheduling to once per second
+    pub subtasks: Arc<TaskManager>,    // Subtasks manager for graceful shutdown
     /// Whether to show the welcome/onboarding screen
     pub show_welcome_screen: bool,
     /// The welcome screen instance (only created if needed)
@@ -625,6 +626,7 @@ impl AppState {
             task_result_receiver,
             theme_preference,
             last_scheduled_vote_check: Instant::now(),
+            last_repaint_request: Instant::now(),
             subtasks,
             show_welcome_screen: !onboarding_completed,
             welcome_screen: None,
@@ -855,6 +857,14 @@ impl App for AppState {
                     self.visible_screen_mut().refresh();
                 }
             }
+        }
+
+        // Schedule a periodic repaint every ~1 second so timed messages update
+        // their countdown and other periodic UI elements stay current.
+        // Throttled so we don't re-schedule on every frame during user interaction.
+        if self.last_repaint_request.elapsed() >= Duration::from_secs(1) {
+            ctx.request_repaint_after(Duration::from_secs(1));
+            self.last_repaint_request = Instant::now();
         }
 
         // **Poll the instant_send_receiver for any new InstantSend messages**

--- a/src/app.rs
+++ b/src/app.rs
@@ -84,8 +84,8 @@ pub struct AppState {
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
-    last_repaint_request: Instant,     // Throttle periodic repaint scheduling to once per second
-    pub subtasks: Arc<TaskManager>,    // Subtasks manager for graceful shutdown
+    last_repaint_request: Instant,      // Throttle periodic repaint scheduling to once per second
+    pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
     /// Whether to show the welcome/onboarding screen
     pub show_welcome_screen: bool,
     /// The welcome screen instance (only created if needed)


### PR DESCRIPTION
egui only redraws on user input or explicit repaint requests. Screens that display auto-dismissing messages with a countdown timer (e.g. "Error refreshing identity... (10s)") never scheduled repaints, so the countdown froze and the message stayed visible indefinitely until the user moved their mouse.

Add a throttled periodic repaint (once per second) in AppState::update() so all timed UI elements stay current without per-screen changes.

Closes dashpay/dash-evo-tool#546

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Throttled periodic UI repaints to roughly once per second, reducing unnecessary redraws.
  * Results in lower CPU/GPU usage, smoother runtime responsiveness, and improved startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->