### PR TITLE
fix(wallet): use mode-aware broadcast for platform funding in SPV mode

### DIFF
--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -4,7 +4,6 @@ use crate::context::{AppContext, get_transaction_info};
 use crate::model::fee_estimation::PlatformFeeEstimator;
 use crate::model::proof_log_item::{ProofLogItem, RequestType};
 use crate::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
-use crate::spv::CoreBackendMode;
 use dash_sdk::dash_spv::Network;
 use dash_sdk::dpp::ProtocolError;
 use dash_sdk::dpp::address_funds::PlatformAddress;
@@ -104,33 +103,18 @@ impl AppContext {
                     ) {
                         Ok(transaction) => transaction,
                         Err(e) => {
-                            match self.core_backend_mode() {
-                                CoreBackendMode::Rpc => {
-                                    wallet
-                                        .reload_utxos(
-                                            &self
-                                                .core_client
-                                                .read()
-                                                .expect("Core client lock was poisoned"),
-                                            self.network,
-                                            Some(self),
-                                        )
-                                        .map_err(|e| e.to_string())?;
-                                    wallet.registration_asset_lock_transaction(
-                                        sdk.network,
-                                        amount,
-                                        true,
-                                        identity_index,
-                                        Some(self),
-                                    )?
-                                }
-                                CoreBackendMode::Spv => {
-                                    // SPV wallet state is authoritative — UTXOs are synced
-                                    // continuously via compact block filters. No Core RPC
-                                    // fallback available.
-                                    return Err(e);
-                                }
+                            // Reload UTXOs (RPC: fetches from Core; SPV: no-op).
+                            // Only retry if something actually changed.
+                            if !wallet.reload_utxos(self)? {
+                                return Err(e);
                             }
+                            wallet.registration_asset_lock_transaction(
+                                sdk.network,
+                                amount,
+                                true,
+                                identity_index,
+                                Some(self),
+                            )?
                         }
                     }
                 };

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -3,7 +3,6 @@ use crate::backend_task::{BackendTaskSuccessResult, FeeResult};
 use crate::context::{AppContext, get_transaction_info};
 use crate::model::fee_estimation::PlatformFeeEstimator;
 use crate::model::proof_log_item::{ProofLogItem, RequestType};
-use crate::spv::CoreBackendMode;
 use dash_sdk::Error;
 use dash_sdk::dpp::ProtocolError;
 use dash_sdk::dpp::block::extended_epoch_info::ExtendedEpochInfo;
