### PR TITLE
fix: replace expect()/unwrap() panics with error propagation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -267,7 +267,22 @@ impl AppState {
         let mut wallets_balances_screen = WalletsBalancesScreen::new(&mainnet_app_context);
 
         let selected_main_screen = settings.root_screen_type;
-        let chosen_network = settings.network;
+        // Validate that the saved network has an available context; fall back to mainnet if not
+        let chosen_network = match settings.network {
+            Network::Testnet if testnet_app_context.is_none() => {
+                tracing::warn!("Saved network is Testnet but context unavailable, defaulting to mainnet");
+                Network::Dash
+            }
+            Network::Devnet if devnet_app_context.is_none() => {
+                tracing::warn!("Saved network is Devnet but context unavailable, defaulting to mainnet");
+                Network::Dash
+            }
+            Network::Regtest if local_app_context.is_none() => {
+                tracing::warn!("Saved network is Regtest but context unavailable, defaulting to mainnet");
+                Network::Dash
+            }
+            other => other,
+        };
         network_chooser_screen.current_network = chosen_network;
 
         if let (Network::Testnet, Some(testnet_app_context)) =
@@ -696,13 +711,16 @@ impl AppState {
     }
 
     pub fn current_app_context(&self) -> &Arc<AppContext> {
+        // Note: change_network() guards against switching to unavailable networks,
+        // so the fallback branches below should never be reached in practice.
+        // They exist as defense-in-depth and log at error level to aid debugging.
         match self.chosen_network {
             Network::Dash => &self.mainnet_app_context,
             Network::Testnet => {
                 if let Some(ctx) = self.testnet_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::warn!("Testnet app context not available, falling back to mainnet");
+                    tracing::error!("BUG: Testnet app context not available but network is set to Testnet. Falling back to mainnet to avoid crash.");
                     &self.mainnet_app_context
                 }
             }
@@ -710,7 +728,7 @@ impl AppState {
                 if let Some(ctx) = self.devnet_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::warn!("Devnet app context not available, falling back to mainnet");
+                    tracing::error!("BUG: Devnet app context not available but network is set to Devnet. Falling back to mainnet to avoid crash.");
                     &self.mainnet_app_context
                 }
             }
@@ -718,15 +736,13 @@ impl AppState {
                 if let Some(ctx) = self.local_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::warn!(
-                        "Local/Regtest app context not available, falling back to mainnet"
-                    );
+                    tracing::error!("BUG: Local/Regtest app context not available but network is set to Regtest. Falling back to mainnet to avoid crash.");
                     &self.mainnet_app_context
                 }
             }
             _ => {
-                tracing::warn!(
-                    "Unknown network variant {:?} in current_app_context, falling back to mainnet",
+                tracing::error!(
+                    "BUG: Unknown network variant {:?} in current_app_context. Falling back to mainnet to avoid crash.",
                     self.chosen_network
                 );
                 &self.mainnet_app_context
@@ -783,6 +799,23 @@ impl AppState {
     }
 
     pub fn change_network(&mut self, network: Network) {
+        // Verify the target network context exists before switching
+        let context_available = match network {
+            Network::Dash => true, // Mainnet is always available
+            Network::Testnet => self.testnet_app_context.is_some(),
+            Network::Devnet => self.devnet_app_context.is_some(),
+            Network::Regtest => self.local_app_context.is_some(),
+            _ => false,
+        };
+
+        if !context_available {
+            tracing::error!(
+                "Cannot switch to {:?}: network context not available. Staying on current network.",
+                network
+            );
+            return;
+        }
+
         self.chosen_network = network;
         let app_context = self.current_app_context().clone();
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -698,13 +698,39 @@ impl AppState {
     pub fn current_app_context(&self) -> &Arc<AppContext> {
         match self.chosen_network {
             Network::Dash => &self.mainnet_app_context,
-            Network::Testnet => self.testnet_app_context.as_ref().expect("expected testnet"),
-            Network::Devnet => self.devnet_app_context.as_ref().expect("expected devnet"),
-            Network::Regtest => self.local_app_context.as_ref().expect("expected local"),
-            _ => unreachable!(
-                "Unknown network variant {:?} in current_app_context",
-                self.chosen_network
-            ),
+            Network::Testnet => {
+                if let Some(ctx) = self.testnet_app_context.as_ref() {
+                    ctx
+                } else {
+                    tracing::warn!("Testnet app context not available, falling back to mainnet");
+                    &self.mainnet_app_context
+                }
+            }
+            Network::Devnet => {
+                if let Some(ctx) = self.devnet_app_context.as_ref() {
+                    ctx
+                } else {
+                    tracing::warn!("Devnet app context not available, falling back to mainnet");
+                    &self.mainnet_app_context
+                }
+            }
+            Network::Regtest => {
+                if let Some(ctx) = self.local_app_context.as_ref() {
+                    ctx
+                } else {
+                    tracing::warn!(
+                        "Local/Regtest app context not available, falling back to mainnet"
+                    );
+                    &self.mainnet_app_context
+                }
+            }
+            _ => {
+                tracing::warn!(
+                    "Unknown network variant {:?} in current_app_context, falling back to mainnet",
+                    self.chosen_network
+                );
+                &self.mainnet_app_context
+            }
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -411,15 +411,21 @@ impl AppState {
             .map(|s| s.disable_zmq)
             .unwrap_or(false);
         let mainnet_core_zmq_listener = if !mainnet_disable_zmq {
-            Some(
-                CoreZMQListener::spawn_listener(
-                    Network::Dash,
-                    &mainnet_core_zmq_endpoint,
-                    core_message_sender.clone(), // Clone the sender for each listener
-                    Some(mainnet_app_context.sx_zmq_status.clone()),
-                )
-                .expect("Failed to create mainnet InstantSend listener"),
-            )
+            match CoreZMQListener::spawn_listener(
+                Network::Dash,
+                &mainnet_core_zmq_endpoint,
+                core_message_sender.clone(),
+                Some(mainnet_app_context.sx_zmq_status.clone()),
+            ) {
+                Ok(listener) => Some(listener),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to create mainnet ZMQ listener: {}. ZMQ features will be unavailable for mainnet.",
+                        e
+                    );
+                    None
+                }
+            }
         } else {
             None
         };
@@ -438,15 +444,21 @@ impl AppState {
             .map(|s| s.disable_zmq)
             .unwrap_or(false);
         let testnet_core_zmq_listener = if !testnet_disable_zmq {
-            Some(
-                CoreZMQListener::spawn_listener(
-                    Network::Testnet,
-                    &testnet_core_zmq_endpoint,
-                    core_message_sender.clone(), // Use the original sender or create a new one if needed
-                    testnet_tx_zmq_status_option,
-                )
-                .expect("Failed to create testnet InstantSend listener"),
-            )
+            match CoreZMQListener::spawn_listener(
+                Network::Testnet,
+                &testnet_core_zmq_endpoint,
+                core_message_sender.clone(),
+                testnet_tx_zmq_status_option,
+            ) {
+                Ok(listener) => Some(listener),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to create testnet ZMQ listener: {}. ZMQ features will be unavailable for testnet.",
+                        e
+                    );
+                    None
+                }
+            }
         } else {
             None
         };
@@ -465,15 +477,21 @@ impl AppState {
             .map(|s| s.disable_zmq)
             .unwrap_or(false);
         let devnet_core_zmq_listener = if !devnet_disable_zmq {
-            Some(
-                CoreZMQListener::spawn_listener(
-                    Network::Devnet,
-                    &devnet_core_zmq_endpoint,
-                    core_message_sender.clone(),
-                    devnet_tx_zmq_status_option,
-                )
-                .expect("Failed to create devnet InstantSend listener"),
-            )
+            match CoreZMQListener::spawn_listener(
+                Network::Devnet,
+                &devnet_core_zmq_endpoint,
+                core_message_sender.clone(),
+                devnet_tx_zmq_status_option,
+            ) {
+                Ok(listener) => Some(listener),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to create devnet ZMQ listener: {}. ZMQ features will be unavailable for devnet.",
+                        e
+                    );
+                    None
+                }
+            }
         } else {
             None
         };
@@ -492,15 +510,21 @@ impl AppState {
             .map(|s| s.disable_zmq)
             .unwrap_or(false);
         let local_core_zmq_listener = if !local_disable_zmq {
-            Some(
-                CoreZMQListener::spawn_listener(
-                    Network::Regtest,
-                    &local_core_zmq_endpoint,
-                    core_message_sender,
-                    local_tx_zmq_status_option,
-                )
-                .expect("Failed to create local InstantSend listener"),
-            )
+            match CoreZMQListener::spawn_listener(
+                Network::Regtest,
+                &local_core_zmq_endpoint,
+                core_message_sender,
+                local_tx_zmq_status_option,
+            ) {
+                Ok(listener) => Some(listener),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to create local ZMQ listener: {}. ZMQ features will be unavailable for local/regtest.",
+                        e
+                    );
+                    None
+                }
+            }
         } else {
             None
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -165,20 +165,15 @@ impl BitOrAssign for AppAction {
     }
 }
 impl AppState {
-    pub fn new(ctx: egui::Context) -> Self {
-        create_app_user_data_directory_if_not_exists()
-            .expect("Failed to create app user_data directory");
+    pub fn new(ctx: egui::Context) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        create_app_user_data_directory_if_not_exists()?;
         copy_env_file_if_not_exists();
         initialize_logger();
-        let db_file_path = app_user_data_file_path("data.db").expect("should create db file path");
-        let db = Arc::new(Database::new(&db_file_path).unwrap());
-        db.initialize(&db_file_path).unwrap();
+        let db_file_path = app_user_data_file_path("data.db")?;
+        let db = Arc::new(Database::new(&db_file_path)?);
+        db.initialize(&db_file_path)?;
 
-        let settings = db
-            .get_settings()
-            .expect("expected to get settings")
-            .map(Settings::from)
-            .unwrap_or_default();
+        let settings = db.get_settings()?.map(Settings::from).unwrap_or_default();
         let password_info = settings.password_info;
         let theme_preference = settings.theme_mode;
         let overwrite_dash_conf = settings.overwrite_dash_conf;
@@ -186,21 +181,14 @@ impl AppState {
 
         let subtasks = Arc::new(TaskManager::new());
         let connection_status = Arc::new(ConnectionStatus::new());
-        let mainnet_app_context = match AppContext::new(
+        let mainnet_app_context = AppContext::new(
             Network::Dash,
             db.clone(),
             password_info.clone(),
             subtasks.clone(),
             connection_status.clone(),
-        ) {
-            Some(context) => context,
-            None => {
-                tracing::error!(
-                    "Failed to create the AppContext. Expected Dash config for mainnet."
-                );
-                std::process::exit(1);
-            }
-        };
+        )
+        .ok_or("Failed to create AppContext for mainnet. Check your Dash configuration.")?;
         let testnet_app_context = AppContext::new(
             Network::Testnet,
             db.clone(),
@@ -686,7 +674,7 @@ impl AppState {
             }
         }
 
-        app_state
+        Ok(app_state)
     }
 
     /// Allows enabling or disabling animations globally for the app.

--- a/src/app.rs
+++ b/src/app.rs
@@ -267,57 +267,36 @@ impl AppState {
         let mut wallets_balances_screen = WalletsBalancesScreen::new(&mainnet_app_context);
 
         let selected_main_screen = settings.root_screen_type;
-        // Validate the saved network and collect a user-visible warning if we must switch away.
-        let (chosen_network, startup_network_warning) = match settings.network {
-            Network::Dash => (Network::Dash, None),
-            Network::Testnet if testnet_app_context.is_none() => {
-                tracing::warn!(
-                    "Saved network is Testnet but context unavailable, defaulting to mainnet"
+        // Validate that the saved network has an available context.
+        // We fail fast instead of silently routing user actions to a different network.
+        let chosen_network = match settings.network {
+            Network::Dash => Network::Dash,
+            Network::Testnet => {
+                assert!(
+                    testnet_app_context.is_some(),
+                    "Saved network is Testnet but no Testnet AppContext is configured"
                 );
-                (
-                    Network::Dash,
-                    Some(
-                        "Saved network (Testnet) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
-                    ),
-                )
+                Network::Testnet
             }
-            Network::Testnet => (Network::Testnet, None),
-            Network::Devnet if devnet_app_context.is_none() => {
-                tracing::warn!(
-                    "Saved network is Devnet but context unavailable, defaulting to mainnet"
+            Network::Devnet => {
+                assert!(
+                    devnet_app_context.is_some(),
+                    "Saved network is Devnet but no Devnet AppContext is configured"
                 );
-                (
-                    Network::Dash,
-                    Some(
-                        "Saved network (Devnet) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
-                    ),
-                )
+                Network::Devnet
             }
-            Network::Devnet => (Network::Devnet, None),
-            Network::Regtest if local_app_context.is_none() => {
-                tracing::warn!(
-                    "Saved network is Regtest but context unavailable, defaulting to mainnet"
+            Network::Regtest => {
+                assert!(
+                    local_app_context.is_some(),
+                    "Saved network is Regtest but no Regtest AppContext is configured"
                 );
-                (
-                    Network::Dash,
-                    Some(
-                        "Saved network (Regtest) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
-                    ),
-                )
+                Network::Regtest
             }
-            Network::Regtest => (Network::Regtest, None),
             unsupported_network => {
-                tracing::warn!(
-                    "Saved network {:?} is unsupported, defaulting to mainnet",
+                panic!(
+                    "Saved network {:?} is unsupported. Refusing automatic fallback.",
                     unsupported_network
                 );
-                (
-                    Network::Dash,
-                    Some(format!(
-                        "Saved network ({:?}) is unsupported. Switched to Mainnet.",
-                        unsupported_network
-                    )),
-                )
             }
         };
         network_chooser_screen.current_network = chosen_network;
@@ -696,12 +675,6 @@ impl AppState {
             welcome_screen: None,
         };
 
-        if let Some(message) = startup_network_warning.as_deref() {
-            app_state
-                .visible_screen_mut()
-                .display_message(message, MessageType::Error);
-        }
-
         // Initialize welcome screen if needed (after mainnet_app_context is owned by the struct)
         if app_state.show_welcome_screen {
             app_state.welcome_screen =
@@ -795,19 +768,9 @@ impl AppState {
             return;
         }
 
-        let unavailable_network = self.chosen_network;
-        tracing::error!(
-            "BUG: selected network {:?} has no AppContext. Switching to mainnet to prevent silent misrouting.",
-            unavailable_network
-        );
-
-        self.change_network(Network::Dash);
-        self.visible_screen_mut().display_message(
-            &format!(
-                "Selected network ({:?}) is unavailable. Switched to Mainnet to prevent accidental transactions.",
-                unavailable_network
-            ),
-            MessageType::Error,
+        panic!(
+            "BUG: selected network {:?} has no AppContext. Refusing to auto-switch networks.",
+            self.chosen_network
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -713,7 +713,10 @@ impl AppState {
             Network::Testnet => self.testnet_app_context.as_ref().expect("expected testnet"),
             Network::Devnet => self.devnet_app_context.as_ref().expect("expected devnet"),
             Network::Regtest => self.local_app_context.as_ref().expect("expected local"),
-            _ => todo!(),
+            _ => unreachable!(
+                "Unknown network variant {:?} in current_app_context",
+                self.chosen_network
+            ),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -270,15 +270,21 @@ impl AppState {
         // Validate that the saved network has an available context; fall back to mainnet if not
         let chosen_network = match settings.network {
             Network::Testnet if testnet_app_context.is_none() => {
-                tracing::warn!("Saved network is Testnet but context unavailable, defaulting to mainnet");
+                tracing::warn!(
+                    "Saved network is Testnet but context unavailable, defaulting to mainnet"
+                );
                 Network::Dash
             }
             Network::Devnet if devnet_app_context.is_none() => {
-                tracing::warn!("Saved network is Devnet but context unavailable, defaulting to mainnet");
+                tracing::warn!(
+                    "Saved network is Devnet but context unavailable, defaulting to mainnet"
+                );
                 Network::Dash
             }
             Network::Regtest if local_app_context.is_none() => {
-                tracing::warn!("Saved network is Regtest but context unavailable, defaulting to mainnet");
+                tracing::warn!(
+                    "Saved network is Regtest but context unavailable, defaulting to mainnet"
+                );
                 Network::Dash
             }
             other => other,
@@ -720,7 +726,9 @@ impl AppState {
                 if let Some(ctx) = self.testnet_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::error!("BUG: Testnet app context not available but network is set to Testnet. Falling back to mainnet to avoid crash.");
+                    tracing::error!(
+                        "BUG: Testnet app context not available but network is set to Testnet. Falling back to mainnet to avoid crash."
+                    );
                     &self.mainnet_app_context
                 }
             }
@@ -728,7 +736,9 @@ impl AppState {
                 if let Some(ctx) = self.devnet_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::error!("BUG: Devnet app context not available but network is set to Devnet. Falling back to mainnet to avoid crash.");
+                    tracing::error!(
+                        "BUG: Devnet app context not available but network is set to Devnet. Falling back to mainnet to avoid crash."
+                    );
                     &self.mainnet_app_context
                 }
             }
@@ -736,7 +746,9 @@ impl AppState {
                 if let Some(ctx) = self.local_app_context.as_ref() {
                     ctx
                 } else {
-                    tracing::error!("BUG: Local/Regtest app context not available but network is set to Regtest. Falling back to mainnet to avoid crash.");
+                    tracing::error!(
+                        "BUG: Local/Regtest app context not available but network is set to Regtest. Falling back to mainnet to avoid crash."
+                    );
                     &self.mainnet_app_context
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -267,27 +267,58 @@ impl AppState {
         let mut wallets_balances_screen = WalletsBalancesScreen::new(&mainnet_app_context);
 
         let selected_main_screen = settings.root_screen_type;
-        // Validate that the saved network has an available context; fall back to mainnet if not
-        let chosen_network = match settings.network {
+        // Validate the saved network and collect a user-visible warning if we must switch away.
+        let (chosen_network, startup_network_warning) = match settings.network {
+            Network::Dash => (Network::Dash, None),
             Network::Testnet if testnet_app_context.is_none() => {
                 tracing::warn!(
                     "Saved network is Testnet but context unavailable, defaulting to mainnet"
                 );
-                Network::Dash
+                (
+                    Network::Dash,
+                    Some(
+                        "Saved network (Testnet) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
+                    ),
+                )
             }
+            Network::Testnet => (Network::Testnet, None),
             Network::Devnet if devnet_app_context.is_none() => {
                 tracing::warn!(
                     "Saved network is Devnet but context unavailable, defaulting to mainnet"
                 );
-                Network::Dash
+                (
+                    Network::Dash,
+                    Some(
+                        "Saved network (Devnet) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
+                    ),
+                )
             }
+            Network::Devnet => (Network::Devnet, None),
             Network::Regtest if local_app_context.is_none() => {
                 tracing::warn!(
                     "Saved network is Regtest but context unavailable, defaulting to mainnet"
                 );
-                Network::Dash
+                (
+                    Network::Dash,
+                    Some(
+                        "Saved network (Regtest) is unavailable. Switched to Mainnet to prevent accidental transactions.".to_string(),
+                    ),
+                )
             }
-            other => other,
+            Network::Regtest => (Network::Regtest, None),
+            unsupported_network => {
+                tracing::warn!(
+                    "Saved network {:?} is unsupported, defaulting to mainnet",
+                    unsupported_network
+                );
+                (
+                    Network::Dash,
+                    Some(format!(
+                        "Saved network ({:?}) is unsupported. Switched to Mainnet.",
+                        unsupported_network
+                    )),
+                )
+            }
         };
         network_chooser_screen.current_network = chosen_network;
 
@@ -665,6 +696,12 @@ impl AppState {
             welcome_screen: None,
         };
 
+        if let Some(message) = startup_network_warning.as_deref() {
+            app_state
+                .visible_screen_mut()
+                .display_message(message, MessageType::Error);
+        }
+
         // Initialize welcome screen if needed (after mainnet_app_context is owned by the struct)
         if app_state.show_welcome_screen {
             app_state.welcome_screen =
@@ -717,47 +754,29 @@ impl AppState {
     }
 
     pub fn current_app_context(&self) -> &Arc<AppContext> {
-        // change_network() and enforce_network_context_invariant() keep this valid in normal flow.
-        // Fallback branches remain as last-resort safety to avoid hard crashes in production.
+        // Invariant: chosen_network must always have a corresponding context.
+        // Fail fast on violations to avoid silently routing operations to mainnet.
         match self.chosen_network {
             Network::Dash => &self.mainnet_app_context,
-            Network::Testnet => {
-                if let Some(ctx) = self.testnet_app_context.as_ref() {
-                    ctx
-                } else {
-                    tracing::error!(
-                        "BUG: Testnet app context not available but network is set to Testnet. Falling back to mainnet to avoid crash."
-                    );
-                    &self.mainnet_app_context
-                }
-            }
-            Network::Devnet => {
-                if let Some(ctx) = self.devnet_app_context.as_ref() {
-                    ctx
-                } else {
-                    tracing::error!(
-                        "BUG: Devnet app context not available but network is set to Devnet. Falling back to mainnet to avoid crash."
-                    );
-                    &self.mainnet_app_context
-                }
-            }
-            Network::Regtest => {
-                if let Some(ctx) = self.local_app_context.as_ref() {
-                    ctx
-                } else {
-                    tracing::error!(
-                        "BUG: Local/Regtest app context not available but network is set to Regtest. Falling back to mainnet to avoid crash."
-                    );
-                    &self.mainnet_app_context
-                }
-            }
-            _ => {
-                tracing::error!(
-                    "BUG: Unknown network variant {:?} in current_app_context. Falling back to mainnet to avoid crash.",
-                    self.chosen_network
-                );
-                &self.mainnet_app_context
-            }
+            Network::Testnet => self.testnet_app_context.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "BUG: chosen network is Testnet but testnet_app_context is missing; refusing silent mainnet fallback"
+                )
+            }),
+            Network::Devnet => self.devnet_app_context.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "BUG: chosen network is Devnet but devnet_app_context is missing; refusing silent mainnet fallback"
+                )
+            }),
+            Network::Regtest => self.local_app_context.as_ref().unwrap_or_else(|| {
+                panic!(
+                    "BUG: chosen network is Regtest but local_app_context is missing; refusing silent mainnet fallback"
+                )
+            }),
+            unsupported_network => panic!(
+                "BUG: unsupported network variant {:?} in current_app_context; refusing silent mainnet fallback",
+                unsupported_network
+            ),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -717,9 +717,8 @@ impl AppState {
     }
 
     pub fn current_app_context(&self) -> &Arc<AppContext> {
-        // Note: change_network() guards against switching to unavailable networks,
-        // so the fallback branches below should never be reached in practice.
-        // They exist as defense-in-depth and log at error level to aid debugging.
+        // change_network() and enforce_network_context_invariant() keep this valid in normal flow.
+        // Fallback branches remain as last-resort safety to avoid hard crashes in production.
         match self.chosen_network {
             Network::Dash => &self.mainnet_app_context,
             Network::Testnet => {
@@ -760,6 +759,37 @@ impl AppState {
                 &self.mainnet_app_context
             }
         }
+    }
+
+    fn context_available_for_network(&self, network: Network) -> bool {
+        match network {
+            Network::Dash => true, // Mainnet is always available
+            Network::Testnet => self.testnet_app_context.is_some(),
+            Network::Devnet => self.devnet_app_context.is_some(),
+            Network::Regtest => self.local_app_context.is_some(),
+            _ => false,
+        }
+    }
+
+    fn enforce_network_context_invariant(&mut self) {
+        if self.context_available_for_network(self.chosen_network) {
+            return;
+        }
+
+        let unavailable_network = self.chosen_network;
+        tracing::error!(
+            "BUG: selected network {:?} has no AppContext. Switching to mainnet to prevent silent misrouting.",
+            unavailable_network
+        );
+
+        self.change_network(Network::Dash);
+        self.visible_screen_mut().display_message(
+            &format!(
+                "Selected network ({:?}) is unavailable. Switched to Mainnet to prevent accidental transactions.",
+                unavailable_network
+            ),
+            MessageType::Error,
+        );
     }
 
     // Handle the backend task and send the result through the channel
@@ -811,16 +841,7 @@ impl AppState {
     }
 
     pub fn change_network(&mut self, network: Network) {
-        // Verify the target network context exists before switching
-        let context_available = match network {
-            Network::Dash => true, // Mainnet is always available
-            Network::Testnet => self.testnet_app_context.is_some(),
-            Network::Devnet => self.devnet_app_context.is_some(),
-            Network::Regtest => self.local_app_context.is_some(),
-            _ => false,
-        };
-
-        if !context_available {
+        if !self.context_available_for_network(network) {
             tracing::error!(
                 "Cannot switch to {:?}: network context not available. Staying on current network.",
                 network
@@ -888,6 +909,7 @@ impl App for AppState {
         // Apply Dash theme with user preference
         crate::ui::theme::apply_theme(ctx, self.theme_preference);
 
+        self.enforce_network_context_invariant();
         let active_context = self.current_app_context().clone();
 
         // Poll the receiver for any new task results

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -52,15 +52,20 @@ pub fn core_cookie_path(
     network: Network,
     devnet_name: &Option<String>,
 ) -> Result<PathBuf, std::io::Error> {
-    core_user_data_dir_path().map(|path| {
+    core_user_data_dir_path().and_then(|path| {
         let network_dir = match network {
             Network::Dash => "",
             Network::Testnet => "testnet3",
             Network::Devnet => devnet_name.as_deref().unwrap_or(""),
             Network::Regtest => "regtest",
-            _ => unimplemented!(),
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Unsupported network for cookie path: {:?}", network),
+                ));
+            }
         };
-        path.join(network_dir).join(".cookie")
+        Ok(path.join(network_dir).join(".cookie"))
     })
 }
 

--- a/src/backend_task/contested_names/query_dpns_contested_resources.rs
+++ b/src/backend_task/contested_names/query_dpns_contested_resources.rs
@@ -21,7 +21,7 @@ impl AppContext {
         let data_contract = self.dpns_contract.as_ref();
         let document_type = data_contract
             .document_type_for_name("domain")
-            .expect("expected document type");
+            .map_err(|_| "DPNS contract missing 'domain' document type".to_string())?;
         let Some(contested_index) = document_type.find_contested_index() else {
             return Err(
                 "Contested resource query failed: No contested index on dpns domains.".to_string(),
@@ -128,16 +128,21 @@ impl AppContext {
             let contested_resources_as_strings: Vec<String> = contested_resources
                 .0
                 .into_iter()
-                .map(|contested_resource| {
-                    contested_resource
-                        .0
-                        .as_str()
-                        .expect("expected str")
-                        .to_string()
+                .filter_map(|contested_resource| match contested_resource.0.as_str() {
+                    Some(s) => Some(s.to_string()),
+                    None => {
+                        tracing::warn!(
+                            "Contested resource value is not a string: {:?}",
+                            contested_resource.0
+                        );
+                        None
+                    }
                 })
                 .collect();
 
-            let last_found_name = contested_resources_as_strings.last().unwrap().clone();
+            let Some(last_found_name) = contested_resources_as_strings.last().cloned() else {
+                break;
+            };
 
             let new_names_to_be_updated = self
                 .db

--- a/src/backend_task/contested_names/query_dpns_contested_resources.rs
+++ b/src/backend_task/contested_names/query_dpns_contested_resources.rs
@@ -177,22 +177,32 @@ impl AppContext {
 
             tokio::spawn(async move {
                 // Acquire a permit from the semaphore
-                let _permit: OwnedSemaphorePermit = semaphore.acquire_owned().await.unwrap();
+                let _permit: OwnedSemaphorePermit = match semaphore.acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(e) => {
+                        tracing::error!("Semaphore closed while querying dpns end times: {}", e);
+                        return;
+                    }
+                };
 
                 match self_ref.query_dpns_ending_times(sdk, sender.clone()).await {
                     Ok(_) => {
                         // Send a refresh message if the query succeeded
-                        sender
-                            .send(TaskResult::Refresh)
-                            .await
-                            .expect("expected to send refresh");
+                        if let Err(e) = sender.send(TaskResult::Refresh).await {
+                            tracing::warn!(
+                                "Failed to send refresh after dpns end times query: {}",
+                                e
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::error!("Error querying dpns end times: {}", e);
-                        sender
-                            .send(TaskResult::Error(e))
-                            .await
-                            .expect("expected to send error");
+                        if let Err(send_err) = sender.send(TaskResult::Error(e)).await {
+                            tracing::warn!(
+                                "Failed to send error for dpns end times query: {}",
+                                send_err
+                            );
+                        }
                     }
                 }
             })
@@ -210,7 +220,17 @@ impl AppContext {
             // Spawn each task with a permit from the semaphore
             let handle = tokio::spawn(async move {
                 // Acquire a permit from the semaphore
-                let _permit: OwnedSemaphorePermit = semaphore.acquire_owned().await.unwrap();
+                let _permit: OwnedSemaphorePermit = match semaphore.acquire_owned().await {
+                    Ok(permit) => permit,
+                    Err(e) => {
+                        tracing::error!(
+                            "Semaphore closed while querying vote contenders for {}: {}",
+                            name,
+                            e
+                        );
+                        return;
+                    }
+                };
 
                 // Perform the query
                 match self_ref
@@ -219,17 +239,23 @@ impl AppContext {
                 {
                     Ok(_) => {
                         // Send a refresh message if the query succeeded
-                        sender
-                            .send(TaskResult::Refresh)
-                            .await
-                            .expect("expected to send refresh");
+                        if let Err(e) = sender.send(TaskResult::Refresh).await {
+                            tracing::warn!(
+                                "Failed to send refresh after vote contenders query for {}: {}",
+                                name,
+                                e
+                            );
+                        }
                     }
                     Err(e) => {
                         tracing::error!("Error querying dpns vote contenders for {}: {}", name, e);
-                        sender
-                            .send(TaskResult::Error(e))
-                            .await
-                            .expect("expected to send error");
+                        if let Err(send_err) = sender.send(TaskResult::Error(e)).await {
+                            tracing::warn!(
+                                "Failed to send error for vote contenders query for {}: {}",
+                                name,
+                                send_err
+                            );
+                        }
                     }
                 }
             });

--- a/src/backend_task/contested_names/query_dpns_vote_contenders.rs
+++ b/src/backend_task/contested_names/query_dpns_vote_contenders.rs
@@ -22,7 +22,7 @@ impl AppContext {
         let data_contract = self.dpns_contract.as_ref();
         let document_type = data_contract
             .document_type_for_name("domain")
-            .expect("expected document type");
+            .map_err(|_| "DPNS contract missing 'domain' document type".to_string())?;
         let Some(contested_index) = document_type.find_contested_index() else {
             return Err("No contested index on dpns domains".to_string());
         };

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -36,7 +36,7 @@ impl AppContext {
         let data_contract = self.dpns_contract.as_ref();
         let document_type = data_contract
             .document_type_for_name("domain")
-            .expect("expected document type");
+            .map_err(|_| "DPNS contract missing 'domain' document type".to_string())?;
 
         let Some(contested_index) = document_type.find_contested_index() else {
             return Err("Error voting: No contested index on dpns domains".to_string());

--- a/src/backend_task/contract.rs
+++ b/src/backend_task/contract.rs
@@ -100,9 +100,20 @@ impl AppContext {
 
                                 let mut token_infos = vec![];
                                 for token in contract.tokens() {
-                                    let token_configuration = contract
+                                    let token_configuration = match contract
                                         .expected_token_configuration(*token.0)
-                                        .expect("Expected to get token configuration");
+                                    {
+                                        Ok(config) => config,
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                "Skipping token at position {} in contract {}: {}",
+                                                token.0,
+                                                contract.id(),
+                                                e
+                                            );
+                                            continue;
+                                        }
+                                    };
                                     let token_name = {
                                         let TokenConfigurationConvention::V0(conventions) =
                                             &token_configuration.conventions();

--- a/src/backend_task/dashpay/contacts.rs
+++ b/src/backend_task/dashpay/contacts.rs
@@ -261,7 +261,9 @@ pub async fn load_contacts(
         for (_, outgoing_doc) in outgoing.iter() {
             if let Some(Value::Identifier(to_id_bytes)) = outgoing_doc.properties().get("toUserId")
             {
-                let to_id = Identifier::from_bytes(to_id_bytes.as_slice()).unwrap();
+                let Ok(to_id) = Identifier::from_bytes(to_id_bytes.as_slice()) else {
+                    continue;
+                };
                 if to_id == from_id {
                     // Mutual contact found
                     contacts.insert(from_id);
@@ -305,7 +307,13 @@ pub async fn load_contacts(
                 if let Some(Value::Bytes(enc_user_id)) = props.get("encToUserId")
                     && let Ok(decrypted_id) = decrypt_to_user_id(enc_user_id, &enc_user_id_key)
                 {
-                    let contact_id = Identifier::from_bytes(&decrypted_id).unwrap();
+                    let Ok(contact_id) = Identifier::from_bytes(&decrypted_id) else {
+                        tracing::warn!(
+                            "Failed to parse decrypted contact ID (length {}), skipping contact info entry",
+                            decrypted_id.len()
+                        );
+                        continue;
+                    };
 
                     // Decrypt private data if available
                     let mut nickname = None;

--- a/src/backend_task/dashpay/contacts.rs
+++ b/src/backend_task/dashpay/contacts.rs
@@ -262,6 +262,10 @@ pub async fn load_contacts(
             if let Some(Value::Identifier(to_id_bytes)) = outgoing_doc.properties().get("toUserId")
             {
                 let Ok(to_id) = Identifier::from_bytes(to_id_bytes.as_slice()) else {
+                    tracing::warn!(
+                        "Failed to parse contact request toUserId ({} bytes), skipping",
+                        to_id_bytes.len()
+                    );
                     continue;
                 };
                 if to_id == from_id {

--- a/src/backend_task/dashpay/payments.rs
+++ b/src/backend_task/dashpay/payments.rs
@@ -296,7 +296,7 @@ pub async fn send_payment_to_contact_impl(
             "{}_{}",
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_default()
                 .as_millis(),
             to_contact_id.to_string(Encoding::Base58)
         ),
@@ -309,7 +309,7 @@ pub async fn send_payment_to_contact_impl(
         memo: memo.clone(),
         timestamp: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs(),
         status: PaymentStatus::Broadcast,
         address_index,

--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -320,10 +320,11 @@ impl AppContext {
             Err(e) => return Err(format!("Error fetching identity: {}", e)),
         };
 
-        let identity = existing_identity.clone().unwrap_or_else(|| {
-            Identity::new_with_id_and_keys(identity_id, public_keys, sdk.version())
-                .expect("expected to make identity")
-        });
+        let identity = match existing_identity.clone() {
+            Some(id) => id,
+            None => Identity::new_with_id_and_keys(identity_id, public_keys, sdk.version())
+                .map_err(|e| format!("Failed to create identity: {}", e))?,
+        };
 
         let wallet_seed_hash = { wallet.read().unwrap().seed_hash() };
         let mut qualified_identity = QualifiedIdentity {
@@ -602,21 +603,24 @@ impl AppContext {
                                 );
                             }
 
-                            let identity_create_transition =
-                                IdentityCreateTransition::try_from_identity_with_signer(
-                                    identity,
-                                    asset_lock_proof,
-                                    asset_lock_proof_private_key.inner.as_ref(),
-                                    &qualified_identity,
-                                    &NativeBlsModule,
-                                    0,
-                                    self.platform_version(),
-                                )
-                                .expect("expected to make transition");
-                            format!(
-                                "error: {}, transaction is {:?}",
-                                e, identity_create_transition
-                            )
+                            match IdentityCreateTransition::try_from_identity_with_signer(
+                                identity,
+                                asset_lock_proof,
+                                asset_lock_proof_private_key.inner.as_ref(),
+                                &qualified_identity,
+                                &NativeBlsModule,
+                                0,
+                                self.platform_version(),
+                            ) {
+                                Ok(transition) => format!(
+                                    "error: {}, transaction is {:?}",
+                                    e, transition
+                                ),
+                                Err(transition_err) => format!(
+                                    "error: {}, also failed to recreate transition for debugging: {}",
+                                    e, transition_err
+                                ),
+                            }
                         })
                 } else {
                     Err(e.to_string())

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -422,20 +422,23 @@ impl AppContext {
                                 );
                             }
 
-                            let identity_create_transition =
-                                IdentityTopUpTransition::try_from_identity(
-                                    &qualified_identity.identity,
-                                    asset_lock_proof,
-                                    asset_lock_proof_private_key.inner.as_ref(),
-                                    0,
-                                    self.platform_version(),
-                                    None,
-                                )
-                                .expect("expected to make transition");
-                            format!(
-                                "error: {}, transaction is {:?}",
-                                e, identity_create_transition
-                            )
+                            match IdentityTopUpTransition::try_from_identity(
+                                &qualified_identity.identity,
+                                asset_lock_proof,
+                                asset_lock_proof_private_key.inner.as_ref(),
+                                0,
+                                self.platform_version(),
+                                None,
+                            ) {
+                                Ok(transition) => format!(
+                                    "error: {}, transaction is {:?}",
+                                    e, transition
+                                ),
+                                Err(transition_err) => format!(
+                                    "error: {}, also failed to recreate transition for debugging: {}",
+                                    e, transition_err
+                                ),
+                            }
                         })?
                 } else {
                     return Err(error_string);

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -28,7 +28,6 @@ use dash_sdk::query_types::{
     CurrentQuorumsInfo, NoParamQuery, ProtocolVersionUpgrades, TotalCreditsInPlatform,
 };
 use dash_sdk::query_types::AddressInfo;
-use itertools::Itertools;
 use std::sync::Arc;
 use chrono::{prelude::*, LocalResult};
 use chrono_humanize::{Accuracy, HumanTime, Tense};
@@ -203,60 +202,65 @@ fn format_withdrawal_documents_with_daily_limit(
     withdrawal_documents: &[Document],
     total_credits_on_platform: Credits,
     network: Network,
-) -> String {
+) -> Result<String, String> {
     let total_amount: Credits = withdrawal_documents
         .iter()
         .map(|document| {
             document
                 .properties()
                 .get_integer::<Credits>(AMOUNT)
-                .expect("expected amount on withdrawal")
+                .map_err(|e| format!("Failed to get withdrawal amount: {}", e))
         })
+        .collect::<Result<Vec<Credits>, String>>()?
+        .into_iter()
         .sum();
 
-    let amounts = withdrawal_documents
+    let amounts: Vec<String> = withdrawal_documents
         .iter()
         .map(|document| {
-            let index = document.created_at().expect("expected created at");
-            let utc_datetime =
-                DateTime::<Utc>::from_timestamp_millis(index as i64).expect("expected date time");
+            let index = document
+                .created_at()
+                .ok_or("Withdrawal document missing created_at timestamp")?;
+            let utc_datetime = DateTime::<Utc>::from_timestamp_millis(index as i64)
+                .ok_or("Invalid withdrawal created_at timestamp")?;
             let local_datetime: DateTime<Local> = utc_datetime.with_timezone(&Local);
 
             let amount = document
                 .properties()
                 .get_integer::<Credits>(AMOUNT)
-                .expect("expected amount on withdrawal");
-            let status: WithdrawalStatus = document
+                .map_err(|e| format!("Failed to get withdrawal amount: {}", e))?;
+            let status_u8: u8 = document
                 .properties()
                 .get_integer::<u8>(STATUS)
-                .expect("expected status on withdrawal")
+                .map_err(|e| format!("Failed to get withdrawal status: {}", e))?;
+            let status: WithdrawalStatus = status_u8
                 .try_into()
-                .expect("expected a withdrawal status");
+                .map_err(|_| format!("Invalid withdrawal status value: {}", status_u8))?;
             let owner_id = document.owner_id();
             let address_bytes = document
                 .properties()
                 .get_bytes(OUTPUT_SCRIPT)
-                .expect("expected output script");
+                .map_err(|e| format!("Failed to get withdrawal output script: {}", e))?;
             let output_script = ScriptBuf::from_bytes(address_bytes);
             let address = Address::from_script(&output_script, network)
                 .map(|addr| addr.to_string())
                 .unwrap_or_else(|e| format!("Invalid Address: {}", e));
-            format!(
+            Ok(format!(
                 "{}: {:.8} Dash for {} towards {} ({})",
                 local_datetime.format("%Y-%m-%d %H:%M:%S"),
                 amount as f64 / (dash_to_credits!(1) as f64),
                 owner_id,
                 address,
                 status,
-            )
+            ))
         })
-        .join("\n    ");
+        .collect::<Result<Vec<String>, String>>()?;
 
     let daily_withdrawal_limit =
         daily_withdrawal_limit(total_credits_on_platform, PlatformVersion::latest())
-            .expect("expected to get daily withdrawal limit");
+            .map_err(|e| format!("Failed to calculate daily withdrawal limit: {}", e))?;
 
-    format!(
+    Ok(format!(
         "Withdrawal Information:\n\n\
          Total Amount: {:.8} Dash\n\
          Daily Withdrawal Limit: {:.8} Dash\n\
@@ -265,68 +269,73 @@ fn format_withdrawal_documents_with_daily_limit(
         total_amount as f64 / (dash_to_credits!(1) as f64),
         daily_withdrawal_limit as f64 / (dash_to_credits!(1) as f64),
         daily_withdrawal_limit.saturating_sub(0) as f64 / (dash_to_credits!(1) as f64), // We don't have 24h amount
-        amounts
-    )
+        amounts.join("\n    ")
+    ))
 }
 
 fn format_withdrawal_documents_to_bare_info(
     withdrawal_documents: &[Document],
     network: Network,
-) -> String {
+) -> Result<String, String> {
     let total_amount: Credits = withdrawal_documents
         .iter()
         .map(|document| {
             document
                 .properties()
                 .get_integer::<Credits>(AMOUNT)
-                .expect("expected amount on withdrawal")
+                .map_err(|e| format!("Failed to get withdrawal amount: {}", e))
         })
+        .collect::<Result<Vec<Credits>, String>>()?
+        .into_iter()
         .sum();
 
-    let amounts = withdrawal_documents
+    let amounts: Vec<String> = withdrawal_documents
         .iter()
         .map(|document| {
-            let index = document.created_at().expect("expected created at");
-            let utc_datetime =
-                DateTime::<Utc>::from_timestamp_millis(index as i64).expect("expected date time");
+            let index = document
+                .created_at()
+                .ok_or("Withdrawal document missing created_at timestamp")?;
+            let utc_datetime = DateTime::<Utc>::from_timestamp_millis(index as i64)
+                .ok_or("Invalid withdrawal created_at timestamp")?;
             let local_datetime: DateTime<Local> = utc_datetime.with_timezone(&Local);
 
             let amount = document
                 .properties()
                 .get_integer::<Credits>(AMOUNT)
-                .expect("expected amount on withdrawal");
-            let status: WithdrawalStatus = document
+                .map_err(|e| format!("Failed to get withdrawal amount: {}", e))?;
+            let status_u8: u8 = document
                 .properties()
                 .get_integer::<u8>(STATUS)
-                .expect("expected status on withdrawal")
+                .map_err(|e| format!("Failed to get withdrawal status: {}", e))?;
+            let status: WithdrawalStatus = status_u8
                 .try_into()
-                .expect("expected a withdrawal status");
+                .map_err(|_| format!("Invalid withdrawal status value: {}", status_u8))?;
             let owner_id = document.owner_id();
             let address_bytes = document
                 .properties()
                 .get_bytes(OUTPUT_SCRIPT)
-                .expect("expected output script");
+                .map_err(|e| format!("Failed to get withdrawal output script: {}", e))?;
             let output_script = ScriptBuf::from_bytes(address_bytes);
-            let address =
-                Address::from_script(&output_script, network).expect("expected an address");
-            format!(
+            let address = Address::from_script(&output_script, network)
+                .map_err(|e| format!("Failed to parse withdrawal address: {}", e))?;
+            Ok(format!(
                 "{}: {:.8} Dash for {} towards {} ({})",
                 local_datetime.format("%Y-%m-%d %H:%M:%S"),
                 amount as f64 / (dash_to_credits!(1) as f64),
                 owner_id,
                 address,
                 status,
-            )
+            ))
         })
-        .join("\n    ");
+        .collect::<Result<Vec<String>, String>>()?;
 
-    format!(
+    Ok(format!(
         "Withdrawal Information:\n\n\
          Total Amount: {:.8} Dash\n\n\
          Recent Withdrawals:\n    {}",
         total_amount as f64 / (dash_to_credits!(1) as f64),
-        amounts
-    )
+        amounts.join("\n    ")
+    ))
 }
 
 impl AppContext {
@@ -446,7 +455,7 @@ impl AppContext {
                     SystemDataContract::Withdrawals,
                     PlatformVersion::latest(),
                 )
-                .expect("expected to get withdrawal contract");
+                .map_err(|e| format!("Failed to load withdrawal contract: {}", e))?;
 
                 // Try the simplest possible query first - no where clauses or ordering
                 let queued_document_query = DocumentQuery {
@@ -470,7 +479,7 @@ impl AppContext {
                                     &withdrawal_docs,
                                     total_credits.0,
                                     self.network,
-                                );
+                                )?;
                                 Ok(BackendTaskSuccessResult::PlatformInfo(
                                     PlatformInfoTaskResult::TextResult(formatted),
                                 ))
@@ -480,7 +489,7 @@ impl AppContext {
                                 let formatted = format_withdrawal_documents_to_bare_info(
                                     &withdrawal_docs,
                                     self.network,
-                                );
+                                )?;
                                 Ok(BackendTaskSuccessResult::PlatformInfo(
                                     PlatformInfoTaskResult::TextResult(formatted),
                                 ))
@@ -496,7 +505,7 @@ impl AppContext {
                     SystemDataContract::Withdrawals,
                     PlatformVersion::latest(),
                 )
-                .expect("expected to get withdrawal contract");
+                .map_err(|e| format!("Failed to load withdrawal contract: {}", e))?;
 
                 let completed_document_query = DocumentQuery {
                     data_contract: Arc::new(withdrawal_contract),
@@ -551,44 +560,63 @@ impl AppContext {
                                     document
                                         .properties()
                                         .get_integer::<Credits>(AMOUNT)
-                                        .expect("expected amount on withdrawal")
+                                        .map_err(|e| {
+                                            format!("Failed to get withdrawal amount: {}", e)
+                                        })
                                 })
+                                .collect::<Result<Vec<Credits>, String>>()?
+                                .into_iter()
                                 .sum();
 
-                            let amounts = withdrawal_docs
+                            let amounts: Vec<String> = withdrawal_docs
                                 .iter()
                                 .map(|document| {
-                                    let index = document.updated_at().expect("expected updated at");
+                                    let index = document.updated_at().ok_or(
+                                        "Withdrawal document missing updated_at timestamp",
+                                    )?;
                                     let utc_datetime =
                                         DateTime::<Utc>::from_timestamp_millis(index as i64)
-                                            .expect("expected date time");
+                                            .ok_or("Invalid withdrawal updated_at timestamp")?;
                                     let local_datetime: DateTime<Local> =
                                         utc_datetime.with_timezone(&Local);
 
                                     let amount = document
                                         .properties()
                                         .get_integer::<Credits>(AMOUNT)
-                                        .expect("expected amount on withdrawal");
-                                    let status: WithdrawalStatus = document
-                                        .properties()
-                                        .get_integer::<u8>(STATUS)
-                                        .expect("expected status on withdrawal")
-                                        .try_into()
-                                        .expect("expected a withdrawal status");
+                                        .map_err(|e| {
+                                            format!("Failed to get withdrawal amount: {}", e)
+                                        })?;
+                                    let status_u8: u8 =
+                                        document.properties().get_integer::<u8>(STATUS).map_err(
+                                            |e| format!("Failed to get withdrawal status: {}", e),
+                                        )?;
+                                    let status: WithdrawalStatus =
+                                        status_u8.try_into().map_err(|_| {
+                                            format!(
+                                                "Invalid withdrawal status value: {}",
+                                                status_u8
+                                            )
+                                        })?;
                                     let owner_id = document.owner_id();
                                     let address_bytes = document
                                         .properties()
                                         .get_bytes(OUTPUT_SCRIPT)
-                                        .expect("expected output script");
+                                        .map_err(|e| {
+                                            format!("Failed to get withdrawal output script: {}", e)
+                                        })?;
                                     let transaction_index = document
                                         .properties()
                                         .get_integer::<u64>(TRANSACTION_INDEX)
-                                        .expect("expected transaction index");
+                                        .map_err(|e| {
+                                            format!("Failed to get transaction index: {}", e)
+                                        })?;
                                     let output_script = ScriptBuf::from_bytes(address_bytes);
                                     let address =
                                         Address::from_script(&output_script, self.network)
-                                            .expect("expected an address");
-                                    format!(
+                                            .map_err(|e| {
+                                                format!("Failed to parse withdrawal address: {}", e)
+                                            })?;
+                                    Ok(format!(
                                         "TX #{}: {:.8} Dash for {} to {} ({}) at {}",
                                         transaction_index,
                                         amount as f64 / (dash_to_credits!(1) as f64),
@@ -596,9 +624,9 @@ impl AppContext {
                                         address,
                                         status,
                                         local_datetime.format("%Y-%m-%d %H:%M:%S"),
-                                    )
+                                    ))
                                 })
-                                .join("\n    ");
+                                .collect::<Result<Vec<String>, String>>()?;
 
                             let formatted = format!(
                                 "Recently Completed Withdrawals:\n\n\
@@ -607,7 +635,7 @@ impl AppContext {
                                  Recent Transactions:\n    {}",
                                 total_amount as f64 / (dash_to_credits!(1) as f64),
                                 withdrawal_docs.len(),
-                                amounts
+                                amounts.join("\n    ")
                             );
 
                             Ok(BackendTaskSuccessResult::PlatformInfo(

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -268,7 +268,7 @@ fn format_withdrawal_documents_with_daily_limit(
          Recent Withdrawals:\n    {}",
         total_amount as f64 / (dash_to_credits!(1) as f64),
         daily_withdrawal_limit as f64 / (dash_to_credits!(1) as f64),
-        daily_withdrawal_limit.saturating_sub(0) as f64 / (dash_to_credits!(1) as f64), // We don't have 24h amount
+        daily_withdrawal_limit as f64 / (dash_to_credits!(1) as f64), // TODO: subtract actual 24h withdrawal amount when available
         amounts.join("\n    ")
     ))
 }

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -612,9 +612,10 @@ impl AppContext {
                                             format!("Failed to get transaction index: {}", e)
                                         })?;
                                     let output_script = ScriptBuf::from_bytes(address_bytes);
-                                    let address = Address::from_script(&output_script, self.network)
-                                        .map(|addr| addr.to_string())
-                                        .unwrap_or_else(|e| format!("Invalid Address: {}", e));
+                                    let address =
+                                        Address::from_script(&output_script, self.network)
+                                            .map(|addr| addr.to_string())
+                                            .unwrap_or_else(|e| format!("Invalid Address: {}", e));
                                     Ok(format!(
                                         "TX #{}: {:.8} Dash for {} to {} ({}) at {}",
                                         transaction_index,

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -612,11 +612,9 @@ impl AppContext {
                                             format!("Failed to get transaction index: {}", e)
                                         })?;
                                     let output_script = ScriptBuf::from_bytes(address_bytes);
-                                    let address =
-                                        Address::from_script(&output_script, self.network)
-                                            .map_err(|e| {
-                                                format!("Failed to parse withdrawal address: {}", e)
-                                            })?;
+                                    let address = Address::from_script(&output_script, self.network)
+                                        .map(|addr| addr.to_string())
+                                        .unwrap_or_else(|e| format!("Invalid Address: {}", e));
                                     Ok(format!(
                                         "TX #{}: {:.8} Dash for {} to {} ({}) at {}",
                                         transaction_index,

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -317,7 +317,8 @@ fn format_withdrawal_documents_to_bare_info(
                 .map_err(|e| format!("Failed to get withdrawal output script: {}", e))?;
             let output_script = ScriptBuf::from_bytes(address_bytes);
             let address = Address::from_script(&output_script, network)
-                .map_err(|e| format!("Failed to parse withdrawal address: {}", e))?;
+                .map(|addr| addr.to_string())
+                .unwrap_or_else(|e| format!("Invalid Address: {}", e));
             Ok(format!(
                 "{}: {:.8} Dash for {} towards {} ({})",
                 local_datetime.format("%Y-%m-%d %H:%M:%S"),

--- a/src/components/core_p2p_handler.rs
+++ b/src/components/core_p2p_handler.rs
@@ -51,7 +51,7 @@ impl CoreP2PHandler {
             Network::Testnet => 19999, // Dash Testnet default
             Network::Devnet => 29999,  // Dash Devnet default
             Network::Regtest => 29999, // Dash Regtest default
-            _ => panic!("Unsupported network type"),
+            _ => return Err(format!("Unsupported network type: {:?}", network)),
         });
         let stream = TcpStream::connect_timeout(
             &format!("127.0.0.1:{}", port)

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,8 +302,13 @@ impl NetworkConfig {
     }
 
     /// List of DAPI addresses
-    pub fn dapi_address_list(&self) -> AddressList {
-        AddressList::from_str(&self.dapi_addresses).expect("Could not parse DAPI addresses")
+    pub fn dapi_address_list(&self) -> Result<AddressList, String> {
+        AddressList::from_str(&self.dapi_addresses).map_err(|e| {
+            format!(
+                "Could not parse DAPI addresses '{}': {}",
+                self.dapi_addresses, e
+            )
+        })
     }
 
     /// Update just the `core_rpc_password` in a builder-like manner.
@@ -371,7 +376,7 @@ mod tests {
     #[test]
     fn test_dapi_address_list_single_address() {
         let config = make_network_config("https://127.0.0.1:443", 9998);
-        let list = config.dapi_address_list();
+        let list = config.dapi_address_list().unwrap();
         assert_eq!(list.len(), 1);
     }
 
@@ -381,17 +386,21 @@ mod tests {
             "https://127.0.0.1:443,https://192.168.1.1:443,https://10.0.0.1:443",
             9998,
         );
-        let list = config.dapi_address_list();
+        let list = config.dapi_address_list().unwrap();
         assert_eq!(list.len(), 3);
     }
 
     #[test]
-    #[should_panic(expected = "Could not parse DAPI addresses")]
-    fn test_dapi_address_list_empty_panics() {
+    fn test_dapi_address_list_empty_returns_error() {
         let config = make_network_config("", 9998);
-        let _list = config.dapi_address_list();
+        let result = config.dapi_address_list();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Could not parse DAPI addresses")
+        );
     }
-
     // ── NetworkConfig::update_core_rpc_password ─────────────────────
 
     #[test]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -121,74 +121,136 @@ impl AppContext {
         let (sx_zmq_status, rx_zmq_status) = crossbeam_channel::unbounded();
 
         // Create both providers; bind to app context later (post construction) due to circularity
-        let spv_provider =
-            SpvProvider::new(db.clone(), network).expect("Failed to initialize SPV provider");
-        let rpc_provider = RpcProvider::new(db.clone(), network, &network_config)
-            .expect("Failed to initialize RPC provider");
+        let spv_provider = match SpvProvider::new(db.clone(), network) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(?network, "Failed to initialize SPV provider: {e}");
+                return None;
+            }
+        };
+        let rpc_provider = match RpcProvider::new(db.clone(), network, &network_config) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(?network, "Failed to initialize RPC provider: {e}");
+                return None;
+            }
+        };
 
         // Default to SPV provider initially; UI can switch backend after
-        let sdk = initialize_sdk(&network_config, network, spv_provider.clone());
+        let sdk = match initialize_sdk(&network_config, network, spv_provider.clone()) {
+            Ok(sdk) => sdk,
+            Err(e) => {
+                tracing::error!("Failed to initialize SDK: {e}");
+                return None;
+            }
+        };
         let platform_version = sdk.version();
 
-        let dpns_contract = load_system_data_contract(SystemDataContract::DPNS, platform_version)
-            .expect("expected to load dpns contract");
+        let dpns_contract =
+            match load_system_data_contract(SystemDataContract::DPNS, platform_version) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(?network, "Failed to load DPNS contract: {e}");
+                    return None;
+                }
+            };
 
         let withdrawal_contract =
-            load_system_data_contract(SystemDataContract::Withdrawals, platform_version)
-                .expect("expected to get withdrawal contract");
+            match load_system_data_contract(SystemDataContract::Withdrawals, platform_version) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(?network, "Failed to load Withdrawals contract: {e}");
+                    return None;
+                }
+            };
 
         let token_history_contract =
-            load_system_data_contract(SystemDataContract::TokenHistory, platform_version)
-                .expect("expected to get token history contract");
+            match load_system_data_contract(SystemDataContract::TokenHistory, platform_version) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(?network, "Failed to load TokenHistory contract: {e}");
+                    return None;
+                }
+            };
 
         let keyword_search_contract =
-            load_system_data_contract(SystemDataContract::KeywordSearch, platform_version)
-                .expect("expected to get keyword search contract");
+            match load_system_data_contract(SystemDataContract::KeywordSearch, platform_version) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(?network, "Failed to load KeywordSearch contract: {e}");
+                    return None;
+                }
+            };
 
         let dashpay_contract =
-            load_system_data_contract(SystemDataContract::Dashpay, platform_version)
-                .expect("expected to get dashpay contract");
+            match load_system_data_contract(SystemDataContract::Dashpay, platform_version) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::error!(?network, "Failed to load Dashpay contract: {e}");
+                    return None;
+                }
+            };
 
         let addr = format!(
             "http://{}:{}",
             network_config.core_host, network_config.core_rpc_port
         );
-        let cookie_path = core_cookie_path(network, &network_config.devnet_name)
-            .expect("expected to get cookie path");
+        let cookie_path = match core_cookie_path(network, &network_config.devnet_name) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(?network, "Failed to get core cookie path: {e}");
+                return None;
+            }
+        };
 
-        // Try cookie authentication first
+        // Try cookie authentication first, then user/password
         let core_client = match Client::new(&addr, Auth::CookieFile(cookie_path.clone())) {
-            Ok(client) => Ok(client),
+            Ok(client) => client,
             Err(_) => {
-                // If cookie auth fails, try user/password authentication
                 tracing::info!(
                     "Failed to authenticate using .cookie file at {:?}, falling back to user/pass",
                     cookie_path,
                 );
-                Client::new(
+                match Client::new(
                     &addr,
                     Auth::UserPass(
                         network_config.core_rpc_user.to_string(),
                         network_config.core_rpc_password.to_string(),
                     ),
-                )
+                ) {
+                    Ok(client) => client,
+                    Err(e) => {
+                        tracing::error!(?network, "Failed to create CoreClient: {e}");
+                        return None;
+                    }
+                }
+            }
+        };
+
+        let wallets: BTreeMap<_, _> = match db.get_wallets(&network) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!(?network, "Failed to load wallets from database: {e}");
+                return None;
             }
         }
-        .expect("Failed to create CoreClient");
+        .into_iter()
+        .map(|w| (w.seed_hash(), Arc::new(RwLock::new(w))))
+        .collect();
 
-        let wallets: BTreeMap<_, _> = db
-            .get_wallets(&network)
-            .expect("expected to get wallets")
-            .into_iter()
-            .map(|w| (w.seed_hash(), Arc::new(RwLock::new(w))))
-            .collect();
-
-        let single_key_wallets: BTreeMap<_, _> = db
-            .get_single_key_wallets(network)
-            .expect("expected to get single key wallets")
-            .into_iter()
-            .map(|w| (w.key_hash(), Arc::new(RwLock::new(w))))
-            .collect();
+        let single_key_wallets: BTreeMap<_, _> = match db.get_single_key_wallets(network) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!(
+                    ?network,
+                    "Failed to load single key wallets from database: {e}"
+                );
+                return None;
+            }
+        }
+        .into_iter()
+        .map(|w| (w.key_hash(), Arc::new(RwLock::new(w))))
+        .collect();
 
         let developer_mode_enabled = config.developer_mode.unwrap_or(false);
 
@@ -459,7 +521,7 @@ impl AppContext {
                     .read()
                     .map_err(|_| "SPV provider lock poisoned".to_string())?
                     .clone();
-                initialize_sdk(&cfg, self.network, provider)
+                initialize_sdk(&cfg, self.network, provider)?
             }
             CoreBackendMode::Rpc => {
                 // Create a fresh RPC provider with the new config
@@ -473,7 +535,7 @@ impl AppContext {
                         .map_err(|_| "RPC provider lock poisoned".to_string())?;
                     *guard = rpc_provider.clone();
                 }
-                initialize_sdk(&cfg, self.network, rpc_provider)
+                initialize_sdk(&cfg, self.network, rpc_provider)?
             }
         };
 
@@ -518,6 +580,6 @@ pub(crate) const fn default_platform_version(network: &Network) -> &'static Plat
         Network::Testnet => &PLATFORM_V11,
         Network::Devnet => &PLATFORM_V11,
         Network::Regtest => &PLATFORM_V11,
-        _ => panic!("unsupported network"),
+        _ => &PLATFORM_V11,
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -580,6 +580,6 @@ pub(crate) const fn default_platform_version(network: &Network) -> &'static Plat
         Network::Testnet => &PLATFORM_V11,
         Network::Devnet => &PLATFORM_V11,
         Network::Regtest => &PLATFORM_V11,
-        _ => &PLATFORM_V11,
+        _ => panic!("Unsupported network for default_platform_version"),
     }
 }

--- a/src/context/transaction_processing.rs
+++ b/src/context/transaction_processing.rs
@@ -240,13 +240,18 @@ impl AppContext {
                     self.network,
                 )?;
 
-                let first = payload
-                    .credit_outputs
-                    .first()
-                    .expect("Expected at least one credit output");
+                let first = payload.credit_outputs.first().ok_or_else(|| {
+                    rusqlite::Error::InvalidParameterName(
+                        "Asset lock transaction has no credit outputs".to_string(),
+                    )
+                })?;
 
-                let address = Address::from_script(&first.script_pubkey, self.network)
-                    .expect("expected an address");
+                let address =
+                    Address::from_script(&first.script_pubkey, self.network).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Failed to derive address from asset lock credit output script: {e}"
+                        ))
+                    })?;
 
                 // Add the asset lock to the wallet's unused_asset_locks
                 wallet

--- a/src/database/contacts.rs
+++ b/src/database/contacts.rs
@@ -73,9 +73,9 @@ impl crate::database::Database {
             ],
             |row| {
                 Ok((
-                    row.get::<_, String>(0).unwrap_or_default(),
-                    row.get::<_, String>(1).unwrap_or_default(),
-                    row.get::<_, i32>(2).unwrap_or(0) != 0,
+                    row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+                    row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                    row.get::<_, Option<i32>>(2)?.unwrap_or(0) != 0,
                 ))
             },
         );

--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -356,12 +356,21 @@ impl Database {
         match result {
             Ok((locked_votes, abstain_votes, awarded_to, ending_time)) => {
                 // Compare the current values with the new values
+                let db_awarded_to = awarded_to
+                    .as_ref()
+                    .map(|id| {
+                        Identifier::from_bytes(id).map_err(|e| {
+                            rusqlite::Error::InvalidParameterName(format!(
+                                "Invalid awarded_to identifier ({} bytes): {}",
+                                id.len(),
+                                e
+                            ))
+                        })
+                    })
+                    .transpose()?;
                 let should_update = locked_votes != contested_name.locked_votes
                     || abstain_votes != contested_name.abstain_votes
-                    || awarded_to
-                        .as_ref()
-                        .and_then(|id| Identifier::from_bytes(id).ok())
-                        != contested_name.awarded_to
+                    || db_awarded_to != contested_name.awarded_to
                     || ending_time != contested_name.end_time;
 
                 if should_update {

--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -74,7 +74,16 @@ impl Database {
 
             // Convert `awarded_to` to `Identifier` if it exists
             let awarded_to_id = awarded_to
-                .map(|id| Identifier::from_bytes(&id).expect("Expected 32 bytes for awarded_to"));
+                .map(|id| {
+                    Identifier::from_bytes(&id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid awarded_to identifier ({} bytes): {}",
+                            id.len(),
+                            e
+                        ))
+                    })
+                })
+                .transpose()?;
 
             let state = if locked {
                 ContestState::Locked
@@ -82,7 +91,10 @@ impl Database {
                 ContestState::WonBy(awarded_to_id)
             } else if let Some(created_at) = created_at {
                 let elapsed_time = Duration::from_millis(
-                    (std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64)
+                    (std::time::UNIX_EPOCH
+                        .elapsed()
+                        .unwrap_or_default()
+                        .as_millis() as u64)
                         .saturating_sub(created_at),
                 );
 
@@ -115,16 +127,26 @@ impl Database {
                 (identity_id, contestant_name, votes, document_id)
             {
                 let contestant = Contestant {
-                    id: Identifier::from_bytes(&identity_id)
-                        .expect("Expected 32 bytes for identity_id"),
+                    id: Identifier::from_bytes(&identity_id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid identity_id identifier ({} bytes): {}",
+                            identity_id.len(),
+                            e
+                        ))
+                    })?,
                     name: contestant_name,
                     info: identity_info.unwrap_or_default(),
                     votes,
                     created_at,
                     created_at_block_height,
                     created_at_core_block_height,
-                    document_id: Identifier::from_bytes(&document_id)
-                        .expect("Expected 32 bytes for document_id"),
+                    document_id: Identifier::from_bytes(&document_id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid document_id identifier ({} bytes): {}",
+                            document_id.len(),
+                            e
+                        ))
+                    })?,
                 };
 
                 // Add the contestant to the contestants list
@@ -155,7 +177,10 @@ impl Database {
         } else {
             Duration::from_secs(60 * 90)
         };
-        let current_timestamp = std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64;
+        let current_timestamp = std::time::UNIX_EPOCH
+            .elapsed()
+            .unwrap_or_default()
+            .as_millis() as u64;
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT
@@ -208,7 +233,16 @@ impl Database {
 
             // Convert `awarded_to` to `Identifier` if it exists
             let awarded_to_id = awarded_to
-                .map(|id| Identifier::from_bytes(&id).expect("Expected 32 bytes for awarded_to"));
+                .map(|id| {
+                    Identifier::from_bytes(&id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid awarded_to identifier ({} bytes): {}",
+                            id.len(),
+                            e
+                        ))
+                    })
+                })
+                .transpose()?;
 
             let state = if locked {
                 ContestState::Locked
@@ -216,7 +250,10 @@ impl Database {
                 ContestState::WonBy(awarded_to_id)
             } else if let Some(created_at) = created_at {
                 let elapsed_time = Duration::from_millis(
-                    (std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64)
+                    (std::time::UNIX_EPOCH
+                        .elapsed()
+                        .unwrap_or_default()
+                        .as_millis() as u64)
                         .saturating_sub(created_at),
                 );
 
@@ -249,16 +286,26 @@ impl Database {
                 (identity_id, contestant_name, votes, document_id)
             {
                 let contestant = Contestant {
-                    id: Identifier::from_bytes(&identity_id)
-                        .expect("Expected 32 bytes for identity_id"),
+                    id: Identifier::from_bytes(&identity_id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid identity_id identifier ({} bytes): {}",
+                            identity_id.len(),
+                            e
+                        ))
+                    })?,
                     name: contestant_name,
                     info: identity_info.unwrap_or_default(),
                     votes,
                     created_at,
                     created_at_block_height,
                     created_at_core_block_height,
-                    document_id: Identifier::from_bytes(&document_id)
-                        .expect("Expected 32 bytes for document_id"),
+                    document_id: Identifier::from_bytes(&document_id).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid document_id identifier ({} bytes): {}",
+                            document_id.len(),
+                            e
+                        ))
+                    })?,
                 };
 
                 // Add the contestant to the contestants list
@@ -311,9 +358,10 @@ impl Database {
                 // Compare the current values with the new values
                 let should_update = locked_votes != contested_name.locked_votes
                     || abstain_votes != contested_name.abstain_votes
-                    || awarded_to.as_ref().map(|id| {
-                        Identifier::from_bytes(id).expect("expected 32 bytes for awarded to")
-                    }) != contested_name.awarded_to
+                    || awarded_to
+                        .as_ref()
+                        .and_then(|id| Identifier::from_bytes(id).ok())
+                        != contested_name.awarded_to
                     || ending_time != contested_name.end_time;
 
                 if should_update {

--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -76,11 +76,12 @@ impl Database {
             let awarded_to_id = awarded_to
                 .map(|id| {
                     Identifier::from_bytes(&id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid awarded_to identifier ({} bytes): {}",
-                            id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            3,
+                            rusqlite::types::Type::Blob,
+                            format!("Invalid awarded_to identifier ({} bytes): {}", id.len(), e)
+                                .into(),
+                        )
                     })
                 })
                 .transpose()?;
@@ -128,11 +129,16 @@ impl Database {
             {
                 let contestant = Contestant {
                     id: Identifier::from_bytes(&identity_id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid identity_id identifier ({} bytes): {}",
-                            identity_id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            7,
+                            rusqlite::types::Type::Blob,
+                            format!(
+                                "Invalid identity_id identifier ({} bytes): {}",
+                                identity_id.len(),
+                                e
+                            )
+                            .into(),
+                        )
                     })?,
                     name: contestant_name,
                     info: identity_info.unwrap_or_default(),
@@ -141,11 +147,16 @@ impl Database {
                     created_at_block_height,
                     created_at_core_block_height,
                     document_id: Identifier::from_bytes(&document_id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid document_id identifier ({} bytes): {}",
-                            document_id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            13,
+                            rusqlite::types::Type::Blob,
+                            format!(
+                                "Invalid document_id identifier ({} bytes): {}",
+                                document_id.len(),
+                                e
+                            )
+                            .into(),
+                        )
                     })?,
                 };
 
@@ -235,11 +246,12 @@ impl Database {
             let awarded_to_id = awarded_to
                 .map(|id| {
                     Identifier::from_bytes(&id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid awarded_to identifier ({} bytes): {}",
-                            id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            3,
+                            rusqlite::types::Type::Blob,
+                            format!("Invalid awarded_to identifier ({} bytes): {}", id.len(), e)
+                                .into(),
+                        )
                     })
                 })
                 .transpose()?;
@@ -287,11 +299,16 @@ impl Database {
             {
                 let contestant = Contestant {
                     id: Identifier::from_bytes(&identity_id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid identity_id identifier ({} bytes): {}",
-                            identity_id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            7,
+                            rusqlite::types::Type::Blob,
+                            format!(
+                                "Invalid identity_id identifier ({} bytes): {}",
+                                identity_id.len(),
+                                e
+                            )
+                            .into(),
+                        )
                     })?,
                     name: contestant_name,
                     info: identity_info.unwrap_or_default(),
@@ -300,11 +317,16 @@ impl Database {
                     created_at_block_height,
                     created_at_core_block_height,
                     document_id: Identifier::from_bytes(&document_id).map_err(|e| {
-                        rusqlite::Error::InvalidParameterName(format!(
-                            "Invalid document_id identifier ({} bytes): {}",
-                            document_id.len(),
-                            e
-                        ))
+                        rusqlite::Error::FromSqlConversionFailure(
+                            13,
+                            rusqlite::types::Type::Blob,
+                            format!(
+                                "Invalid document_id identifier ({} bytes): {}",
+                                document_id.len(),
+                                e
+                            )
+                            .into(),
+                        )
                     })?,
                 };
 
@@ -360,11 +382,16 @@ impl Database {
                     .as_ref()
                     .map(|id| {
                         Identifier::from_bytes(id).map_err(|e| {
-                            rusqlite::Error::InvalidParameterName(format!(
-                                "Invalid awarded_to identifier ({} bytes): {}",
-                                id.len(),
-                                e
-                            ))
+                            rusqlite::Error::FromSqlConversionFailure(
+                                2,
+                                rusqlite::types::Type::Blob,
+                                format!(
+                                    "Invalid awarded_to identifier ({} bytes): {}",
+                                    id.len(),
+                                    e
+                                )
+                                .into(),
+                            )
                         })
                     })
                     .transpose()?;

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -37,11 +37,11 @@ impl Database {
             if current_version != DEFAULT_DB_VERSION {
                 self.backup_db(db_file_path)?;
                 if let Err(e) = self.try_perform_migration(current_version, DEFAULT_DB_VERSION) {
-                    let version_after_migration = self.db_schema_version()?;
-                    panic!(
-                        "Database migration from version {} to {} failed, database is at version {}. Error: {:?}",
+                    let version_after_migration = self.db_schema_version().unwrap_or(0);
+                    return Err(rusqlite::Error::InvalidParameterName(format!(
+                        "Database migration from version {} to {} failed (database is at version {}): {}",
                         current_version, DEFAULT_DB_VERSION, version_after_migration, e
-                    );
+                    )));
                 }
             }
         }

--- a/src/database/scheduled_votes.rs
+++ b/src/database/scheduled_votes.rs
@@ -156,13 +156,14 @@ impl Database {
             let contested_name: String = row.get(1)?;
             let vote_choice_string: String = row.get(2)?;
             let time: u64 = row.get(3)?;
-            let executed_successfully: bool = match row.get(4)? {
+            let executed_successfully: bool = match row.get::<_, i64>(4)? {
                 0 => false,
                 1 => true,
                 other => {
                     tracing::warn!(
-                        "Unexpected value {} for executed column in scheduled_votes, defaulting to false",
-                        other
+                        "Unexpected 'executed' value {} for scheduled vote '{}', treating as not executed",
+                        other,
+                        contested_name
                     );
                     false
                 }

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -448,9 +448,7 @@ impl Database {
                 })?;
 
             let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
-                rusqlite::Error::InvalidParameterName(
-                    "Seed hash should be 32 bytes".to_string(),
-                )
+                rusqlite::Error::InvalidParameterName("Seed hash should be 32 bytes".to_string())
             })?;
             let closed_wallet_seed = ClosedKeyItem {
                 seed_hash: seed_hash_array,
@@ -808,9 +806,7 @@ impl Database {
             let raw_transaction: Vec<u8> = row.get(9)?;
 
             let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
-                rusqlite::Error::InvalidParameterName(
-                    "Seed hash should be 32 bytes".to_string(),
-                )
+                rusqlite::Error::InvalidParameterName("Seed hash should be 32 bytes".to_string())
             })?;
             let txid = Txid::from_slice(&txid_bytes).map_err(|e| {
                 rusqlite::Error::InvalidParameterName(format!("Invalid transaction txid: {}", e))
@@ -922,9 +918,7 @@ impl Database {
             let nonce: i64 = row.get(3)?;
             let last_full_sync_balance: Option<i64> = row.get(4)?;
             let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
-                rusqlite::Error::InvalidParameterName(
-                    "Seed hash should be 32 bytes".to_string(),
-                )
+                rusqlite::Error::InvalidParameterName("Seed hash should be 32 bytes".to_string())
             })?;
             Ok((
                 seed_hash_array,

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -685,30 +685,49 @@ impl Database {
             let islock_data: Option<Vec<u8>> = row.get(3)?;
             let chain_locked_height: Option<CoreBlockHeight> = row.get(4)?;
 
-            let wallet_seed_hash_array: [u8; 32] =
-                wallet_seed.try_into().expect("Seed should be 64 bytes");
-            let tx: Transaction = deserialize(&tx_data).expect("Failed to deserialize transaction");
+            let wallet_seed_hash_array: [u8; 32] = wallet_seed.try_into().map_err(|_| {
+                rusqlite::Error::InvalidParameterName("Wallet seed should be 32 bytes".to_string())
+            })?;
+            let tx: Transaction = deserialize(&tx_data).map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!(
+                    "Failed to deserialize asset lock transaction: {}",
+                    e
+                ))
+            })?;
 
             // Ensure the transaction payload is AssetLockPayloadType
             let Some(TransactionPayload::AssetLockPayloadType(payload)) =
                 &tx.special_transaction_payload
             else {
-                panic!("Expected AssetLockPayloadType in special_transaction_payload");
+                return Err(rusqlite::Error::InvalidParameterName(
+                    "Expected AssetLockPayloadType in special_transaction_payload".to_string(),
+                ));
             };
 
             // Get the first credit output
-            let first = payload
-                .credit_outputs
-                .first()
-                .expect("Expected at least one credit output");
+            let first =
+                payload
+                    .credit_outputs
+                    .first()
+                    .ok_or(rusqlite::Error::InvalidParameterName(
+                        "Expected at least one credit output in asset lock".to_string(),
+                    ))?;
 
-            let address =
-                Address::from_script(&first.script_pubkey, *network).expect("expected an address");
+            let address = Address::from_script(&first.script_pubkey, *network).map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!(
+                    "Failed to derive address from credit output: {}",
+                    e
+                ))
+            })?;
 
             let (islock, proof) = if let Some(islock_bytes) = islock_data {
                 // Deserialize the InstantLock
-                let is_lock: InstantLock =
-                    deserialize(&islock_bytes).expect("Failed to deserialize InstantLock");
+                let is_lock: InstantLock = deserialize(&islock_bytes).map_err(|e| {
+                    rusqlite::Error::InvalidParameterName(format!(
+                        "Failed to deserialize InstantLock: {}",
+                        e
+                    ))
+                })?;
                 (
                     Some(is_lock.clone()),
                     Some(AssetLockProof::Instant(InstantAssetLockProof::new(

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -140,8 +140,7 @@ impl Database {
     ) -> rusqlite::Result<()> {
         let conn = self.conn.lock().unwrap();
 
-        let address = check_address_for_network(address.as_unchecked().clone(), network)
-            .expect("Expected address to be valid for network");
+        let address = check_address_for_network(address.as_unchecked().clone(), network)?;
 
         // Step 1: Check if the address already exists for the given seed.
         let mut stmt = conn.prepare(
@@ -441,8 +440,12 @@ impl Database {
 
             // Reconstruct the extended public keys
             let master_ecdsa_extended_public_key =
-                ExtendedPubKey::decode(&master_ecdsa_bip44_account_0_epk_bytes)
-                    .expect("Failed to decode ExtendedPubKey");
+                ExtendedPubKey::decode(&master_ecdsa_bip44_account_0_epk_bytes).map_err(|e| {
+                    rusqlite::Error::InvalidParameterName(format!(
+                        "Failed to decode ExtendedPubKey: {}",
+                        e
+                    ))
+                })?;
 
             let seed_hash_array: [u8; 32] =
                 seed_hash.try_into().expect("Seed hash should be 32 bytes");
@@ -457,9 +460,11 @@ impl Database {
                 WalletSeed::Closed(closed_wallet_seed)
             } else {
                 WalletSeed::Open(OpenWalletSeed {
-                    seed: encrypted_seed
-                        .try_into()
-                        .expect("expected to decrypt seed with no password"),
+                    seed: encrypted_seed.try_into().map_err(|_| {
+                        rusqlite::Error::InvalidParameterName(
+                            "Seed should be 64 bytes for open wallet".to_string(),
+                        )
+                    })?,
                     wallet_info: closed_wallet_seed,
                 })
             };
@@ -553,12 +558,21 @@ impl Database {
             } else {
                 // Standard Core addresses - validate network
                 let address_unchecked =
-                    Address::from_str(&address_str).expect("Invalid address format");
+                    Address::from_str(&address_str).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!(
+                            "Invalid address format '{}': {}",
+                            address_str, e
+                        ))
+                    })?;
                 check_address_for_network(address_unchecked, network)?
             };
 
-            let derivation_path = DerivationPath::from_str(&derivation_path)
-                .expect("Expected to convert to derivation path");
+            let derivation_path = DerivationPath::from_str(&derivation_path).map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!(
+                    "Invalid derivation path '{}': {}",
+                    derivation_path, e
+                ))
+            })?;
 
             let path_type = DerivationPathType::from_bits_truncate(path_type);
 
@@ -645,11 +659,18 @@ impl Database {
             let script_pubkey: Vec<u8> = row.get(4)?;
 
             let address = Address::from_str(&address)
-                .expect("Invalid address format")
+                .map_err(|e| {
+                    rusqlite::Error::InvalidParameterName(format!(
+                        "Invalid UTXO address format '{}': {}",
+                        address, e
+                    ))
+                })?
                 .assume_checked();
 
             let outpoint = OutPoint {
-                txid: Txid::from_slice(&txid).expect("Invalid txid"),
+                txid: Txid::from_slice(&txid).map_err(|e| {
+                    rusqlite::Error::InvalidParameterName(format!("Invalid UTXO txid: {}", e))
+                })?,
                 vout: vout as u32,
             };
             let tx_out = TxOut {
@@ -782,12 +803,23 @@ impl Database {
 
             let seed_hash_array: [u8; 32] =
                 seed_hash.try_into().expect("Seed hash should be 32 bytes");
-            let txid = Txid::from_slice(&txid_bytes).expect("Invalid txid bytes");
-            let transaction: Transaction =
-                deserialize(&raw_transaction).expect("Failed to deserialize transaction");
+            let txid = Txid::from_slice(&txid_bytes).map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!("Invalid transaction txid: {}", e))
+            })?;
+            let transaction: Transaction = deserialize(&raw_transaction).map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!(
+                    "Failed to deserialize transaction: {}",
+                    e
+                ))
+            })?;
             let block_hash = block_hash_bytes
                 .as_ref()
-                .map(|bytes| BlockHash::from_slice(bytes).expect("Invalid block hash"));
+                .map(|bytes| {
+                    BlockHash::from_slice(bytes).map_err(|e| {
+                        rusqlite::Error::InvalidParameterName(format!("Invalid block hash: {}", e))
+                    })
+                })
+                .transpose()?;
             let fee = fee.map(|f| f as u64);
             let height = height.map(|h| h as u32);
 

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -447,8 +447,11 @@ impl Database {
                     ))
                 })?;
 
-            let seed_hash_array: [u8; 32] =
-                seed_hash.try_into().expect("Seed hash should be 32 bytes");
+            let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
+                rusqlite::Error::InvalidParameterName(
+                    "Seed hash should be 32 bytes".to_string(),
+                )
+            })?;
             let closed_wallet_seed = ClosedKeyItem {
                 seed_hash: seed_hash_array,
                 encrypted_seed: encrypted_seed.clone(),
@@ -524,8 +527,11 @@ impl Database {
             let path_type: u32 = row.get(5)?;
             let total_received: Option<u64> = row.get(6)?;
 
-            let seed_hash_array: [u8; 32] =
-                seed_hash.try_into().expect("Seed hash should be 32 bytes");
+            let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
+                rusqlite::Error::InvalidParameterName(
+                    "Seed hash should be 32 bytes".to_string(),
+                )
+            })?;
 
             // Convert u32 to DerivationPathReference safely
             let path_reference =
@@ -801,8 +807,11 @@ impl Database {
             let is_ours: bool = row.get(8)?;
             let raw_transaction: Vec<u8> = row.get(9)?;
 
-            let seed_hash_array: [u8; 32] =
-                seed_hash.try_into().expect("Seed hash should be 32 bytes");
+            let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
+                rusqlite::Error::InvalidParameterName(
+                    "Seed hash should be 32 bytes".to_string(),
+                )
+            })?;
             let txid = Txid::from_slice(&txid_bytes).map_err(|e| {
                 rusqlite::Error::InvalidParameterName(format!("Invalid transaction txid: {}", e))
             })?;
@@ -912,8 +921,11 @@ impl Database {
             let balance: i64 = row.get(2)?;
             let nonce: i64 = row.get(3)?;
             let last_full_sync_balance: Option<i64> = row.get(4)?;
-            let seed_hash_array: [u8; 32] =
-                seed_hash.try_into().expect("Seed hash should be 32 bytes");
+            let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
+                rusqlite::Error::InvalidParameterName(
+                    "Seed hash should be 32 bytes".to_string(),
+                )
+            })?;
             Ok((
                 seed_hash_array,
                 address_str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,6 @@ async fn start(app_data_dir: &std::path::Path) -> Result<(), eframe::Error> {
     eframe::run_native(
         &format!("Dash Evo Tool v{}", VERSION),
         native_options,
-        Box::new(|cc| Ok(Box::new(crate::app::AppState::new(cc.egui_ctx.clone())))),
+        Box::new(|cc| Ok(Box::new(crate::app::AppState::new(cc.egui_ctx.clone())?))),
     )
 }

--- a/src/sdk_wrapper.rs
+++ b/src/sdk_wrapper.rs
@@ -10,9 +10,9 @@ pub fn initialize_sdk<P: ContextProvider + 'static>(
     config: &NetworkConfig,
     network: Network,
     context_provider: P,
-) -> Sdk {
+) -> Result<Sdk, String> {
     // Setup Platform SDK
-    let address_list = config.dapi_address_list();
+    let address_list = config.dapi_address_list()?;
     let request_settings = RequestSettings {
         connect_timeout: Some(Duration::from_secs(1)),
         timeout: Some(Duration::from_secs(10)),
@@ -28,7 +28,7 @@ pub fn initialize_sdk<P: ContextProvider + 'static>(
         .with_context_provider(context_provider)
         .with_settings(request_settings)
         .build()
-        .expect("Failed to build SDK");
+        .map_err(|e| format!("Failed to build SDK: {e}"))?;
 
     info!(
         ?network,
@@ -36,5 +36,5 @@ pub fn initialize_sdk<P: ContextProvider + 'static>(
         "SDK initialized successfully"
     );
 
-    sdk
+    Ok(sdk)
 }

--- a/src/ui/contracts_documents/add_contracts_screen.rs
+++ b/src/ui/contracts_documents/add_contracts_screen.rs
@@ -82,7 +82,7 @@ impl AddContractsScreen {
                 self.add_contracts_status = AddContractsStatus::WaitingForResult(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .expect("Time went backwards")
+                        .unwrap_or_default()
                         .as_secs(),
                 );
                 AppAction::BackendTask(BackendTask::ContractTask(Box::new(
@@ -369,7 +369,7 @@ impl ScreenLike for AddContractsScreen {
                 AddContractsStatus::WaitingForResult(start_time) => {
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .expect("Time went backwards")
+                        .unwrap_or_default()
                         .as_secs();
                     let elapsed_seconds = now - start_time;
 

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -211,7 +211,7 @@ impl DocumentQueryScreen {
                         // Set the status to waiting and capture the current time
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         self.document_query_status = DocumentQueryStatus::WaitingForResult(now);
                         self.current_page = 1; // Reset to first page
@@ -346,7 +346,7 @@ impl DocumentQueryScreen {
                     DocumentQueryStatus::WaitingForResult(start_time) => {
                         let time_elapsed = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs()
                             - start_time;
                         ui.horizontal(|ui| {
@@ -390,7 +390,7 @@ impl DocumentQueryScreen {
                         self.document_query_status = DocumentQueryStatus::WaitingForResult(
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
+                                .unwrap_or_default()
                                 .as_secs(),
                         );
                         self.current_page -= 1;
@@ -403,7 +403,7 @@ impl DocumentQueryScreen {
                         self.document_query_status = DocumentQueryStatus::WaitingForResult(
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
+                                .unwrap_or_default()
                                 .as_secs(),
                         );
                         self.current_page = 1;
@@ -424,7 +424,7 @@ impl DocumentQueryScreen {
                         self.document_query_status = DocumentQueryStatus::WaitingForResult(
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
+                                .unwrap_or_default()
                                 .as_secs(),
                         );
                         if self.current_page > 1 {

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -383,7 +383,7 @@ impl DocumentActionScreen {
                         self.broadcast_status = BroadcastStatus::Fetching(
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .unwrap()
+                                .unwrap_or_default()
                                 .as_secs(),
                         );
                         action = AppAction::BackendTask(BackendTask::DocumentTask(Box::new(
@@ -464,7 +464,7 @@ impl DocumentActionScreen {
         if let BroadcastStatus::Fetching(start) = &self.broadcast_status {
             let elapsed = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_default()
                 .as_secs()
                 - start;
             ui.add_space(10.0);
@@ -507,7 +507,7 @@ impl DocumentActionScreen {
                     self.broadcast_status = BroadcastStatus::Fetching(
                         SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_secs(),
                     );
                     action = AppAction::BackendTask(BackendTask::DocumentTask(Box::new(
@@ -523,7 +523,7 @@ impl DocumentActionScreen {
         if let BroadcastStatus::Fetching(start) = &self.broadcast_status {
             let elapsed = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_default()
                 .as_secs()
                 - start;
             ui.add_space(10.0);
@@ -572,7 +572,7 @@ impl DocumentActionScreen {
                         self.broadcast_status = BroadcastStatus::Fetching(
                             SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .unwrap()
+                                .unwrap_or_default()
                                 .as_secs(),
                         );
                         action = AppAction::BackendTask(BackendTask::DocumentTask(Box::new(
@@ -589,7 +589,7 @@ impl DocumentActionScreen {
         if let BroadcastStatus::Fetching(start) = &self.broadcast_status {
             let elapsed = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_default()
                 .as_secs()
                 - start;
             ui.add_space(10.0);
@@ -925,7 +925,7 @@ impl DocumentActionScreen {
                 self.broadcast_status = BroadcastStatus::Broadcasting(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap()
+                        .unwrap_or_default()
                         .as_secs(),
                 );
                 action = AppAction::BackendTask(task);
@@ -938,7 +938,7 @@ impl DocumentActionScreen {
                 ui.add_space(10.0);
                 let elapsed = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs()
                     - start_time;
                 ui.label(format!("Broadcasting... {}s", elapsed));
@@ -947,7 +947,7 @@ impl DocumentActionScreen {
                 ui.add_space(10.0);
                 let elapsed = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs()
                     - start_time;
                 ui.label(format!("Fetching... {}s", elapsed));

--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -564,7 +564,7 @@ impl ScreenLike for GroupActionsScreen {
                     self.fetch_group_actions_status = FetchGroupActionsStatus::WaitingForResult(
                         SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs(),
                     );
                     fetch_clicked = true;
@@ -598,7 +598,7 @@ impl ScreenLike for GroupActionsScreen {
                 FetchGroupActionsStatus::WaitingForResult(start_time) => {
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .expect("Time went backwards")
+                        .unwrap_or_default()
                         .as_secs();
                     let elapsed = now - start_time;
                     let status = if elapsed < 60 {

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -268,7 +268,7 @@ impl RegisterDataContractScreen {
                 // Show how long we've been broadcasting
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed = now - start_time;
                 ui.label(format!(
@@ -279,7 +279,7 @@ impl RegisterDataContractScreen {
             BroadcastStatus::ProofError(start_time) => {
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed = now - start_time;
                 ui.label("Broadcasted but received proof error. ⚠");
@@ -299,7 +299,7 @@ impl RegisterDataContractScreen {
             self.broadcast_status = BroadcastStatus::Broadcasting(
                 SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs(),
             );
         }
@@ -357,7 +357,7 @@ impl ScreenLike for RegisterDataContractScreen {
                 self.broadcast_status = BroadcastStatus::Broadcasting(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap()
+                        .unwrap_or_default()
                         .as_secs(),
                 );
             }
@@ -369,7 +369,7 @@ impl ScreenLike for RegisterDataContractScreen {
                 self.broadcast_status = BroadcastStatus::ProofError(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap()
+                        .unwrap_or_default()
                         .as_secs(),
                 );
             }

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -277,7 +277,7 @@ impl UpdateDataContractScreen {
                 // Show how long we've been fetching nonce
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed = now - start_time;
                 ui.label(format!(
@@ -289,7 +289,7 @@ impl UpdateDataContractScreen {
                 // Show how long we've been broadcasting
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed = now - start_time;
                 ui.label("Fetched nonce successfully. ✅ ");
@@ -301,7 +301,7 @@ impl UpdateDataContractScreen {
             BroadcastStatus::ProofError(start_time) => {
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed = now - start_time;
                 ui.label("Fetched nonce successfully. ✅ ");
@@ -321,7 +321,7 @@ impl UpdateDataContractScreen {
             self.broadcast_status = BroadcastStatus::FetchingNonce(
                 SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_secs(),
             );
         }
@@ -378,7 +378,7 @@ impl ScreenLike for UpdateDataContractScreen {
                 self.broadcast_status = BroadcastStatus::Broadcasting(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap()
+                        .unwrap_or_default()
                         .as_secs(),
                 );
             }
@@ -390,7 +390,7 @@ impl ScreenLike for UpdateDataContractScreen {
                 self.broadcast_status = BroadcastStatus::ProofError(
                     SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .unwrap()
+                        .unwrap_or_default()
                         .as_secs(),
                 );
             }

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -17,7 +17,7 @@ use dash_sdk::platform::Identifier;
 use egui::{ColorImage, RichText, ScrollArea, TextureHandle, Ui};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::error;
+use tracing::warn;
 
 const PUBLIC_PROFILE_INFO_TEXT: &str = "About Public Profiles:\n\n\
     This is the contact's public DashPay profile.\n\n\
@@ -193,7 +193,7 @@ impl ContactProfileViewerScreen {
                     }
                 }
                 Err(e) => {
-                    error!("Failed to fetch contact avatar image: {}", e);
+                    warn!("Failed to fetch contact avatar image: {}", e);
                 }
             }
         });

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -2,6 +2,7 @@ use crate::app::AppAction;
 use crate::backend_task::identity::{IdentityInputToLoad, IdentityTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
+use crate::lock_helper::RwLockExt;
 use crate::model::qualified_identity::IdentityType;
 use crate::model::wallet::Wallet;
 use crate::ui::components::info_popup::InfoPopup;
@@ -109,7 +110,12 @@ pub struct AddExistingIdentityScreen {
 
 impl AddExistingIdentityScreen {
     pub fn new(app_context: &Arc<AppContext>) -> Self {
-        let selected_wallet = app_context.wallets.read().unwrap().values().next().cloned();
+        let selected_wallet = app_context
+            .wallets
+            .read_or_recover()
+            .values()
+            .next()
+            .cloned();
         let testnet_loaded_nodes = if app_context.network == Network::Testnet {
             load_testnet_nodes_from_yml(".testnet_nodes.yml")
         } else {
@@ -161,13 +167,12 @@ impl AddExistingIdentityScreen {
         }
 
         let wallets_snapshot: Vec<(String, Arc<RwLock<Wallet>>)> = {
-            let wallets_guard = self.app_context.wallets.read().unwrap();
+            let wallets_guard = self.app_context.wallets.read_or_recover();
             wallets_guard
                 .values()
                 .map(|wallet| {
                     let alias = wallet
-                        .read()
-                        .unwrap()
+                        .read_or_recover()
                         .alias
                         .clone()
                         .unwrap_or_else(|| "Unnamed Wallet".to_string());
@@ -454,7 +459,7 @@ impl AddExistingIdentityScreen {
         if ui.add_enabled(is_valid_id, button).clicked() {
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
+                .unwrap_or_default()
                 .as_secs();
             self.add_identity_status = AddIdentityStatus::WaitingForResult(now);
             action = self.load_identity_clicked();
@@ -480,13 +485,12 @@ impl AddExistingIdentityScreen {
     fn render_wallet_selection(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             if self.app_context.has_wallet.load(Ordering::Relaxed) {
-                let wallets = &self.app_context.wallets.read().unwrap();
+                let wallets = &self.app_context.wallets.read_or_recover();
                 let wallet_aliases: Vec<String> = wallets
                     .values()
                     .map(|wallet| {
                         wallet
-                            .read()
-                            .unwrap()
+                            .read_or_recover()
                             .alias
                             .clone()
                             .unwrap_or_else(|| "Unnamed Wallet".to_string())
@@ -656,7 +660,7 @@ impl AddExistingIdentityScreen {
         if ui.add(button).clicked() {
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
+                .unwrap_or_default()
                 .as_secs();
             self.add_identity_status = AddIdentityStatus::WaitingForResult(now);
             self.backend_message = None;
@@ -691,13 +695,12 @@ impl AddExistingIdentityScreen {
         ui.add_space(15.0);
 
         let wallets_snapshot: Vec<(String, Arc<RwLock<Wallet>>)> = {
-            let wallets_guard = self.app_context.wallets.read().unwrap();
+            let wallets_guard = self.app_context.wallets.read_or_recover();
             wallets_guard
                 .values()
                 .map(|wallet| {
                     let alias = wallet
-                        .read()
-                        .unwrap()
+                        .read_or_recover()
                         .alias
                         .clone()
                         .unwrap_or_else(|| "Unnamed Wallet".to_string());
@@ -813,7 +816,7 @@ impl AddExistingIdentityScreen {
         if ui.add_enabled(is_valid, button).clicked() {
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
+                .unwrap_or_default()
                 .as_secs();
             self.add_identity_status = AddIdentityStatus::WaitingForResult(now);
             self.backend_message = None;
@@ -823,7 +826,7 @@ impl AddExistingIdentityScreen {
             let selected_wallet_seed_hash = if self.identity_associated_with_wallet {
                 self.selected_wallet
                     .as_ref()
-                    .map(|wallet| wallet.read().unwrap().seed_hash())
+                    .map(|wallet| wallet.read_or_recover().seed_hash())
             } else {
                 None
             };
@@ -848,7 +851,7 @@ impl AddExistingIdentityScreen {
         let selected_wallet_seed_hash = if self.identity_associated_with_wallet {
             self.selected_wallet
                 .as_ref()
-                .map(|wallet| wallet.read().unwrap().seed_hash())
+                .map(|wallet| wallet.read_or_recover().seed_hash())
         } else {
             None
         };
@@ -1096,7 +1099,7 @@ impl ScreenLike for AddExistingIdentityScreen {
                         }
                         LoadIdentityMode::Wallet => {
                             let wallets_len = {
-                                let wallets = self.app_context.wallets.read().unwrap();
+                                let wallets = self.app_context.wallets.read_or_recover();
                                 wallets.len()
                             };
                             inner_action |= self.render_by_wallet(ui, wallets_len);
@@ -1115,7 +1118,7 @@ impl ScreenLike for AddExistingIdentityScreen {
                         AddIdentityStatus::WaitingForResult(start_time) => {
                             let now = SystemTime::now()
                                 .duration_since(UNIX_EPOCH)
-                                .expect("Time went backwards")
+                                .unwrap_or_default()
                                 .as_secs();
                             let elapsed_seconds = now - start_time;
 

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -2,7 +2,6 @@ use crate::app::AppAction;
 use crate::backend_task::identity::{IdentityInputToLoad, IdentityTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
-use crate::lock_helper::RwLockExt;
 use crate::model::qualified_identity::IdentityType;
 use crate::model::wallet::Wallet;
 use crate::ui::components::info_popup::InfoPopup;
@@ -110,12 +109,7 @@ pub struct AddExistingIdentityScreen {
 
 impl AddExistingIdentityScreen {
     pub fn new(app_context: &Arc<AppContext>) -> Self {
-        let selected_wallet = app_context
-            .wallets
-            .read_or_recover()
-            .values()
-            .next()
-            .cloned();
+        let selected_wallet = app_context.wallets.read().unwrap().values().next().cloned();
         let testnet_loaded_nodes = if app_context.network == Network::Testnet {
             load_testnet_nodes_from_yml(".testnet_nodes.yml")
         } else {
@@ -167,12 +161,13 @@ impl AddExistingIdentityScreen {
         }
 
         let wallets_snapshot: Vec<(String, Arc<RwLock<Wallet>>)> = {
-            let wallets_guard = self.app_context.wallets.read_or_recover();
+            let wallets_guard = self.app_context.wallets.read().unwrap();
             wallets_guard
                 .values()
                 .map(|wallet| {
                     let alias = wallet
-                        .read_or_recover()
+                        .read()
+                        .unwrap()
                         .alias
                         .clone()
                         .unwrap_or_else(|| "Unnamed Wallet".to_string());
@@ -485,12 +480,13 @@ impl AddExistingIdentityScreen {
     fn render_wallet_selection(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
             if self.app_context.has_wallet.load(Ordering::Relaxed) {
-                let wallets = &self.app_context.wallets.read_or_recover();
+                let wallets = &self.app_context.wallets.read().unwrap();
                 let wallet_aliases: Vec<String> = wallets
                     .values()
                     .map(|wallet| {
                         wallet
-                            .read_or_recover()
+                            .read()
+                            .unwrap()
                             .alias
                             .clone()
                             .unwrap_or_else(|| "Unnamed Wallet".to_string())
@@ -695,12 +691,13 @@ impl AddExistingIdentityScreen {
         ui.add_space(15.0);
 
         let wallets_snapshot: Vec<(String, Arc<RwLock<Wallet>>)> = {
-            let wallets_guard = self.app_context.wallets.read_or_recover();
+            let wallets_guard = self.app_context.wallets.read().unwrap();
             wallets_guard
                 .values()
                 .map(|wallet| {
                     let alias = wallet
-                        .read_or_recover()
+                        .read()
+                        .unwrap()
                         .alias
                         .clone()
                         .unwrap_or_else(|| "Unnamed Wallet".to_string());
@@ -826,7 +823,7 @@ impl AddExistingIdentityScreen {
             let selected_wallet_seed_hash = if self.identity_associated_with_wallet {
                 self.selected_wallet
                     .as_ref()
-                    .map(|wallet| wallet.read_or_recover().seed_hash())
+                    .map(|wallet| wallet.read().unwrap().seed_hash())
             } else {
                 None
             };
@@ -851,7 +848,7 @@ impl AddExistingIdentityScreen {
         let selected_wallet_seed_hash = if self.identity_associated_with_wallet {
             self.selected_wallet
                 .as_ref()
-                .map(|wallet| wallet.read_or_recover().seed_hash())
+                .map(|wallet| wallet.read().unwrap().seed_hash())
         } else {
             None
         };
@@ -1099,7 +1096,7 @@ impl ScreenLike for AddExistingIdentityScreen {
                         }
                         LoadIdentityMode::Wallet => {
                             let wallets_len = {
-                                let wallets = self.app_context.wallets.read_or_recover();
+                                let wallets = self.app_context.wallets.read().unwrap();
                                 wallets.len()
                             };
                             inner_action |= self.render_by_wallet(ui, wallets_len);

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -644,7 +644,7 @@ impl ScreenLike for AddKeyScreen {
                 // Set the status to waiting and capture the current time
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.add_key_status = AddKeyStatus::WaitingForResult(now);
                 inner_action |= self.validate_and_add_key();
@@ -658,7 +658,7 @@ impl ScreenLike for AddKeyScreen {
                 AddKeyStatus::WaitingForResult(start_time) => {
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .expect("Time went backwards")
+                        .unwrap_or_default()
                         .as_secs();
                     let elapsed_seconds = now - start_time;
 

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -545,7 +545,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
                 // Set the status to waiting and capture the current time
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.register_dpns_name_status = RegisterDpnsNameStatus::WaitingForResult(now);
                 inner_action = self.register_dpns_name_clicked();
@@ -561,7 +561,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
                 RegisterDpnsNameStatus::WaitingForResult(start_time) => {
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
-                        .expect("Time went backwards")
+                        .unwrap_or_default()
                         .as_secs();
                     let elapsed_seconds = now - start_time;
 

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -320,7 +320,7 @@ impl TransferScreen {
         // Set waiting state
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.transfer_credits_status = TransferCreditsStatus::WaitingForResult(now);
 
@@ -373,7 +373,7 @@ impl TransferScreen {
         // Set waiting state and create backend task
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.transfer_credits_status = TransferCreditsStatus::WaitingForResult(now);
 
@@ -771,7 +771,7 @@ impl ScreenLike for TransferScreen {
                     TransferCreditsStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed_seconds = now - start_time;
 

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -275,7 +275,7 @@ impl WithdrawalScreen {
                 self.confirmation_dialog = None;
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.withdraw_from_identity_status =
                     WithdrawFromIdentityStatus::WaitingForResult(now);
@@ -614,7 +614,7 @@ impl ScreenLike for WithdrawalScreen {
                     WithdrawFromIdentityStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed_seconds = now - start_time;
 

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -616,7 +616,7 @@ impl ScreenLike for WithdrawalScreen {
                             .duration_since(UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs();
-                        let elapsed_seconds = now - start_time;
+                        let elapsed_seconds = now.saturating_sub(*start_time);
 
                         let display_time = if elapsed_seconds < 60 {
                             format!(

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -5,6 +5,7 @@ use crate::backend_task::system_task::SystemTask;
 use crate::config::Config;
 use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
+use crate::lock_helper::RwLockExt;
 use crate::model::wallet::DerivationPathHelpers;
 use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
 use crate::ui::components::component_trait::Component;
@@ -443,7 +444,7 @@ impl NetworkChooserScreen {
                         if let Some(local_app_context) = &self.local_app_context {
                             {
                                 // Overwrite the config field with the new password
-                                let mut cfg_lock = local_app_context.config.write().unwrap();
+                                let mut cfg_lock = local_app_context.config.write_or_recover();
                                 *cfg_lock = updated_local_config;
                             }
 
@@ -2039,7 +2040,7 @@ impl ScreenLike for NetworkChooserScreen {
             if self.any_rpc_backend() {
                 let current_time = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards");
+                    .unwrap_or_default();
                 if let Some(time) = self.recheck_time {
                     if current_time.as_millis() as u64 >= time {
                         action = AppAction::BackendTask(BackendTask::CoreTask(

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -5,7 +5,6 @@ use crate::backend_task::system_task::SystemTask;
 use crate::config::Config;
 use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
-use crate::lock_helper::RwLockExt;
 use crate::model::wallet::DerivationPathHelpers;
 use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
 use crate::ui::components::component_trait::Component;
@@ -444,7 +443,7 @@ impl NetworkChooserScreen {
                         if let Some(local_app_context) = &self.local_app_context {
                             {
                                 // Overwrite the config field with the new password
-                                let mut cfg_lock = local_app_context.config.write_or_recover();
+                                let mut cfg_lock = local_app_context.config.write().unwrap();
                                 *cfg_lock = updated_local_config;
                             }
 

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -264,7 +264,7 @@ impl BurnTokensScreen {
                 self.confirmation_dialog = None;
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.status = BurnTokensStatus::WaitingForResult(now);
 
@@ -655,7 +655,7 @@ impl ScreenLike for BurnTokensScreen {
                     BurnTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Burning... elapsed: {} seconds", elapsed));

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -215,7 +215,7 @@ impl ClaimTokensScreen {
 
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.status = ClaimTokensStatus::WaitingForResult(now);
 
@@ -576,7 +576,7 @@ impl ScreenLike for ClaimTokensScreen {
                     ClaimTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Claiming... elapsed: {}s", elapsed));

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -286,7 +286,7 @@ impl DestroyFrozenFundsScreen {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.status = DestroyFrozenFundsStatus::WaitingForResult(now);
 
@@ -625,7 +625,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                     DestroyFrozenFundsStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!(

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -287,7 +287,7 @@ impl PurchaseTokenScreen {
                 self.confirmation_dialog = None;
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.status = PurchaseTokensStatus::WaitingForResult(now);
 
@@ -639,7 +639,7 @@ impl ScreenLike for PurchaseTokenScreen {
                     PurchaseTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Purchasing... elapsed: {} seconds", elapsed));

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -277,7 +277,7 @@ impl FreezeTokensScreen {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.status = FreezeTokensStatus::WaitingForResult(now);
 
@@ -623,7 +623,7 @@ impl ScreenLike for FreezeTokensScreen {
                     FreezeTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Freezing... elapsed: {}s", elapsed));

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -310,7 +310,7 @@ impl MintTokensScreen {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.status = MintTokensStatus::WaitingForResult(now);
 
@@ -708,7 +708,7 @@ impl ScreenLike for MintTokensScreen {
                     MintTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Minting... elapsed: {} seconds", elapsed));

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -219,7 +219,7 @@ impl PauseTokensScreen {
 
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.status = PauseTokensStatus::WaitingForResult(now);
 
@@ -528,7 +528,7 @@ impl ScreenLike for PauseTokensScreen {
                     PauseTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Pausing... elapsed: {}s", elapsed));

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -219,7 +219,7 @@ impl ResumeTokensScreen {
 
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 self.status = ResumeTokensStatus::WaitingForResult(now);
 
@@ -528,7 +528,7 @@ impl ScreenLike for ResumeTokensScreen {
                     ResumeTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .unwrap()
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Resuming... elapsed: {}s", elapsed));

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -728,7 +728,7 @@ impl SetTokenPriceScreen {
         // Set waiting state
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.status = SetTokenPriceStatus::WaitingForResult(now);
 
@@ -1143,7 +1143,7 @@ impl ScreenLike for SetTokenPriceScreen {
                     SetTokenPriceStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Setting price... elapsed: {} seconds", elapsed));

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -225,7 +225,7 @@ impl TransferTokensScreen {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.transfer_tokens_status = TransferTokensStatus::WaitingForResult(now);
 
@@ -552,7 +552,7 @@ impl ScreenLike for TransferTokensScreen {
                     TransferTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed_seconds = now - start_time;
 

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -279,7 +279,7 @@ impl UnfreezeTokensScreen {
 
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs();
         self.status = UnfreezeTokensStatus::WaitingForResult(now);
 
@@ -612,7 +612,7 @@ impl ScreenLike for UnfreezeTokensScreen {
                     UnfreezeTokensStatus::WaitingForResult(start_time) => {
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         let elapsed = now - start_time;
                         ui.label(format!("Unfreezing... elapsed: {}s", elapsed));

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -676,7 +676,7 @@ impl UpdateTokenConfigScreen {
                 ui.label("No parameters to edit for this entry.");
             }
             TokenConfigurationChangeItem::MarketplaceTradeMode(_) => {
-                unimplemented!("marketplace settings not implemented yet")
+                ui.label("Marketplace settings are not yet supported.");
             }
         }
         });

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -237,7 +237,7 @@ impl TransitionVisualizerScreen {
                         // Mark as submitting
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
-                            .expect("Time went backwards")
+                            .unwrap_or_default()
                             .as_secs();
                         self.broadcast_status = TransitionBroadcastStatus::Submitting(now);
 
@@ -265,7 +265,7 @@ impl TransitionVisualizerScreen {
             TransitionBroadcastStatus::Submitting(start_time) => {
                 let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .expect("Time went backwards")
+                    .unwrap_or_default()
                     .as_secs();
                 let elapsed_seconds = now - start_time;
 

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -485,7 +485,7 @@ impl WalletSendScreen {
     fn now_epoch_secs() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
+            .unwrap_or_default()
             .as_secs()
     }
 

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -16,7 +16,7 @@ use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use eframe::egui::{self, ComboBox, Context};
 use eframe::epaint::TextureHandle;
 use egui::load::SizedTexture;
-use egui::{Color32, Frame, Margin, RichText, TextureOptions};
+use egui::{Frame, Margin, RichText, TextureOptions};
 use std::sync::{Arc, RwLock};
 
 use super::WalletsBalancesScreen;

--- a/tests/e2e/navigation.rs
+++ b/tests/e2e/navigation.rs
@@ -12,7 +12,9 @@ fn test_basic_navigation() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -35,7 +37,9 @@ fn test_navigation_responsive_layout() {
 
     for size in sizes {
         let mut harness = Harness::builder().with_max_steps(50).build_eframe(|ctx| {
-            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                .expect("Failed to create AppState")
+                .with_animations(false)
         });
 
         harness.set_size(size);
@@ -50,7 +54,9 @@ fn test_rapid_frame_navigation() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(300).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -68,7 +74,9 @@ fn test_extended_navigation_stability() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(500).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1280.0, 720.0));
@@ -88,7 +96,9 @@ fn test_minimum_size_navigation() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(50).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Very small window

--- a/tests/e2e/wallet_flows.rs
+++ b/tests/e2e/wallet_flows.rs
@@ -12,7 +12,9 @@ fn test_wallet_state_initialization() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -26,7 +28,9 @@ fn test_wallet_balance_rendering() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -42,7 +46,9 @@ fn test_wallet_ui_responsiveness() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(200).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -62,7 +68,9 @@ fn test_wallet_resize_stability() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(150).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Test various resize scenarios

--- a/tests/kittest/create_asset_lock_screen.rs
+++ b/tests/kittest/create_asset_lock_screen.rs
@@ -7,7 +7,9 @@ fn test_create_asset_lock_screen_renders() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -21,7 +23,9 @@ fn test_create_asset_lock_screen_resize() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Test various window sizes
@@ -45,7 +49,9 @@ fn test_create_asset_lock_screen_frame_stability() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(200).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));

--- a/tests/kittest/identities_screen.rs
+++ b/tests/kittest/identities_screen.rs
@@ -7,7 +7,9 @@ fn test_identities_screen_renders() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -21,7 +23,9 @@ fn test_minimum_window_size() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(50).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Test with a small window size
@@ -36,7 +40,9 @@ fn test_window_resize() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Start small
@@ -59,7 +65,9 @@ fn test_frame_batch_processing() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(150).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));

--- a/tests/kittest/network_chooser.rs
+++ b/tests/kittest/network_chooser.rs
@@ -9,7 +9,9 @@ fn test_network_chooser_renders() {
 
     // Create a test harness for the egui app
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Set the window size
@@ -26,7 +28,9 @@ fn test_app_handles_frame_stepping() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(50).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(800.0, 600.0));
@@ -51,7 +55,9 @@ fn test_app_renders_at_various_sizes() {
 
     for size in sizes {
         let mut harness = Harness::builder().with_max_steps(50).build_eframe(|ctx| {
-            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                .expect("Failed to create AppState")
+                .with_animations(false)
         });
 
         harness.set_size(size);

--- a/tests/kittest/startup.rs
+++ b/tests/kittest/startup.rs
@@ -10,7 +10,9 @@ fn test_app_startup() {
 
     // Create a test harness for the egui app
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     // Set the window size

--- a/tests/kittest/wallets_screen.rs
+++ b/tests/kittest/wallets_screen.rs
@@ -7,7 +7,9 @@ fn test_wallets_screen_renders() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -21,7 +23,9 @@ fn test_app_stability_over_many_frames() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(200).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(1024.0, 768.0));
@@ -37,7 +41,9 @@ fn test_rapid_frame_stepping() {
     let _guard = rt.enter();
 
     let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
-        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone()).with_animations(false)
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("Failed to create AppState")
+            .with_animations(false)
     });
 
     harness.set_size(egui::vec2(800.0, 600.0));


### PR DESCRIPTION
## Summary

- Replace ~40 `.expect()` / `.unwrap()` / `panic!()` / `unreachable!()` / `unimplemented!()` calls across backend, database, context, and UI layers with proper error propagation or safe fallbacks
- **Backend tasks**: contested names, identity registration/top-up, contract loading, platform info, contacts — all now return `Result` instead of panicking
- **Database layer**: wallet loading, contested names, tokens, scheduled votes, contacts, asset lock DB, initialization/migration — errors propagate instead of crashing
- **AppContext::new()**: 13 `.expect()` calls replaced with match blocks that log errors and return `None`, so a misconfigured network context fails gracefully instead of taking down the whole app
- **Config/SDK**: `dapi_address_list()`, `insight_api_uri()`, and `initialize_sdk()` now return `Result` instead of panicking on bad input
- **UI**: `SystemTime::now().duration_since(UNIX_EPOCH).expect()` replaced with `.unwrap_or_default()` across 26 files; `unimplemented!()` in marketplace settings replaced with informational label

## Motivation

The application had numerous panic-prone code paths that could crash the entire GUI if any upstream data was malformed, a network was misconfigured, or a database query returned unexpected results. This PR systematically eliminates these crash vectors by:
1. Returning `Result`/`Option` from fallible functions
2. Using `match` blocks with `tracing::error!` logging before returning `None`
3. Using `.unwrap_or_default()` for non-critical timestamp operations
4. Replacing `unreachable!()` with safe default branches

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes clean
- [x] `cargo +nightly fmt --all` applied
- [ ] Manual testing: verify app starts and functions normally on mainnet/testnet
- [ ] Verify graceful failure when a network config is intentionally broken (should log error, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Converted many crash paths into graceful errors, warnings, and safe fallbacks (app initialization, network/context selection, ZMQ listeners, background tasks, DB, wallets, identity flows).
  * Improved validation and automatic fallbacks for unavailable network contexts.

* **UI**
  * Made time/elapsed displays resilient to clock anomalies.
  * Replaced an unimplemented crash with a "marketplace not supported" label.
  * Expanded public profile text and lowered avatar-fetch log severity.

* **Tests**
  * Updated tests to handle fallible app-state initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->