### PR TITLE
chore(github): add CODEOWNERS for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @PastaPastaPasta @lklimek


### PR DESCRIPTION
## Summary

Add a repository-level `CODEOWNERS` file so GitHub automatically requests reviews from the two default reviewers.

## Changes

- Create `.github/CODEOWNERS`
- Set default owners for all files to:
  - `@PastaPastaPasta`
  - `@lklimek`

## Validation

- Confirmed `.github/CODEOWNERS` exists on branch with expected owner entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to establish maintainers for repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->