@@ -111,27 +110,21 @@ impl AppContext {
                             Some(self),
                         ) {
                             Ok(transaction) => transaction,
-                            Err(e) => match self.core_backend_mode() {
-                                CoreBackendMode::Rpc => {
-                                    let core_client = self.core_client.read().map_err(|e| {
-                                        format!("Core client lock was poisoned: {}", e)
-                                    })?;
-                                    wallet
-                                        .reload_utxos(&core_client, self.network, Some(self))
-                                        .map_err(|e| e.to_string())?;
-                                    wallet.top_up_asset_lock_transaction(
-                                        sdk.network,
-                                        amount,
-                                        true,
-                                        identity_index,
-                                        top_up_index,
-                                        Some(self),
-                                    )?
-                                }
-                                CoreBackendMode::Spv => {
+                            Err(e) => {
+                                // Reload UTXOs (RPC: fetches from Core; SPV: no-op).
+                                // Only retry if something actually changed.
+                                if !wallet.reload_utxos(self)? {
                                     return Err(e);
                                 }
-                            },
+                                wallet.top_up_asset_lock_transaction(
+                                    sdk.network,
+                                    amount,
+                                    true,
+                                    identity_index,
+                                    top_up_index,
+                                    Some(self),
+                                )?
+                            }
                         };
                         (
                             tx_result.0,

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -22,7 +22,6 @@ impl AppContext {
         destination: PlatformAddress,
         fee_deduct_from_output: bool,
     ) -> Result<BackendTaskSuccessResult, String> {
-        use dash_sdk::dashcore_rpc::RpcApi;
         use dash_sdk::dpp::address_funds::AddressFundsFeeStrategyStep;
         use dash_sdk::platform::transition::top_up_address::TopUpAddress;
 
@@ -62,28 +61,36 @@ impl AppContext {
                 Some(self),
             ) {
                 Ok((tx, private_key, address, _change, utxos)) => (tx, private_key, address, utxos),
-                Err(_) => {
-                    // Reload UTXOs and try again
-                    wallet
-                        .reload_utxos(
-                            &self
-                                .core_client
-                                .read()
-                                .expect("Core client lock was poisoned"),
-                            self.network,
-                            Some(self),
-                        )
-                        .map_err(|e| e.to_string())?;
+                Err(e) => match self.core_backend_mode() {
+                    CoreBackendMode::Rpc => {
+                        // Reload UTXOs from Core RPC and try again
+                        wallet
+                            .reload_utxos(
+                                &self
+                                    .core_client
+                                    .read()
+                                    .expect("Core client lock was poisoned"),
+                                self.network,
+                                Some(self),
+                            )
+                            .map_err(|e| e.to_string())?;
 
-                    let (tx, private_key, address, _change, utxos) = wallet
-                        .generic_asset_lock_transaction(
-                            self.network,
-                            asset_lock_amount,
-                            allow_take_fee_from_amount,
-                            Some(self),
-                        )?;
-                    (tx, private_key, address, utxos)
-                }
+                        let (tx, private_key, address, _change, utxos) = wallet
+                            .generic_asset_lock_transaction(
+                                self.network,
+                                asset_lock_amount,
+                                allow_take_fee_from_amount,
+                                Some(self),
+                            )?;
+                        (tx, private_key, address, utxos)
+                    }
+                    CoreBackendMode::Spv => {
+                        // SPV wallet state is authoritative — UTXOs are synced
+                        // continuously via compact block filters. No Core RPC
+                        // fallback available.
+                        return Err(e);
+                    }
+                },
             }
         };
 
@@ -95,11 +102,9 @@ impl AppContext {
             proofs.insert(tx_id, None);
         }
 
-        // Step 3: Broadcast the transaction
-        self.core_client
-            .read()
-            .expect("Core client lock was poisoned")
-            .send_raw_transaction(&asset_lock_transaction)
+        // Step 3: Broadcast the transaction (mode-aware: RPC or SPV)
+        self.broadcast_raw_transaction(&asset_lock_transaction)
+            .await
             .map_err(|e| format!("Failed to broadcast asset lock transaction: {}", e))?;
 
         // Step 4: Remove used UTXOs from wallet

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -2,12 +2,9 @@ use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::wallet::PlatformSyncMode;
 use crate::context::AppContext;
 use crate::model::wallet::WalletSeedHash;
-use crate::spv::CoreBackendMode;
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
-use dash_sdk::dpp::prelude::AssetLockProof;
 use std::sync::Arc;
-use std::time::Duration;
 
 impl AppContext {
     /// Fund a platform address directly from wallet UTXOs.
@@ -61,36 +58,21 @@ impl AppContext {
                 Some(self),
             ) {
                 Ok((tx, private_key, address, _change, utxos)) => (tx, private_key, address, utxos),
-                Err(e) => match self.core_backend_mode() {
-                    CoreBackendMode::Rpc => {
-                        // Reload UTXOs from Core RPC and try again
-                        wallet
-                            .reload_utxos(
-                                &self
-                                    .core_client
-                                    .read()
-                                    .expect("Core client lock was poisoned"),
-                                self.network,
-                                Some(self),
-                            )
-                            .map_err(|e| e.to_string())?;
-
-                        let (tx, private_key, address, _change, utxos) = wallet
-                            .generic_asset_lock_transaction(
-                                self.network,
-                                asset_lock_amount,
-                                allow_take_fee_from_amount,
-                                Some(self),
-                            )?;
-                        (tx, private_key, address, utxos)
-                    }
-                    CoreBackendMode::Spv => {
-                        // SPV wallet state is authoritative — UTXOs are synced
-                        // continuously via compact block filters. No Core RPC
-                        // fallback available.
+                Err(e) => {
+                    // Reload UTXOs (RPC: fetches from Core; SPV: no-op).
+                    // Only retry if something actually changed.
+                    if !wallet.reload_utxos(self)? {
                         return Err(e);
                     }
-                },
+                    let (tx, private_key, address, _change, utxos) = wallet
+                        .generic_asset_lock_transaction(
+                            self.network,
+                            asset_lock_amount,
+                            allow_take_fee_from_amount,
+                            Some(self),
+                        )?;
+                    (tx, private_key, address, utxos)
+                }
             }
         };
 
@@ -146,55 +128,49 @@ impl AppContext {
             wallet.recalculate_affected_address_balances(&used_utxos, self)?;
         }
 
-        // Step 5: Wait for asset lock proof (InstantLock or ChainLock) with timeout
-        let asset_lock_proof: AssetLockProof;
-        let timeout = tokio::time::sleep(Duration::from_secs(300)); // 5 minute timeout
-        tokio::pin!(timeout);
+        // Step 5: Wait for asset lock proof (InstantLock or ChainLock) via shared helper.
+        // On timeout the helper cleans up the finality tracking entry.
+        // Post-timeout recovery is mode-dependent:
+        //   RPC  — fire-and-forget refresh_wallet_info to reconcile spent UTXOs
+        //   SPV  — spent UTXOs are reconciled automatically on the next sync cycle
+        let asset_lock_proof = match self.wait_for_asset_lock_proof(tx_id).await {
+            Ok(proof) => proof,
+            Err(timeout_err) => {
+                use crate::spv::CoreBackendMode;
 
-        loop {
-            tokio::select! {
-                _ = &mut timeout => {
-                    // Best-effort cleanup: use try_lock to avoid blocking the
-                    // async runtime if another thread holds the mutex.
-                    if let Ok(mut proofs) = self.transactions_waiting_for_finality.try_lock() {
-                        proofs.remove(&tx_id);
-                    }
-
-                    // Auto-refresh wallet UTXOs in RPC mode so the broadcast tx's
-                    // spent inputs are reconciled (the tx was already broadcast and
-                    // may confirm later). SPV handles its own reconciliation.
-                    if self.core_backend_mode() == CoreBackendMode::Rpc
-                        && let Some(wallet_arc) = self.wallets.read().ok()
+                match self.core_backend_mode() {
+                    CoreBackendMode::Rpc => {
+                        if let Some(wallet_arc) = self
+                            .wallets
+                            .read()
+                            .ok()
                             .and_then(|w| w.get(&seed_hash).cloned())
-                    {
-                        let ctx = Arc::clone(self);
-                        // Fire-and-forget — don't block the error return on refresh
-                        tokio::task::spawn_blocking(move || {
-                            if let Err(e) = ctx.refresh_wallet_info(wallet_arc) {
-                                tracing::warn!("Failed to auto-refresh wallet after timeout: {}", e);
-                            }
-                        });
+                        {
+                            let ctx = Arc::clone(self);
+                            // Fire-and-forget — don't block the error return on refresh
+                            tokio::task::spawn_blocking(move || {
+                                if let Err(e) = ctx.refresh_wallet_info(wallet_arc) {
+                                    tracing::warn!(
+                                        "Failed to auto-refresh wallet after timeout: {}",
+                                        e
+                                    );
+                                }
+                            });
+                        }
                     }
+                    CoreBackendMode::Spv => {
+                        tracing::warn!(
+                            "Asset lock proof timed out in SPV mode (tx {}). \
+                             Spent UTXOs will be reconciled automatically during \
+                             the next SPV sync cycle when a new block arrives.",
+                            tx_id
+                        );
+                    }
+                }
 
-                    return Err("Timeout waiting for asset lock proof — no InstantLock or ChainLock received within 5 minutes".to_string());
-                }
-                _ = tokio::time::sleep(Duration::from_millis(200)) => {
-                    // Brief lock to check for proof — acquired and released quickly
-                    // so contention is minimal.
-                    let proofs = self.transactions_waiting_for_finality.lock().unwrap();
-                    if let Some(Some(proof)) = proofs.get(&tx_id) {
-                        asset_lock_proof = proof.clone();
-                        break;
-                    }
-                }
+                return Err(timeout_err);
             }
-        }
-
-        // Step 6: Clean up the finality tracking
-        {
-            let mut proofs = self.transactions_waiting_for_finality.lock().unwrap();
-            proofs.remove(&tx_id);
-        }
+        };
 
         // Step 7: Get wallet, SDK, and derive a fresh change address if needed
         let (wallet, sdk, change_platform_address) = {

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -4,6 +4,7 @@ use crate::context::AppContext;
 use crate::model::wallet::WalletSeedHash;
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
+use dash_sdk::dpp::dashcore::hashes::Hash;
 use std::sync::Arc;
 
 impl AppContext {
@@ -84,15 +85,11 @@ impl AppContext {
             proofs.insert(tx_id, None);
         }
 
-        // Step 3: Broadcast the transaction (mode-aware: RPC or SPV)
-        self.broadcast_raw_transaction(&asset_lock_transaction)
-            .await
-            .map_err(|e| format!("Failed to broadcast asset lock transaction: {}", e))?;
-
-        // Step 3.5: Store the asset lock transaction in the database immediately
-        // after broadcast. The SPV finality listener retrieves the transaction
-        // from the DB to process InstantLock/ChainLock events — without this
-        // store, the finality proof is never populated and the wait loop times out.
+        // Step 3: Store the asset lock transaction in the database *before*
+        // broadcast. The SPV finality listener retrieves the transaction from
+        // the DB to process InstantLock/ChainLock events — if the store happened
+        // after broadcast, a fast InstantSend could arrive before the DB row
+        // exists, causing the finality proof to be missed.
         self.db
             .store_asset_lock_transaction(
                 &asset_lock_transaction,
@@ -103,7 +100,24 @@ impl AppContext {
             )
             .map_err(|e| format!("Failed to store asset lock transaction: {}", e))?;
 
-        // Step 4: Remove used UTXOs from wallet
+        // Step 4: Broadcast the transaction (mode-aware: RPC or SPV).
+        // On failure, clean up the finality tracking entry and pre-stored DB row.
+        // TODO: The broadcast may have reached the network before our connection
+        // dropped. Deleting the DB row could lose a valid tx. Consider adding a
+        // status column to asset_lock_transaction and marking it as "broadcast_failed"
+        // instead, so recovery logic can re-check and re-broadcast if needed.
+        if let Err(e) = self
+            .broadcast_raw_transaction(&asset_lock_transaction)
+            .await
+        {
+            if let Ok(mut proofs) = self.transactions_waiting_for_finality.try_lock() {
+                proofs.remove(&tx_id);
+            }
+            let _ = self.db.delete_asset_lock_transaction(tx_id.as_byte_array());
+            return Err(format!("Failed to broadcast asset lock transaction: {}", e));
+        }
+
+        // Step 5: Remove used UTXOs from wallet
         {
             let wallet_arc = {
                 let wallets = self.wallets.read().unwrap();
@@ -128,7 +142,7 @@ impl AppContext {
             wallet.recalculate_affected_address_balances(&used_utxos, self)?;
         }
 
-        // Step 5: Wait for asset lock proof (InstantLock or ChainLock) via shared helper.
+        // Step 6: Wait for asset lock proof (InstantLock or ChainLock) via shared helper.
         // On timeout the helper cleans up the finality tracking entry.
         // Post-timeout recovery is mode-dependent:
         //   RPC  — fire-and-forget refresh_wallet_info to reconcile spent UTXOs

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -107,6 +107,20 @@ impl AppContext {
             .await
             .map_err(|e| format!("Failed to broadcast asset lock transaction: {}", e))?;
 
+        // Step 3.5: Store the asset lock transaction in the database immediately
+        // after broadcast. The SPV finality listener retrieves the transaction
+        // from the DB to process InstantLock/ChainLock events — without this
+        // store, the finality proof is never populated and the wait loop times out.
+        self.db
+            .store_asset_lock_transaction(
+                &asset_lock_transaction,
+                asset_lock_amount,
+                None, // No islock yet — SPV/ZMQ will update this
+                &seed_hash,
+                self.network,
+            )
+            .map_err(|e| format!("Failed to store asset lock transaction: {}", e))?;
+
         // Step 4: Remove used UTXOs from wallet
         {
             let wallet_arc = {

--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -191,30 +191,30 @@ impl Wallet {
                 .insert(*outpoint, tx_out.clone());
         }
 
-        // Always persist changes to the database
-        let db = &app_context.db;
+        // Persist changes to the database only when something actually changed
+        if changed {
+            let db = &app_context.db;
 
-        // Remove UTXOs that are no longer unspent
-        for outpoint in removed_outpoints {
-            db.drop_utxo(&outpoint, &network.to_string())
+            for outpoint in removed_outpoints {
+                db.drop_utxo(&outpoint, &network.to_string())
+                    .map_err(|e| e.to_string())?;
+            }
+
+            for outpoint in added_outpoints {
+                let tx_out = &new_utxo_map[&outpoint];
+                let address = Address::from_script(&tx_out.script_pubkey, network)
+                    .map_err(|e| e.to_string())?;
+
+                db.insert_utxo(
+                    outpoint.txid.as_ref(),
+                    outpoint.vout,
+                    &address,
+                    tx_out.value,
+                    tx_out.script_pubkey.as_bytes(),
+                    network,
+                )
                 .map_err(|e| e.to_string())?;
-        }
-
-        // Add new UTXOs
-        for outpoint in added_outpoints {
-            let tx_out = &new_utxo_map[&outpoint];
-            let address =
-                Address::from_script(&tx_out.script_pubkey, network).map_err(|e| e.to_string())?;
-
-            db.insert_utxo(
-                outpoint.txid.as_ref(),
-                outpoint.vout,
-                &address,
-                tx_out.value,
-                tx_out.script_pubkey.as_bytes(),
-                network,
-            )
-            .map_err(|e| e.to_string())?;
+            }
         }
 
         Ok(changed)

--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -1,8 +1,9 @@
 use crate::context::AppContext;
 use crate::model::wallet::{DerivationPathHelpers, Wallet};
+use crate::spv::CoreBackendMode;
+use dash_sdk::dashcore_rpc::RpcApi;
 use dash_sdk::dashcore_rpc::json::ListUnspentResultEntry;
-use dash_sdk::dashcore_rpc::{Client, RpcApi};
-use dash_sdk::dpp::dashcore::{Address, Network, OutPoint, TxOut};
+use dash_sdk::dpp::dashcore::{Address, OutPoint, TxOut};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 impl Wallet {
@@ -89,14 +90,27 @@ impl Wallet {
         }
     }
 
-    pub fn reload_utxos(
-        &mut self,
-        core_client: &Client,
-        network: Network,
-        save: Option<&AppContext>,
-    ) -> Result<HashMap<OutPoint, TxOut>, String> {
+    /// Reload UTXOs from Core RPC, updating both in-memory state and database.
+    ///
+    /// Returns `true` if the UTXO set changed (something was added or
+    /// removed), `false` if nothing changed. In SPV mode this is a no-op
+    /// (`Ok(false)`) because the wallet state is authoritative — UTXOs are
+    /// synced continuously via compact block filters.
+    pub fn reload_utxos(&mut self, app_context: &AppContext) -> Result<bool, String> {
+        let network = app_context.network;
+
+        // SPV wallet state is authoritative — reload is a no-op.
+        if app_context.core_backend_mode() == CoreBackendMode::Spv {
+            return Ok(false);
+        }
+
+        let core_client = app_context
+            .core_client
+            .read()
+            .map_err(|e| format!("Core client lock was poisoned: {}", e))?;
+
         // Collect Core chain addresses for which we want to load UTXOs.
-        // Platform addresses  are NOT valid on Core chain and must be excluded.
+        // Platform addresses are NOT valid on Core chain and must be excluded.
         let addresses: Vec<_> = self
             .known_addresses
             .iter()
@@ -120,7 +134,8 @@ impl Wallet {
                 .map_err(|e| e.to_string())?
         };
 
-        // Use the RPC client to list unspent outputs.
+        // Drop the RPC client guard before the rest of the bookkeeping
+        drop(core_client);
 
         // Initialize the HashMap to store the new UTXOs.
         let mut new_utxo_map = HashMap::new();
@@ -152,6 +167,8 @@ impl Wallet {
         let added_outpoints: HashSet<_> =
             new_outpoints.difference(&old_outpoints).cloned().collect();
 
+        let changed = !removed_outpoints.is_empty() || !added_outpoints.is_empty();
+
         // Now update self.utxos by removing UTXOs not present in new_outpoints
         let current_utxos = &mut self.utxos;
         // Remove UTXOs that are no longer unspent
@@ -174,36 +191,33 @@ impl Wallet {
                 .insert(*outpoint, tx_out.clone());
         }
 
-        // If save is Some, update the database
-        if let Some(app_context) = save {
-            let db = &app_context.db;
+        // Always persist changes to the database
+        let db = &app_context.db;
 
-            // Remove UTXOs that are no longer unspent
-            for outpoint in removed_outpoints {
-                db.drop_utxo(&outpoint, &network.to_string())
-                    .map_err(|e| e.to_string())?;
-            }
-
-            // Add new UTXOs
-            for outpoint in added_outpoints {
-                let tx_out = &new_utxo_map[&outpoint];
-                let address = Address::from_script(&tx_out.script_pubkey, network)
-                    .map_err(|e| e.to_string())?;
-
-                db.insert_utxo(
-                    outpoint.txid.as_ref(),
-                    outpoint.vout,
-                    &address,
-                    tx_out.value,
-                    tx_out.script_pubkey.as_bytes(),
-                    network,
-                )
+        // Remove UTXOs that are no longer unspent
+        for outpoint in removed_outpoints {
+            db.drop_utxo(&outpoint, &network.to_string())
                 .map_err(|e| e.to_string())?;
-            }
         }
 
-        // Return the new UTXO map
-        Ok(new_utxo_map)
+        // Add new UTXOs
+        for outpoint in added_outpoints {
+            let tx_out = &new_utxo_map[&outpoint];
+            let address =
+                Address::from_script(&tx_out.script_pubkey, network).map_err(|e| e.to_string())?;
+
+            db.insert_utxo(
+                outpoint.txid.as_ref(),
+                outpoint.vout,
+                &address,
+                tx_out.value,
+                tx_out.script_pubkey.as_bytes(),
+                network,
+            )
+            .map_err(|e| e.to_string())?;
+        }
+
+        Ok(changed)
     }
 
     /// Get all addresses with their total UTXO balances


### PR DESCRIPTION
## Summary

- `fund_platform_address_from_wallet_utxos()` called `core_client.send_raw_transaction()` directly, bypassing the mode-aware `broadcast_raw_transaction()` helper used by every other asset lock caller (register_identity, top_up_identity, create_asset_lock)
- This broke core-to-platform transfers in SPV mode where no RPC connection is available — the broadcast would fail immediately with an RPC error
- Also guards the UTXO reload fallback with a `core_backend_mode()` check, matching the established pattern in `register_identity.rs` and `top_up_identity.rs`
- **Review-discovered fix**: Added missing `store_asset_lock_transaction()` call after broadcast. Without this, the SPV finality listener cannot retrieve the transaction from the DB to process InstantLock/ChainLock events, causing the wait loop to always time out after 5 minutes (pre-existing bug, but now reachable with the SPV broadcast fix)

### Refactoring (review follow-up)

- **CODE-01**: Simplified `reload_utxos` signature from `(&Client, Network, Option<&AppContext>)` to `(&AppContext)` — all three values came from `AppContext` anyway. Returns `Result<bool, String>` where `true` = UTXOs changed, `false` = no change (including SPV no-op). Callers skip retry when no changes detected.
- **SEC-03**: `core_client.read()` now uses `map_err` instead of `.expect()`, preventing panics on lock poisoning
- **SEC-04**: Replaced inline `tokio::select!` timeout loop in `fund_platform_address_from_wallet_utxos` with shared `wait_for_asset_lock_proof()` helper. Added mode-aware post-timeout recovery (RPC: fire-and-forget `refresh_wallet_info`; SPV: `tracing::warn` about automatic reconciliation)

### Review fixes

- **CODE-01**: Moved `store_asset_lock_transaction` before `broadcast_raw_transaction` to eliminate race where SPV finality listener fires before the DB row exists. On broadcast failure, DB row is cleaned up with a TODO noting future status-column improvement.
- **CODE-02**: Guarded DB persistence in `reload_utxos` with `if changed` to skip empty-set iteration
- **CODE-04**: Renumbered step comments sequentially (1–9, no gaps)

## Test plan

- [ ] In SPV mode (no local Dash Core running), fund a platform address from wallet UTXOs — should broadcast via SPV manager and succeed
- [ ] In RPC mode, fund a platform address from wallet UTXOs — should continue working as before via Core RPC
- [ ] In RPC mode, verify UTXO reload fallback still triggers on initial asset lock creation failure
- [ ] In SPV mode, verify asset lock creation failure returns original error (no pointless retry)
- [ ] Verify broadcast failure cleans up DB row and finality tracking entry
- [ ] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [ ] `cargo test --all-features --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Better recovery when asset-lock transactions fail: wallet state reload only triggers a retry if UTXOs changed, reducing duplicate attempts.
  * Broadcast failures now clean up incomplete state to avoid stale records and incorrect balances.

* **Improvements**
  * Transactions are persisted before broadcast for greater reliability.
  * Unified retry flow across modes and improved finality wait handling with mode-specific recovery and balance refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->