### PR TITLE
refactor(wallet): replace Option<&AppContext> with &AppContext in register_addresses params

### DIFF
--- a/src/backend_task/core/create_asset_lock.rs
+++ b/src/backend_task/core/create_asset_lock.rs
@@ -21,11 +21,11 @@ impl AppContext {
             let mut wallet_guard = wallet.write().map_err(|e| e.to_string())?;
 
             wallet_guard.registration_asset_lock_transaction(
+                self,
                 self.network,
                 amount_duffs,
                 allow_take_fee_from_amount,
                 identity_index,
-                Some(self),
             )?
         };
 
@@ -64,12 +64,12 @@ impl AppContext {
             let mut wallet_guard = wallet.write().map_err(|e| e.to_string())?;
 
             wallet_guard.top_up_asset_lock_transaction(
+                self,
                 self.network,
                 amount_duffs,
                 allow_take_fee_from_amount,
                 identity_index,
                 top_up_index,
-                Some(self),
             )?
         };
 

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -346,11 +346,11 @@ impl AppContext {
                 return Err("Wallet must be unlocked".to_string());
             }
             wallet_guard.build_multi_recipient_payment_transaction(
+                self,
                 self.network,
                 &parsed_recipients,
                 DEFAULT_TX_FEE,
                 request.subtract_fee_from_amount,
-                Some(self),
             )?
         };
 

