### PR TITLE
fix(ui): replace f64 round-trip with integer arithmetic in max amount calculations

### DIFF
--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -134,8 +134,8 @@ impl TransferScreen {
         ui.add_space(5.0);
 
         // Calculate max amount minus fee for the "Max" button
-        let max_amount_minus_fee = (self.max_amount as f64 / 100_000_000_000.0 - 0.0002).max(0.0);
-        let max_amount_credits = (max_amount_minus_fee * 100_000_000_000.0) as u64;
+        // 0.0002 DASH = 20_000_000 credits (1 DASH = 100_000_000_000 credits)
+        let max_amount_credits = self.max_amount.saturating_sub(20_000_000);
 
         let amount_input = self.amount_input.get_or_insert_with(|| {
             AmountInput::new(Amount::new_dash(0.0))

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -107,8 +107,8 @@ impl WithdrawalScreen {
     }
 
     fn render_amount_input(&mut self, ui: &mut Ui) {
-        let max_amount_minus_fee = (self.max_amount as f64 / 100_000_000_000.0 - 0.005).max(0.0);
-        let max_amount_credits = (max_amount_minus_fee * 100_000_000_000.0) as u64;
+        // 0.005 DASH = 500_000_000 credits (1 DASH = 100_000_000_000 credits)
+        let max_amount_credits = self.max_amount.saturating_sub(500_000_000);
 
         // Lazy initialization with basic configuration
         let amount_input = self.withdrawal_amount_input.get_or_insert_with(|| {


### PR DESCRIPTION
## Issue

The "Max" button in transfer and withdraw screens uses a floating-point round-trip (`u64→f64→u64`) to subtract fee estimates from the available balance. This can cause precision loss with large credit amounts, potentially resulting in incorrect max values.

## Changes

Replace the floating-point arithmetic with integer `saturating_sub`:

```rust
// Before (precision loss possible)
let max_amount_minus_fee = (self.max_amount as f64 / 100_000_000_000.0 - 0.0002).max(0.0);
let max_amount_credits = (max_amount_minus_fee * 100_000_000_000.0) as u64;

// After (exact integer arithmetic)
let max_amount_credits = self.max_amount.saturating_sub(20_000_000);
```

- **transfer_screen.rs**: 0.0002 DASH = 20,000,000 credits
- **withdraw_screen.rs**: 0.005 DASH = 500,000,000 credits

`saturating_sub` also handles the edge case where balance < fee (returns 0 instead of underflowing).

## Validation

- `cargo check` ✅
- `cargo fmt` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal calculation logic for transfer and withdrawal amount limits to improve performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->