### PR TITLE
fix: replace expect() on settings save in network chooser with warnings

### DIFF
--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -858,9 +858,9 @@ impl NetworkChooserScreen {
                     if ui.button("Select File").clicked()
                         && let Some(path) = rfd::FileDialog::new().pick_file()
                     {
+                        let previous_custom_dash_qt_path = self.custom_dash_qt_path.clone();
                         let file_name = path.file_name().and_then(|f| f.to_str());
                         if let Some(file_name) = file_name {
-                            self.custom_dash_qt_path = None;
                             self.custom_dash_qt_error_message = None;
 
                             // Handle macOS .app bundles
@@ -888,6 +888,11 @@ impl NetworkChooserScreen {
                                 self.custom_dash_qt_error_message = None;
                                 if let Err(e) = self.save() {
                                     tracing::warn!("Failed to save Dash-Qt path setting: {}", e);
+                                    self.custom_dash_qt_error_message = Some(
+                                        "Failed to save Dash-Qt path setting. Please try again."
+                                            .to_string(),
+                                    );
+                                    self.custom_dash_qt_path = previous_custom_dash_qt_path;
                                 }
                             } else {
                                 let required_file_name = if cfg!(target_os = "windows") {
@@ -906,26 +911,33 @@ impl NetworkChooserScreen {
                     }
 
                     if self.custom_dash_qt_path.is_some() && ui.button("Clear").clicked() {
+                        let previous_custom_dash_qt_path = self.custom_dash_qt_path.clone();
                         self.custom_dash_qt_path = Some(PathBuf::new());
                         self.custom_dash_qt_error_message = None;
                         if let Err(e) = self.save() {
                             tracing::warn!("Failed to save cleared Dash-Qt path setting: {}", e);
+                            self.custom_dash_qt_error_message = Some(
+                                "Failed to clear Dash-Qt path setting. Please try again."
+                                    .to_string(),
+                            );
+                            self.custom_dash_qt_path = previous_custom_dash_qt_path;
                         }
                     }
                 });
 
-                if let Some(ref file) = self.custom_dash_qt_path {
-                    if !file.as_os_str().is_empty() {
-                        ui.horizontal(|ui| {
-                            ui.label("Path:");
-                            ui.label(
-                                egui::RichText::new(format_path_for_display(file))
-                                    .color(DashColors::SUCCESS)
-                                    .italics(),
-                            );
-                        });
-                    }
-                } else if let Some(ref error) = self.custom_dash_qt_error_message {
+                if let Some(ref file) = self.custom_dash_qt_path
+                    && !file.as_os_str().is_empty()
+                {
+                    ui.horizontal(|ui| {
+                        ui.label("Path:");
+                        ui.label(
+                            egui::RichText::new(format_path_for_display(file))
+                                .color(DashColors::SUCCESS)
+                                .italics(),
+                        );
+                    });
+                }
+                if let Some(ref error) = self.custom_dash_qt_error_message {
                     let error_color = Color32::from_rgb(255, 100, 100);
                     let error = error.clone();
                     Frame::new()
@@ -956,12 +968,20 @@ impl NetworkChooserScreen {
                 ui.add_space(8.0);
 
                 ui.horizontal(|ui| {
+                    let previous_overwrite_dash_conf = self.overwrite_dash_conf;
                     if StyledCheckbox::new(&mut self.overwrite_dash_conf, "Overwrite dash.conf")
                         .show(ui)
                         .clicked()
-                        && let Err(e) = self.save()
                     {
-                        tracing::warn!("Failed to save overwrite_dash_conf setting: {}", e);
+                        self.custom_dash_qt_error_message = None;
+                        if let Err(e) = self.save() {
+                            tracing::warn!("Failed to save overwrite_dash_conf setting: {}", e);
+                            self.custom_dash_qt_error_message = Some(
+                                "Failed to save overwrite dash.conf setting. Please try again."
+                                    .to_string(),
+                            );
+                            self.overwrite_dash_conf = previous_overwrite_dash_conf;
+                        }
                     }
                     ui.label(
                         egui::RichText::new("Auto-configure required settings")

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -959,10 +959,9 @@ impl NetworkChooserScreen {
                     if StyledCheckbox::new(&mut self.overwrite_dash_conf, "Overwrite dash.conf")
                         .show(ui)
                         .clicked()
+                        && let Err(e) = self.save()
                     {
-                        if let Err(e) = self.save() {
-                            tracing::warn!("Failed to save overwrite_dash_conf setting: {}", e);
-                        }
+                        tracing::warn!("Failed to save overwrite_dash_conf setting: {}", e);
                     }
                     ui.label(
                         egui::RichText::new("Auto-configure required settings")

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -886,7 +886,9 @@ impl NetworkChooserScreen {
                             if is_valid {
                                 self.custom_dash_qt_path = Some(resolved_path);
                                 self.custom_dash_qt_error_message = None;
-                                self.save().expect("Expected to save db settings");
+                                if let Err(e) = self.save() {
+                                    tracing::warn!("Failed to save Dash-Qt path setting: {}", e);
+                                }
                             } else {
                                 let required_file_name = if cfg!(target_os = "windows") {
                                     "dash-qt.exe"
@@ -906,7 +908,9 @@ impl NetworkChooserScreen {
                     if self.custom_dash_qt_path.is_some() && ui.button("Clear").clicked() {
                         self.custom_dash_qt_path = Some(PathBuf::new());
                         self.custom_dash_qt_error_message = None;
-                        self.save().expect("Expected to save db settings");
+                        if let Err(e) = self.save() {
+                            tracing::warn!("Failed to save cleared Dash-Qt path setting: {}", e);
+                        }
                     }
                 });
 
@@ -956,7 +960,9 @@ impl NetworkChooserScreen {
                         .show(ui)
                         .clicked()
                     {
-                        self.save().expect("Expected to save db settings");
+                        if let Err(e) = self.save() {
+                            tracing::warn!("Failed to save overwrite_dash_conf setting: {}", e);
+                        }
                     }
                     ui.label(
                         egui::RichText::new("Auto-configure required settings")


### PR DESCRIPTION
Replace 3 panicking `expect()` calls on `self.save()` in the network chooser screen with `if let Err` + `tracing::warn`.

## Problem

The network chooser screen calls `self.save().expect("Expected to save db settings")` in three places — when setting the Dash-Qt path, clearing it, and toggling the overwrite-dash-conf checkbox. If the save fails (e.g., disk full, permissions), the entire application panics.

## Fix

Replace each `expect()` with `if let Err(e) = self.save()` and log a warning. A failure to persist a UI preference should degrade gracefully, not crash the app.

Cherry-picked from `ralph/improvements` (commit 73452b6a).

## Validation

**What was tested:**
- `cargo clippy --all-features --all-targets -- -D warnings` — lint check confirming no remaining `expect()` on save paths
- `cargo test --all-features --workspace` — full workspace test suite

**Results:**
- All local commands passed
- `Clippy` CI check — pass (5m24s)
- `Test Suite` CI check — pass (7m32s)

**Environment:** Local macOS arm64; GitHub Actions CI (ubuntu-latest)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery when selecting or clearing custom Dash-Qt paths—previous settings are preserved if save operations fail.
  * Enhanced error messaging in advanced settings to provide clearer feedback when configuration changes cannot be saved.

* **Improvements**
  * Refined path display logic in the network settings screen for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->