--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -413,10 +413,11 @@ impl AppContext {
         {
             let (public_key_map, public_key_hash_map) = wallet
                 .identity_authentication_ecdsa_public_keys_data_map(
+                    self,
+                    true,
                     self.network,
                     identity_index,
                     0..top_bound,
-                    Some(self),
                 )?;
             let wallet_private_keys = self.build_wallet_private_key_map(
                 identity,
@@ -434,10 +435,11 @@ impl AppContext {
         for candidate_index in 0..MAX_IDENTITY_INDEX {
             let (public_key_map, public_key_hash_map) = wallet
                 .identity_authentication_ecdsa_public_keys_data_map(
+                    self,
+                    false,
                     self.network,
                     candidate_index,
                     0..top_bound,
-                    None,
                 )?;
 
             if !Self::identity_matches_wallet_key_material(
@@ -450,10 +452,11 @@ impl AppContext {
 
             let (public_key_map, public_key_hash_map) = wallet
                 .identity_authentication_ecdsa_public_keys_data_map(
+                    self,
+                    true,
                     self.network,
                     candidate_index,
                     0..top_bound,
-                    Some(self),
                 )?;
 
             let wallet_private_keys = self.build_wallet_private_key_map(

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -160,10 +160,11 @@ impl AppContext {
             let mut wallet = wallet_arc_ref.wallet.write().unwrap();
             wallet_seed_hash = wallet.seed_hash();
             wallet.identity_authentication_ecdsa_public_keys_data_map(
+                self,
+                true,
                 self.network,
                 identity_index,
                 0..top_bound,
-                Some(self),
             )?
         };
 

--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -95,11 +95,11 @@ impl AppContext {
                     let mut wallet = wallet.write().map_err(|e| e.to_string())?;
                     wallet_id = wallet.seed_hash();
                     match wallet.registration_asset_lock_transaction(
+                        self,
                         sdk.network,
                         amount,
                         true,
                         identity_index,
-                        Some(self),
                     ) {
                         Ok(transaction) => transaction,
                         Err(e) => {
@@ -109,11 +109,11 @@ impl AppContext {
                                 return Err(e);
                             }
                             wallet.registration_asset_lock_transaction(
+                                self,
                                 sdk.network,
                                 amount,
                                 true,
                                 identity_index,
-                                Some(self),
                             )?
                         }
                     }
@@ -201,12 +201,12 @@ impl AppContext {
                     let mut wallet = wallet.write().unwrap();
                     wallet_id = wallet.seed_hash();
                     wallet.registration_asset_lock_transaction_for_utxo(
+                        self,
                         sdk.network,
                         utxo,
                         tx_out.clone(),
                         input_address.clone(),
                         identity_index,
-                        Some(self),
                     )?
                 };
 

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -102,12 +102,12 @@ impl AppContext {
                         let mut wallet = wallet.write().map_err(|e| e.to_string())?;
                         let seed_hash = wallet.seed_hash();
                         let tx_result = match wallet.top_up_asset_lock_transaction(
+                            self,
                             sdk.network,
                             amount,
                             true,
                             identity_index,
                             top_up_index,
-                            Some(self),
                         ) {
                             Ok(transaction) => transaction,
                             Err(e) => {
@@ -117,12 +117,12 @@ impl AppContext {
                                     return Err(e);
                                 }
                                 wallet.top_up_asset_lock_transaction(
+                                    self,
                                     sdk.network,
                                     amount,
                                     true,
                                     identity_index,
                                     top_up_index,
-                                    Some(self),
                                 )?
                             }
                         };
@@ -179,13 +179,13 @@ impl AppContext {
                         let mut wallet = wallet.write().unwrap();
                         let seed_hash = wallet.seed_hash();
                         let tx_result = wallet.top_up_asset_lock_transaction_for_utxo(
+                            self,
                             sdk.network,
                             utxo,
                             tx_out.clone(),
                             input_address.clone(),
                             identity_index,
                             top_up_index,
-                            Some(self),
                         )?;
                         (tx_result.0, tx_result.1, seed_hash)
                     };

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -53,10 +53,10 @@ impl AppContext {
 
             // Try to create the asset lock transaction, reload UTXOs if needed
             match wallet.generic_asset_lock_transaction(
+                self,
                 self.network,
                 asset_lock_amount,
                 allow_take_fee_from_amount,
-                Some(self),
             ) {
                 Ok((tx, private_key, address, _change, utxos)) => (tx, private_key, address, utxos),
                 Err(e) => {
@@ -67,10 +67,10 @@ impl AppContext {
                     }
                     let (tx, private_key, address, _change, utxos) = wallet
                         .generic_asset_lock_transaction(
+                            self,
                             self.network,
                             asset_lock_amount,
                             allow_take_fee_from_amount,
-                            Some(self),
                         )?;
                     (tx, private_key, address, utxos)
                 }

--- a/src/model/wallet/asset_lock_transaction.rs
+++ b/src/model/wallet/asset_lock_transaction.rs
@@ -163,11 +163,11 @@ impl Wallet {
     #[allow(clippy::type_complexity)]
     pub fn registration_asset_lock_transaction(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         amount: u64,
         allow_take_fee_from_amount: bool,
         identity_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<
         (
             Transaction,
@@ -177,29 +177,26 @@ impl Wallet {
         ),
         String,
     > {
-        let private_key = self.identity_registration_ecdsa_private_key(
-            network,
-            identity_index,
-            register_addresses,
-        )?;
+        let private_key =
+            self.identity_registration_ecdsa_private_key(app_context, network, identity_index)?;
         self.asset_lock_transaction_from_private_key(
+            app_context,
             network,
             amount,
             allow_take_fee_from_amount,
             private_key,
-            register_addresses,
         )
     }
 
     #[allow(clippy::type_complexity)]
     pub fn top_up_asset_lock_transaction(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         amount: u64,
         allow_take_fee_from_amount: bool,
         identity_index: u32,
         top_up_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<
         (
             Transaction,
@@ -210,17 +207,17 @@ impl Wallet {
         String,
     > {
         let private_key = self.identity_top_up_ecdsa_private_key(
+            app_context,
             network,
             identity_index,
             top_up_index,
-            register_addresses,
         )?;
         self.asset_lock_transaction_from_private_key(
+            app_context,
             network,
             amount,
             allow_take_fee_from_amount,
             private_key,
-            register_addresses,
         )
     }
 
@@ -229,10 +226,10 @@ impl Wallet {
     #[allow(clippy::type_complexity)]
     pub fn generic_asset_lock_transaction(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         amount: u64,
         allow_take_fee_from_amount: bool,
-        register_addresses: Option<&AppContext>,
     ) -> Result<
         (
             Transaction,
@@ -256,11 +253,11 @@ impl Wallet {
 
         let (tx, returned_private_key, change_address, used_utxos) = self
             .asset_lock_transaction_from_private_key(
+                app_context,
                 network,
                 amount,
                 allow_take_fee_from_amount,
                 private_key,
-                register_addresses,
             )?;
 
         Ok((
@@ -275,11 +272,11 @@ impl Wallet {
     #[allow(clippy::type_complexity)]
     fn asset_lock_transaction_from_private_key(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         amount: u64,
         allow_take_fee_from_amount: bool,
         private_key: PrivateKey,
-        register_addresses: Option<&AppContext>,
     ) -> Result<
         (
             Transaction,
@@ -323,7 +320,7 @@ impl Wallet {
         };
 
         let (change_output, change_address) = if let Some(change) = change_option {
-            let change_address = self.change_address(network, register_addresses)?;
+            let change_address = self.change_address(network, Some(app_context))?;
             (
                 Some(TxOut {
                     value: change,
@@ -431,27 +428,22 @@ impl Wallet {
             })?;
 
         // Transaction is fully built and signed; commit the UTXO removals now.
-        if let Some(context) = register_addresses {
-            self.remove_selected_utxos(&utxos, &context.db, network)?;
-        }
+        self.remove_selected_utxos(&utxos, &app_context.db, network)?;
 
         Ok((tx, private_key, change_address, utxos))
     }
 
     pub fn registration_asset_lock_transaction_for_utxo(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         utxo: OutPoint,
         previous_tx_output: TxOut,
         input_address: Address,
         identity_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<(Transaction, PrivateKey), String> {
-        let private_key = self.identity_registration_ecdsa_private_key(
-            network,
-            identity_index,
-            register_addresses,
-        )?;
+        let private_key =
+            self.identity_registration_ecdsa_private_key(app_context, network, identity_index)?;
         self.asset_lock_transaction_for_utxo_from_private_key(
             network,
             utxo,
@@ -464,19 +456,19 @@ impl Wallet {
     #[allow(clippy::too_many_arguments)]
     pub fn top_up_asset_lock_transaction_for_utxo(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         utxo: OutPoint,
         previous_tx_output: TxOut,
         input_address: Address,
         identity_index: u32,
         top_up_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<(Transaction, PrivateKey), String> {
         let private_key = self.identity_top_up_ecdsa_private_key(
+            app_context,
             network,
             identity_index,
             top_up_index,
-            register_addresses,
         )?;
         self.asset_lock_transaction_for_utxo_from_private_key(
             network,

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -798,10 +798,11 @@ impl Wallet {
     #[allow(clippy::type_complexity)]
     pub fn identity_authentication_ecdsa_public_keys_data_map(
         &mut self,
+        app_context: &AppContext,
+        register_addresses: bool,
         network: Network,
         identity_index: u32,
         key_index_range: Range<u32>,
-        register_addresses: Option<&AppContext>,
     ) -> Result<(BTreeMap<Vec<u8>, u32>, BTreeMap<[u8; 20], u32>), String> {
         let mut public_key_result_map = BTreeMap::new();
         let mut public_key_hash_result_map = BTreeMap::new();
@@ -822,7 +823,7 @@ impl Wallet {
                 key_index,
             );
             public_key_hash_result_map.insert(public_key.pubkey_hash().to_byte_array(), key_index);
-            if let Some(app_context) = register_addresses {
+            if register_addresses {
                 self.register_address_from_public_key(
                     &public_key,
                     &derivation_path,
@@ -838,10 +839,10 @@ impl Wallet {
 
     pub fn identity_authentication_ecdsa_private_key(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         identity_index: u32,
         key_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<(PrivateKey, DerivationPath), String> {
         let derivation_path = DerivationPath::identity_authentication_path(
             network,
@@ -860,15 +861,13 @@ impl Wallet {
             .expect("derivation should not be able to fail");
 
         let private_key = extended_public_key.to_priv();
-        if let Some(app_context) = register_addresses {
-            self.register_address_from_private_key(
-                &private_key,
-                &derivation_path,
-                DerivationPathType::SINGLE_USER_AUTHENTICATION,
-                DerivationPathReference::BlockchainIdentities,
-                app_context,
-            )?;
-        }
+        self.register_address_from_private_key(
+            &private_key,
+            &derivation_path,
+            DerivationPathType::SINGLE_USER_AUTHENTICATION,
+            DerivationPathReference::BlockchainIdentities,
+            app_context,
+        )?;
 
         Ok((private_key, derivation_path))
     }
@@ -1327,10 +1326,10 @@ impl Wallet {
 
     pub fn identity_top_up_ecdsa_private_key(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         identity_index: u32,
         top_up_index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<PrivateKey, String> {
         let derivation_path =
             DerivationPath::identity_top_up_path(network, identity_index, top_up_index);
@@ -1339,24 +1338,22 @@ impl Wallet {
             .expect("derivation should not be able to fail");
         let private_key = extended_private_key.to_priv();
 
-        if let Some(app_context) = register_addresses {
-            self.register_address_from_private_key(
-                &private_key,
-                &derivation_path,
-                DerivationPathType::CREDIT_FUNDING,
-                DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
-                app_context,
-            )?;
-        }
+        self.register_address_from_private_key(
+            &private_key,
+            &derivation_path,
+            DerivationPathType::CREDIT_FUNDING,
+            DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
+            app_context,
+        )?;
         Ok(private_key)
     }
 
     /// Generate Core key for identity registration
     pub fn identity_registration_ecdsa_private_key(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         index: u32,
-        register_addresses: Option<&AppContext>,
     ) -> Result<PrivateKey, String> {
         let derivation_path = DerivationPath::identity_registration_path(network, index);
         let extended_private_key = derivation_path
@@ -1364,15 +1361,13 @@ impl Wallet {
             .expect("derivation should not be able to fail");
         let private_key = extended_private_key.to_priv();
 
-        if let Some(app_context) = register_addresses {
-            self.register_address_from_private_key(
-                &private_key,
-                &derivation_path,
-                DerivationPathType::CREDIT_FUNDING,
-                DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
-                app_context,
-            )?;
-        }
+        self.register_address_from_private_key(
+            &private_key,
+            &derivation_path,
+            DerivationPathType::CREDIT_FUNDING,
+            DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
+            app_context,
+        )?;
         Ok(private_key)
     }
 
@@ -1543,12 +1538,12 @@ impl Wallet {
 
     pub fn build_standard_payment_transaction(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         recipient: &Address,
         amount: u64,
         fee: u64,
         subtract_fee_from_amount: bool,
-        register_addresses: Option<&AppContext>,
     ) -> Result<Transaction, String> {
         if !networks_address_compatible(recipient.network(), &network) {
             return Err(format!(
@@ -1584,7 +1579,7 @@ impl Wallet {
         }];
 
         if let Some(change) = change_option {
-            let change_address = self.change_address(network, register_addresses)?;
+            let change_address = self.change_address(network, Some(app_context))?;
             outputs.push(TxOut {
                 value: change,
                 script_pubkey: change_address.script_pubkey(),
@@ -1654,9 +1649,7 @@ impl Wallet {
             })?;
 
         // Transaction is fully built and signed; commit the UTXO removals now.
-        if let Some(context) = register_addresses {
-            self.remove_selected_utxos(&utxos, &context.db, network)?;
-        }
+        self.remove_selected_utxos(&utxos, &app_context.db, network)?;
 
         Ok(tx)
     }
@@ -1664,11 +1657,11 @@ impl Wallet {
     /// Build a transaction with multiple recipients
     pub fn build_multi_recipient_payment_transaction(
         &mut self,
+        app_context: &AppContext,
         network: Network,
         recipients: &[(Address, u64)],
         fee: u64,
         subtract_fee_from_amount: bool,
-        register_addresses: Option<&AppContext>,
     ) -> Result<Transaction, String> {
         if recipients.is_empty() {
             return Err("No recipients specified".to_string());
@@ -1733,7 +1726,7 @@ impl Wallet {
 
         // Add change output if needed
         if let Some(change) = change_option {
-            let change_address = self.change_address(network, register_addresses)?;
+            let change_address = self.change_address(network, Some(app_context))?;
             outputs.push(TxOut {
                 value: change,
                 script_pubkey: change_address.script_pubkey(),
@@ -1803,9 +1796,7 @@ impl Wallet {
             })?;
 
         // Transaction is fully built and signed; commit the UTXO removals now.
-        if let Some(context) = register_addresses {
-            self.remove_selected_utxos(&utxos, &context.db, network)?;
-        }
+        self.remove_selected_utxos(&utxos, &app_context.db, network)?;
 
         Ok(tx)
     }

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -212,10 +212,10 @@ impl AddNewIdentityScreen {
 
             let mut wallet = wallet_lock.write().expect("wallet lock failed");
             let master_key = wallet.identity_authentication_ecdsa_private_key(
+                app_context,
                 app_context.network,
                 identity_id_number,
                 0,
-                Some(app_context),
             )?;
 
             let other_keys = default_keys
@@ -225,10 +225,10 @@ impl AddNewIdentityScreen {
                     |(i, (key_type, purpose, security_level, contract_bounds))| {
                         Ok((
                             wallet.identity_authentication_ecdsa_private_key(
+                                app_context,
                                 app_context.network,
                                 identity_id_number,
                                 (i + 1).try_into().expect("key index must fit u32"), // key index 0 is the master key
-                                Some(app_context),
                             )?,
                             key_type,
                             purpose,
@@ -947,10 +947,10 @@ impl AddNewIdentityScreen {
             // Update the master private key and keys input from the wallet
             self.identity_keys.master_private_key =
                 Some(wallet.identity_authentication_ecdsa_private_key(
+                    &self.app_context,
                     self.app_context.network,
                     identity_index,
                     0,
-                    Some(&self.app_context),
                 )?);
 
             // Update the additional keys input (preserving contract bounds)
@@ -963,10 +963,10 @@ impl AddNewIdentityScreen {
                     |(key_index, (_, key_type, purpose, security_level, contract_bounds))| {
                         Ok((
                             wallet.identity_authentication_ecdsa_private_key(
+                                &self.app_context,
                                 self.app_context.network,
                                 identity_index,
                                 key_index as u32 + 1,
-                                Some(&self.app_context),
                             )?,
                             *key_type,
                             *purpose,
@@ -997,10 +997,10 @@ impl AddNewIdentityScreen {
             self.identity_keys.keys_input.push((
                 wallet
                     .identity_authentication_ecdsa_private_key(
+                        &self.app_context,
                         self.app_context.network,
                         self.identity_id_number,
                         new_key_index,
-                        Some(&self.app_context),
                     )
                     .expect("expected to have decrypted wallet"),
                 key_type,


### PR DESCRIPTION
## Summary

All 12 wallet functions that accepted `register_addresses: Option<&AppContext>` now require `&AppContext` unconditionally, placed first after `&mut self` per project convention.

### Details

- Every caller already passed `Some(...)` except one search-loop optimization in `load_identity.rs`
- The `Option` wrapper masked silently skipped UTXO removal and address registration
- For `identity_authentication_ecdsa_public_keys_data_map`, a separate `register_addresses: bool` flag preserves the search-loop optimization (pass `false` to skip DB registration)
- `if let Some(app_context) = register_addresses` guards removed — inner code now runs unconditionally
- 10 files changed, net -13 lines

### Files modified

**Signatures + bodies:**
- `src/model/wallet/mod.rs` — 6 functions
- `src/model/wallet/asset_lock_transaction.rs` — 6 functions

**Callers:**
- `src/backend_task/core/create_asset_lock.rs`
- `src/backend_task/core/mod.rs`
- `src/backend_task/identity/register_identity.rs`
- `src/backend_task/identity/top_up_identity.rs`
- `src/backend_task/identity/load_identity.rs`
- `src/backend_task/identity/load_identity_from_wallet.rs`
- `src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs`
- `src/ui/identities/add_new_identity_screen/mod.rs`

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --all-features --workspace` — 42 passed, 0 failed
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API design for wallet transaction functions and identity operations by restructuring how application context is passed throughout the system. These changes enhance code clarity and maintainability with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->