### PR TITLE
backport: feat(ui): add Auto Update button for dashmate RPC password

### DIFF
--- a/docs/ai-design/2026-02-24-dashmate-auto-update/manual-test-scenarios.md
+++ b/docs/ai-design/2026-02-24-dashmate-auto-update/manual-test-scenarios.md
@@ -1,0 +1,201 @@
+# Manual Test Scenarios: Dashmate Auto Update (PR #641)
+
+## Overview
+
+PR #641 adds an "Auto Update" button next to the local network (Regtest) password field in the Network Chooser screen. When clicked, it reads the RPC password from `~/.dashmate/config.json` (using the `local_seed` config name) and auto-fills the password field, saving it to the application config.
+
+---
+
+## Scenario 1: Auto Update button is visible on the Local Network tab
+
+### Preconditions
+
+- Dash Evo Tool is built and running.
+- The Network Chooser screen is accessible.
+
+### Steps
+
+1. Open the application.
+2. Navigate to the Network Chooser screen.
+3. Select the **Local Network** (Regtest) tab.
+4. Locate the RPC password text field.
+
+### Expected Results
+
+- The password text field is visible.
+- A **"Save"** button is displayed next to the text field.
+- An **"Auto Update"** button is displayed next to the Save button.
+- Both buttons are clearly labeled and not overlapping.
+
+---
+
+## Scenario 2: Successful auto-fill with dashmate installed and configured
+
+### Preconditions
+
+- Dashmate is installed on the machine.
+- `~/.dashmate/config.json` exists and contains a valid `local_seed` configuration with an RPC password at the JSON path: `configs.local_seed.core.rpc.users.dashmate.password`.
+- The password field is either empty or contains a different value.
+
+### Steps
+
+1. Open the application and navigate to Network Chooser > Local Network.
+2. Note the current value in the password text field.
+3. Click the **"Auto Update"** button.
+
+### Expected Results
+
+- The password text field is immediately populated with the password value from `~/.dashmate/config.json`.
+- The password is automatically saved to the application config (no need to click Save separately).
+- No error messages are displayed.
+
+### Verification
+
+- Close and reopen the application.
+- Navigate back to Network Chooser > Local Network.
+- Confirm the password field still contains the auto-filled value (persistence check).
+
+---
+
+## Scenario 3: Auto Update when dashmate is not installed
+
+### Preconditions
+
+- Dashmate is **not** installed, meaning `~/.dashmate/config.json` does not exist.
+- The password field may contain any value (empty or pre-filled).
+
+### Steps
+
+1. Open the application and navigate to Network Chooser > Local Network.
+2. Note the current value in the password text field.
+3. Click the **"Auto Update"** button.
+
+### Expected Results
+
+- The password field retains its previous value (unchanged).
+- An error is logged (check application logs / terminal output for a message like: `Auto update failed: Failed to read /home/<user>/.dashmate/config.json: No such file or directory`).
+- **Note:** Currently there is no visible UI error feedback to the user -- the error only appears in `tracing::error!` logs. Verify whether this is acceptable UX or if a user-visible message should be shown.
+
+---
+
+## Scenario 4: Auto Update when dashmate config exists but has no local_seed entry
+
+### Preconditions
+
+- `~/.dashmate/config.json` exists but does not contain a `local_seed` key under `configs`, or the `local_seed` entry does not have the expected `core.rpc.users.dashmate.password` path.
+
+### Steps
+
+1. Open the application and navigate to Network Chooser > Local Network.
+2. Click the **"Auto Update"** button.
+
+### Expected Results
+
+- The password field retains its previous value (unchanged).
+- An error is logged: `Auto update failed: Password not found in dashmate config 'local_seed'`.
+- No crash or panic occurs.
+
+---
+
+## Scenario 5: Auto Update when dashmate config contains malformed JSON
+
+### Preconditions
+
+- `~/.dashmate/config.json` exists but contains invalid JSON (e.g., a truncated file or syntax error).
+
+### Steps
+
+1. Open the application and navigate to Network Chooser > Local Network.
+2. Click the **"Auto Update"** button.
+
+### Expected Results
+
+- The password field retains its previous value (unchanged).
+- An error is logged: `Auto update failed: Failed to parse dashmate config: ...`.
+- No crash or panic occurs.
+
+---
+
+## Scenario 6: Manual Save button still works independently
+
+### Preconditions
+
+- The application is running and on the Local Network tab.
+
+### Steps
+
+1. Navigate to Network Chooser > Local Network.
+2. Clear the password field and type a custom password, e.g., `my_custom_password`.
+3. Click the **"Save"** button (not Auto Update).
+4. Close and reopen the application.
+5. Navigate back to Network Chooser > Local Network.
+
+### Expected Results
+
+- After step 3, the password is saved to the application config.
+- After step 5, the password field shows `my_custom_password`, confirming persistence.
+
+---
+
+## Scenario 7: Auto Update overwrites a previously saved manual password
+
+### Preconditions
+
+- Dashmate is installed with a valid `local_seed` config containing a known RPC password (e.g., `dashmate_password_123`).
+- A different password was previously saved manually (e.g., `old_manual_password`).
+
+### Steps
+
+1. Navigate to Network Chooser > Local Network.
+2. Confirm the field shows `old_manual_password`.
+3. Click **"Auto Update"**.
+
+### Expected Results
+
+- The password field now shows `dashmate_password_123`.
+- The new password is automatically persisted.
+- Closing and reopening the application confirms the dashmate password is retained.
+
+---
+
+## Scenario 8: Auto Update button is not present on non-Local networks
+
+### Preconditions
+
+- The application is running.
+
+### Steps
+
+1. Navigate to the Network Chooser screen.
+2. Select the **Mainnet** tab.
+3. Look for an "Auto Update" button in the network configuration area.
+4. Repeat for **Testnet** and **Devnet** tabs.
+
+### Expected Results
+
+- The "Auto Update" button is **not** displayed on Mainnet, Testnet, or Devnet tabs.
+- The button only appears on the Local Network (Regtest) tab where the dashmate password field is shown.
+
+---
+
+## Edge Cases
+
+### E1: Config save failure
+
+- If `Config::load()` or `config.save()` fails after Auto Update reads the password successfully, the password field will be updated in the UI but may not persist across restarts. This mirrors the existing Save button behavior.
+
+### E2: Empty password in dashmate config
+
+- If the dashmate config contains an empty string for the password value (`"password": ""`), the Auto Update should still fill the field with an empty string and save it. Verify the field is cleared and the empty value is persisted.
+
+### E3: Very long password in dashmate config
+
+- If the dashmate config contains an unusually long password string, verify the text field displays it correctly without UI layout issues.
+
+### E4: File permission issues
+
+- If `~/.dashmate/config.json` exists but is not readable by the current user, verify the error is handled gracefully (logged, no crash, password field unchanged).
+
+### E5: Concurrent dashmate config changes
+
+- If the dashmate config is being written to by dashmate while the user clicks Auto Update, the read may fail or return partial data. Verify no crash occurs (the JSON parse error path should handle this).

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -109,6 +109,7 @@ pub struct NetworkChooserScreen {
     use_local_spv_node: bool,
     auto_start_spv: bool,
     close_dash_qt_on_exit: bool,
+    dashmate_auto_update_error: Option<String>,
 }
 
 impl NetworkChooserScreen {
@@ -208,6 +209,7 @@ impl NetworkChooserScreen {
             use_local_spv_node,
             auto_start_spv,
             close_dash_qt_on_exit,
+            dashmate_auto_update_error: None,
         }
     }
 
