### PR TITLE
fix(ui): add wallet alias trimming and 64-char length limit

### DIFF
--- a/src/model/wallet/alias.rs
+++ b/src/model/wallet/alias.rs
@@ -1,0 +1,165 @@
+use std::fmt;
+
+pub const MAX_CHARS: usize = 64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AliasError {
+    EmptyOrWhitespace,
+    TooLong {
+        max_chars: usize,
+        actual_chars: usize,
+    },
+}
+
+impl fmt::Display for AliasError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AliasError::EmptyOrWhitespace => {
+                write!(
+                    f,
+                    "Enter a name with at least one non-whitespace character."
+                )
+            }
+            AliasError::TooLong {
+                max_chars,
+                actual_chars,
+            } => {
+                write!(
+                    f,
+                    "Name is {actual_chars} characters; the limit is {max_chars}."
+                )
+            }
+        }
+    }
+}
+
+pub fn validate_optional_alias(alias_input: &str) -> Result<Option<&str>, AliasError> {
+    let trimmed_alias = alias_input.trim();
+    if trimmed_alias.is_empty() {
+        return Ok(None);
+    }
+
+    validate_alias_length(trimmed_alias).map(Some)
+}
+
+pub fn validate_required_alias(alias_input: &str) -> Result<&str, AliasError> {
+    let trimmed_alias = alias_input.trim();
+    if trimmed_alias.is_empty() {
+        return Err(AliasError::EmptyOrWhitespace);
+    }
+
+    validate_alias_length(trimmed_alias)
+}
+
+fn validate_alias_length(alias: &str) -> Result<&str, AliasError> {
+    let actual_chars = alias.chars().count();
+    if actual_chars > MAX_CHARS {
+        return Err(AliasError::TooLong {
+            max_chars: MAX_CHARS,
+            actual_chars,
+        });
+    }
+
+    Ok(alias)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AliasError, MAX_CHARS, validate_optional_alias, validate_required_alias};
+
+    #[test]
+    fn optional_alias_allows_empty_input() {
+        assert_eq!(validate_optional_alias(""), Ok(None));
+        assert_eq!(validate_optional_alias("   "), Ok(None));
+    }
+
+    #[test]
+    fn required_alias_rejects_empty_input() {
+        assert_eq!(
+            validate_required_alias(""),
+            Err(AliasError::EmptyOrWhitespace)
+        );
+        assert_eq!(
+            validate_required_alias("\t  \n"),
+            Err(AliasError::EmptyOrWhitespace)
+        );
+    }
+
+    #[test]
+    fn accepts_single_ascii_character() {
+        assert_eq!(validate_optional_alias("a"), Ok(Some("a")));
+        assert_eq!(validate_required_alias("a"), Ok("a"));
+    }
+
+    #[test]
+    fn accepts_exactly_sixty_four_ascii_characters() {
+        let alias = "a".repeat(MAX_CHARS);
+        assert_eq!(validate_optional_alias(&alias), Ok(Some(alias.as_str())));
+        assert_eq!(validate_required_alias(&alias), Ok(alias.as_str()));
+    }
+
+    #[test]
+    fn rejects_sixty_five_ascii_characters() {
+        let alias = "a".repeat(MAX_CHARS + 1);
+        assert_eq!(
+            validate_optional_alias(&alias),
+            Err(AliasError::TooLong {
+                max_chars: MAX_CHARS,
+                actual_chars: MAX_CHARS + 1,
+            })
+        );
+        assert_eq!(
+            validate_required_alias(&alias),
+            Err(AliasError::TooLong {
+                max_chars: MAX_CHARS,
+                actual_chars: MAX_CHARS + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn accepts_exactly_sixty_four_multibyte_codepoints() {
+        let alias = "界".repeat(MAX_CHARS);
+        assert_eq!(alias.chars().count(), MAX_CHARS);
+        assert!(alias.len() > MAX_CHARS);
+        assert_eq!(validate_optional_alias(&alias), Ok(Some(alias.as_str())));
+        assert_eq!(validate_required_alias(&alias), Ok(alias.as_str()));
+    }
+
+    #[test]
+    fn rejects_sixty_five_multibyte_codepoints() {
+        let alias = "界".repeat(MAX_CHARS + 1);
+        assert_eq!(alias.chars().count(), MAX_CHARS + 1);
+        assert!(alias.len() > MAX_CHARS + 1);
+        assert_eq!(
+            validate_optional_alias(&alias),
+            Err(AliasError::TooLong {
+                max_chars: MAX_CHARS,
+                actual_chars: MAX_CHARS + 1,
+            })
+        );
+        assert_eq!(
+            validate_required_alias(&alias),
+            Err(AliasError::TooLong {
+                max_chars: MAX_CHARS,
+                actual_chars: MAX_CHARS + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn display_messages_are_actionable() {
+        assert_eq!(
+            AliasError::EmptyOrWhitespace.to_string(),
+            "Enter a name with at least one non-whitespace character."
+        );
+        assert_eq!(
+            AliasError::TooLong {
+                max_chars: MAX_CHARS,
+                actual_chars: MAX_CHARS + 1,
+            }
+            .to_string(),
+            "Name is 65 characters; the limit is 64."
+        );
+    }
+}

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -1,3 +1,4 @@
+pub mod alias;
 pub mod auth_pubkey_cache;
 pub mod birth_height;
 pub mod encryption;

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -1,6 +1,7 @@
 use crate::app::AppAction;
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
+use crate::model::wallet::alias::validate_optional_alias;
 use crate::ui::components::entropy_grid::U256EntropyGrid;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::password_input::PasswordInput;
@@ -10,6 +11,7 @@ use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::identities::funding_common::generate_qr_code_image;
 use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::wallets::alias_input::render_optional_alias_input;
 use crate::ui::{RootScreenType, Screen, ScreenLike};
 use bip39::{Language, Mnemonic};
 use dash_sdk::dpp::dashcore::Address;
@@ -108,6 +110,16 @@ impl AddNewWalletScreen {
         self.seed_phrase = Some(mnemonic);
     }
 
+    fn resolve_wallet_alias(&self) -> Result<String, String> {
+        let existing_wallet_count = self
+            .app_context
+            .wallets
+            .read()
+            .map(|w| w.len())
+            .unwrap_or(0);
+        resolve_wallet_alias(&self.alias_input, existing_wallet_count)
+    }
+
     fn save_wallet(&mut self) -> Result<AppAction, String> {
         if let Some(mnemonic) = &self.seed_phrase {
             let seed = mnemonic.to_seed("");
@@ -119,17 +131,7 @@ impl AddNewWalletScreen {
             };
 
             // Generate default wallet name if none provided
-            let wallet_alias = if self.alias_input.trim().is_empty() {
-                let existing_wallet_count = self
-                    .app_context
-                    .wallets
-                    .read()
-                    .map(|w| w.len())
-                    .unwrap_or(0);
-                format!("Wallet {}", existing_wallet_count + 1)
-            } else {
-                self.alias_input.clone()
-            };
+            let wallet_alias = self.resolve_wallet_alias()?;
 
             let wallet = Wallet::new_from_seed(
                 seed,
@@ -616,10 +618,7 @@ impl ScreenLike for AddNewWalletScreen {
 
                     ui.add_space(8.0);
 
-                    ui.horizontal(|ui| {
-                        ui.label("Wallet Name:");
-                        ui.text_edit_singleline(&mut self.alias_input);
-                    });
+                    render_optional_alias_input(ui, "Wallet Name:", &mut self.alias_input);
 
                     ui.add_space(10.0);
                     ui.separator();
@@ -732,5 +731,114 @@ impl ScreenLike for AddNewWalletScreen {
 
         action |= pending_action;
         action
+    }
+}
+
+fn resolve_wallet_alias(alias_input: &str, existing_wallet_count: usize) -> Result<String, String> {
+    if let Some(alias) = validate_optional_alias(alias_input).map_err(|e| e.to_string())? {
+        Ok(alias.to_string())
+    } else {
+        Ok(format!("Wallet {}", existing_wallet_count + 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AddNewWalletScreen, resolve_wallet_alias};
+    use crate::app_dir::ensure_env_file;
+    use crate::context::AppContext;
+    use crate::context::connection_status::ConnectionStatus;
+    use crate::database::test_helpers::create_database_at_path;
+    use crate::model::wallet::alias::MAX_CHARS;
+    use crate::utils::tasks::TaskManager;
+    use bip39::Mnemonic;
+    use dash_sdk::dpp::dashcore::Network;
+    use std::sync::Arc;
+
+    fn offline_ctx() -> (Arc<AppContext>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().to_path_buf();
+        ensure_env_file(&data_dir);
+        let db = Arc::new(create_database_at_path(&data_dir.join("data.db")).expect("db"));
+        let app_kv = AppContext::open_app_kv(&data_dir).expect("app kv");
+        let secret_store = AppContext::open_secret_store(&data_dir).expect("secret store");
+        let ctx = AppContext::new(
+            data_dir,
+            Network::Testnet,
+            db,
+            Arc::new(TaskManager::new()),
+            Arc::new(ConnectionStatus::new()),
+            egui::Context::default(),
+            app_kv,
+            secret_store,
+            crate::model::user_role::UserRoleCell::default(),
+        )
+        .expect("offline testnet AppContext::new");
+        (ctx, temp_dir)
+    }
+
+    fn test_mnemonic() -> Mnemonic {
+        Mnemonic::parse_normalized(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .expect("mnemonic should parse")
+    }
+
+    #[test]
+    fn resolve_wallet_alias_falls_back_for_whitespace_only_input() {
+        let alias = resolve_wallet_alias("   \n\t  ", 2).expect("alias should resolve");
+        assert_eq!(alias, "Wallet 3");
+    }
+
+    #[test]
+    fn resolve_wallet_alias_preserves_invalid_input_on_validation_error() {
+        let raw = "a".repeat(MAX_CHARS + 1);
+        let err = resolve_wallet_alias(&raw, 0).expect_err("alias should be rejected");
+
+        assert!(err.contains("Name is"));
+        assert_eq!(raw.chars().count(), MAX_CHARS + 1);
+    }
+
+    #[tokio::test]
+    async fn save_wallet_uses_default_name_for_whitespace_only_alias() {
+        let (app_context, _tmp) = offline_ctx();
+        let mnemonic = test_mnemonic();
+        let expected_seed_hash = {
+            use crate::model::wallet::ClosedKeyItem;
+            ClosedKeyItem::compute_seed_hash(&mnemonic.to_seed(""))
+        };
+        let mut screen = AddNewWalletScreen::new(&app_context);
+        screen.seed_phrase = Some(mnemonic);
+        screen.alias_input = "  \n\t ".to_string();
+
+        screen.save_wallet().expect("save should succeed");
+
+        let expected_wallet = app_context
+            .wallets
+            .read()
+            .unwrap()
+            .values()
+            .find(|wallet| wallet.read().unwrap().seed_hash() == expected_seed_hash)
+            .cloned()
+            .expect("wallet should be registered");
+        assert_eq!(
+            expected_wallet.read().unwrap().alias.as_deref(),
+            Some("Wallet 1")
+        );
+    }
+
+    #[test]
+    fn save_wallet_rejects_over_limit_alias_without_registering_wallet() {
+        let (app_context, _tmp) = offline_ctx();
+        let mut screen = AddNewWalletScreen::new(&app_context);
+        screen.seed_phrase = Some(test_mnemonic());
+        screen.alias_input = "a".repeat(MAX_CHARS + 1);
+
+        let err = screen
+            .save_wallet()
+            .expect_err("over-limit alias should be rejected");
+
+        assert!(err.contains("Name is"));
+        assert!(app_context.wallets.read().unwrap().is_empty());
     }
 }

--- a/src/ui/wallets/alias_input.rs
+++ b/src/ui/wallets/alias_input.rs
@@ -1,0 +1,102 @@
+use crate::model::wallet::alias::MAX_CHARS;
+use egui::{RichText, TextEdit, Ui};
+
+pub(crate) const ALIAS_COUNTER_SHOW_THRESHOLD: usize = 50;
+pub(crate) const OPTIONAL_ALIAS_HELPER_TEXT: &str = "Leave blank to use a default name.";
+
+pub(crate) fn render_optional_alias_input(ui: &mut Ui, label: &str, alias_input: &mut String) {
+    ui.horizontal(|ui| {
+        ui.label(label);
+        ui.add(TextEdit::singleline(alias_input).char_limit(MAX_CHARS));
+    });
+
+    ui.horizontal(|ui| {
+        ui.label(RichText::new(OPTIONAL_ALIAS_HELPER_TEXT).weak().size(12.0));
+
+        let raw_char_count = alias_input.chars().count();
+        if raw_char_count > ALIAS_COUNTER_SHOW_THRESHOLD {
+            ui.label(
+                RichText::new(format!("{raw_char_count}/{MAX_CHARS}"))
+                    .weak()
+                    .size(12.0),
+            );
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ALIAS_COUNTER_SHOW_THRESHOLD, OPTIONAL_ALIAS_HELPER_TEXT, render_optional_alias_input,
+    };
+    use crate::model::wallet::alias::MAX_CHARS;
+    use egui::accesskit::Role;
+    use egui_kittest::Harness;
+    use egui_kittest::kittest::Queryable;
+
+    #[test]
+    fn optional_alias_input_enforces_char_limit() {
+        let mut harness = Harness::new_ui_state(
+            |ui, alias_input: &mut String| {
+                render_optional_alias_input(ui, "Name:", alias_input);
+            },
+            String::new(),
+        );
+
+        let text_input = harness.get_by_role(Role::TextInput);
+        text_input.focus();
+        text_input.type_text(&"a".repeat(MAX_CHARS + 5));
+        harness.run();
+
+        let expected = "a".repeat(MAX_CHARS);
+        assert_eq!(harness.state().chars().count(), MAX_CHARS);
+        assert_eq!(
+            harness.get_by_role(Role::TextInput).value().as_deref(),
+            Some(expected.as_str())
+        );
+    }
+
+    #[test]
+    fn optional_alias_input_shows_helper_and_counter_near_limit() {
+        let alias_input = "a".repeat(ALIAS_COUNTER_SHOW_THRESHOLD + 1);
+        let mut harness = Harness::new_ui_state(
+            |ui, alias_input: &mut String| {
+                render_optional_alias_input(ui, "Name:", alias_input);
+            },
+            alias_input,
+        );
+
+        harness.run();
+
+        assert!(harness.query_by_label(OPTIONAL_ALIAS_HELPER_TEXT).is_some());
+        assert!(
+            harness
+                .query_by_label(&format!(
+                    "{}/{}",
+                    ALIAS_COUNTER_SHOW_THRESHOLD + 1,
+                    MAX_CHARS
+                ))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn optional_alias_input_does_not_render_inline_error() {
+        let mut harness = Harness::new_ui_state(
+            |ui, alias_input: &mut String| {
+                render_optional_alias_input(ui, "Name:", alias_input);
+            },
+            " ".repeat(MAX_CHARS),
+        );
+
+        harness.run();
+
+        assert!(harness.query_by_label(OPTIONAL_ALIAS_HELPER_TEXT).is_some());
+        assert!(
+            harness
+                .query_by_label("Enter a name with at least one non-whitespace character.")
+                .is_none()
+        );
+        assert!(harness.query_by_label_contains("Name is ").is_none());
+    }
+}

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -9,8 +9,10 @@ use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::{RootScreenType, Screen, ScreenLike};
 
 use crate::model::wallet::Wallet;
+use crate::model::wallet::alias::validate_optional_alias;
 use crate::ui::components::password_input::PasswordInput;
 use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::wallets::alias_input::render_optional_alias_input;
 use bip39::Mnemonic;
 use egui::{ComboBox, Grid, RichText, Ui, Vec2};
 use std::sync::Arc;
@@ -126,17 +128,7 @@ impl ImportMnemonicScreen {
             );
         }
 
-        let alias = if self.alias_input.trim().is_empty() {
-            let existing_wallet_count = self
-                .app_context
-                .single_key_wallets
-                .read()
-                .map(|w| w.len())
-                .unwrap_or(0);
-            Some(format!("Key {number}", number = existing_wallet_count + 1))
-        } else {
-            Some(self.alias_input.clone())
-        };
+        let alias = Some(self.resolve_single_key_wallet_alias()?);
 
         // The single import path takes WIF only — normalise hex input to
         // WIF first so users can paste either shape while every import
@@ -184,6 +176,41 @@ impl ImportMnemonicScreen {
         Ok(AppAction::None)
     }
 
+    fn resolve_hd_wallet_alias(&self) -> Result<String, String> {
+        let existing_wallet_count = self
+            .app_context
+            .wallets
+            .read()
+            .map(|w| w.len())
+            .unwrap_or(0);
+        if let Some(alias) =
+            validate_optional_alias(&self.alias_input).map_err(|e| e.to_string())?
+        {
+            Ok(alias.to_string())
+        } else {
+            Ok(format!(
+                "Wallet {number}",
+                number = existing_wallet_count + 1
+            ))
+        }
+    }
+
+    fn resolve_single_key_wallet_alias(&self) -> Result<String, String> {
+        let existing_wallet_count = self
+            .app_context
+            .single_key_wallets
+            .read()
+            .map(|w| w.len())
+            .unwrap_or(0);
+        if let Some(alias) =
+            validate_optional_alias(&self.alias_input).map_err(|e| e.to_string())?
+        {
+            Ok(alias.to_string())
+        } else {
+            Ok(format!("Key {number}", number = existing_wallet_count + 1))
+        }
+    }
+
     fn save_wallet(&mut self) -> Result<AppAction, String> {
         if let Some(mnemonic) = &self.seed_phrase {
             let seed = mnemonic.to_seed("");
@@ -195,17 +222,7 @@ impl ImportMnemonicScreen {
             };
 
             // Generate default wallet name if none provided
-            let wallet_alias = if self.alias_input.trim().is_empty() {
-                let existing_wallet_count = self
-                    .app_context
-                    .wallets
-                    .read()
-                    .map(|w| w.len())
-                    .unwrap_or(0);
-                format!("Wallet {number}", number = existing_wallet_count + 1)
-            } else {
-                self.alias_input.clone()
-            };
+            let wallet_alias = self.resolve_hd_wallet_alias()?;
 
             let wallet = Wallet::new_from_seed(
                 seed,
@@ -583,10 +600,7 @@ impl ScreenLike for ImportMnemonicScreen {
 
                     ui.add_space(8.0);
 
-                    ui.horizontal(|ui| {
-                        ui.label("Name:");
-                        ui.text_edit_singleline(&mut self.alias_input);
-                    });
+                    render_optional_alias_input(ui, "Name:", &mut self.alias_input);
 
                     step += 1;
 
@@ -699,5 +713,150 @@ impl ScreenLike for ImportMnemonicScreen {
 
         action |= pending_action;
         action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ImportMnemonicScreen;
+    use crate::app_dir::ensure_env_file;
+    use crate::context::AppContext;
+    use crate::context::connection_status::ConnectionStatus;
+    use crate::database::test_helpers::create_database_at_path;
+    use crate::model::wallet::Wallet;
+    use crate::model::wallet::alias::MAX_CHARS;
+    use crate::model::wallet::birth_height::WalletOrigin;
+    use crate::utils::tasks::TaskManager;
+    use bip39::Mnemonic;
+    use dash_sdk::dpp::dashcore::Network;
+    use std::sync::Arc;
+
+    fn offline_ctx() -> (Arc<AppContext>, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp_dir.path().to_path_buf();
+        ensure_env_file(&data_dir);
+        let db = Arc::new(create_database_at_path(&data_dir.join("data.db")).expect("db"));
+        let app_kv = AppContext::open_app_kv(&data_dir).expect("app kv");
+        let secret_store = AppContext::open_secret_store(&data_dir).expect("secret store");
+        let ctx = AppContext::new(
+            data_dir,
+            Network::Testnet,
+            db,
+            Arc::new(TaskManager::new()),
+            Arc::new(ConnectionStatus::new()),
+            egui::Context::default(),
+            app_kv,
+            secret_store,
+            crate::model::user_role::UserRoleCell::default(),
+        )
+        .expect("offline testnet AppContext::new");
+        (ctx, temp_dir)
+    }
+
+    fn test_mnemonic() -> Mnemonic {
+        Mnemonic::parse_normalized(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .expect("mnemonic should parse")
+    }
+
+    fn register_existing_hd_wallet(app_context: &Arc<AppContext>, alias: &str, seed_byte: u8) {
+        let seed = [seed_byte; 64];
+        let wallet = Wallet::new_from_seed(seed, Network::Testnet, Some(alias.to_string()), None)
+            .expect("wallet should build");
+        app_context
+            .register_wallet(wallet, &seed, WalletOrigin::Imported)
+            .expect("wallet should register");
+    }
+
+    #[tokio::test]
+    async fn resolve_hd_wallet_alias_falls_back_for_whitespace_only_input() {
+        let (app_context, _tmp) = offline_ctx();
+        for i in 0..4 {
+            register_existing_hd_wallet(&app_context, &format!("Existing {i}"), 7 + i as u8);
+        }
+        let mut screen = ImportMnemonicScreen::new(&app_context);
+        screen.alias_input = "   ".to_string();
+
+        let alias = screen
+            .resolve_hd_wallet_alias()
+            .expect("alias should resolve");
+
+        assert_eq!(alias, "Wallet 5");
+    }
+
+    #[test]
+    fn resolve_single_key_wallet_alias_falls_back_for_whitespace_only_input() {
+        let (app_context, _tmp) = offline_ctx();
+        // Count defaults from the in-memory map length; leave it empty so Key 1 is chosen.
+        let mut screen = ImportMnemonicScreen::new(&app_context);
+        screen.alias_input = "  \n ".to_string();
+
+        let alias = screen
+            .resolve_single_key_wallet_alias()
+            .expect("alias should resolve");
+
+        assert_eq!(alias, "Key 1");
+    }
+
+    #[test]
+    fn resolve_wallet_alias_preserves_invalid_input_on_validation_error() {
+        let raw = "x".repeat(MAX_CHARS + 1);
+        let (app_context, _tmp) = offline_ctx();
+        let mut screen = ImportMnemonicScreen::new(&app_context);
+        screen.alias_input = raw.clone();
+
+        let err = screen
+            .resolve_hd_wallet_alias()
+            .expect_err("alias should be rejected");
+
+        assert!(err.contains("Name is"));
+        assert_eq!(raw.chars().count(), MAX_CHARS + 1);
+    }
+
+    #[tokio::test]
+    async fn save_wallet_uses_default_wallet_n_alias_for_whitespace_only_input() {
+        let (app_context, _tmp) = offline_ctx();
+        let mnemonic = test_mnemonic();
+        let expected_seed = mnemonic.to_seed("");
+        let expected_seed_hash = {
+            use crate::model::wallet::ClosedKeyItem;
+            ClosedKeyItem::compute_seed_hash(&expected_seed)
+        };
+        let mut screen = ImportMnemonicScreen::new(&app_context);
+        screen.seed_phrase = Some(mnemonic);
+        screen.alias_input = "  \n\t ".to_string();
+        screen.identity_scan_count = 0;
+
+        screen.save_wallet().expect("save should succeed");
+
+        let expected_wallet = app_context
+            .wallets
+            .read()
+            .unwrap()
+            .values()
+            .find(|wallet| wallet.read().unwrap().seed_hash() == expected_seed_hash)
+            .cloned()
+            .expect("wallet should be registered");
+        assert_eq!(
+            expected_wallet.read().unwrap().alias.as_deref(),
+            Some("Wallet 1")
+        );
+    }
+
+    #[test]
+    fn save_wallet_rejects_over_limit_alias_without_registering_wallet() {
+        let (app_context, _tmp) = offline_ctx();
+        let mut screen = ImportMnemonicScreen::new(&app_context);
+        screen.seed_phrase = Some(test_mnemonic());
+        screen.alias_input = "a".repeat(MAX_CHARS + 1);
+        screen.identity_scan_count = 0;
+
+        let err = screen
+            .save_wallet()
+            .expect_err("over-limit alias should be rejected");
+
+        assert!(err.contains("Name is"));
+        assert!(app_context.wallets.read().unwrap().is_empty());
     }
 }

--- a/src/ui/wallets/mod.rs
+++ b/src/ui/wallets/mod.rs
@@ -1,4 +1,5 @@
 pub mod add_new_wallet_screen;
+mod alias_input;
 pub mod asset_lock_detail_screen;
 pub mod create_asset_lock_screen;
 pub mod import_mnemonic_screen;

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -16,9 +16,8 @@ use crate::context::feature_gate::FeatureGate;
 use crate::model::fee_estimation::format_duffs_as_dash;
 use crate::model::spv_status::SpvStatus;
 use crate::model::user_role::UserRole;
-use crate::model::wallet::{
-    TransactionStatus, Wallet, WalletSeedHash, WalletTransaction, validate_wallet_alias,
-};
+use crate::model::wallet::alias::{MAX_CHARS as WALLET_ALIAS_MAX_CHARS, validate_required_alias};
+use crate::model::wallet::{TransactionStatus, Wallet, WalletSeedHash, WalletTransaction};
 use crate::ui::components::MessageBanner;
 use crate::ui::components::component_trait::Component;
 use crate::ui::components::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};
@@ -2646,16 +2645,15 @@ impl ScreenLike for WalletsBalancesScreen {
                             };
                             let text_edit = egui::TextEdit::singleline(alias)
                                 .hint_text("Enter wallet name")
+                                .char_limit(WALLET_ALIAS_MAX_CHARS)
                                 .desired_width(250.0);
                             ui.add(text_edit);
 
                             ui.add_space(10.0);
 
                             ui.horizontal(|ui| {
-                                if ComponentStyles::add_secondary_button(
-                                    ui, "Cancel", dark_mode,
-                                )
-                                .clicked()
+                                if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode)
+                                    .clicked()
                                 {
                                     cancel = true;
                                 }
@@ -2663,15 +2661,19 @@ impl ScreenLike for WalletsBalancesScreen {
                                 ui.add_space(8.0);
 
                                 if ComponentStyles::add_primary_button(ui, "Save").clicked() {
-                                    if let Err(error) = validate_wallet_alias(alias) {
-                                        MessageBanner::set_global(
-                                            ctx,
-                                            "The wallet name is too long. Use 64 characters or fewer and try again.",
-                                            MessageType::Error,
-                                        )
-                                        .with_details(error);
-                                    } else {
-                                        save = true;
+                                    match validate_required_alias(alias) {
+                                        Ok(trimmed) => {
+                                            *alias = trimmed.to_string();
+                                            save = true;
+                                        }
+                                        Err(error) => {
+                                            MessageBanner::set_global(
+                                                ctx,
+                                                error.to_string(),
+                                                MessageType::Error,
+                                            )
+                                            .with_details(error);
+                                        }
                                     }
                                 }
                             });


### PR DESCRIPTION
## Issue

Wallet alias input has no length limit and doesn't trim whitespace, which can lead to:
- Excessively long wallet names that break UI layouts
- Leading/trailing whitespace in wallet names
- Wallets named with only spaces getting saved with whitespace instead of using the default name

## Changes

**`src/ui/wallets/add_new_wallet_screen.rs`:**

1. **Trim whitespace** before saving the wallet alias
2. **Enforce 64-character limit** on the input field (truncates excess)
3. **Visual character counter** appears when approaching the limit (`N/64` shown when >50 chars)

## Validation

- `cargo check` ✅
- `cargo clippy --all-features --all-targets -- -D warnings` ✅
- `cargo fmt` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wallet/key alias inputs now support optional aliases with shared helper text; blank or whitespace-only values use auto-generated default names.
  * Enforces a 64-character maximum with a live character counter (shown after a threshold).

* **Bug Fixes**
  * Rename, add, and import flows no longer silently truncate invalid (over-limit) aliases—saving is rejected instead.
  * Alias updates now correctly surface failures when the target wallet/key can’t be found, keeping rename dialogs open with an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->