### PR TITLE
refactor: remove unused Insight API and show_in_ui config fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ MAINNET_core_rpc_port=9998
 MAINNET_core_rpc_user=dashrpc
 MAINNET_core_rpc_password=password
 MAINNET_core_zmq_endpoint=tcp://127.0.0.1:23708
-MAINNET_show_in_ui=true
 
 TESTNET_dapi_addresses=https://34.214.48.68:1443,https://52.12.176.90:1443,https://52.34.144.50:1443,https://44.240.98.102:1443,https://54.201.32.131:1443,https://52.10.229.11:1443,https://52.13.132.146:1443,https://52.40.219.41:1443,https://54.149.33.167:1443,https://35.164.23.245:1443,https://52.33.28.47:1443,https://52.43.13.92:1443,https://52.89.154.48:1443,https://52.24.124.162:1443,https://35.85.21.179:1443,https://54.187.14.232:1443,https://54.68.235.201:1443,https://52.13.250.182:1443
 TESTNET_core_host=127.0.0.1
@@ -16,7 +15,6 @@ TESTNET_core_rpc_port=19998
 TESTNET_core_rpc_user=dashrpc
 TESTNET_core_rpc_password=password
 TESTNET_core_zmq_endpoint=tcp://127.0.0.1:23709
-TESTNET_show_in_ui=true
 
 DEVNET_dapi_addresses=http://54.203.116.91:1443,http://52.88.16.46:1443,http://34.222.214.170:1443,http://54.214.77.108:1443,http://52.40.186.234:1443,http://54.202.231.20:1443,http://35.89.246.86:1443,http://18.246.227.21:1443,http://44.245.96.164:1443,http://44.247.160.52:1443
 DEVNET_core_host=127.0.0.1
@@ -24,7 +22,6 @@ DEVNET_core_rpc_port=29998
 DEVNET_core_rpc_user=dashrpc
 DEVNET_core_rpc_password=password
 DEVNET_core_zmq_endpoint=tcp://127.0.0.1:23710
-DEVNET_show_in_ui=true
 
 LOCAL_dapi_addresses=http://127.0.0.1:2443,http://127.0.0.1:2543,http://127.0.0.1:2643
 LOCAL_core_host=127.0.0.1
@@ -34,4 +31,3 @@ LOCAL_core_rpc_user=dashmate
 # dashmate config get core.rpc.users.dashmate.password --config=local_seed
 LOCAL_core_rpc_password=password
 LOCAL_core_zmq_endpoint=tcp://127.0.0.1:50298
-LOCAL_show_in_ui=true

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ MAINNET_core_host=127.0.0.1
 MAINNET_core_rpc_port=9998
 MAINNET_core_rpc_user=dashrpc
 MAINNET_core_rpc_password=password
-MAINNET_insight_api_url=https://insight.dash.org/insight-api
 MAINNET_core_zmq_endpoint=tcp://127.0.0.1:23708
 MAINNET_show_in_ui=true
 
@@ -16,7 +15,6 @@ TESTNET_core_host=127.0.0.1
 TESTNET_core_rpc_port=19998
 TESTNET_core_rpc_user=dashrpc
 TESTNET_core_rpc_password=password
-TESTNET_insight_api_url=https://testnet-insight.dash.org/insight-api
 TESTNET_core_zmq_endpoint=tcp://127.0.0.1:23709
 TESTNET_show_in_ui=true
 
@@ -25,7 +23,6 @@ DEVNET_core_host=127.0.0.1
 DEVNET_core_rpc_port=29998
 DEVNET_core_rpc_user=dashrpc
 DEVNET_core_rpc_password=password
-DEVNET_insight_api_url=
 DEVNET_core_zmq_endpoint=tcp://127.0.0.1:23710
 DEVNET_show_in_ui=true
 
@@ -36,6 +33,5 @@ LOCAL_core_rpc_user=dashmate
 # Use dashmate cli to retrive it: 
 # dashmate config get core.rpc.users.dashmate.password --config=local_seed
 LOCAL_core_rpc_password=password
