### PR TITLE
ci: cancel in-progress workflow runs on new push

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,10 @@ on:
       - "v*-dev"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
       - "v*-dev"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Add `concurrency` groups to `clippy.yml` and `tests.yml` workflows
- Automatically cancels in-progress CI runs when a new push is made to the same branch/PR
- Reduces wasted CI minutes on superseded commits

## Test plan
- [ ] Verify clippy workflow includes concurrency group
- [ ] Verify tests workflow includes concurrency group
- [ ] Push two commits in quick succession to a PR and confirm the first run is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)