### PR TITLE
fix: address Lukasz review comments from PR #564

### DIFF
--- a/src/backend_task/dashpay.rs
+++ b/src/backend_task/dashpay.rs
@@ -168,14 +168,9 @@ impl AppContext {
                 request_id,
             } => contact_requests::reject_contact_request(self, sdk, identity, request_id).await,
             DashPayTask::LoadPaymentHistory { identity } => {
-                // Load locally stored payment records from database.
-                // Full blockchain-based history (scanning DIP-15 addresses via SPV)
-                // remains deferred until SPV support is available.
+                // Reuse the shared payment history loader to avoid duplicating logic.
                 let identity_id = identity.identity.id();
-                let stored = self
-                    .db
-                    .load_payment_history(&identity_id, 100)
-                    .map_err(|e| format!("Failed to load payment history: {}", e))?;
+                let records = payments::load_payment_history(self, &identity_id, None).await?;
 
                 let network_str = self.network.to_string();
                 let contacts = self
@@ -183,36 +178,38 @@ impl AppContext {
                     .load_dashpay_contacts(&identity_id, &network_str)
                     .unwrap_or_default();
 
-                let mut results = Vec::new();
-                for sp in stored {
-                    let is_incoming = sp.to_identity_id == identity_id.to_buffer().to_vec();
-                    let contact_bytes = if is_incoming {
-                        &sp.from_identity_id
-                    } else {
-                        &sp.to_identity_id
-                    };
+                let results: Vec<_> = records
+                    .into_iter()
+                    .map(|rec| {
+                        let is_incoming = rec.to_identity == identity_id;
+                        let contact_id = if is_incoming {
+                            rec.from_identity
+                        } else {
+                            rec.to_identity
+                        };
 
-                    let contact_name = contacts
-                        .iter()
-                        .find(|c| c.contact_identity_id == *contact_bytes)
-                        .and_then(|c| c.username.clone().or(c.display_name.clone()))
-                        .unwrap_or_else(|| {
-                            if let Ok(cid) = Identifier::from_bytes(contact_bytes) {
-                                let s = cid.to_string(Encoding::Base58);
+                        let contact_name = contacts
+                            .iter()
+                            .find(|c| {
+                                Identifier::from_bytes(&c.contact_identity_id)
+                                    .map(|id| id == contact_id)
+                                    .unwrap_or(false)
+                            })
+                            .and_then(|c| c.username.clone().or(c.display_name.clone()))
+                            .unwrap_or_else(|| {
+                                let s = contact_id.to_string(Encoding::Base58);
                                 format!("Unknown ({})", &s[..s.len().min(8)])
-                            } else {
-                                "Unknown".to_string()
-                            }
-                        });
+                            });
 
-                    results.push((
-                        sp.tx_id,
-                        contact_name,
-                        sp.amount as u64,
-                        is_incoming,
-                        sp.memo.unwrap_or_default(),
-                    ));
-                }
+                        (
+                            rec.tx_id.unwrap_or_default(),
+                            contact_name,
+                            rec.amount,
+                            is_incoming,
+                            rec.memo.unwrap_or_default(),
+                        )
+                    })
+                    .collect();
 
                 Ok(BackendTaskSuccessResult::DashPayPaymentHistory(results))
             }

--- a/src/backend_task/dashpay/payments.rs
+++ b/src/backend_task/dashpay/payments.rs
@@ -19,7 +19,7 @@ pub struct PaymentRecord {
     pub from_identity: Identifier,
     pub to_identity: Identifier,
     pub from_address: Option<Address>,
-    pub to_address: Address,
+    pub to_address: Option<Address>,
     pub amount: u64,
     pub tx_id: Option<String>,
     pub memo: Option<String>,
@@ -303,7 +303,7 @@ pub async fn send_payment_to_contact_impl(
         from_identity: from_identity.identity.id(),
         to_identity: to_contact_id,
         from_address: None,
-        to_address: to_address.clone(),
+        to_address: Some(to_address.clone()),
         amount: amount_duffs,
         tx_id: Some(txid.clone()),
         memo: memo.clone(),
@@ -375,9 +375,29 @@ pub async fn load_payment_history(
 
         let status = match sp.status.as_str() {
             "confirmed" => PaymentStatus::Confirmed(1),
-            "failed" => PaymentStatus::Failed(sp.status.clone()),
+            "failed" => PaymentStatus::Failed("Transaction failed".to_string()),
             "pending" => PaymentStatus::Pending,
             _ => PaymentStatus::Broadcast,
+        };
+
+        let amount = if sp.amount < 0 {
+            tracing::warn!(
+                "Payment {} has negative amount {}, clamping to 0",
+                sp.id, sp.amount
+            );
+            0u64
+        } else {
+            sp.amount as u64
+        };
+
+        let timestamp = if sp.created_at < 0 {
+            tracing::warn!(
+                "Payment {} has negative timestamp {}, using 0",
+                sp.id, sp.created_at
+            );
+            0u64
+        } else {
+            sp.created_at as u64
         };
 
         records.push(PaymentRecord {
@@ -385,15 +405,11 @@ pub async fn load_payment_history(
             from_identity: from_id,
             to_identity: to_id,
             from_address: None,
-            to_address: Address::p2pkh(
-                &dash_sdk::dpp::dashcore::PublicKey::from_slice(&[0x02; 33])
-                    .map_err(|e| format!("Key error: {}", e))?,
-                app_context.network,
-            ),
-            amount: sp.amount as u64,
+            to_address: None,
+            amount,
             tx_id: Some(sp.tx_id),
             memo: sp.memo,
-            timestamp: sp.created_at as u64,
+            timestamp,
             status,
             address_index: 0,
         });
@@ -449,7 +465,7 @@ mod tests {
             from_identity: from_id,
             to_identity: to_id,
             from_address: None,
-            to_address: create_test_address(),
+            to_address: Some(create_test_address()),
             amount: 100_000_000, // 1 Dash
             tx_id: None,
             memo: Some("Test payment".to_string()),
@@ -513,7 +529,7 @@ mod tests {
             from_identity: Identifier::random(),
             to_identity: Identifier::random(),
             from_address: Some(create_test_address()),
-            to_address: create_test_address(),
+            to_address: Some(create_test_address()),
             amount: 50_000_000, // 0.5 Dash
             tx_id: Some("abc123def456".to_string()),
             memo: None,
@@ -561,7 +577,7 @@ mod tests {
             from_identity: Identifier::random(),
             to_identity: Identifier::random(),
             from_address: None,
-            to_address: create_test_address(),
+            to_address: Some(create_test_address()),
             amount: 100_000_000,
             tx_id: Some("tx123".to_string()),
             memo: Some("Original memo".to_string()),

--- a/src/backend_task/dashpay/payments.rs
+++ b/src/backend_task/dashpay/payments.rs
@@ -383,7 +383,8 @@ pub async fn load_payment_history(
         let amount = if sp.amount < 0 {
             tracing::warn!(
                 "Payment {} has negative amount {}, clamping to 0",
-                sp.id, sp.amount
+                sp.id,
+                sp.amount
             );
             0u64
         } else {
@@ -393,7 +394,8 @@ pub async fn load_payment_history(
         let timestamp = if sp.created_at < 0 {
             tracing::warn!(
                 "Payment {} has negative timestamp {}, using 0",
-                sp.id, sp.created_at
+                sp.id,
+                sp.created_at
             );
             0u64
         } else {

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -366,11 +366,14 @@ impl ContactRequests {
 
     /// Trigger backend fetches for identity profiles that aren't cached locally.
     fn fetch_unresolved_profiles(&self, unresolved_ids: Vec<Identifier>) -> AppAction {
-        if unresolved_ids.is_empty() || self.selected_identity.is_none() {
+        let Some(identity) = self.selected_identity.as_ref() else {
+            return AppAction::None;
+        };
+        if unresolved_ids.is_empty() {
             return AppAction::None;
         }
 
-        let identity = self.selected_identity.as_ref().unwrap().clone();
+        let identity = identity.clone();
         let tasks: Vec<BackendTask> = unresolved_ids
             .into_iter()
             .map(|contact_id| {

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -1,4 +1,4 @@
-use crate::app::AppAction;
+use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::dashpay::DashPayTask;
 use crate::backend_task::dashpay::errors::DashPayError;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
@@ -243,52 +243,83 @@ impl ContactRequests {
     /// Resolve usernames and display names for contact requests using local DB cache.
     /// Returns a list of identity IDs that were not found locally and need Platform fetching.
     fn resolve_names_from_local_cache(&mut self) -> Vec<Identifier> {
+        use std::collections::HashMap;
+
         let network_str = self.app_context.network.to_string();
         let mut unresolved_ids = Vec::new();
+
+        // Pre-load contacts once to avoid N+1 queries inside the loop
+        let contacts_by_id: HashMap<Identifier, (Option<String>, Option<String>)> =
+            if let Some(selected_identity) = &self.selected_identity {
+                let owner_id = selected_identity.identity.id();
+                self.app_context
+                    .db
+                    .load_dashpay_contacts(&owner_id, &network_str)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|c| {
+                        Identifier::from_bytes(&c.contact_identity_id)
+                            .ok()
+                            .map(|id| (id, (c.username, c.display_name)))
+                    })
+                    .collect()
+            } else {
+                HashMap::new()
+            };
+
+        // Collect all identity IDs we need to look up profiles for
+        let incoming_ids: Vec<Identifier> = self
+            .incoming_requests
+            .values()
+            .filter(|r| r.from_username.is_none() && r.from_display_name.is_none())
+            .map(|r| r.from_identity)
+            .collect();
+        let outgoing_ids: Vec<Identifier> = self
+            .outgoing_requests
+            .values()
+            .filter(|r| r.to_username.is_none() && r.to_display_name.is_none())
+            .map(|r| r.to_identity)
+            .collect();
+
+        // Pre-load profiles for all needed IDs (one DB query each, but only for unresolved)
+        let mut profiles_cache: HashMap<Identifier, Option<String>> = HashMap::new();
+        for id in incoming_ids.iter().chain(outgoing_ids.iter()) {
+            if !profiles_cache.contains_key(id) {
+                let display_name = self
+                    .app_context
+                    .db
+                    .load_dashpay_profile(id, &network_str)
+                    .ok()
+                    .flatten()
+                    .and_then(|p| p.display_name);
+                profiles_cache.insert(*id, display_name);
+            }
+        }
 
         // Resolve names for incoming requests (need from_identity info)
         for request in self.incoming_requests.values_mut() {
             if request.from_username.is_some() || request.from_display_name.is_some() {
-                continue; // Already resolved
+                continue;
             }
 
             let identity_id = request.from_identity;
             let mut found = false;
 
             // Try profile cache first (has display_name)
-            if let Ok(Some(profile)) = self
-                .app_context
-                .db
-                .load_dashpay_profile(&identity_id, &network_str)
-                && profile.display_name.is_some()
-            {
-                request.from_display_name = profile.display_name;
+            if let Some(Some(display_name)) = profiles_cache.get(&identity_id) {
+                request.from_display_name = Some(display_name.clone());
                 found = true;
             }
 
             // Try contacts cache (has username and display_name)
-            if let Some(selected_identity) = &self.selected_identity {
-                let owner_id = selected_identity.identity.id();
-                if let Ok(contacts) = self
-                    .app_context
-                    .db
-                    .load_dashpay_contacts(&owner_id, &network_str)
-                {
-                    for contact in contacts {
-                        if let Ok(contact_id) = Identifier::from_bytes(&contact.contact_identity_id)
-                            && contact_id == identity_id
-                        {
-                            if request.from_username.is_none() {
-                                request.from_username = contact.username;
-                            }
-                            if request.from_display_name.is_none() {
-                                request.from_display_name = contact.display_name;
-                            }
-                            found = true;
-                            break;
-                        }
-                    }
+            if let Some((username, display_name)) = contacts_by_id.get(&identity_id) {
+                if request.from_username.is_none() {
+                    request.from_username = username.clone();
                 }
+                if request.from_display_name.is_none() {
+                    request.from_display_name = display_name.clone();
+                }
+                found = true;
             }
 
             if !found {
@@ -299,46 +330,27 @@ impl ContactRequests {
         // Resolve names for outgoing requests (need to_identity info)
         for request in self.outgoing_requests.values_mut() {
             if request.to_username.is_some() || request.to_display_name.is_some() {
-                continue; // Already resolved
+                continue;
             }
 
             let identity_id = request.to_identity;
             let mut found = false;
 
             // Try profile cache first
-            if let Ok(Some(profile)) = self
-                .app_context
-                .db
-                .load_dashpay_profile(&identity_id, &network_str)
-                && profile.display_name.is_some()
-            {
-                request.to_display_name = profile.display_name;
+            if let Some(Some(display_name)) = profiles_cache.get(&identity_id) {
+                request.to_display_name = Some(display_name.clone());
                 found = true;
             }
 
             // Try contacts cache
-            if let Some(selected_identity) = &self.selected_identity {
-                let owner_id = selected_identity.identity.id();
-                if let Ok(contacts) = self
-                    .app_context
-                    .db
-                    .load_dashpay_contacts(&owner_id, &network_str)
-                {
-                    for contact in contacts {
-                        if let Ok(contact_id) = Identifier::from_bytes(&contact.contact_identity_id)
-                            && contact_id == identity_id
-                        {
-                            if request.to_username.is_none() {
-                                request.to_username = contact.username;
-                            }
-                            if request.to_display_name.is_none() {
-                                request.to_display_name = contact.display_name;
-                            }
-                            found = true;
-                            break;
-                        }
-                    }
+            if let Some((username, display_name)) = contacts_by_id.get(&identity_id) {
+                if request.to_username.is_none() {
+                    request.to_username = username.clone();
                 }
+                if request.to_display_name.is_none() {
+                    request.to_display_name = display_name.clone();
+                }
+                found = true;
             }
 
             if !found {
@@ -359,17 +371,17 @@ impl ContactRequests {
         }
 
         let identity = self.selected_identity.as_ref().unwrap().clone();
-        let mut action = AppAction::None;
+        let tasks: Vec<BackendTask> = unresolved_ids
+            .into_iter()
+            .map(|contact_id| {
+                BackendTask::DashPayTask(Box::new(DashPayTask::FetchContactProfile {
+                    identity: identity.clone(),
+                    contact_id,
+                }))
+            })
+            .collect();
 
-        for contact_id in unresolved_ids {
-            let task = BackendTask::DashPayTask(Box::new(DashPayTask::FetchContactProfile {
-                identity: identity.clone(),
-                contact_id,
-            }));
-            action |= AppAction::BackendTask(task);
-        }
-
-        action
+        AppAction::BackendTasks(tasks, BackendTasksExecutionMode::Concurrent)
     }
 
     /// Update contact request names from a fetched profile document.

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -1089,7 +1089,10 @@ impl ScreenLike for ContactsList {
                             nickname: contact_data.nickname.clone(),
                             is_hidden: contact_data.is_hidden,
                             account_reference: contact_data.account_reference,
-                            created_at: None, // Will be set by database on save
+                            created_at: Some(std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs() as i64), // Fallback to current time for filter/sort
                         };
                         self.contacts.insert(contact_data.identity_id, contact);
 
@@ -1133,7 +1136,10 @@ impl ScreenLike for ContactsList {
                             nickname: contact_data.nickname,
                             is_hidden: contact_data.is_hidden,
                             account_reference: contact_data.account_reference,
-                            created_at: None, // No database timestamp available
+                            created_at: Some(std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_secs() as i64), // Fallback to current time for filter/sort
                         };
                         self.contacts.insert(contact_data.identity_id, contact);
                     }

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -1089,10 +1089,12 @@ impl ScreenLike for ContactsList {
                             nickname: contact_data.nickname.clone(),
                             is_hidden: contact_data.is_hidden,
                             account_reference: contact_data.account_reference,
-                            created_at: Some(std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs() as i64), // Fallback to current time for filter/sort
+                            created_at: Some(
+                                std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs() as i64,
+                            ), // Fallback to current time for filter/sort
                         };
                         self.contacts.insert(contact_data.identity_id, contact);
 
@@ -1136,10 +1138,12 @@ impl ScreenLike for ContactsList {
                             nickname: contact_data.nickname,
                             is_hidden: contact_data.is_hidden,
                             account_reference: contact_data.account_reference,
-                            created_at: Some(std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_secs() as i64), // Fallback to current time for filter/sort
+                            created_at: Some(
+                                std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_secs() as i64,
+                            ), // Fallback to current time for filter/sort
                         };
                         self.contacts.insert(contact_data.identity_id, contact);
                     }


### PR DESCRIPTION
## Summary

Addresses all 9 review comments from @lklimek on PR #564.

### Changes

**1. CRITICAL — `BitOrAssign` drops tasks** (`contact_requests.rs`)
`fetch_unresolved_profiles()` used `action |= AppAction::BackendTask(task)` in a loop, but `BitOrAssign` for `AppAction` simply replaces `self` with `rhs` — only the last profile fetch would fire. Fixed by collecting all tasks into a `Vec` and using `AppAction::BackendTasks(..., Concurrent)`.

**2. HIGH — Dummy `[0x02; 33]` pubkey** (`payments.rs`)
`load_payment_history()` created a fake-but-valid P2PKH address from a dummy compressed public key. Changed `PaymentRecord.to_address` to `Option<Address>` and use `None` for historical records loaded from the database.

**3. HIGH — `i64 as u64` wrapping for amounts** (`payments.rs`)
`sp.amount as u64` silently wraps negative values. Added bounds checking with `tracing::warn!` for negative amounts, clamping to 0.

**4. MEDIUM — Duplicate payment history logic** (`dashpay.rs`)
`DashPayTask::LoadPaymentHistory` handler had its own inline implementation duplicating `payments::load_payment_history()`. Refactored to call the shared function and convert results.

**5. MEDIUM — N+1 database queries** (`contact_requests.rs`)
`resolve_names_from_local_cache()` called `load_dashpay_contacts()` per-request inside the loop. Fixed by pre-loading all contacts once into a `HashMap` for O(1) lookups.

**6. MEDIUM — `created_at: None` breaks filters** (`contacts_list.rs`)
Contacts from `DashPayContactsWithInfo` results got `created_at: None`, breaking "Recent" filter and "Date added" sort. Fixed by using current timestamp as fallback.

**7. LOW — `"failed"` as failure reason** (`payments.rs`)
`PaymentStatus::Failed(sp.status.clone())` stored the literal string "failed". Changed to use descriptive "Transaction failed" message.

**8. LOW — `i64 as u64` for timestamps** (`payments.rs`)
Same wrapping risk as #3 for `sp.created_at as u64`. Fixed consistently with bounds checking.

**9. LOW — `i64 as u64` in dashpay.rs** 
Eliminated entirely by fix #4 (duplicate code removed).