### PR TITLE
backport: refactor(database): wrap connection in Arc<Mutex> and add shared_connection()

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -18,7 +18,7 @@ mod wallet;
 
 use dash_sdk::dpp::dashcore::Network;
 use rusqlite::{Connection, Params};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// Error indicating a corrupted data blob in the database.
 ///
@@ -41,15 +41,23 @@ impl From<CorruptedBlobError> for rusqlite::Error {
 
 #[derive(Debug)]
 pub struct Database {
-    conn: Mutex<Connection>,
+    conn: Arc<Mutex<Connection>>,
 }
 
 impl Database {
     pub fn new<P: AsRef<std::path::Path>>(path: P) -> rusqlite::Result<Self> {
         let conn = Connection::open(path)?;
         Ok(Self {
-            conn: Mutex::new(conn),
+            conn: Arc::new(Mutex::new(conn)),
         })
+    }
+
+    /// Get a shared reference to the underlying connection.
+    ///
+    /// Used by `ClientPersistentCommitmentTree` to share the same SQLite
+    /// connection for the shielded commitment tree tables.
+    pub fn shared_connection(&self) -> Arc<Mutex<Connection>> {
+        self.conn.clone()
     }
 
     pub fn execute<P: Params>(&self, sql: &str, params: P) -> rusqlite::Result<usize> {


### PR DESCRIPTION
## Summary

- Changes `Database.conn` from `Mutex<Connection>` to `Arc<Mutex<Connection>>`
- Adds `shared_connection()` method to get a cloneable reference to the underlying connection
- All existing code continues to work identically (same lock semantics)
- Enables future consumers to share the SQLite connection without going through `Database` methods

## Test plan
- [ ] Build succeeds with no warnings
- [ ] All existing tests pass
- [ ] Database operations work identically (no behavioral change)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database connection management to support concurrent access scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->