### PR TITLE
build: update dash-sdk dependency and remove rust-dashcore patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,8 +1716,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1784,8 +1784,8 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "dpp",
  "drive",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -1873,8 +1873,8 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "heck",
  "quote",
@@ -1883,8 +1883,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1918,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1951,7 +1951,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1977,12 +1977,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2034,8 +2034,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2045,8 +2045,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2298,8 +2298,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2309,8 +2309,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2357,8 +2357,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2382,8 +2382,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -2964,8 +2964,8 @@ dependencies = [
 
 [[package]]
 name = "feature-flags-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4013,7 +4013,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4412,7 +4412,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://www.github.com/dashpay/rust-dashcore?rev=6affdaa5db30c04f533cfac4a81b9939d1cf2545#6affdaa5db30c04f533cfac4a81b9939d1cf2545"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=a05d256f59743c69df912462dd77dd487e1ff5b2#a05d256f59743c69df912462dd77dd487e1ff5b2"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -4427,8 +4427,8 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4619,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5677,8 +5677,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5686,8 +5686,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5697,8 +5697,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5717,8 +5717,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version",
@@ -5728,8 +5728,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5900,7 +5900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5921,7 +5921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -6437,8 +6437,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "backon",
  "chrono",
@@ -7577,8 +7577,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8325,8 +8325,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8970,19 +8970,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -9732,8 +9719,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "3.0.1"
-source = "git+https://github.com/dashpay/platform?rev=d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7#d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7"
+version = "3.1.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=b445b6f0e0bd486357f86100ba8b7fddab283bd7#b445b6f0e0bd486357f86100ba8b7fddab283bd7"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "b445b6f0e0bd486357f86100ba8b7fddab283bd7", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -90,17 +90,6 @@ egui_kittest = { version = "0.33.3", features = ["eframe"] }
 
 [build-dependencies]
 winres = "0.1"
-
-[patch."https://github.com/dashpay/rust-dashcore"]
-dash-network = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dash-spv = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dashcore = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dashcore-private = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dashcore-rpc = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dashcore-rpc-json = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-dashcore_hashes = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-key-wallet = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
-key-wallet-manager = { git = "https://www.github.com/dashpay/rust-dashcore", rev = "6affdaa5db30c04f533cfac4a81b9939d1cf2545" }
 
 [lints.rust.unexpected_cfgs]
 level = "warn"


### PR DESCRIPTION
## Summary
This PR updates the dash-sdk dependency to a newer revision and removes the patch section for rust-dashcore dependencies, indicating that these dependencies are now properly resolved through the updated dash-sdk.

## Key Changes
- Updated `dash-sdk` git revision from `d6f4eb9ac9feafaa914f06e1b78eb66beceef3b7` to `b445b6f0e0bd486357f86100ba8b7fddab283bd7`
- Removed the `[patch."https://github.com/dashpay/rust-dashcore"]` section that was patching 10 dashcore-related dependencies:
  - dash-network
  - dash-spv
  - dashcore
  - dashcore-private
  - dashcore-rpc
  - dashcore-rpc-json
  - dashcore_hashes
  - key-wallet
  - key-wallet-manager

## Implementation Details
The removal of the patch section suggests that the newer dash-sdk revision now properly manages its transitive dependencies on rust-dashcore, eliminating the need for manual patches. This simplifies the dependency management and reduces maintenance overhead.

https://claude.ai/code/session_01PBXkJ5WWNGH29EabTq5zkW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to the latest versions
  * Simplified dependency management by removing explicit version overrides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->