### PR TITLE
fix: correct hardcoded timestamps and wrong profile field name

### DIFF
--- a/src/backend_task/dashpay/contacts.rs
+++ b/src/backend_task/dashpay/contacts.rs
@@ -444,7 +444,7 @@ pub async fn load_contacts(
                     .map(|s| s.to_string());
 
                 let bio = props
-                    .get("bio")
+                    .get("publicMessage")
                     .and_then(|v| v.as_text())
                     .map(|s| s.to_string());
 

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -17,9 +17,38 @@ use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, Screen, ScreenLike, ScreenType};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::platform::Identifier;
+use chrono::{LocalResult, TimeZone, Utc};
+use chrono_humanize::HumanTime;
 use egui::{Frame, Margin, RichText, ScrollArea, Ui};
 use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, RwLock};
+
+/// Format a timestamp (seconds or milliseconds since epoch) as a human-readable
+/// relative time string (e.g. "3 hours ago"). Returns `None` if the timestamp
+/// is zero or cannot be parsed.
+fn format_relative_time(timestamp: u64) -> Option<String> {
+    if timestamp == 0 {
+        return None;
+    }
+    // Distinguish seconds vs milliseconds: timestamps after year ~2001 in millis
+    // exceed 1_000_000_000_000, while second-based timestamps won't until year 33658.
+    let dt_result = if timestamp > 1_000_000_000_000 {
+        Utc.timestamp_millis_opt(timestamp as i64)
+    } else {
+        Utc.timestamp_opt(timestamp as i64, 0)
+    };
+    match dt_result {
+        LocalResult::Single(dt) => {
+            let human = HumanTime::from(dt).to_string();
+            if human.contains("seconds") {
+                Some("just now".to_string())
+            } else {
+                Some(human)
+            }
+        }
+        _ => None,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ContactRequest {
@@ -593,8 +622,11 @@ impl ContactRequests {
                                         }
 
                                         // Timestamp
+                                        let time_text = format_relative_time(request.timestamp)
+                                            .map(|t| format!("Received: {}", t))
+                                            .unwrap_or_else(|| "Received: unknown".to_string());
                                         ui.label(
-                                            RichText::new("Received: 1 day ago").small().color(DashColors::text_secondary(dark_mode)),
+                                            RichText::new(time_text).small().color(DashColors::text_secondary(dark_mode)),
                                         );
                                     });
 
@@ -772,7 +804,10 @@ impl ContactRequests {
 
                                         // Status
                                         ui.label(RichText::new("Status: Pending").small().color(DashColors::text_secondary(dark_mode)));
-                                        ui.label(RichText::new("Sent: 2 days ago").small().color(DashColors::text_secondary(dark_mode)));
+                                        let sent_time_text = format_relative_time(request.timestamp)
+                                            .map(|t| format!("Sent: {}", t))
+                                            .unwrap_or_else(|| "Sent: unknown".to_string());
+                                        ui.label(RichText::new(sent_time_text).small().color(DashColors::text_secondary(dark_mode)));
                                     });
 
                                     ui.with_layout(

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -23,8 +23,35 @@ use dash_sdk::dpp::balances::credits::Credits;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::Identifier;
+use chrono::{LocalResult, TimeZone, Utc};
+use chrono_humanize::HumanTime;
 use egui::{Frame, Margin, RichText, ScrollArea, TextEdit, Ui};
 use std::sync::{Arc, RwLock};
+
+/// Format a timestamp (seconds or milliseconds since epoch) as a human-readable
+/// relative time string (e.g. "3 hours ago"). Returns `None` if the timestamp
+/// is zero or cannot be parsed.
+fn format_relative_time(timestamp: u64) -> Option<String> {
+    if timestamp == 0 {
+        return None;
+    }
+    let dt_result = if timestamp > 1_000_000_000_000 {
+        Utc.timestamp_millis_opt(timestamp as i64)
+    } else {
+        Utc.timestamp_opt(timestamp as i64, 0)
+    };
+    match dt_result {
+        LocalResult::Single(dt) => {
+            let human = HumanTime::from(dt).to_string();
+            if human.contains("seconds") {
+                Some("just now".to_string())
+            } else {
+                Some(human)
+            }
+        }
+        _ => None,
+    }
+}
 
 const PAYMENT_GUIDELINES_INFO_TEXT: &str = "Payment Guidelines:\n\n\
     Payments to contacts use encrypted payment channels.\n\n\
@@ -767,11 +794,16 @@ impl PaymentHistory {
                                     );
 
                                     // Timestamp
-                                    ui.label(
-                                        RichText::new("• 2 days ago")
-                                            .small()
-                                            .color(DashColors::text_secondary(dark_mode)),
-                                    );
+                                    let payment_time_text = format_relative_time(payment.timestamp)
+                                        .map(|t| format!("• {}", t))
+                                        .unwrap_or_default();
+                                    if !payment_time_text.is_empty() {
+                                        ui.label(
+                                            RichText::new(payment_time_text)
+                                                .small()
+                                                .color(DashColors::text_secondary(dark_mode)),
+                                        );
+                                    }
                                 });
                             });
                         });


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs:

### Bug 1: Hardcoded relative timestamps
Several UI locations displayed hardcoded strings instead of computing relative time from the actual timestamp data:
- `contact_requests.rs` — "Received: 1 day ago" (incoming requests)
- `contact_requests.rs` — "Sent: 2 days ago" (outgoing requests)
- `send_payment.rs` — "2 days ago" (payment history)

Now uses `chrono` + `chrono-humanize` (already project dependencies) to compute human-readable relative timestamps from the `timestamp` field on `ContactRequest` and `PaymentRecord` structs. Handles both second-based timestamps (from the local database via `unixepoch()`) and millisecond-based timestamps (from DPP `doc.created_at()`). Falls back gracefully when the timestamp is zero or invalid.

### Bug 2: Wrong profile field name
`contacts.rs` used `.get("bio")` to look up the public message field from the DashPay contract profile document. The correct field name is `"publicMessage"`, which is consistent with every other usage in the codebase.

Fixes #579