### PR TITLE
fix: address CodeRabbit review feedback on local network docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ LOCAL_dapi_addresses=http://127.0.0.1:2443,http://127.0.0.1:2543,http://127.0.0.
 LOCAL_core_host=127.0.0.1
 LOCAL_core_rpc_port=20302
 LOCAL_core_rpc_user=dashmate
-# Use dashmate cli to retrive it: 
+# Use dashmate cli to retrieve it: 
 # dashmate config get core.rpc.users.dashmate.password --config=local_seed
 LOCAL_core_rpc_password=password
 LOCAL_insight_api_url=http://localhost:3001/insight-api

--- a/docs/local-network.md
+++ b/docs/local-network.md
@@ -64,8 +64,8 @@ dashmate config get platform.dapi.envoy.http.port --config=local_3
 # ZMQ endpoint port
 dashmate config get core.zmq.port --config=local_seed
 
-# Insight API port
-dashmate config get platform.drive.abci.tokioConsole.port --config=local_seed
+# Insight API port (default 3001; not managed by dashmate — check the
+# Insight API service configuration or INSIGHT_PORT environment variable)
 ```
 
 ### Variable reference


### PR DESCRIPTION
Addresses CodeRabbit review comments on #595:

- **Fix wrong Insight API port command** (docs/local-network.md line 68): The command `dashmate config get platform.drive.abci.tokioConsole.port` retrieves a Tokio Console debugging port, not the Insight API port. Replaced with a comment noting the default port (3001) and that it's configured via the Insight API service, not dashmate.

- **Fix typo** (.env.example line 38): `retrive` → `retrieve`

---
🤖 *This was generated by an automated review bot.*
Don't want automated PRs or comments on your code? You can opt out by replying here or messaging @PastaPastaPasta on Slack — we'll make sure the bot skips your PRs/repos going forward.