### PR TITLE
fix: add iteration limit to SPV fee calculation loop

### DIFF
--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -499,11 +499,13 @@ impl AppContext {
                     .map(|h| h.current_height())
             })
             .ok_or("Cannot build transaction: SPV sync height is not yet known")?;
+        const MAX_FEE_ITERATIONS: usize = 50;
+
         let total_amount: u64 = recipients.iter().map(|(_, amt)| *amt).sum();
         let mut scale_factor = 1.0f64;
         let mut attempted_fallback = false;
 
-        loop {
+        for _ in 0..MAX_FEE_ITERATIONS {
             let scaled_recipients: Vec<(Address, u64)> = recipients
                 .iter()
                 .map(|(addr, amt)| (addr.clone(), (*amt as f64 * scale_factor) as u64))
@@ -545,6 +547,8 @@ impl AppContext {
                 }
             }
         }
+
+        Err("Could not build transaction after maximum fee adjustment attempts".to_string())
     }
 
     fn estimate_fallback_amount(


### PR DESCRIPTION
Replace unbounded `loop` with a capped `for` loop (max 50 iterations) in the SPV fee calculation to prevent potential infinite loops.

## Problem

The fee estimation loop in `build_transaction_for_spv_wallet` uses an unbounded `loop` that adjusts a scale factor to find a valid transaction. If the scale factor converges without meeting either exit condition (successful build or `InsufficientFunds` with no progress), the loop runs forever.

## Fix

Cap the loop at 50 iterations and return a clear error if no valid transaction is found within that budget. 50 iterations is generous — in practice, convergence happens within 2-3 iterations.

Cherry-picked from `ralph/improvements` (commit 557acb23).

## Validation

**What was tested:**
- `cargo clippy --all-features --all-targets -- -D warnings` — lint check
- `cargo test --all-features --workspace` — full workspace test suite

**Results:**
- All local commands passed
- `Clippy` CI check — pass (5m27s)
- `Test Suite` CI check — pass (7m1s)

**Environment:** Local macOS arm64; GitHub Actions CI (ubuntu-latest)
