### PR TITLE
fix(ui): prevent contract chooser from expanding multiple contracts on single click

### DIFF
--- a/src/context/contract_token_db.rs
+++ b/src/context/contract_token_db.rs
@@ -8,21 +8,28 @@ use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::platform::{DataContract, Identifier};
 use dash_sdk::query_types::IndexMap;
 use rusqlite::Result;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 impl AppContext {
-    /// Retrieves all contracts from the database plus the system contracts from app context.
+    /// Retrieves system contracts plus contracts from the database.
+    ///
+    /// System contracts are always returned first in fixed order:
+    /// `dpns`, `token_history`, `withdrawals`, `keyword_search`, `dashpay`.
+    /// DB contracts are appended after and deduplicated by contract id against system contracts.
+    ///
+    /// `limit` and `offset` are applied to the DB query only. If `offset` is provided
+    /// without a `limit`, an unbounded limit is used so offset semantics remain valid.
     pub fn get_contracts(
         &self,
         limit: Option<u32>,
         offset: Option<u32>,
     ) -> Result<Vec<QualifiedContract>> {
-        // Get contracts from the database
-        let mut contracts = self.db.get_contracts(self, limit, offset)?;
+        let db_limit = limit.or(offset.map(|_| u32::MAX));
+        let db_contracts = self.db.get_contracts(self, db_limit, offset)?;
 
-        // Build the list of system contracts to prepend
-        let system_contracts = vec![
+        let system_contracts = [
             QualifiedContract {
                 contract: Arc::clone(&self.dpns_contract).as_ref().clone(),
                 alias: Some("dpns".to_string()),
@@ -45,20 +52,18 @@ impl AppContext {
             },
         ];
 
-        // Collect system contract IDs in a map to deduplicate DB contracts that match.
-        let system_contracts_by_id: std::collections::BTreeMap<_, _> = system_contracts
-            .iter()
-            .map(|c| (c.contract.id(), ()))
-            .collect();
-
-        // Remove any DB contracts that duplicate a system contract
-        contracts.retain(|c| !system_contracts_by_id.contains_key(&c.contract.id()));
-
-        // Prepend system contracts in order
-        let mut result = system_contracts;
-        result.append(&mut contracts);
-
-        Ok(result)
+        let mut seen_contract_ids = BTreeMap::new();
+        Ok(system_contracts
+            .into_iter()
+            .chain(db_contracts)
+            .filter_map(|qualified_contract| {
+                let contract_id = qualified_contract.contract.id();
+                seen_contract_ids
+                    .insert(contract_id, ())
+                    .is_none()
+                    .then_some(qualified_contract)
+            })
+            .collect())
     }
 
     pub fn get_contract_by_id(

--- a/src/context/contract_token_db.rs
+++ b/src/context/contract_token_db.rs
@@ -4,6 +4,7 @@ use crate::model::wallet::WalletSeedHash;
 use crate::ui::tokens::tokens_screen::{IdentityTokenBalance, IdentityTokenIdentifier};
 use bincode::config;
 use dash_sdk::dpp::data_contract::TokenConfiguration;
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::platform::{DataContract, Identifier};
 use dash_sdk::query_types::IndexMap;
 use rusqlite::Result;
@@ -20,52 +21,44 @@ impl AppContext {
         // Get contracts from the database
         let mut contracts = self.db.get_contracts(self, limit, offset)?;
 
-        // Add the DPNS contract to the list
-        let dpns_contract = QualifiedContract {
-            contract: Arc::clone(&self.dpns_contract).as_ref().clone(),
-            alias: Some("dpns".to_string()),
-        };
+        // Build the list of system contracts to prepend
+        let system_contracts = vec![
+            QualifiedContract {
+                contract: Arc::clone(&self.dpns_contract).as_ref().clone(),
+                alias: Some("dpns".to_string()),
+            },
+            QualifiedContract {
+                contract: Arc::clone(&self.token_history_contract).as_ref().clone(),
+                alias: Some("token_history".to_string()),
+            },
+            QualifiedContract {
+                contract: Arc::clone(&self.withdraws_contract).as_ref().clone(),
+                alias: Some("withdrawals".to_string()),
+            },
+            QualifiedContract {
+                contract: Arc::clone(&self.keyword_search_contract).as_ref().clone(),
+                alias: Some("keyword_search".to_string()),
+            },
+            QualifiedContract {
+                contract: Arc::clone(&self.dashpay_contract).as_ref().clone(),
+                alias: Some("dashpay".to_string()),
+            },
+        ];
 
-        // Insert the DPNS contract at 0
-        contracts.insert(0, dpns_contract);
+        // Collect system contract IDs to deduplicate DB contracts that match
+        let system_ids: std::collections::HashSet<_> = system_contracts
+            .iter()
+            .map(|c| c.contract.id())
+            .collect();
 
-        // Add the token history contract to the list
-        let token_history_contract = QualifiedContract {
-            contract: Arc::clone(&self.token_history_contract).as_ref().clone(),
-            alias: Some("token_history".to_string()),
-        };
+        // Remove any DB contracts that duplicate a system contract
+        contracts.retain(|c| !system_ids.contains(&c.contract.id()));
 
-        // Insert the token history contract at 1
-        contracts.insert(1, token_history_contract);
+        // Prepend system contracts in order
+        let mut result = system_contracts;
+        result.append(&mut contracts);
 
-        // Add the withdrawal contract to the list
-        let withdraws_contract = QualifiedContract {
-            contract: Arc::clone(&self.withdraws_contract).as_ref().clone(),
-            alias: Some("withdrawals".to_string()),
-        };
-
-        // Insert the withdrawal contract at 2
-        contracts.insert(2, withdraws_contract);
-
-        // Add the keyword search contract to the list
-        let keyword_search_contract = QualifiedContract {
-            contract: Arc::clone(&self.keyword_search_contract).as_ref().clone(),
-            alias: Some("keyword_search".to_string()),
-        };
-
-        // Insert the keyword search contract at 3
-        contracts.insert(3, keyword_search_contract);
-
-        // Add the DashPay contract to the list
-        let dashpay_contract = QualifiedContract {
-            contract: Arc::clone(&self.dashpay_contract).as_ref().clone(),
-            alias: Some("dashpay".to_string()),
-        };
-
-        // Insert the DashPay contract at 4
-        contracts.insert(4, dashpay_contract);
-
-        Ok(contracts)
+        Ok(result)
     }
 
     pub fn get_contract_by_id(

--- a/src/context/contract_token_db.rs
+++ b/src/context/contract_token_db.rs
@@ -46,10 +46,8 @@ impl AppContext {
         ];
 
         // Collect system contract IDs to deduplicate DB contracts that match
-        let system_ids: std::collections::HashSet<_> = system_contracts
-            .iter()
-            .map(|c| c.contract.id())
-            .collect();
+        let system_ids: std::collections::HashSet<_> =
+            system_contracts.iter().map(|c| c.contract.id()).collect();
 
         // Remove any DB contracts that duplicate a system contract
         contracts.retain(|c| !system_ids.contains(&c.contract.id()));

--- a/src/context/contract_token_db.rs
+++ b/src/context/contract_token_db.rs
@@ -45,12 +45,14 @@ impl AppContext {
             },
         ];
 
-        // Collect system contract IDs to deduplicate DB contracts that match
-        let system_ids: std::collections::HashSet<_> =
-            system_contracts.iter().map(|c| c.contract.id()).collect();
+        // Collect system contract IDs in a map to deduplicate DB contracts that match.
+        let system_contracts_by_id: std::collections::BTreeMap<_, _> = system_contracts
+            .iter()
+            .map(|c| (c.contract.id(), ()))
+            .collect();
 
         // Remove any DB contracts that duplicate a system contract
-        contracts.retain(|c| !system_ids.contains(&c.contract.id()));
+        contracts.retain(|c| !system_contracts_by_id.contains_key(&c.contract.id()));
 
         // Prepend system contracts in order
         let mut result = system_contracts;


### PR DESCRIPTION
## Issue

Clicking any contract in the Contracts chooser panel would also expand another contract. For example, clicking only the GWR contract would expand both DPNS and GWR simultaneously (and vice versa).

## Root Cause

The GWR contract shown as `GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec` **is** the DPNS contract — that's DPNS's Base58-encoded contract ID.

`get_contracts()` always injects system contracts (DPNS, DashPay, etc.) at fixed positions, but if the same contract was also added manually by the user (e.g. by fetching the DPNS contract by ID), it would exist in the database too. This resulted in two entries with the same contract ID but different display names — one showing "DPNS" (from the system alias) and one showing the raw Base58 ID (from the DB with no alias).

Since the expand/collapse state in `ContractChooserState.expanded_contracts` is keyed by contract ID, toggling either entry toggled the same key, causing both to expand or collapse simultaneously.

## Fix

1. **Deduplicate contracts**: After fetching from the DB, filter out any contracts whose ID matches a system contract before prepending the system contracts. This prevents duplicates.

2. **Scope egui widget IDs**: Wrap each contract's entire rendering block (header + content) in `ui.push_id(&contract_id)` for robustness — prevents potential widget ID collisions between different contracts' +/- buttons.

## Testing

- `cargo check` and `cargo fmt` pass
- Manual verification: expanding any single contract should only expand that contract
- The duplicate DPNS entry will no longer appear in the list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering of contract retrieval to display system contracts first in a consistent, predictable order.
  * Fixed an issue where duplicate contracts could appear in results through enhanced deduplication logic.
  * Enhanced pagination handling to ensure offset and limit parameters work correctly together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

**What was tested:**
- `cargo check` — verified compilation after deduplication and egui `push_id` changes
- `cargo fmt` — formatting clean
- Manual UI verification: clicking a single contract in the chooser only expands that contract; duplicate DPNS entry no longer appears

**Results:**
- All local commands passed
- `Clippy` CI check — pass (5m25s)
- `Test Suite` CI check — pass (7m41s)

**Environment:** Local macOS arm64; GitHub Actions CI (ubuntu-latest)
