### PR TITLE
fix: use correct DashPay profile field "publicMessage" instead of "bio"

### DIFF
--- a/src/backend_task/dashpay/contacts.rs
+++ b/src/backend_task/dashpay/contacts.rs
@@ -444,7 +444,7 @@ pub async fn load_contacts(
                     .map(|s| s.to_string());
 
                 let bio = props
-                    .get("bio")
+                    .get("publicMessage")
                     .and_then(|v| v.as_text())
                     .map(|s| s.to_string());
 


### PR DESCRIPTION
The DashPay contract schema defines the field as `publicMessage`, not `bio`. This caused profile bios to never load in contact info.

One-line fix in `contacts.rs`.

Split from #580 — field name fix only, no unrelated changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected profile bio retrieval for contacts to display the correct profile information when viewing contact profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->