### PR TITLE
backport: feat(ui): add is_platform_address() helper and address constants

### DIFF
--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1115,3 +1115,21 @@ pub fn show_group_token_success_screen_with_fee(
     });
     action
 }
+
+/// Check if a string looks like a Platform Bech32m address.
+///
+/// Supports both the current prefix (`dash1`/`tdash1`) and the legacy
+/// prefix (`evo1`/`tevo1`) so that old addresses stored in the DB or
+/// copied from older tools continue to work.
+pub fn is_platform_address(s: &str) -> bool {
+    s.starts_with("dash1")
+        || s.starts_with("tdash1")
+        || s.starts_with("evo1")
+        || s.starts_with("tevo1")
+}
+
+/// Human-readable hint for Platform address input fields.
+pub const PLATFORM_ADDRESS_HINT: &str = "dash1... or tdash1...";
+
+/// Example Platform address prefixes for error messages.
+pub const PLATFORM_ADDRESS_EXAMPLES: &str = "dash1.../tdash1...";

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1133,3 +1133,67 @@ pub const PLATFORM_ADDRESS_HINT: &str = "dash1... or tdash1...";
 
 /// Example Platform address prefixes for error messages.
 pub const PLATFORM_ADDRESS_EXAMPLES: &str = "dash1.../tdash1...";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_platform_address_accepts_current_mainnet_prefix() {
+        assert!(is_platform_address("dash1qpq0sac8k"));
+    }
+
+    #[test]
+    fn is_platform_address_accepts_current_testnet_prefix() {
+        assert!(is_platform_address("tdash1qpq0sac8k"));
+    }
+
+    #[test]
+    fn is_platform_address_accepts_legacy_mainnet_prefix() {
+        assert!(is_platform_address("evo1qpq0sac8k"));
+    }
+
+    #[test]
+    fn is_platform_address_accepts_legacy_testnet_prefix() {
+        assert!(is_platform_address("tevo1qpq0sac8k"));
+    }
+
+    #[test]
+    fn is_platform_address_rejects_base58_address() {
+        assert!(!is_platform_address("XqLYPDTADW6EYuQmTcEAx81o8EHTKwqTK8"));
+    }
+
+    #[test]
+    fn is_platform_address_rejects_empty_string() {
+        assert!(!is_platform_address(""));
+    }
+
+    #[test]
+    fn is_platform_address_rejects_random_text() {
+        assert!(!is_platform_address("hello world"));
+    }
+
+    #[test]
+    fn is_platform_address_rejects_partial_prefix() {
+        assert!(!is_platform_address("das"));
+        assert!(!is_platform_address("tdas"));
+        assert!(!is_platform_address("ev"));
+        assert!(!is_platform_address("tev"));
+    }
+
+    #[test]
+    fn is_platform_address_accepts_prefix_only() {
+        // Bare prefix with no payload — the function is prefix-based,
+        // full Bech32m validation is done elsewhere.
+        assert!(is_platform_address("dash1"));
+        assert!(is_platform_address("tdash1"));
+        assert!(is_platform_address("evo1"));
+        assert!(is_platform_address("tevo1"));
+    }
+
+    #[test]
+    fn platform_address_constants_are_non_empty() {
+        assert!(!PLATFORM_ADDRESS_HINT.is_empty());
+        assert!(!PLATFORM_ADDRESS_EXAMPLES.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `is_platform_address()` function supporting both current (`dash1`/`tdash1`) and legacy (`evo1`/`tevo1`) prefixes
- Adds `PLATFORM_ADDRESS_HINT` and `PLATFORM_ADDRESS_EXAMPLES` constants for consistent UI text

## Test plan
- [ ] Verify function recognizes `dash1...`, `tdash1...`, `evo1...`, `tevo1...` prefixes
- [ ] Verify function rejects non-platform addresses

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>