-LOCAL_insight_api_url=http://localhost:3001/insight-api
 LOCAL_core_zmq_endpoint=tcp://127.0.0.1:50298
 LOCAL_show_in_ui=true

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,8 +43,6 @@ pub struct NetworkConfig {
     pub devnet_name: Option<String>,
     /// Optional wallet private key to instantiate the wallet
     pub wallet_private_key: Option<String>,
-    /// Should this network be visible in the UI
-    pub show_in_ui: bool,
 }
 
 impl Config {
@@ -127,10 +125,6 @@ impl Config {
                 )
                 .map_err(|e| ConfigError::LoadError(e.to_string()))?;
             }
-
-            // Whether or not to show in UI
-            writeln!(env_file, "{}show_in_ui={}", prefix, config.show_in_ui)
-                .map_err(|e| ConfigError::LoadError(e.to_string()))?;
 
             // Add a blank line after each config block
             writeln!(env_file).map_err(|e| ConfigError::LoadError(e.to_string()))?;
@@ -335,7 +329,6 @@ mod tests {
             core_zmq_endpoint: Some("tcp://127.0.0.1:23708".to_string()),
             devnet_name: None,
             wallet_private_key: None,
-            show_in_ui: true,
         }
     }
 
@@ -563,7 +556,6 @@ mod tests {
             if let Some(ref zmq) = cfg.core_zmq_endpoint {
                 output.push_str(&format!("MAINNET_core_zmq_endpoint={}\n", zmq));
             }
-            output.push_str(&format!("MAINNET_show_in_ui={}\n", cfg.show_in_ui));
         }
 
         assert!(output.contains("MAINNET_dapi_addresses=https://1.1.1.1:443"));
@@ -571,7 +563,6 @@ mod tests {
         assert!(output.contains("MAINNET_core_rpc_user=dashrpc"));
         assert!(output.contains("MAINNET_core_rpc_password=password"));
         assert!(output.contains("MAINNET_core_zmq_endpoint=tcp://127.0.0.1:23708"));
-        assert!(output.contains("MAINNET_show_in_ui=true"));
     }
 
     // ── envy parsing roundtrip ──────────────────────────────────────
@@ -595,7 +586,6 @@ mod tests {
             "TEST_RT_core_zmq_endpoint".into(),
             "tcp://127.0.0.1:29999".into(),
         );
-        env_map.insert("TEST_RT_show_in_ui".into(), "true".into());
 
         // Use envy's from_iter to parse from our map (same as from_env but testable)
         let result: Result<NetworkConfig, _> = envy::prefixed("TEST_RT_")
@@ -611,7 +601,6 @@ mod tests {
             config.core_zmq_endpoint,
             Some("tcp://127.0.0.1:29999".to_string())
         );
-        assert!(config.show_in_ui);
         assert!(config.devnet_name.is_none());
         assert!(config.wallet_private_key.is_none());
     }
