### PR TITLE
feat(ui): tri-state connection indicator (red/orange/green)

### DIFF
--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -12,6 +12,29 @@ use std::time::{Duration, Instant};
 
 const REFRESH_CONNECTED: Duration = Duration::from_secs(10);
 const REFRESH_DISCONNECTED: Duration = Duration::from_secs(2);
+
+/// Three-state connection indicator matching the UI's red/orange/green circle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum OverallConnectionState {
+    /// No connection at all — red indicator.
+    Disconnected = 0,
+    /// All subsystems connected but still syncing data — orange indicator.
+    Syncing = 1,
+    /// Fully connected and operational — green indicator.
+    Synced = 2,
+}
+
+impl From<u8> for OverallConnectionState {
+    fn from(v: u8) -> Self {
+        match v {
+            1 => Self::Syncing,
+            2 => Self::Synced,
+            _ => Self::Disconnected,
+        }
+    }
+}
+
 /// Tracks the connection status to currently active network, and provides helper methods
 /// to determine overall connectivity status.
 ///
@@ -23,7 +46,7 @@ pub struct ConnectionStatus {
     spv_status: AtomicU8,
     backend_mode: AtomicU8,
     disable_zmq: AtomicBool,
-    overall_connected: AtomicBool,
+    overall_state: AtomicU8,
     last_update: Mutex<Instant>,
     dapi_total_endpoints: AtomicU16,
     dapi_available_endpoints: AtomicU16,
@@ -37,7 +60,7 @@ impl ConnectionStatus {
             spv_status: AtomicU8::new(SpvStatus::Idle as u8),
             backend_mode: AtomicU8::new(CoreBackendMode::Rpc.as_u8()),
             disable_zmq: AtomicBool::new(false),
-            overall_connected: AtomicBool::new(false),
+            overall_state: AtomicU8::new(OverallConnectionState::Disconnected as u8),
             last_update: Mutex::new(Instant::now()),
             dapi_total_endpoints: AtomicU16::new(0),
             dapi_available_endpoints: AtomicU16::new(0),
@@ -48,7 +71,7 @@ impl ConnectionStatus {
     /// so the status reflects the new network from a clean slate.
     ///
     /// `backend_mode` should be the new network's current backend mode so that
-    /// `overall_connected()` and `tooltip_text()` read the correct mode immediately.
+    /// `overall_state()` and `tooltip_text()` read the correct mode immediately.
     pub fn reset(&self, backend_mode: CoreBackendMode) {
         self.rpc_online.store(false, Ordering::Relaxed);
         if let Ok(mut status) = self.zmq_status.lock() {
@@ -59,7 +82,10 @@ impl ConnectionStatus {
         self.backend_mode
             .store(backend_mode.as_u8(), Ordering::Relaxed);
         self.disable_zmq.store(false, Ordering::Relaxed);
-        self.overall_connected.store(false, Ordering::Relaxed);
+        self.overall_state.store(
+            OverallConnectionState::Disconnected as u8,
+            Ordering::Relaxed,
+        );
         // Set last_update to epoch so the next trigger_refresh fires immediately
         if let Ok(mut last) = self.last_update.lock() {
             *last = Instant::now() - REFRESH_CONNECTED;
@@ -153,28 +179,47 @@ impl ConnectionStatus {
         status.is_active()
     }
 
-    pub fn overall_connected(&self) -> bool {
-        self.overall_connected.load(Ordering::Relaxed)
+    pub fn overall_state(&self) -> OverallConnectionState {
+        self.overall_state.load(Ordering::Relaxed).into()
     }
 
-    pub fn refresh_overall(&self) {
+    pub fn refresh_state(&self) {
         let backend_mode = self.backend_mode();
         let disable_zmq = self.disable_zmq();
         let spv_status = self.spv_status();
         let dapi_available = self.dapi_available();
-        let connected = match backend_mode {
+
+        let state = match backend_mode {
             CoreBackendMode::Rpc => {
-                self.rpc_online() && (disable_zmq || self.zmq_connected()) && dapi_available
+                // RPC mode: no intermediate syncing state exposed, so red or green only.
+                if self.rpc_online() && (disable_zmq || self.zmq_connected()) && dapi_available {
+                    OverallConnectionState::Synced
+                } else {
+                    OverallConnectionState::Disconnected
+                }
             }
-            CoreBackendMode::Spv => Self::spv_connected(spv_status) && dapi_available,
+            CoreBackendMode::Spv => {
+                if !dapi_available {
+                    OverallConnectionState::Disconnected
+                } else {
+                    match spv_status {
+                        SpvStatus::Running => OverallConnectionState::Synced,
+                        SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Stopping => {
+                            OverallConnectionState::Syncing
+                        }
+                        _ => OverallConnectionState::Disconnected,
+                    }
+                }
+            }
         };
-        self.overall_connected.store(connected, Ordering::Relaxed);
+        self.overall_state.store(state as u8, Ordering::Relaxed);
     }
 
     pub fn tooltip_text(&self) -> String {
         let backend_mode = self.backend_mode();
         let disable_zmq = self.disable_zmq();
         let spv_status = self.spv_status();
+        let overall = self.overall_state();
         let dapi_status = format!("DAPI: {}", self.dapi_status_label());
         match backend_mode {
             CoreBackendMode::Rpc => {
@@ -191,27 +236,27 @@ impl ConnectionStatus {
                     "ZMQ: Disconnected"
                 };
 
-                if self.overall_connected() {
-                    format!(
-                        "Connected to Dash Core Wallet\n{rpc_status}\n{zmq_status}\n{dapi_status}"
-                    )
-                } else if self.rpc_online() {
-                    format!(
-                        "Dash Core connection incomplete\n{rpc_status}\n{zmq_status}\n{dapi_status}"
-                    )
-                } else {
-                    format!(
-                        "Disconnected from Dash Core Wallet. Click to start it.\n{rpc_status}\n{zmq_status}\n{dapi_status}"
-                    )
-                }
+                let header = match overall {
+                    OverallConnectionState::Synced => "Connected to Dash Core Wallet",
+                    // RPC mode doesn't currently produce Syncing, but kept for forward-compat.
+                    OverallConnectionState::Syncing => "Syncing to Dash Core Wallet",
+                    OverallConnectionState::Disconnected if self.rpc_online() => {
+                        "Dash Core connection incomplete"
+                    }
+                    OverallConnectionState::Disconnected => {
+                        "Disconnected from Dash Core Wallet. Click to start it."
+                    }
+                };
+                format!("{header}\n{rpc_status}\n{zmq_status}\n{dapi_status}")
             }
             CoreBackendMode::Spv => {
                 let spv_label = format!("SPV: {:?}", spv_status);
-                if self.overall_connected() {
-                    format!("SPV connected\n{spv_label}\n{dapi_status}")
-                } else {
-                    format!("SPV disconnected\n{spv_label}\n{dapi_status}")
-                }
+                let header = match overall {
+                    OverallConnectionState::Synced => "SPV synced",
+                    OverallConnectionState::Syncing => "SPV syncing",
+                    OverallConnectionState::Disconnected => "SPV disconnected",
+                };
+                format!("{header}\n{spv_label}\n{dapi_status}")
             }
         }
     }
@@ -250,12 +295,12 @@ impl ConnectionStatus {
                         devnet_chainlock,
                         local_chainlock,
                     );
-                    self.refresh_overall();
+                    self.refresh_state();
                 }
                 BackendTaskSuccessResult::CoreItem(CoreItem::ChainLock(_, network)) => {
                     if *network == active_network {
                         self.set_rpc_online(true);
-                        self.refresh_overall();
+                        self.refresh_state();
                     }
                 }
                 _ => {}
@@ -265,7 +310,7 @@ impl ConnectionStatus {
                     "Failed to get best chain lock for mainnet, testnet, devnet, and local",
                 ) {
                     self.set_rpc_online(false);
-                    self.refresh_overall();
+                    self.refresh_state();
                 }
             }
             _ => {}
@@ -283,7 +328,7 @@ impl ConnectionStatus {
             // Poll frequently during SPV shutdown so the UI updates
             // within ~200ms of the Stopping → Stopped transition.
             Duration::from_millis(200)
-        } else if self.overall_connected() {
+        } else if self.overall_state() == OverallConnectionState::Synced {
             REFRESH_CONNECTED
         } else {
             REFRESH_DISCONNECTED
@@ -346,7 +391,7 @@ impl ConnectionStatus {
             self.set_dapi_status(total, available);
         }
 
-        self.refresh_overall();
+        self.refresh_state();
     }
 }
 

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -379,15 +379,7 @@ impl ConnectionStatus {
             let sdk = app_context.sdk.load();
             let address_list = sdk.address_list();
             let total = address_list.len() as u16;
-            // get_live_address() returns Option<&Uri>, so count it as 1 if available, 0 if not
-            // TODO: once Dash Platform SDK supports rust-dashcore v0.42,
-            // update platform and use get_live_addresses() which returns all available addresses
-            //for more accurate status
-            let available = if address_list.get_live_address().is_some() {
-                1
-            } else {
-                0
-            };
+            let available = address_list.get_live_addresses().len() as u16;
             self.set_dapi_status(total, available);
         }
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -76,7 +76,7 @@ impl AppContext {
         // next throttled trigger_refresh() cycle (2-10 seconds).
         self.connection_status
             .set_spv_status(self.spv_manager.status().status);
-        self.connection_status.refresh_overall();
+        self.connection_status.refresh_state();
         Ok(())
     }
 
@@ -778,7 +778,7 @@ impl AppContext {
         // next throttled trigger_refresh() cycle (2-10 seconds).
         self.connection_status
             .set_spv_status(self.spv_manager.status().status);
-        self.connection_status.refresh_overall();
+        self.connection_status.refresh_state();
         // Reset the throttle timer so trigger_refresh() starts polling
         // at 200ms intervals and picks up the Stopped transition quickly.
         self.connection_status.reset_timer();

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -112,15 +112,12 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
     };
 
     // Pulsation: synced = normal pulse, syncing = slower pulse, disconnected = none
-    let pulse_scale = if overall == OverallConnectionState::Disconnected {
-        1.0
-    } else {
-        let time = ui.ctx().input(|i| i.time as f32);
-        match overall {
-            OverallConnectionState::Synced => 1.0 + 0.2 * (time * 2.0).sin(),
-            OverallConnectionState::Syncing => 1.0 + 0.15 * (time * 1.2).sin(),
-            OverallConnectionState::Disconnected => unreachable!(),
-        }
+    let time = ui.ctx().input(|i| i.time as f32);
+
+    let pulse_scale = match overall {
+        OverallConnectionState::Synced => 1.0 + 0.2 * (time * 2.0).sin(),
+        OverallConnectionState::Syncing => 1.0 + 0.15 * (time * 1.2).sin(),
+        OverallConnectionState::Disconnected => 1.0, // No pulse when disconnected
     };
 
     // Wrap in a container that can be positioned vertically

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -2,6 +2,7 @@ use crate::app::{AppAction, DesiredAppAction};
 use crate::backend_task::BackendTask;
 use crate::backend_task::core::CoreTask;
 use crate::context::AppContext;
+use crate::context::connection_status::OverallConnectionState;
 use crate::spv::CoreBackendMode;
 use crate::ui::ScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape};
@@ -98,22 +99,28 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
     let mut action = AppAction::None;
     let status = app_context.connection_status();
     let backend_mode = status.backend_mode();
-    let connected = status.overall_connected();
-
-    // Get time for pulsating animation (only when connected)
-    let pulse_scale = if connected {
-        let time = ui.ctx().input(|i| i.time as f32);
-        1.0 + 0.2 * (time * 2.0).sin() // Pulsate between 1.0 and 1.2
-    } else {
-        1.0 // No pulsation when disconnected
-    };
+    let overall = status.overall_state();
 
     let dark_mode = ui.ctx().style().visuals.dark_mode;
     let circle_size = 14.0;
-    let color = if connected {
-        DashColors::success_color(dark_mode)
+
+    // Three-state color: green (synced), orange (syncing), red (disconnected)
+    let color = match overall {
+        OverallConnectionState::Synced => DashColors::success_color(dark_mode),
+        OverallConnectionState::Syncing => DashColors::warning_color(dark_mode),
+        OverallConnectionState::Disconnected => DashColors::error_color(dark_mode),
+    };
+
+    // Pulsation: synced = normal pulse, syncing = slower pulse, disconnected = none
+    let pulse_scale = if overall == OverallConnectionState::Disconnected {
+        1.0
     } else {
-        DashColors::error_color(dark_mode)
+        let time = ui.ctx().input(|i| i.time as f32);
+        match overall {
+            OverallConnectionState::Synced => 1.0 + 0.2 * (time * 2.0).sin(),
+            OverallConnectionState::Syncing => 1.0 + 0.15 * (time * 1.2).sin(),
+            OverallConnectionState::Disconnected => unreachable!(),
+        }
     };
 
     // Wrap in a container that can be positioned vertically
@@ -132,7 +139,7 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
                     let center = rect.center();
 
                     // Draw the background circle with pulsating effect
-                    let bg_radius = if connected {
+                    let bg_radius = if overall != OverallConnectionState::Disconnected {
                         (circle_size / 2.0 + 3.0) * pulse_scale
                     } else {
                         circle_size / 2.0 // Same size as main circle when disconnected
@@ -143,14 +150,15 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
                     // Draw the main circle
                     ui.painter().circle_filled(center, circle_size / 2.0, color);
 
-                    // Request repaint for animation (only when connected and pulsating)
-                    if connected {
+                    // Request repaint for animation (only when not disconnected)
+                    if overall != OverallConnectionState::Disconnected {
                         app_context.repaint_animation(ui.ctx());
                     }
                     let tip = status.tooltip_text();
                     let resp = resp.on_hover_text(tip);
 
                     if resp.clicked()
+                        && overall == OverallConnectionState::Disconnected
                         && backend_mode == CoreBackendMode::Rpc
                         && !status.rpc_online()
                     {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -4,7 +4,7 @@ use crate::backend_task::core::CoreTask;
 use crate::backend_task::system_task::SystemTask;
 use crate::config::Config;
 use crate::context::AppContext;
-use crate::context::connection_status::ConnectionStatus;
+use crate::context::connection_status::{ConnectionStatus, OverallConnectionState};
 use crate::model::wallet::DerivationPathHelpers;
 use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
 use crate::ui::components::component_trait::Component;
@@ -489,14 +489,14 @@ impl NetworkChooserScreen {
             } else {
                 None
             };
-            let overall_connected = status.overall_connected();
+            let overall_state = status.overall_state();
             let dapi_total = status.dapi_total_endpoints();
             let dapi_available = status.dapi_available();
             let dapi_label = status.dapi_status_label();
 
             // Button on the left with status
             ui.horizontal(|ui| {
-                if overall_connected {
+                if overall_state != OverallConnectionState::Disconnected {
                     if current_backend_mode == CoreBackendMode::Spv {
                         let is_stopping = spv_status == SpvStatus::Stopping;
                         let disconnect_button = egui::Button::new(
@@ -520,15 +520,16 @@ impl NetworkChooserScreen {
                         if let Some(snap) = &snapshot {
                             match snap.status {
                                 SpvStatus::Running => {
-                                    ui.colored_label(DashColors::SUCCESS, "Fully Synced - The SPV client can now be used for transacting and querying.");
+                                    ui.colored_label(DashColors::SUCCESS, "Synced - The SPV client can now be used for transacting and querying.");
                                 }
                                 SpvStatus::Syncing | SpvStatus::Starting => {
+                                    let warning_color = DashColors::warning_color(dark_mode);
                                     ui.style_mut().visuals.widgets.inactive.fg_stroke.color =
-                                        DashColors::DASH_BLUE;
+                                        warning_color;
                                     ui.style_mut().visuals.widgets.hovered.fg_stroke.color =
-                                        DashColors::DASH_BLUE;
+                                        warning_color;
                                     ui.style_mut().visuals.widgets.active.fg_stroke.color =
-                                        DashColors::DASH_BLUE;
+                                        warning_color;
                                     ui.spinner();
                                     ui.label(egui::RichText::new("Syncing..."));
                                 }
@@ -548,9 +549,9 @@ impl NetworkChooserScreen {
                     } else {
                         // For Core mode, just show status since it can switch networks freely
                         let label = if disable_zmq {
-                            "✅ Connected (RPC, ZMQ disabled)"
+                            "✅ Synced (RPC, ZMQ disabled)"
                         } else {
-                            "✅ Connected (RPC + ZMQ)"
+                            "✅ Synced (RPC + ZMQ)"
                         };
                         ui.colored_label(DashColors::DASH_BLUE, label);
                     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

### User Story

Imagine you're a Dash Evo Tool user who just connected your wallet. The top-bar circle turns green and says "Connected," but the Networks tab says "Offline." You wonder if something is broken — but actually, your wallet is just syncing blocks. With this change, you'll see an orange circle with "Syncing" status while blocks sync, green "Synced" when everything is ready, and red "Disconnected" only when truly offline. The same terminology appears everywhere, so there's no more confusion.

### Details

Closes #333
Closes #62

## What was done?

Replaced the binary connected/disconnected connection indicator with a three-state model:

- **Disconnected** (Red) — any required subsystem is unavailable
- **Syncing** (Orange) — SPV is starting/syncing/stopping, with DAPI available
- **Synced** (Green) — fully connected and operational

### Changes by file

| File | Change |
|---|---|
| `src/context/connection_status.rs` | Added `OverallConnectionState` enum (`#[repr(u8)]`), replaced `AtomicBool` with `AtomicU8`, renamed `overall_connected()` → `overall_state()` and `refresh_overall()` → `refresh_state()` |
| `src/context/wallet_lifecycle.rs` | Updated 2 call sites to use renamed method |
| `src/ui/components/top_panel.rs` | Three-color circle (green/orange/red) with differentiated pulsation; restored `!status.rpc_online()` guard on click-to-launch |
| `src/ui/network_chooser_screen.rs` | Consistent tri-state labels; SPV syncing spinner uses orange instead of blue |

### Design decisions

- RPC mode currently only produces `Disconnected` or `Synced` (no syncing state tracked yet) — tooltip has a forward-compat comment for the unreachable `Syncing` arm
- `SpvStatus::Stopping` maps to `Syncing` (orange) so the "Disconnecting..." spinner remains visible during shutdown
- Pulsation: normal rate for Synced, slower/subtler for Syncing, none for Disconnected

## How has this been tested?

- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo test --all-features --workspace` — 42 passed, 0 failed
- Code reviewed by parallel agents (code-reviewer + rust-developer) — 2 findings fixed before merge

## Breaking Changes

None. Internal API renames (`overall_connected` → `overall_state`) are fully contained.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run code review with specialist agents
- [x] All review findings have been addressed
- [x] Clippy and fmt pass cleanly
- [x] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced connection status indicator now displays three distinct states (Disconnected, Syncing, Synced) with color-coded visual feedback and animations to better communicate network synchronization progress.
  * Updated status labels throughout the interface for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
