### PR TITLE
fix(spv): zero out stale per-address balances during reconciliation

### DIFF
--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -720,9 +720,21 @@ impl AppContext {
                 // Update in-memory UTXOs map
                 w.utxos = new_utxos;
 
+                // Zero out balances for known addresses that no longer have any UTXOs.
+                // Without this, spent addresses retain stale non-zero balances because
+                // per_address_sum only contains addresses with current UTXOs.
+                for addr in &known_addresses {
+                    if !w.utxos.contains_key(addr)
+                        && let Err(e) = w.update_address_balance(addr, 0, self)
+                    {
+                        tracing::debug!(address = %addr, error = %e, "Failed to zero spent address balance");
+                    }
+                }
+
                 for (addr, sum) in per_address_sum.into_iter() {
-                    // Update wallet and DB through model helper
-                    let _ = w.update_address_balance(&addr, sum, self);
+                    if let Err(e) = w.update_address_balance(&addr, sum, self) {
+                        tracing::debug!(address = %addr, error = %e, "Failed to update address balance");
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- During SPV reconciliation, addresses with fully spent UTXOs retained stale non-zero balances in the address table
- The `per_address_sum` map only contains addresses with current UTXOs, so spent addresses were never updated to zero
- Added a loop that explicitly zeroes `address_balances` for any known address absent from the refreshed UTXO map, with debug logging on failure

## Test plan
- [ ] Transfer funds out of a DET wallet address so it has 0 UTXOs
- [ ] Verify the address table shows balance = 0 (previously showed stale old balance)
- [ ] Verify top-level wallet balance remains correct
- [ ] Verify addresses receiving new funds display correctly

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallet balance tracking to ensure addresses with no remaining UTXOs now correctly display zero balance
  * Enhanced error logging for balance update failures to improve troubleshooting visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->