### PR TITLE
fix(ui): add scroll to keys popup for identities with many keys

### DIFF
--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -724,6 +724,9 @@ impl IdentitiesScreen {
                                                         .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
                                                         .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.ctx().style().visuals.dark_mode)))
                                                         .show(|ui| {
+                                                            // Wrap in a scroll area so popups with many keys are accessible
+                                                            let max_popup_height = ui.ctx().content_rect().height() * 0.6;
+                                                            egui::ScrollArea::vertical().max_height(max_popup_height).show(ui, |ui| {
                                                             let dark_mode = ui.ctx().style().visuals.dark_mode;
 
                                                             // Main Identity Keys
@@ -792,6 +795,7 @@ impl IdentitiesScreen {
                                                                     )));
                                                                    ui.close_kind(egui::UiKind::Menu);
                                                                 }
+                                                            }); // end ScrollArea
                                                         },
                                                     );
                                                 }


### PR DESCRIPTION
## Problem

The keys popup on the identity screen has no scroll capability. When an identity has many keys (16+), keys at the bottom are inaccessible depending on window/screen size.

Reported by thephez.

## Fix

Wrap the popup content in a vertical `ScrollArea` with a max height of 60% of the viewport height. Keys beyond the visible area are now reachable via scrolling.

## Changes

- `src/ui/identities/identities_screen.rs`: Added `egui::ScrollArea::vertical().max_height(...)` around the keys popup content

## Build

`cargo check` passes with zero warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced popup functionality within identity management by implementing scrollable content areas. Identity-related popups now seamlessly handle large lists with automatic scrolling capabilities, effectively preventing content overflow and ensuring all information remains visible and fully accessible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->