@@ -626,7 +615,6 @@ mod tests {
         env_map.insert("OPT_core_rpc_port".into(), "29998".into());
         env_map.insert("OPT_core_rpc_user".into(), "user".into());
         env_map.insert("OPT_core_rpc_password".into(), "pass".into());
-        env_map.insert("OPT_show_in_ui".into(), "false".into());
         env_map.insert("OPT_devnet_name".into(), "devnet-evo".into());
         env_map.insert("OPT_wallet_private_key".into(), "cVBZ1234abcd".into());
 
@@ -636,7 +624,6 @@ mod tests {
         let config = result.unwrap();
         assert_eq!(config.devnet_name, Some("devnet-evo".to_string()));
         assert_eq!(config.wallet_private_key, Some("cVBZ1234abcd".to_string()));
-        assert!(!config.show_in_ui);
         assert!(config.core_zmq_endpoint.is_none());
     }
 
@@ -651,7 +638,6 @@ mod tests {
         // core_rpc_port intentionally missing
         env_map.insert("MISS_core_rpc_user".into(), "user".into());
         env_map.insert("MISS_core_rpc_password".into(), "pass".into());
-        env_map.insert("MISS_show_in_ui".into(), "true".into());
 
         let result: Result<NetworkConfig, _> =
             envy::prefixed("MISS_").from_iter(env_map.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -668,7 +654,6 @@ mod tests {
         env_map.insert("BAD_core_rpc_port".into(), "not_a_number".into());
         env_map.insert("BAD_core_rpc_user".into(), "user".into());
         env_map.insert("BAD_core_rpc_password".into(), "pass".into());
-        env_map.insert("BAD_show_in_ui".into(), "true".into());
 
         let result: Result<NetworkConfig, _> =
             envy::prefixed("BAD_").from_iter(env_map.iter().map(|(k, v)| (k.clone(), v.clone())));

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use crate::app_dir::app_user_data_file_path;
 use dash_sdk::dapi_client::AddressList;
 use dash_sdk::dpp::dashcore::Network;
-use dash_sdk::sdk::Uri;
 use serde::Deserialize;
 use tempfile::NamedTempFile;
 
@@ -38,8 +37,6 @@ pub struct NetworkConfig {
     pub core_rpc_user: String,
     /// Password for Dash Core RPC interface
     pub core_rpc_password: String,
-    /// URL of the Insight API
-    pub insight_api_url: String,
     /// ZMQ endpoint for Core blockchain events (e.g., tcp://127.0.0.1:23708)
     pub core_zmq_endpoint: Option<String>,
     /// Devnet network name if one exists
@@ -108,13 +105,6 @@ impl Config {
                 prefix, config.core_rpc_password
             )
             .map_err(|e| ConfigError::LoadError(e.to_string()))?;
-            writeln!(
-                env_file,
-                "{}insight_api_url={}",
-                prefix, config.insight_api_url
-            )
-            .map_err(|e| ConfigError::LoadError(e.to_string()))?;
-
             if let Some(core_zmq_endpoint) = &config.core_zmq_endpoint {
                 writeln!(
                     env_file,
@@ -315,18 +305,11 @@ impl NetworkConfig {
             && !self.core_rpc_password.is_empty()
             && self.core_rpc_port != 0
             && !self.dapi_addresses.is_empty()
-            && Uri::from_str(&self.insight_api_url).is_ok()
     }
 
     /// List of DAPI addresses
     pub fn dapi_address_list(&self) -> AddressList {
         AddressList::from_str(&self.dapi_addresses).expect("Could not parse DAPI addresses")
-    }
-
-    /// Insight API URI
-    #[allow(dead_code)] // May be used for insight API access
-    pub fn insight_api_uri(&self) -> Uri {
-        Uri::from_str(&self.insight_api_url).expect("invalid insight API URL")
     }
 
     /// Update just the `core_rpc_password` in a builder-like manner.
@@ -342,18 +325,13 @@ mod tests {
     use super::*;
 
     /// Helper to create a minimal valid NetworkConfig for testing
-    fn make_network_config(
-        dapi_addresses: &str,
-        insight_api_url: &str,
-        port: u16,
-    ) -> NetworkConfig {
+    fn make_network_config(dapi_addresses: &str, port: u16) -> NetworkConfig {
         NetworkConfig {
             dapi_addresses: dapi_addresses.to_string(),
             core_host: "127.0.0.1".to_string(),
             core_rpc_port: port,
             core_rpc_user: "dashrpc".to_string(),
             core_rpc_password: "password".to_string(),
-            insight_api_url: insight_api_url.to_string(),
             core_zmq_endpoint: Some("tcp://127.0.0.1:23708".to_string()),
             devnet_name: None,
             wallet_private_key: None,
@@ -365,55 +343,33 @@ mod tests {
 
     #[test]
     fn test_is_valid_with_all_fields() {
-        let config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let config = make_network_config("https://127.0.0.1:443", 9998);
         assert!(config.is_valid());
     }
 
     #[test]
     fn test_is_valid_empty_user() {
-        let mut config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let mut config = make_network_config("https://127.0.0.1:443", 9998);
         config.core_rpc_user = String::new();
         assert!(!config.is_valid());
     }
 
     #[test]
     fn test_is_valid_empty_password() {
-        let mut config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let mut config = make_network_config("https://127.0.0.1:443", 9998);
         config.core_rpc_password = String::new();
         assert!(!config.is_valid());
     }
 
     #[test]
     fn test_is_valid_zero_port() {
-        let config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            0,
-        );
+        let config = make_network_config("https://127.0.0.1:443", 0);
         assert!(!config.is_valid());
     }
 
     #[test]
     fn test_is_valid_empty_dapi_addresses() {
-        let config = make_network_config("", "https://insight.dash.org/insight-api", 9998);
-        assert!(!config.is_valid());
-    }
-
-    #[test]
-    fn test_is_valid_invalid_insight_url() {
-        let config = make_network_config("https://127.0.0.1:443", "not a valid url \x00", 9998);
+        let config = make_network_config("", 9998);
         assert!(!config.is_valid());
     }
 
@@ -421,11 +377,7 @@ mod tests {
 
     #[test]
     fn test_dapi_address_list_single_address() {
-        let config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let config = make_network_config("https://127.0.0.1:443", 9998);
         let list = config.dapi_address_list();
         assert_eq!(list.len(), 1);
     }
@@ -434,7 +386,6 @@ mod tests {
     fn test_dapi_address_list_multiple_addresses() {
         let config = make_network_config(
             "https://127.0.0.1:443,https://192.168.1.1:443,https://10.0.0.1:443",
-            "https://insight.dash.org/insight-api",
             9998,
         );
         let list = config.dapi_address_list();
@@ -444,46 +395,15 @@ mod tests {
     #[test]
     #[should_panic(expected = "Could not parse DAPI addresses")]
     fn test_dapi_address_list_empty_panics() {
-        let config = make_network_config("", "https://insight.dash.org/insight-api", 9998);
+        let config = make_network_config("", 9998);
         let _list = config.dapi_address_list();
-    }
-
-    // ── NetworkConfig::insight_api_uri ───────────────────────────────
-
-    #[test]
-    fn test_insight_api_uri_valid() {
-        let config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
-        let uri = config.insight_api_uri();
-        assert_eq!(uri.to_string(), "https://insight.dash.org/insight-api");
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid insight API URL")]
-    fn test_insight_api_uri_invalid_panics() {
-        let config = make_network_config("https://127.0.0.1:443", "not a valid url \x00", 9998);
-        let _uri = config.insight_api_uri();
-    }
-
-    #[test]
-    #[should_panic(expected = "invalid insight API URL")]
-    fn test_insight_api_uri_empty_panics() {
-        let config = make_network_config("https://127.0.0.1:443", "", 9998);
-        let _uri = config.insight_api_uri();
     }
 
     // ── NetworkConfig::update_core_rpc_password ─────────────────────
 
     #[test]
     fn test_update_core_rpc_password() {
-        let config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let config = make_network_config("https://127.0.0.1:443", 9998);
         assert_eq!(config.core_rpc_password, "password");
         let updated = config.update_core_rpc_password("new_secret".to_string());
         assert_eq!(updated.core_rpc_password, "new_secret");
@@ -496,11 +416,7 @@ mod tests {
 
     #[test]
     fn test_config_for_network_mainnet() {
-        let mainnet_cfg = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let mainnet_cfg = make_network_config("https://127.0.0.1:443", 9998);
         let config = Config {
             mainnet_config: Some(mainnet_cfg),
             testnet_config: None,
@@ -517,26 +433,10 @@ mod tests {
     #[test]
     fn test_config_for_network_all_networks() {
         let config = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://main.example.com",
-                9998,
-            )),
-            testnet_config: Some(make_network_config(
-                "https://2.2.2.2:1443",
-                "https://test.example.com",
-                19998,
-            )),
-            devnet_config: Some(make_network_config(
-                "http://3.3.3.3:1443",
-                "http://dev.example.com",
-                29998,
-            )),
-            local_config: Some(make_network_config(
-                "http://127.0.0.1:2443",
-                "http://localhost:3001",
-                20302,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
+            testnet_config: Some(make_network_config("https://2.2.2.2:1443", 19998)),
+            devnet_config: Some(make_network_config("http://3.3.3.3:1443", 29998)),
+            local_config: Some(make_network_config("http://127.0.0.1:2443", 20302)),
             developer_mode: Some(true),
         };
         let main = config.config_for_network(Network::Dash).as_ref().unwrap();
@@ -567,11 +467,7 @@ mod tests {
             developer_mode: None,
         };
         assert!(config.mainnet_config.is_none());
-        let new_cfg = make_network_config(
-            "https://1.1.1.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let new_cfg = make_network_config("https://1.1.1.1:443", 9998);
         config.update_config_for_network(Network::Dash, new_cfg);
         assert!(config.mainnet_config.is_some());
         assert_eq!(config.mainnet_config.as_ref().unwrap().core_rpc_port, 9998);
@@ -580,21 +476,13 @@ mod tests {
     #[test]
     fn test_update_config_replaces_existing() {
         let mut config = Config {
-            mainnet_config: Some(make_network_config(
-                "https://old.example.com:443",
-                "https://old.example.com",
-                1111,
-            )),
+            mainnet_config: Some(make_network_config("https://old.example.com:443", 1111)),
             testnet_config: None,
             devnet_config: None,
             local_config: None,
             developer_mode: None,
         };
-        let new_cfg = make_network_config(
-            "https://new.example.com:443",
-            "https://new.example.com",
-            2222,
-        );
+        let new_cfg = make_network_config("https://new.example.com:443", 2222);
         config.update_config_for_network(Network::Dash, new_cfg);
         let main = config.mainnet_config.as_ref().unwrap();
         assert_eq!(main.core_rpc_port, 2222);
@@ -612,15 +500,15 @@ mod tests {
         };
         config.update_config_for_network(
             Network::Testnet,
-            make_network_config("https://t.example.com:1443", "https://t.example.com", 19998),
+            make_network_config("https://t.example.com:1443", 19998),
         );
         config.update_config_for_network(
             Network::Devnet,
-            make_network_config("http://d.example.com:1443", "http://d.example.com", 29998),
+            make_network_config("http://d.example.com:1443", 29998),
         );
         config.update_config_for_network(
             Network::Regtest,
-            make_network_config("http://127.0.0.1:2443", "http://localhost:3001", 20302),
+            make_network_config("http://127.0.0.1:2443", 20302),
         );
         assert!(config.testnet_config.is_some());
         assert!(config.devnet_config.is_some());
@@ -631,11 +519,7 @@ mod tests {
 
     #[test]
     fn test_network_config_optional_fields() {
-        let mut config = make_network_config(
-            "https://127.0.0.1:443",
-            "https://insight.dash.org/insight-api",
-            9998,
-        );
+        let mut config = make_network_config("https://127.0.0.1:443", 9998);
         // Defaults
         assert!(config.devnet_name.is_none());
         assert!(config.wallet_private_key.is_none());
@@ -658,16 +542,8 @@ mod tests {
         // We can't easily test save() directly since it depends on app_user_data_file_path,
         // but we can verify the save format by manually constructing what save() would write.
         let config = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://insight.dash.org/insight-api",
-                9998,
-            )),
-            testnet_config: Some(make_network_config(
-                "https://2.2.2.2:1443",
-                "https://testnet-insight.dash.org/insight-api",
-                19998,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
+            testnet_config: Some(make_network_config("https://2.2.2.2:1443", 19998)),
             devnet_config: None,
             local_config: None,
             developer_mode: Some(true),
@@ -684,10 +560,6 @@ mod tests {
                 "MAINNET_core_rpc_password={}\n",
                 cfg.core_rpc_password
             ));
-            output.push_str(&format!(
-                "MAINNET_insight_api_url={}\n",
-                cfg.insight_api_url
-            ));
             if let Some(ref zmq) = cfg.core_zmq_endpoint {
                 output.push_str(&format!("MAINNET_core_zmq_endpoint={}\n", zmq));
             }
@@ -698,7 +570,6 @@ mod tests {
         assert!(output.contains("MAINNET_core_rpc_port=9998"));
         assert!(output.contains("MAINNET_core_rpc_user=dashrpc"));
         assert!(output.contains("MAINNET_core_rpc_password=password"));
-        assert!(output.contains("MAINNET_insight_api_url=https://insight.dash.org/insight-api"));
         assert!(output.contains("MAINNET_core_zmq_endpoint=tcp://127.0.0.1:23708"));
         assert!(output.contains("MAINNET_show_in_ui=true"));
     }
@@ -721,10 +592,6 @@ mod tests {
         env_map.insert("TEST_RT_core_rpc_user".into(), "testuser".into());
         env_map.insert("TEST_RT_core_rpc_password".into(), "testpass".into());
         env_map.insert(
-            "TEST_RT_insight_api_url".into(),
-            "https://insight.example.com/api".into(),
-        );
-        env_map.insert(
             "TEST_RT_core_zmq_endpoint".into(),
             "tcp://127.0.0.1:29999".into(),
         );
@@ -740,7 +607,6 @@ mod tests {
         assert_eq!(config.core_rpc_port, 9998);
         assert_eq!(config.core_rpc_user, "testuser");
         assert_eq!(config.core_rpc_password, "testpass");
-        assert_eq!(config.insight_api_url, "https://insight.example.com/api");
         assert_eq!(
             config.core_zmq_endpoint,
             Some("tcp://127.0.0.1:29999".to_string())
@@ -760,7 +626,6 @@ mod tests {
         env_map.insert("OPT_core_rpc_port".into(), "29998".into());
         env_map.insert("OPT_core_rpc_user".into(), "user".into());
         env_map.insert("OPT_core_rpc_password".into(), "pass".into());
-        env_map.insert("OPT_insight_api_url".into(), "http://localhost:3001".into());
         env_map.insert("OPT_show_in_ui".into(), "false".into());
         env_map.insert("OPT_devnet_name".into(), "devnet-evo".into());
         env_map.insert("OPT_wallet_private_key".into(), "cVBZ1234abcd".into());
@@ -786,7 +651,6 @@ mod tests {
         // core_rpc_port intentionally missing
         env_map.insert("MISS_core_rpc_user".into(), "user".into());
         env_map.insert("MISS_core_rpc_password".into(), "pass".into());
-        env_map.insert("MISS_insight_api_url".into(), "http://localhost".into());
         env_map.insert("MISS_show_in_ui".into(), "true".into());
 
         let result: Result<NetworkConfig, _> =
@@ -804,7 +668,6 @@ mod tests {
         env_map.insert("BAD_core_rpc_port".into(), "not_a_number".into());
         env_map.insert("BAD_core_rpc_user".into(), "user".into());
         env_map.insert("BAD_core_rpc_password".into(), "pass".into());
-        env_map.insert("BAD_insight_api_url".into(), "http://localhost".into());
         env_map.insert("BAD_show_in_ui".into(), "true".into());
 
         let result: Result<NetworkConfig, _> =
@@ -817,11 +680,7 @@ mod tests {
     #[test]
     fn test_config_developer_mode() {
         let config = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://insight.dash.org",
-                9998,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
             testnet_config: None,
             devnet_config: None,
             local_config: None,
@@ -830,11 +689,7 @@ mod tests {
         assert_eq!(config.developer_mode, Some(true));
 
         let config_off = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://insight.dash.org",
-                9998,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
             testnet_config: None,
             devnet_config: None,
             local_config: None,
@@ -843,11 +698,7 @@ mod tests {
         assert_eq!(config_off.developer_mode, Some(false));
 
         let config_none = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://insight.dash.org",
-                9998,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
             testnet_config: None,
             devnet_config: None,
             local_config: None,
@@ -861,11 +712,7 @@ mod tests {
     #[test]
     fn test_config_clone() {
         let config = Config {
-            mainnet_config: Some(make_network_config(
-                "https://1.1.1.1:443",
-                "https://insight.dash.org",
-                9998,
-            )),
+            mainnet_config: Some(make_network_config("https://1.1.1.1:443", 9998)),
             testnet_config: None,
             devnet_config: None,
             local_config: None,

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -23,7 +23,6 @@ fn test_network_config() -> NetworkConfig {
         core_zmq_endpoint: Some("tcp://127.0.0.1:23709".to_string()),
         devnet_name: None,
         wallet_private_key: None,
-        show_in_ui: true,
     }
 }
 

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -20,7 +20,6 @@ fn test_network_config() -> NetworkConfig {
         core_rpc_port: 19998,
         core_rpc_user: "dashrpc".to_string(),
         core_rpc_password: "password".to_string(),
-        insight_api_url: "https://testnet-insight.dash.org/insight-api".to_string(),
         core_zmq_endpoint: Some("tcp://127.0.0.1:23709".to_string()),
         devnet_name: None,
         wallet_private_key: None,

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -3200,7 +3200,6 @@ mod tests {
                 std::env::set_var("MAINNET_core_rpc_port", "9998");
                 std::env::set_var("MAINNET_core_rpc_user", "dashrpc");
                 std::env::set_var("MAINNET_core_rpc_password", "password");
-                std::env::set_var("MAINNET_insight_api_url", "http://127.0.0.1:3001");
                 std::env::set_var("MAINNET_show_in_ui", "true");
 
                 std::env::set_var("LOCAL_dapi_addresses", "http://127.0.0.1:2443");
@@ -3208,7 +3207,6 @@ mod tests {
                 std::env::set_var("LOCAL_core_rpc_port", "20302");
                 std::env::set_var("LOCAL_core_rpc_user", "dashmate");
                 std::env::set_var("LOCAL_core_rpc_password", "password");
-                std::env::set_var("LOCAL_insight_api_url", "http://127.0.0.1:3001");
                 std::env::set_var("LOCAL_show_in_ui", "true");
             }
         });

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -3200,14 +3200,12 @@ mod tests {
                 std::env::set_var("MAINNET_core_rpc_port", "9998");
                 std::env::set_var("MAINNET_core_rpc_user", "dashrpc");
                 std::env::set_var("MAINNET_core_rpc_password", "password");
-                std::env::set_var("MAINNET_show_in_ui", "true");
 
                 std::env::set_var("LOCAL_dapi_addresses", "http://127.0.0.1:2443");
                 std::env::set_var("LOCAL_core_host", "127.0.0.1");
                 std::env::set_var("LOCAL_core_rpc_port", "20302");
                 std::env::set_var("LOCAL_core_rpc_user", "dashmate");
                 std::env::set_var("LOCAL_core_rpc_password", "password");
-                std::env::set_var("LOCAL_show_in_ui", "true");
             }
         });
     }

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -16,7 +16,7 @@ use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use eframe::egui::{self, ComboBox, Context};
 use eframe::epaint::TextureHandle;
 use egui::load::SizedTexture;
-use egui::{Frame, Margin, RichText, TextureOptions};
+use egui::{Color32, Frame, Margin, RichText, TextureOptions};
 use std::sync::{Arc, RwLock};
 
 use super::WalletsBalancesScreen;


### PR DESCRIPTION
Removes unused `insight_api_url` and `show_in_ui` fields from `NetworkConfig`, along with related serialization, environment variable examples, and tests. Simplifies configuration initialization by eliminating dead settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Insight API configuration options from environment files and app network settings.
  * Simplified configuration initialization and related test setup by eliminating those settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->