### PR TITLE
fix: add 30-second timeout to SPV quorum public key lookup

### DIFF
--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -649,14 +649,18 @@ impl SpvManager {
                 )
                 .await
                 .map_err(|_| {
-                    let msg = format!(
+                    tracing::warn!(
                         "Quorum lookup timed out after 30s at height {} for llmq_type={} hash=0x{}",
                         core_chain_locked_height,
                         quorum_type,
                         hex::encode(quorum_hash),
                     );
-                    tracing::warn!("{}", msg);
-                    msg
+                    format!(
+                        "Quorum lookup timed out after 30s at height {} for llmq_type={} hash=0x{}",
+                        core_chain_locked_height,
+                        quorum_type,
+                        hex::encode(quorum_hash),
+                    )
                 })?
                 .map(|q| {
                     tracing::debug!(

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -643,28 +643,40 @@ impl SpvManager {
 
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                interface
-                    .get_quorum_by_height(core_chain_locked_height, llmq_type, qh)
-                    .await
-                    .map(|q| {
-                        tracing::debug!(
-                            "Quorum public key found: type={}, hash={}, height={}",
-                            quorum_type,
-                            hex::encode(quorum_hash),
-                            core_chain_locked_height
-                        );
-                        *q.quorum_entry.quorum_public_key.as_ref()
-                    })
-                    .map_err(|e| {
-                        tracing::warn!(
-                            "Quorum lookup failed at height {} for llmq_type={} hash=0x{}: {}",
-                            core_chain_locked_height,
-                            quorum_type,
-                            hex::encode(quorum_hash),
-                            e
-                        );
-                        e.to_string()
-                    })
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    interface.get_quorum_by_height(core_chain_locked_height, llmq_type, qh),
+                )
+                .await
+                .map_err(|_| {
+                    let msg = format!(
+                        "Quorum lookup timed out after 30s at height {} for llmq_type={} hash=0x{}",
+                        core_chain_locked_height,
+                        quorum_type,
+                        hex::encode(quorum_hash),
+                    );
+                    tracing::warn!("{}", msg);
+                    msg
+                })?
+                .map(|q| {
+                    tracing::debug!(
+                        "Quorum public key found: type={}, hash={}, height={}",
+                        quorum_type,
+                        hex::encode(quorum_hash),
+                        core_chain_locked_height
+                    );
+                    *q.quorum_entry.quorum_public_key.as_ref()
+                })
+                .map_err(|e| {
+                    tracing::warn!(
+                        "Quorum lookup failed at height {} for llmq_type={} hash=0x{}: {}",
+                        core_chain_locked_height,
+                        quorum_type,
+                        hex::encode(quorum_hash),
+                        e
+                    );
+                    e.to_string()
+                })
             })
         })
     }


### PR DESCRIPTION
Wrap the SPV quorum public key lookup in a 30-second timeout to prevent indefinite hangs.

## Problem

`get_quorum_public_key` calls `get_quorum_by_height` on the SPV client interface with no timeout. If the SPV client is unresponsive or the network request stalls, this blocks the calling thread indefinitely (it runs inside `block_in_place`/`block_on`).

## Fix

Wrap the async lookup in `tokio::time::timeout(Duration::from_secs(30), ...)`. On timeout, a descriptive warning is logged and a clear error is returned with the quorum type, hash, and height for debugging.

30 seconds is generous for a quorum lookup — normal responses arrive in under a second.

Cherry-picked from `ralph/improvements` (commit 9c179886).

## Validation

**What was tested:**
- `cargo clippy --all-features --all-targets -- -D warnings` — lint check
- `cargo test --all-features --workspace` — full workspace test suite

**Results:**
- All local commands passed
- `Clippy` CI check — pass (5m49s)
- `Test Suite` CI check — pass (7m52s)

**Environment:** Local macOS arm64; GitHub Actions CI (ubuntu-latest)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout handling for quorum lookup operations to prevent indefinite hangs. Operations exceeding 30 seconds now return a clear error message instead of waiting indefinitely, improving system reliability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->