### PR TITLE
feat(wallets): hide zero-balance addresses by default

### DIFF
--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -192,6 +192,21 @@ impl WalletsBalancesScreen {
                 .retain(|data| data.account_category == category && data.account_index == index);
         }
 
+        if !self.show_zero_balance_addresses {
+            address_data.retain(|data| {
+                let is_platform_payment = data
+                    .derivation_path
+                    .is_platform_payment(self.app_context.network);
+                if data.account_category.is_key_only() {
+                    true
+                } else if is_platform_payment {
+                    data.platform_credits > 0
+                } else {
+                    data.balance > 0
+                }
+            });
+        }
+
         // Space allocation for UI elements is handled by the layout system
 
         // Render the table

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -192,6 +192,8 @@ impl WalletsBalancesScreen {
                 .retain(|data| data.account_category == category && data.account_index == index);
         }
 
+        let account_address_count = address_data.len();
+
         if !self.show_zero_balance_addresses {
             address_data.retain(|data| {
                 let is_platform_payment = data.account_category == AccountCategory::PlatformPayment;
@@ -204,6 +206,9 @@ impl WalletsBalancesScreen {
                 }
             });
         }
+
+        let show_empty_due_to_balance_filter =
+            !self.show_zero_balance_addresses && account_address_count > 0 && address_data.is_empty();
 
         // Space allocation for UI elements is handled by the layout system
 
@@ -406,6 +411,11 @@ impl WalletsBalancesScreen {
                     });
                 }
             });
+
+        if show_empty_due_to_balance_filter {
+            ui.add_space(8.0);
+            ui.label("No addresses with balance. Enable \"Show zero-balance addresses\" to view all addresses.");
+        }
         action
     }
 }

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -207,8 +207,9 @@ impl WalletsBalancesScreen {
             });
         }
 
-        let show_empty_due_to_balance_filter =
-            !self.show_zero_balance_addresses && account_address_count > 0 && address_data.is_empty();
+        let show_empty_due_to_balance_filter = !self.show_zero_balance_addresses
+            && account_address_count > 0
+            && address_data.is_empty();
 
         // Space allocation for UI elements is handled by the layout system
 

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -194,9 +194,8 @@ impl WalletsBalancesScreen {
 
         if !self.show_zero_balance_addresses {
             address_data.retain(|data| {
-                let is_platform_payment = data
-                    .derivation_path
-                    .is_platform_payment(self.app_context.network);
+                let is_platform_payment =
+                    data.account_category == AccountCategory::PlatformPayment;
                 if data.account_category.is_key_only() {
                     true
                 } else if is_platform_payment {

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -194,8 +194,7 @@ impl WalletsBalancesScreen {
 
         if !self.show_zero_balance_addresses {
             address_data.retain(|data| {
-                let is_platform_payment =
-                    data.account_category == AccountCategory::PlatformPayment;
+                let is_platform_payment = data.account_category == AccountCategory::PlatformPayment;
                 if data.account_category.is_key_only() {
                     true
                 } else if is_platform_payment {

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -207,9 +207,10 @@ impl WalletsBalancesScreen {
             });
         }
 
-        let show_empty_due_to_balance_filter = !self.show_zero_balance_addresses
-            && account_address_count > 0
-            && address_data.is_empty();
+        let hidden_by_balance_filter_count =
+            account_address_count.saturating_sub(address_data.len());
+        let show_balance_filter_hint =
+            !self.show_zero_balance_addresses && hidden_by_balance_filter_count > 0;
 
         // Space allocation for UI elements is handled by the layout system
 
@@ -413,9 +414,17 @@ impl WalletsBalancesScreen {
                 }
             });
 
-        if show_empty_due_to_balance_filter {
+        if show_balance_filter_hint {
             ui.add_space(8.0);
-            ui.label("No addresses with balance. Enable \"Show zero-balance addresses\" to view all addresses.");
+            let address_label = if hidden_by_balance_filter_count == 1 {
+                "address"
+            } else {
+                "addresses"
+            };
+            ui.label(format!(
+                "{} {} hidden by zero-balance filter. Enable \"Show zero-balance addresses\" to view all addresses.",
+                hidden_by_balance_filter_count, address_label
+            ));
         }
         action
     }

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -101,6 +101,7 @@ pub struct WalletsBalancesScreen {
     fund_platform_dialog: FundPlatformAddressDialogState,
     private_key_dialog: PrivateKeyDialogState,
     selected_account: Option<(AccountCategory, Option<u32>)>,
+    show_zero_balance_addresses: bool,
     /// Pending refresh of platform address balances (triggered after transfers)
     pending_platform_balance_refresh: Option<WalletSeedHash>,
     /// Whether we should refresh the wallet after it's unlocked
@@ -193,6 +194,7 @@ impl WalletsBalancesScreen {
             fund_platform_dialog: FundPlatformAddressDialogState::default(),
             private_key_dialog: PrivateKeyDialogState::default(),
             selected_account: None,
+            show_zero_balance_addresses: false,
             pending_platform_balance_refresh: None,
             pending_refresh_after_unlock: false,
             pending_refresh_mode: RefreshMode::default(),
@@ -1151,10 +1153,21 @@ impl WalletsBalancesScreen {
                                 format!("Addresses ({})", category.label(*index))
                             })
                             .unwrap_or_else(|| "Addresses".to_string());
-                        ui.heading(
-                            RichText::new(addresses_heading)
-                                .color(DashColors::text_primary(dark_mode)),
-                        );
+                        ui.horizontal(|ui| {
+                            ui.heading(
+                                RichText::new(addresses_heading)
+                                    .color(DashColors::text_primary(dark_mode)),
+                            );
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    ui.checkbox(
+                                        &mut self.show_zero_balance_addresses,
+                                        "Show zero-balance addresses",
+                                    );
+                                },
+                            );
+                        });
                         ui.add_space(8.0);
                         action |= self.render_address_table(ui);
 


### PR DESCRIPTION
## Summary
- hide zero-balance addresses by default in the wallets addresses table
- add a `Show zero-balance addresses` toggle next to the addresses section header
- keep key-only address rows visible while filtering normal and platform-payment rows by balance

## Testing
- `cargo fmt --all`
- `cargo check -q`
- `cargo test -q wallets_screen -- --nocapture`

This pull request was created by Codex (GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a right-aligned "Show zero-balance addresses" toggle on the wallet balances screen (off by default).
  * When off, key-only addresses remain visible; platform-payment addresses show only if platform credits > 0; other addresses show only if balance > 0.
  * When addresses are hidden, a concise hint appears (e.g., "1 hidden by zero-balance filter" / "N hidden by zero-balance filter. Enable 'Show zero-balance addresses' to view all addresses.").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->