### PR TITLE
backport: fix(wallet): calculate asset lock tx fee dynamically based on input count

### DIFF
--- a/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
+++ b/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
@@ -266,7 +266,7 @@ with "min relay fee not met" now succeed.
   `allow_take_fee_from_amount` path or return an error. Verify no panic or silent data loss occurs.
 
 
-### E4: Concurrent Asset Lock Creation
+### E3: Concurrent Asset Lock Creation
 - If two asset lock transactions are created in quick succession (e.g., rapid identity registration
   attempts), verify that UTXO double-spend is prevented and the second attempt either uses different
   UTXOs or fails gracefully.

--- a/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
+++ b/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
@@ -1,0 +1,277 @@
+# Manual Test Scenarios: Dynamic Asset Lock Fee Calculation
+
+**PR:** #636 (`zk-extract/asset-lock-fee-fix`)
+**Date:** 2026-02-24
+**Component:** `src/model/wallet/asset_lock_transaction.rs`
+
+## Background
+
+This PR replaces the hardcoded 3000 duff fee in `asset_lock_transaction_from_private_key()` with a
+dynamic fee calculated from the estimated transaction size:
+- 10 bytes header + (inputs x 148 bytes) + (outputs x 34 bytes) + 60 bytes payload
+- Minimum fee remains 3000 duffs (via `std::cmp::max`)
+- Change output is recalculated after the real fee is determined
+- Fee shortfall is handled gracefully when `allow_take_fee_from_amount` is set
+
+The change affects three public entry points:
+- `registration_asset_lock_transaction()` -- identity registration
+- `top_up_asset_lock_transaction()` -- identity top-up
+- `generic_asset_lock_transaction()` -- platform address funding
+
+**Note:** `asset_lock_transaction_for_utxo_from_private_key()` (single-UTXO variant) is NOT changed
+by this PR and still uses a hardcoded 3000 duff fee.
+
+---
+
+## Preconditions (all scenarios)
+
+1. Dash Evo Tool is running and connected to **Testnet** (or a Devnet).
+2. A wallet is loaded with known UTXO distribution (check wallet screen for balances).
+3. The wallet has been synced recently (UTXOs are up to date).
+4. Dash Core node is reachable and accepting transactions.
+
+---
+
+## Scenario 1: Single-Input Asset Lock (fee equals minimum)
+
+**Purpose:** Verify that a transaction with 1 input still works correctly and the fee is at least
+3000 duffs. With 1 input and 2 outputs: `10 + 148 + 68 + 60 = 286 bytes`, which is below 3000, so
+the minimum fee of 3000 applies.
+
+### Preconditions
+- Wallet has a single UTXO of at least 50,000 duffs (0.0005 DASH).
+
+### Steps
+1. Navigate to the Identity screen.
+2. Initiate a new identity registration with an amount of 10,000 duffs.
+3. Confirm the transaction.
+
+### Expected Results
+- The asset lock transaction is created and broadcast successfully.
+- The transaction is accepted by the network (no "min relay fee not met" error).
+- The wallet balance decreases by approximately 10,000 + 3,000 = 13,000 duffs.
+- If the UTXO was larger than the required amount, a change output is returned to the wallet.
+- The identity registration proceeds to completion (or awaits proof confirmation).
+
+---
+
+## Scenario 2: Multiple-Input Asset Lock (fee scales with inputs)
+
+**Purpose:** Verify that when many UTXOs are consumed, the fee scales upward with the number of
+inputs, exceeding the 3000 duff minimum.
+
+### Preconditions
+- Wallet has many small UTXOs (e.g., 30 UTXOs of 5,000 duffs each = 150,000 duffs total).
+- No single UTXO is large enough to cover the requested amount alone.
+
+### Steps
+1. Navigate to the Identity screen.
+2. Initiate a new identity registration with an amount of 100,000 duffs (0.001 DASH).
+3. Confirm the transaction.
+
+### Expected Results
+- The transaction consumes multiple UTXOs (approximately 21+ inputs needed for 100,000 + fee).
+- With ~21 inputs: estimated size = `10 + (21 * 148) + (2 * 34) + 60 = 3246 bytes`, so fee should
+  be 3246 duffs (above the 3000 minimum).
+- The transaction is accepted by the network without "min relay fee not met" errors.
+- The wallet balance decreases by the requested amount plus the dynamically calculated fee.
+- Previous behavior with a hardcoded 3000 fee would have been rejected by the network for large
+  input counts, so acceptance confirms the fix works.
+
+---
+
+## Scenario 3: Tight Balance with Fee Deduction from Amount
+
+**Purpose:** Verify that when `allow_take_fee_from_amount` is true and the wallet balance barely
+covers the amount, the fee is correctly deducted from the output amount.
+
+### Preconditions
+- Wallet has exactly one UTXO of 10,000 duffs.
+
+### Steps
+1. Navigate to the platform address funding screen (or identity top-up).
+2. Initiate a funding/top-up for 10,000 duffs with the "deduct fee from amount" option enabled.
+3. Confirm the transaction.
+
+### Expected Results
+- The transaction is created successfully.
+- The actual funded amount is 10,000 - 3,000 = 7,000 duffs (fee deducted from amount).
+- No change output is present in the transaction.
+- The transaction is accepted by the network.
+- The wallet balance drops to 0.
+
+---
+
+## Scenario 4: Insufficient Funds (no fee deduction allowed)
+
+**Purpose:** Verify that a clear error message is shown when the wallet cannot cover the amount
+plus fee and fee deduction is not allowed.
+
+### Preconditions
+- Wallet has exactly one UTXO of 10,000 duffs.
+
+### Steps
+1. Navigate to the platform address funding screen.
+2. Initiate a funding for 10,000 duffs with the "deduct fee from amount" option DISABLED.
+3. Confirm the transaction.
+
+### Expected Results
+- The operation fails with an error message similar to:
+  `"Insufficient funds: need 10000 + 3000 fee, have 10000"`
+- The error message includes the specific amounts (requested, fee, available).
+- No transaction is broadcast to the network.
+- The wallet UTXOs remain unchanged.
+
+---
+
+## Scenario 5: Insufficient Funds (fee deduction allowed but amount too small)
+
+**Purpose:** Verify that when the entire balance would be consumed by the fee alone, a clear error
+is returned even when fee deduction is allowed.
+
+### Preconditions
+- Wallet has exactly one UTXO of 2,500 duffs (less than the minimum 3000 fee).
+
+### Steps
+1. Navigate to the identity registration screen.
+2. Initiate a registration with an amount of 2,500 duffs, with fee deduction from amount enabled.
+3. Confirm the transaction.
+
+### Expected Results
+- The operation fails with `"Insufficient funds for transaction fee"` or the UTXO selection
+  returns None (displayed as an appropriate error in the UI).
+- No transaction is broadcast.
+- Wallet UTXOs remain unchanged.
+
+---
+
+## Scenario 6: Change Output Presence and Correctness
+
+**Purpose:** Verify that the change output is correctly calculated after the dynamic fee is applied,
+not the initial estimate.
+
+### Preconditions
+- Wallet has a single UTXO of 100,000 duffs.
+
+### Steps
+1. Navigate to the Identity screen.
+2. Initiate a new identity registration with an amount of 50,000 duffs.
+3. Confirm the transaction.
+
+### Expected Results
+- The transaction has exactly 2 outputs: the burn output (50,000 duffs) and a change output.
+- Change = 100,000 - 50,000 - fee. With 1 input, 2 outputs: fee = max(3000, 10+148+68+60) = 3000.
+- Change should be 100,000 - 50,000 - 3,000 = 47,000 duffs.
+- The change output goes to a wallet-controlled change address.
+- After the transaction confirms, the wallet shows approximately 47,000 duffs remaining.
+
+---
+
+## Scenario 7: No Change Output (exact amount consumed)
+
+**Purpose:** Verify that when inputs exactly equal amount + fee, no change output is created.
+
+### Preconditions
+- Wallet has a single UTXO of exactly 53,000 duffs.
+
+### Steps
+1. Navigate to the Identity screen.
+2. Initiate a new identity registration with an amount of 50,000 duffs.
+3. Confirm the transaction.
+
+### Expected Results
+- The transaction has exactly 1 output (the burn output for 50,000 duffs). No change output.
+- Fee = 3,000 duffs (1 input, 1 output: `10 + 148 + 34 + 60 = 252`, min 3000 applies).
+- 53,000 - 50,000 - 3,000 = 0, so no change.
+- The wallet balance drops to 0 after confirmation.
+
+---
+
+## Scenario 8: Transaction Acceptance by Network (regression)
+
+**Purpose:** This is the core regression test -- confirm that transactions which previously failed
+with "min relay fee not met" now succeed.
+
+### Preconditions
+- Wallet has 50+ small UTXOs (e.g., from prior dust consolidation or faucet drips).
+
+### Steps
+1. Attempt to register an identity or top up an identity using an amount that requires consuming
+   many UTXOs (e.g., 200,000 duffs spread across 50+ UTXOs of 4,000 duffs each).
+2. Confirm the transaction.
+
+### Expected Results
+- The transaction is broadcast successfully (no RPC error).
+- The transaction is accepted into the mempool (no rejection).
+- With 50 inputs: estimated size = `10 + (50 * 148) + (2 * 34) + 60 = 7538 bytes`.
+- Fee should be 7,538 duffs (well above the old hardcoded 3,000).
+- The identity registration or top-up completes normally after proof confirmation.
+
+---
+
+## Scenario 9: Identity Top-Up with Dynamic Fee
+
+**Purpose:** Verify the fix works for identity top-up flows (not just registration).
+
+### Preconditions
+- An identity already exists in the wallet.
+- Wallet has sufficient balance (e.g., 100,000 duffs).
+
+### Steps
+1. Navigate to the identity detail screen.
+2. Initiate a top-up of 20,000 duffs.
+3. Confirm the transaction.
+
+### Expected Results
+- The asset lock transaction is created with a dynamically calculated fee.
+- The transaction is accepted by the network.
+- The identity balance increases by approximately 20,000 duffs (in credits).
+- Wallet balance decreases by 20,000 + fee.
+
+---
+
+## Scenario 10: Platform Address Funding with Dynamic Fee
+
+**Purpose:** Verify the fix works for the generic platform address funding flow.
+
+### Preconditions
+- Wallet has sufficient balance (e.g., 100,000 duffs).
+- A valid platform address is available to fund.
+
+### Steps
+1. Navigate to the platform address funding screen.
+2. Enter a destination platform address and amount of 30,000 duffs.
+3. Choose "deduct fee from amount" = disabled.
+4. Confirm the transaction.
+
+### Expected Results
+- The asset lock transaction is created with a dynamically calculated fee.
+- The transaction is accepted by the network.
+- The destination platform address receives exactly 30,000 duffs worth of credits (minus platform
+  fees, but not minus Core tx fees).
+- Wallet balance decreases by more than 30,000 duffs (amount + estimated platform fee + Core fee).
+
+---
+
+## Edge Cases
+
+### E1: Very Large Number of Inputs
+- If a wallet has 100+ tiny UTXOs and attempts to spend them all, the fee could exceed 15,000 duffs.
+  Verify the transaction is still accepted and the fee does not consume an unreasonable portion of
+  the amount.
+
+### E2: UTXO Selection Crosses Initial Estimate Threshold
+- The initial estimate of 3000 duffs is used for UTXO selection. If the real fee is higher and
+  causes a shortfall (total inputs < amount + real fee), the code should handle this via the
+  `allow_take_fee_from_amount` path or return an error. Verify no panic or silent data loss occurs.
+
+### E3: Database Connection Change (secondary change in PR)
+- The PR also removes `Arc` wrapping from the `Database.conn` field and removes the
+  `shared_connection()` method. Verify that all database operations (wallet persistence, UTXO
+  tracking, identity storage) continue to work correctly after this change. This is a structural
+  refactor and should not affect behavior.
+
+### E4: Concurrent Asset Lock Creation
+- If two asset lock transactions are created in quick succession (e.g., rapid identity registration
+  attempts), verify that UTXO double-spend is prevented and the second attempt either uses different
+  UTXOs or fails gracefully.