@@ -454,12 +456,18 @@ impl NetworkChooserScreen {
                         match read_dashmate_rpc_password("local_seed") {
                             Ok(password) => {
                                 self.local_network_dashmate_password = password;
+                                self.dashmate_auto_update_error = None;
                                 auto_update_succeeded = true;
                             }
                             Err(e) => {
                                 tracing::error!("Auto update failed: {e}");
+                                self.dashmate_auto_update_error = Some(e);
                             }
                         }
+                    }
+
+                    if save_clicked {
+                        self.dashmate_auto_update_error = None;
                     }
 
                     if (save_clicked || auto_update_succeeded)
@@ -499,6 +507,27 @@ impl NetworkChooserScreen {
                         }
                     }
                 });
+
+                // Show error from dashmate auto-update
+                if let Some(ref error) = self.dashmate_auto_update_error {
+                    ui.add_space(4.0);
+                    let error_color = Color32::from_rgb(255, 100, 100);
+                    let error = error.clone();
+                    Frame::new()
+                        .fill(error_color.gamma_multiply(0.1))
+                        .inner_margin(Margin::symmetric(10, 8))
+                        .corner_radius(5.0)
+                        .stroke(egui::Stroke::new(1.0, error_color))
+                        .show(ui, |ui| {
+                            ui.horizontal(|ui| {
+                                ui.label(RichText::new(&error).color(error_color));
+                                ui.add_space(10.0);
+                                if ui.small_button("Dismiss").clicked() {
+                                    self.dashmate_auto_update_error = None;
+                                }
+                            });
+                        });
+                }
             }
         });
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -7,6 +7,7 @@ use crate::context::AppContext;
 use crate::context::connection_status::{ConnectionStatus, OverallConnectionState};
 use crate::model::wallet::DerivationPathHelpers;
 use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
+use crate::ui::components::MessageBanner;
 use crate::ui::components::component_trait::Component;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::{
@@ -14,7 +15,7 @@ use crate::ui::components::styled::{
 };
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::theme::{DashColors, Shape, ThemeMode};
-use crate::ui::{RootScreenType, ScreenLike};
+use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use crate::utils::path::format_path_for_display;
 use dash_sdk::dash_spv::sync::{ProgressPercentage, SyncProgress as SpvSyncProgress, SyncState};
 use dash_sdk::dpp::dashcore::Network;
@@ -109,7 +110,6 @@ pub struct NetworkChooserScreen {
     use_local_spv_node: bool,
     auto_start_spv: bool,
     close_dash_qt_on_exit: bool,
-    dashmate_auto_update_error: Option<String>,
 }
 
 impl NetworkChooserScreen {
@@ -209,7 +209,6 @@ impl NetworkChooserScreen {
             use_local_spv_node,
             auto_start_spv,
             close_dash_qt_on_exit,
-            dashmate_auto_update_error: None,
         }
     }
 
@@ -456,18 +455,13 @@ impl NetworkChooserScreen {
                         match read_dashmate_rpc_password("local_seed") {
                             Ok(password) => {
                                 self.local_network_dashmate_password = password;
-                                self.dashmate_auto_update_error = None;
                                 auto_update_succeeded = true;
                             }
                             Err(e) => {
                                 tracing::error!("Auto update failed: {e}");
-                                self.dashmate_auto_update_error = Some(e);
+                                MessageBanner::set_global(ui.ctx(), &e, MessageType::Error);
                             }
                         }
-                    }
-
-                    if save_clicked {
-                        self.dashmate_auto_update_error = None;
                     }
 
                     if (save_clicked || auto_update_succeeded)
@@ -507,27 +501,6 @@ impl NetworkChooserScreen {
                         }
                     }
                 });
-
-                // Show error from dashmate auto-update
-                if let Some(ref error) = self.dashmate_auto_update_error {
-                    ui.add_space(4.0);
-                    let error_color = Color32::from_rgb(255, 100, 100);
-                    let error = error.clone();
-                    Frame::new()
-                        .fill(error_color.gamma_multiply(0.1))
-                        .inner_margin(Margin::symmetric(10, 8))
-                        .corner_radius(5.0)
-                        .stroke(egui::Stroke::new(1.0, error_color))
-                        .show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                ui.label(RichText::new(&error).color(error_color));
-                                ui.add_space(10.0);
-                                if ui.small_button("Dismiss").clicked() {
-                                    self.dashmate_auto_update_error = None;
-                                }
-                            });
-                        });
-                }
             }
         });
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -25,6 +25,28 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+/// Reads the dashmate RPC password from `~/.dashmate/config.json`.
+fn read_dashmate_rpc_password(config_name: &str) -> Result<String, String> {
+    let home = directories::UserDirs::new()
+        .map(|dirs| dirs.home_dir().to_path_buf())
+        .ok_or("Could not determine home directory")?;
+    let config_path = home.join(".dashmate").join("config.json");
+    let contents = std::fs::read_to_string(&config_path)
+        .map_err(|e| format!("Failed to read {}: {e}", config_path.display()))?;
+    let json: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse dashmate config: {e}"))?;
+    json.get("configs")
+        .and_then(|c| c.get(config_name))
+        .and_then(|c| c.get("core"))
+        .and_then(|c| c.get("rpc"))
+        .and_then(|c| c.get("users"))
+        .and_then(|c| c.get("dashmate"))
+        .and_then(|c| c.get("password"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("Password not found in dashmate config '{config_name}'"))
+}
+
 #[derive(Debug, Clone)]
 enum SpvClearMessage {
     Success(String),
@@ -425,7 +447,22 @@ impl NetworkChooserScreen {
                 ui.horizontal(|ui| {
                     ui.text_edit_singleline(&mut self.local_network_dashmate_password);
 
-                    if ui.button("Save").clicked()
+                    let save_clicked = ui.button("Save").clicked();
+
+                    let mut auto_update_succeeded = false;
+                    if ui.button("Auto Update").clicked() {
+                        match read_dashmate_rpc_password("local_seed") {
+                            Ok(password) => {
+                                self.local_network_dashmate_password = password;
+                                auto_update_succeeded = true;
+                            }
+                            Err(e) => {
+                                tracing::error!("Auto update failed: {e}");
+                            }
+                        }
+                    }
+
+                    if (save_clicked || auto_update_succeeded)
                         && let Ok(mut config) = Config::load()
                         && let Some(local_cfg) = config.config_for_network(Network::Regtest).clone()
                     {


### PR DESCRIPTION
## Summary

- Adds `read_dashmate_rpc_password()` function that reads the RPC password from `~/.dashmate/config.json`
- Adds "Auto Update" button next to the local network password field in the Network Chooser screen
- On click, reads password from dashmate config (`local_seed` config name) and auto-fills + saves it

> **Note:** When Auto Update fails (no dashmate installed, missing config), the error is only logged via `tracing::error!` — no user-visible feedback in the UI. Consider adding an inline error message.

## Test plan

Manual test scenarios: [`docs/ai-design/2026-02-24-dashmate-auto-update/manual-test-scenarios.md`](docs/ai-design/2026-02-24-dashmate-auto-update/manual-test-scenarios.md)

- [ ] Button present on Local Network tab
- [ ] Successful auto-fill with dashmate installed
- [ ] Graceful handling without dashmate (error logged)
- [ ] Manual Save button still works independently
- [ ] Password persists across app restart

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>