--- a/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
+++ b/docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md
@@ -265,11 +265,6 @@ with "min relay fee not met" now succeed.
   causes a shortfall (total inputs < amount + real fee), the code should handle this via the
   `allow_take_fee_from_amount` path or return an error. Verify no panic or silent data loss occurs.
 
-### E3: Database Connection Change (secondary change in PR)
-- The PR also removes `Arc` wrapping from the `Database.conn` field and removes the
-  `shared_connection()` method. Verify that all database operations (wallet persistence, UTXO
-  tracking, identity storage) continue to work correctly after this change. This is a structural
-  refactor and should not affect behavior.
 
 ### E4: Concurrent Asset Lock Creation
 - If two asset lock transactions are created in quick succession (e.g., rapid identity registration

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -533,3 +533,128 @@ impl Wallet {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fee_single_input_minimum() {
+        // 1 input, amount=10000, total=50000.
+        // With 2 outputs: size = 10 + 148 + 2*34 + 60 = 286 -> fee = max(3000, 286) = 3000.
+        // Change = 50000 - 10000 - 3000 = 37000.
+        let result = calculate_asset_lock_fee(50_000, 10_000, 1, false).expect("should succeed");
+        assert_eq!(result.fee, 3_000);
+        assert_eq!(result.actual_amount, 10_000);
+        assert_eq!(result.change, Some(37_000));
+    }
+
+    #[test]
+    fn fee_scales_with_inputs() {
+        // 21 inputs, amount=50000, total=200000.
+        // With 2 outputs: size = 10 + 21*148 + 2*34 + 60 = 3246, fee = max(3000, 3246) = 3246.
+        // Change = 200000 - 50000 - 3246 = 146754.
+        let result = calculate_asset_lock_fee(200_000, 50_000, 21, false).expect("should succeed");
+        assert!(
+            result.fee > MIN_ASSET_LOCK_FEE,
+            "fee should exceed minimum for many inputs"
+        );
+        assert_eq!(result.fee, 3_246);
+        assert_eq!(result.actual_amount, 50_000);
+        assert_eq!(result.change, Some(146_754));
+    }
+
+    #[test]
+    fn fee_exact_no_change() {
+        // 1 input, amount=47000, total=50000.
+        // With 2 outputs: size = 286, fee = 3000. change = 50000 - 47000 - 3000 = 0 -> None.
+        // Re-check with 1 output: size = 10 + 148 + 34 + 60 = 252, fee = 3000.
+        // 50000 >= 47000 + 3000 -> actual fee = 50000 - 47000 = 3000.
+        let result = calculate_asset_lock_fee(50_000, 47_000, 1, false).expect("should succeed");
+        assert_eq!(result.actual_amount, 47_000);
+        assert_eq!(result.change, None);
+    }
+
+    #[test]
+    fn fee_take_from_amount() {
+        // 1 input, amount=50000, total=50000, allow_take_fee=true.
+        // With 2 outputs: fee = 3000. change = 50000 - 50000 - 3000 < 0.
+        // With 1 output: fee = 3000. 50000 < 50000 + 3000.
+        // Take from amount: actual = 50000 - 3000 = 47000.
+        let result = calculate_asset_lock_fee(50_000, 50_000, 1, true).expect("should succeed");
+        assert_eq!(result.actual_amount, 47_000);
+        assert_eq!(result.change, None);
+    }
+
+    #[test]
+    fn fee_insufficient_funds() {
+        // 1 input, amount=50000, total=50000, allow_take_fee=false.
+        let result = calculate_asset_lock_fee(50_000, 50_000, 1, false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Insufficient funds"));
+    }
+
+    #[test]
+    fn fee_insufficient_for_fee_alone() {
+        // 1 input, amount=2000, total=2000, allow_take_fee=true.
+        // Fee = 3000 > total -> adjusted = 2000 - 3000 = 0 (saturating) -> error.
+        let result = calculate_asset_lock_fee(2_000, 2_000, 1, true);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("Insufficient funds"),
+            "should error when total cannot even cover the fee"
+        );
+    }
+
+    #[test]
+    fn fee_change_eliminated_by_real_fee_should_succeed() {
+        // BUG TEST: 21 inputs, amount=50000, total=53220.
+        //
+        // Initial UTXO selection uses fee estimate of 3000:
+        //   change = 53220 - 50000 - 3000 = 220 -> has_initial_change = true
+        //
+        // Buggy code uses 2 outputs: fee = 10 + 21*148 + 2*34 + 60 = 3246
+        //   53220 < 50000 + 3246 = 53246 -> ERROR (false insufficient funds)
+        //
+        // Correct code recalculates with 1 output: fee = 10 + 21*148 + 1*34 + 60 = 3212
+        //   53220 >= 50000 + 3212 -> succeeds, no change, fee = 3220
+        let result = calculate_asset_lock_fee(53_220, 50_000, 21, false);
+        assert!(
+            result.is_ok(),
+            "should NOT fail with insufficient funds; got: {:?}",
+            result
+        );
+        let result = result.unwrap();
+        assert_eq!(result.actual_amount, 50_000);
+        assert_eq!(result.change, None);
+        // Fee absorbs the leftover: 53220 - 50000 = 3220
+        assert_eq!(result.fee, 3_220);
+    }
+
+    #[test]
+    fn fee_overestimate_when_change_disappears() {
+        // BUG TEST: Verify that when initial change exists under 3000 estimate but
+        // disappears under the real fee, we do not overcharge by counting the
+        // phantom change output.
+        //
+        // 21 inputs, amount=50000, total=53240.
+        // 2-output fee = 3246 -> 53240 < 53246, would fail with buggy code.
+        // 1-output fee = 3212 -> 53240 >= 53212, succeeds. fee = 3240, no change.
+        let result = calculate_asset_lock_fee(53_240, 50_000, 21, false);
+        assert!(
+            result.is_ok(),
+            "should succeed when recalculated without change output; got: {:?}",
+            result
+        );
+        let result = result.unwrap();
+        assert_eq!(result.actual_amount, 50_000);
+        assert_eq!(result.change, None);
+        // The fee with 2 outputs (3246) would be wrong here; only 1 output is needed.
+        // Actual fee = leftover = 53240 - 50000 = 3240, which is >= 1-output minimum (3212).
+        assert!(
+            result.fee < 3_246,
+            "fee should be less than the 2-output estimate of 3246, got {}",
+            result.fee
+        );
+        assert_eq!(result.fee, 3_240);
+    }
+}

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -262,12 +262,19 @@ impl Wallet {
         let total_input_value: u64 = utxos.iter().map(|(_, (tx_out, _))| tx_out.value).sum();
         let num_inputs = utxos.len();
 
-        let fee_result = calculate_asset_lock_fee(
+        let fee_result = match calculate_asset_lock_fee(
             total_input_value,
             amount,
             num_inputs,
             allow_take_fee_from_amount,
-        )?;
+        ) {
+            Ok(result) => result,
+            Err(e) => {
+                // Roll back: restore selected UTXOs to the wallet if fee calculation fails.
+                self.utxos.extend(utxos.into_iter());
+                return Err(e);
+            }
+        };
 
         let actual_amount = fee_result.actual_amount;
         let change_option = fee_result.change;

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -271,7 +271,12 @@ impl Wallet {
             Ok(result) => result,
             Err(e) => {
                 // Roll back: restore selected UTXOs to the wallet if fee calculation fails.
-                self.utxos.extend(utxos.into_iter());
+                for (outpoint, (tx_out, address)) in utxos {
+                    self.utxos
+                        .entry(address)
+                        .or_default()
+                        .insert(outpoint, tx_out);
+                }
                 return Err(e);
             }
         };

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -152,7 +152,13 @@ impl Wallet {
 
         let (utxos, initial_change_option) = self
             .take_unspent_utxos_for(amount, initial_fee_estimate, allow_take_fee_from_amount)
-            .ok_or("take_unspent_utxos_for() returned None".to_string())?;
+            .ok_or_else(|| {
+                format!(
+                    "Not enough spendable funds to create asset lock transaction: \
+                     requested amount {} plus estimated fee {}",
+                    amount, initial_fee_estimate
+                )
+            })?;
 
         // Calculate fee based on actual transaction size so we always meet the
         // min relay fee (1 duff/byte = 1000 duffs/kB).

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -26,6 +26,11 @@ pub(crate) struct AssetLockFeeResult {
 /// Minimum fee for an asset lock transaction (duffs).
 const MIN_ASSET_LOCK_FEE: u64 = 3_000;
 
+/// Minimum value for a change output (duffs). Outputs below this
+/// threshold are considered dust and will be rejected by the network.
+/// For P2PKH outputs the Dash Core dust limit is 546 duffs.
+const DUST_THRESHOLD: u64 = 546;
+
 /// Estimate the transaction size in bytes.
 ///
 /// Assumes P2PKH inputs (~148 B each), standard outputs (~34 B each),
@@ -51,11 +56,14 @@ pub(crate) fn calculate_asset_lock_fee(
     // First pass: assume 2 outputs (1 burn + 1 change).
     let fee_with_change = std::cmp::max(MIN_ASSET_LOCK_FEE, estimate_tx_size(num_inputs, 2) as u64);
 
-    let tentative_change = total_input_value.checked_sub(requested_amount + fee_with_change);
+    let required_with_change = requested_amount
+        .checked_add(fee_with_change)
+        .ok_or("Overflow computing required amount + fee")?;
+    let tentative_change = total_input_value.checked_sub(required_with_change);
 
-    // If there is positive change, we are done.
+    // If change exceeds dust threshold, include it as an output.
     if let Some(change) = tentative_change
-        && change > 0
+        && change >= DUST_THRESHOLD
     {
         return Ok(AssetLockFeeResult {
             fee: fee_with_change,
@@ -68,7 +76,11 @@ pub(crate) fn calculate_asset_lock_fee(
     // Recompute with 1 output (no change).
     let fee_no_change = std::cmp::max(MIN_ASSET_LOCK_FEE, estimate_tx_size(num_inputs, 1) as u64);
 
-    if total_input_value >= requested_amount + fee_no_change {
+    let required_no_change = requested_amount
+        .checked_add(fee_no_change)
+        .ok_or("Overflow computing required amount + fee")?;
+
+    if total_input_value >= required_no_change {
         // Enough funds without a change output. Any leftover becomes
         // additional fee (it is too small for a viable change output).
         return Ok(AssetLockFeeResult {
@@ -234,7 +246,7 @@ impl Wallet {
 
         // Use a small initial estimate to select UTXOs; we recalculate the fee
         // below based on the actual number of inputs.
-        let initial_fee_estimate = 3_000u64;
+        let initial_fee_estimate = MIN_ASSET_LOCK_FEE;
 
         let (utxos, _initial_change_option) = self
             .take_unspent_utxos_for(amount, initial_fee_estimate, allow_take_fee_from_amount)
@@ -656,5 +668,20 @@ mod tests {
             result.fee
         );
         assert_eq!(result.fee, 3_240);
+    }
+    #[test]
+    fn fee_dust_change_absorbed_into_fee() {
+        // 1 input, amount=46500, total=50000.
+        // With 2 outputs: fee = 3000. change = 50000 - 46500 - 3000 = 500.
+        // 500 < DUST_THRESHOLD (546) → change is dust, absorbed into fee.
+        // Falls through to 1-output path: fee = 3000.
+        // 50000 >= 46500 + 3000 → fee = 50000 - 46500 = 3500 (absorbs dust).
+        let result = calculate_asset_lock_fee(50_000, 46_500, 1, false).expect("should succeed");
+        assert_eq!(result.actual_amount, 46_500);
+        assert_eq!(
+            result.change, None,
+            "dust change should not create an output"
+        );
+        assert_eq!(result.fee, 3_500, "dust should be absorbed into fee");
     }
 }

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -145,19 +145,44 @@ impl Wallet {
         let asset_lock_public_key = private_key.public_key(&secp);
 
         let one_time_key_hash = asset_lock_public_key.pubkey_hash();
-        let fee = 3_000;
 
-        let (utxos, change_option) = self
-            .take_unspent_utxos_for(amount, fee, allow_take_fee_from_amount)
+        // Use a small initial estimate to select UTXOs; we recalculate the fee
+        // below based on the actual number of inputs.
+        let initial_fee_estimate = 3_000u64;
+
+        let (utxos, initial_change_option) = self
+            .take_unspent_utxos_for(amount, initial_fee_estimate, allow_take_fee_from_amount)
             .ok_or("take_unspent_utxos_for() returned None".to_string())?;
 
-        let actual_amount = if change_option.is_none() && allow_take_fee_from_amount {
-            // The amount has been adjusted by taking the fee from the amount
-            // Calculate the adjusted amount based on the total value of the UTXOs minus the fee
-            let total_input_value: u64 = utxos.iter().map(|(_, (tx_out, _))| tx_out.value).sum();
-            total_input_value - fee
+        // Calculate fee based on actual transaction size so we always meet the
+        // min relay fee (1 duff/byte = 1000 duffs/kB).
+        // Sizes: P2PKH input ~148 B, output ~34 B, header ~10 B, payload ~60 B.
+        let num_inputs = utxos.len();
+        let has_initial_change = initial_change_option.is_some();
+        let num_outputs = 1 + if has_initial_change { 1 } else { 0 };
+        let estimated_size = 10 + (num_inputs * 148) + (num_outputs * 34) + 60;
+        let fee = std::cmp::max(initial_fee_estimate, estimated_size as u64);
+
+        // Recalculate amount and change with the real fee
+        let total_input_value: u64 = utxos.iter().map(|(_, (tx_out, _))| tx_out.value).sum();
+
+        let (actual_amount, change_option) = if total_input_value < amount + fee {
+            if allow_take_fee_from_amount {
+                // Deduct the fee shortfall from the output amount
+                let adjusted = total_input_value.saturating_sub(fee);
+                if adjusted == 0 {
+                    return Err("Insufficient funds for transaction fee".to_string());
+                }
+                (adjusted, None)
+            } else {
+                return Err(format!(
+                    "Insufficient funds: need {} + {} fee, have {}",
+                    amount, fee, total_input_value
+                ));
+            }
         } else {
-            amount
+            let change = total_input_value - amount - fee;
+            (amount, if change > 0 { Some(change) } else { None })
         };
 
         let payload_output = TxOut {

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -11,6 +11,92 @@ use dash_sdk::dpp::dashcore::{
 use dash_sdk::dpp::key_wallet::psbt::serialize::Serialize;
 use std::collections::BTreeMap;
 
+/// Result of asset lock fee calculation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AssetLockFeeResult {
+    /// Transaction fee in duffs.
+    pub fee: u64,
+    /// Actual amount for the asset lock output (may differ from requested if
+    /// `allow_take_fee_from_amount` is true).
+    pub actual_amount: u64,
+    /// Change to return, or `None` if no change output is needed.
+    pub change: Option<u64>,
+}
+
+/// Minimum fee for an asset lock transaction (duffs).
+const MIN_ASSET_LOCK_FEE: u64 = 3_000;
+
+/// Estimate the transaction size in bytes.
+///
+/// Assumes P2PKH inputs (~148 B each), standard outputs (~34 B each),
+/// a ~10 B header, and a ~60 B asset-lock payload.
+fn estimate_tx_size(num_inputs: usize, num_outputs: usize) -> usize {
+    10 + (num_inputs * 148) + (num_outputs * 34) + 60
+}
+
+/// Calculate fee, actual amount, and change for an asset lock transaction.
+///
+/// Uses an iterative approach: starts assuming a change output exists,
+/// then recomputes if the change disappears under the real fee.
+///
+/// # Errors
+///
+/// Returns an error string if there are insufficient funds.
+pub(crate) fn calculate_asset_lock_fee(
+    total_input_value: u64,
+    requested_amount: u64,
+    num_inputs: usize,
+    allow_take_fee_from_amount: bool,
+) -> Result<AssetLockFeeResult, String> {
+    // First pass: assume 2 outputs (1 burn + 1 change).
+    let fee_with_change = std::cmp::max(MIN_ASSET_LOCK_FEE, estimate_tx_size(num_inputs, 2) as u64);
+
+    let tentative_change = total_input_value.checked_sub(requested_amount + fee_with_change);
+
+    // If there is positive change, we are done.
+    if let Some(change) = tentative_change
+        && change > 0
+    {
+        return Ok(AssetLockFeeResult {
+            fee: fee_with_change,
+            actual_amount: requested_amount,
+            change: Some(change),
+        });
+    }
+
+    // Change is zero or negative under the 2-output fee.
+    // Recompute with 1 output (no change).
+    let fee_no_change = std::cmp::max(MIN_ASSET_LOCK_FEE, estimate_tx_size(num_inputs, 1) as u64);
+
+    if total_input_value >= requested_amount + fee_no_change {
+        // Enough funds without a change output. Any leftover becomes
+        // additional fee (it is too small for a viable change output).
+        return Ok(AssetLockFeeResult {
+            fee: total_input_value - requested_amount,
+            actual_amount: requested_amount,
+            change: None,
+        });
+    }
+
+    // Insufficient for the requested amount at the 1-output fee rate.
+    if allow_take_fee_from_amount {
+        let adjusted = total_input_value.saturating_sub(fee_no_change);
+        if adjusted == 0 {
+            return Err("Insufficient funds for transaction fee".to_string());
+        }
+        Ok(AssetLockFeeResult {
+            fee: fee_no_change,
+            actual_amount: adjusted,
+            change: None,
+        })
+    } else {
+        Err(format!(
+            "Insufficient funds: need {} + {} fee, have {}",
+            requested_amount, fee_no_change, total_input_value
+        ))
+    }
+}
+
 impl Wallet {
     #[allow(clippy::type_complexity)]
     pub fn registration_asset_lock_transaction(
@@ -150,7 +236,7 @@ impl Wallet {
         // below based on the actual number of inputs.
         let initial_fee_estimate = 3_000u64;
 
-        let (utxos, initial_change_option) = self
+        let (utxos, _initial_change_option) = self
             .take_unspent_utxos_for(amount, initial_fee_estimate, allow_take_fee_from_amount)
             .ok_or_else(|| {
                 format!(
@@ -160,36 +246,19 @@ impl Wallet {
                 )
             })?;
 
-        // Calculate fee based on actual transaction size so we always meet the
-        // min relay fee (1 duff/byte = 1000 duffs/kB).
-        // Sizes: P2PKH input ~148 B, output ~34 B, header ~10 B, payload ~60 B.
-        let num_inputs = utxos.len();
-        let has_initial_change = initial_change_option.is_some();
-        let num_outputs = 1 + if has_initial_change { 1 } else { 0 };
-        let estimated_size = 10 + (num_inputs * 148) + (num_outputs * 34) + 60;
-        let fee = std::cmp::max(initial_fee_estimate, estimated_size as u64);
-
-        // Recalculate amount and change with the real fee
+        // Calculate fee, amount, and change using the extracted pure function.
         let total_input_value: u64 = utxos.iter().map(|(_, (tx_out, _))| tx_out.value).sum();
+        let num_inputs = utxos.len();
 
-        let (actual_amount, change_option) = if total_input_value < amount + fee {
-            if allow_take_fee_from_amount {
-                // Deduct the fee shortfall from the output amount
-                let adjusted = total_input_value.saturating_sub(fee);
-                if adjusted == 0 {
-                    return Err("Insufficient funds for transaction fee".to_string());
-                }
-                (adjusted, None)
-            } else {
-                return Err(format!(
-                    "Insufficient funds: need {} + {} fee, have {}",
-                    amount, fee, total_input_value
-                ));
-            }
-        } else {
-            let change = total_input_value - amount - fee;
-            (amount, if change > 0 { Some(change) } else { None })
-        };
+        let fee_result = calculate_asset_lock_fee(
+            total_input_value,
+            amount,
+            num_inputs,
+            allow_take_fee_from_amount,
+        )?;
+
+        let actual_amount = fee_result.actual_amount;
+        let change_option = fee_result.change;
 
         let payload_output = TxOut {
             value: actual_amount,
@@ -463,3 +532,4 @@ impl Wallet {
         Ok((tx, private_key))
     }
 }
+


### PR DESCRIPTION
## Summary

- Replaces hardcoded 3000 duff fee with dynamic calculation based on actual transaction size
- Estimates size as: 10B header + (inputs × 148B) + (outputs × 34B) + 60B payload
- Properly recalculates change output after real fee is known
- Handles fee shortfall gracefully when `allow_take_fee_from_amount` is set

## Test plan

Manual test scenarios: [`docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md`](docs/ai-design/2026-02-24-asset-lock-fee-fix/manual-test-scenarios.md)

- [ ] Single-input asset lock (fee minimum 3000 duffs)
- [ ] Multiple-input asset lock (fee scales with inputs)
- [ ] Tight balance with fee deduction from amount
- [ ] Insufficient funds error with clear message
- [ ] Change output recalculated after dynamic fee
- [ ] Transaction accepted by network (meets min relay fee)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset lock transaction fee calculation to use dynamic sizing instead of fixed values, with a minimum fee of 3000 duffs.
  * Enhanced handling of transaction change outputs and fee deduction scenarios.

* **Documentation**
  * Added comprehensive manual test scenarios for asset lock fee behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->