### PR TITLE
fix(ui): fix message banner icons, dismiss button, text wrapping, and duplicate errors

### DIFF
--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -498,17 +498,38 @@ fn render_banner(
         .corner_radius(Shape::RADIUS_SM as f32)
         .stroke(egui::Stroke::new(Shape::BORDER_WIDTH, fg_color))
         .show(ui, |ui| {
-            ui.horizontal(|ui| {
-                // Icon
+            // First row: icon + wrapping text + right-aligned dismiss
+            let available_width = ui.available_width();
+
+            ui.horizontal_top(|ui| {
+                // Icon (fixed width)
                 ui.label(egui::RichText::new(icon).color(fg_color).strong());
                 ui.add_space(Spacing::XS);
 
-                // Message text
-                ui.label(egui::RichText::new(text).color(fg_color));
+                // Reserve space for dismiss button and annotation on the right
+                let dismiss_width = 40.0;
+                let text_width = (available_width - dismiss_width - 30.0).max(100.0);
+
+                // Message text with wrapping
+                ui.add_sized(
+                    egui::vec2(text_width, 0.0),
+                    egui::Label::new(egui::RichText::new(text).color(fg_color)).wrap(),
+                );
 
                 // Right-aligned: annotation + dismiss
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.small_button("x").clicked() {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
+                    let dismiss_response = ui.add(
+                        egui::Label::new(
+                            egui::RichText::new("\u{274C}")
+                                .color(fg_color)
+                                .font(Typography::body_small()),
+                        )
+                        .sense(egui::Sense::click()),
+                    );
+                    if dismiss_response.hovered() {
+                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                    }
+                    if dismiss_response.clicked() {
                         dismissed = true;
                     }
 
@@ -605,9 +626,9 @@ fn set_banners(ctx: &egui::Context, banners: Vec<BannerState>) {
 
 fn icon_for_type(message_type: MessageType) -> &'static str {
     match message_type {
-        MessageType::Error => "\u{274C}",   // cross mark
-        MessageType::Warning => "\u{26A0}", // warning sign
-        MessageType::Success => "\u{2713}", // check mark
-        MessageType::Info => "\u{2139}",    // info
+        MessageType::Error => "\u{26D4}",   // no entry (⛔)
+        MessageType::Warning => "\u{26A0}", // warning sign (⚠)
+        MessageType::Success => "\u{2705}", // white heavy check mark (✅)
+        MessageType::Info => "\u{1F4AC}",   // speech balloon (💬)
     }
 }

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -508,7 +508,9 @@ fn render_banner(
 
                 // Reserve space for dismiss button and annotation on the right
                 let dismiss_width = 40.0;
-                let text_width = (available_width - dismiss_width - 30.0).max(0.0);
+                let annotation_width = if annotation.is_some() { 52.0 } else { 0.0 };
+                let text_width =
+                    (available_width - dismiss_width - annotation_width - 30.0).max(0.0);
 
                 // Message text with wrapping, left-aligned
                 ui.allocate_ui(egui::vec2(text_width, 0.0), |ui| {

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -509,10 +509,10 @@ fn render_banner(
                 // Reserve space for dismiss button and annotation on the right
                 let dismiss_width = 40.0;
                 let annotation_width = if let Some(ann) = annotation {
-                    // Estimate width: ~7px per character at body_small size + item spacing
-                    let char_width = Typography::SCALE_SM * 0.55;
-                    let measured = ann.len() as f32 * char_width;
-                    measured + ui.spacing().item_spacing.x
+                    // Annotations are short digit strings like "(5s)", "(30s)".
+                    // Average character width ~0.4× font size for digits/parens.
+                    let char_width = Typography::SCALE_SM * 0.4;
+                    ann.len() as f32 * char_width + ui.spacing().item_spacing.x
                 } else {
                     0.0
                 };

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -510,11 +510,10 @@ fn render_banner(
                 let dismiss_width = 40.0;
                 let text_width = (available_width - dismiss_width - 30.0).max(100.0);
 
-                // Message text with wrapping
-                ui.add_sized(
-                    egui::vec2(text_width, 0.0),
-                    egui::Label::new(egui::RichText::new(text).color(fg_color)).wrap(),
-                );
+                // Message text with wrapping, left-aligned
+                ui.allocate_ui(egui::vec2(text_width, 0.0), |ui| {
+                    ui.add(egui::Label::new(egui::RichText::new(text).color(fg_color)).wrap());
+                });
 
                 // Right-aligned: annotation + dismiss
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -502,13 +502,20 @@ fn render_banner(
             let available_width = ui.available_width();
 
             ui.horizontal_top(|ui| {
-                // Icon (fixed width)
+                // Icon
                 ui.label(egui::RichText::new(icon).color(fg_color).strong());
                 ui.add_space(Spacing::XS);
 
                 // Reserve space for dismiss button and annotation on the right
                 let dismiss_width = 40.0;
-                let annotation_width = if annotation.is_some() { 52.0 } else { 0.0 };
+                let annotation_width = if let Some(ann) = annotation {
+                    // Estimate width: ~7px per character at body_small size + item spacing
+                    let char_width = Typography::SCALE_SM * 0.55;
+                    let measured = ann.len() as f32 * char_width;
+                    measured + ui.spacing().item_spacing.x
+                } else {
+                    0.0
+                };
                 let text_width =
                     (available_width - dismiss_width - annotation_width - 30.0).max(0.0);
 

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -508,7 +508,7 @@ fn render_banner(
 
                 // Reserve space for dismiss button and annotation on the right
                 let dismiss_width = 40.0;
-                let text_width = (available_width - dismiss_width - 30.0).max(100.0);
+                let text_width = (available_width - dismiss_width - 30.0).max(0.0);
 
                 // Message text with wrapping, left-aligned
                 ui.allocate_ui(egui::vec2(text_width, 0.0), |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -21,6 +21,7 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::identities::funding_common::WalletFundedScreenStep;
 use crate::ui::theme::DashColors;
+use crate::ui::components::MessageBanner;
 use crate::ui::{MessageType, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::Address;
 use dash_sdk::dashcore_rpc::dashcore::transaction::special_transaction::TransactionPayload;
@@ -1013,14 +1014,12 @@ impl AddNewIdentityScreen {
 }
 
 impl ScreenLike for AddNewIdentityScreen {
-    fn display_message(&mut self, message: &str, message_type: MessageType) {
+    fn display_message(&mut self, _message: &str, message_type: MessageType) {
         if message_type == MessageType::Error {
-            self.error_message = Some(format!("Error registering identity: {}", message));
-            // Reset step so we stop showing "Waiting for Platform acknowledgement"
+            // Reset step so we stop showing "Waiting for Platform acknowledgement".
+            // The error itself is displayed by the global MessageBanner.
             let mut step = self.step.write().unwrap();
             *step = WalletFundedScreenStep::ReadyToCreate;
-        } else {
-            self.error_message = Some(message.to_string());
         }
     }
     fn display_task_result(&mut self, backend_task_success_result: BackendTaskSuccessResult) {
@@ -1101,27 +1100,11 @@ impl ScreenLike for AddNewIdentityScreen {
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
 
-            // Display error message at the top, outside of scroll area
-            if let Some(error_message) = self.error_message.clone() {
-                let message_color = DashColors::ERROR;
-
-                ui.horizontal(|ui| {
-                    egui::Frame::new()
-                        .fill(message_color.gamma_multiply(0.1))
-                        .inner_margin(egui::Margin::symmetric(10, 8))
-                        .corner_radius(5.0)
-                        .stroke(egui::Stroke::new(1.0, message_color))
-                        .show(ui, |ui| {
-                            ui.horizontal(|ui| {
-                                ui.label(egui::RichText::new(&error_message).color(message_color));
-                                ui.add_space(10.0);
-                                if ui.small_button("Dismiss").clicked() {
-                                    self.error_message = None;
-                                }
-                            });
-                        });
-                });
-                ui.add_space(10.0);
+            // Display local validation errors at the top, outside of scroll area.
+            // Backend task errors are shown by the global MessageBanner.
+            if let Some(error_message) = self.error_message.as_ref() {
+                MessageBanner::set_global(ui.ctx(), error_message, MessageType::Error);
+                self.error_message = None;
             }
 
             ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -86,6 +86,8 @@ pub struct AddNewIdentityScreen {
     copied_to_clipboard: Option<Option<String>>,
     identity_keys: IdentityKeys,
     error_message: Option<String>,
+    /// Tracks the last error pushed to the global banner to avoid re-sending each frame.
+    last_global_error: Option<String>,
     wallet_unlock_popup: WalletUnlockPopup,
     show_pop_up_info: Option<String>,
     in_key_selection_advanced_mode: bool,
@@ -152,6 +154,7 @@ impl AddNewIdentityScreen {
                 keys_input: vec![],
             },
             error_message: None,
+            last_global_error: None,
             wallet_unlock_popup: WalletUnlockPopup::new(),
             show_pop_up_info: None,
             in_key_selection_advanced_mode: false,
@@ -1100,11 +1103,16 @@ impl ScreenLike for AddNewIdentityScreen {
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
 
-            // Display local validation errors at the top, outside of scroll area.
-            // Backend task errors are shown by the global MessageBanner.
-            if let Some(error_message) = self.error_message.as_ref() {
-                MessageBanner::set_global(ui.ctx(), error_message, MessageType::Error);
-                self.error_message = None;
+            // Display local validation errors via the global MessageBanner.
+            // Only push when the message changes to avoid resetting the banner each frame
+            // (e.g. try_open_wallet_no_password can re-set error_message every render pass).
+            if self.error_message != self.last_global_error {
+                if let Some(error_message) = self.error_message.as_ref() {
+                    MessageBanner::set_global(ui.ctx(), error_message, MessageType::Error);
+                } else if let Some(old) = self.last_global_error.as_ref() {
+                    MessageBanner::clear_global_message(ui.ctx(), old);
+                }
+                self.last_global_error = self.error_message.clone();
             }
 
             ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -12,6 +12,7 @@ use crate::backend_task::identity::{
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult, FeeResult};
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
+use crate::ui::components::MessageBanner;
 use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
@@ -21,7 +22,6 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::identities::funding_common::WalletFundedScreenStep;
 use crate::ui::theme::DashColors;
-use crate::ui::components::MessageBanner;
 use crate::ui::{MessageType, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::Address;
 use dash_sdk::dashcore_rpc::dashcore::transaction::special_transaction::TransactionPayload;

--- a/tests/kittest/message_banner.rs
+++ b/tests/kittest/message_banner.rs
@@ -15,7 +15,7 @@ fn test_banner_renders_nothing_when_empty() {
         });
     harness.run();
     // No labels should be present (empty banner renders nothing)
-    assert!(harness.query_by_label("x").is_none());
+    assert!(harness.query_by_label("\u{274C}").is_none());
 }
 
 /// Test the global set/has/clear cycle using a standalone egui::Context.
@@ -70,7 +70,7 @@ fn test_banner_renders_error_message() {
     harness.run();
     // The message text and dismiss button should be present
     assert!(harness.query_by_label(message_text).is_some());
-    assert!(harness.query_by_label("x").is_some());
+    assert!(harness.query_by_label("\u{274C}").is_some());
     // Error banners have no auto-dismiss countdown
     assert!(harness.query_by_label_contains("s)").is_none());
 }
@@ -79,10 +79,10 @@ fn test_banner_renders_error_message() {
 #[test]
 fn test_banner_renders_all_types() {
     let variants = [
-        (MessageType::Error, "Error message", "\u{274C}"),
+        (MessageType::Error, "Error message", "\u{26D4}"),
         (MessageType::Warning, "Warning message", "\u{26A0}"),
-        (MessageType::Success, "Success message", "\u{2713}"),
-        (MessageType::Info, "Info message", "\u{2139}"),
+        (MessageType::Success, "Success message", "\u{2705}"),
+        (MessageType::Info, "Info message", "\u{1F4AC}"),
     ];
 
     for (msg_type, text, icon) in variants {
@@ -105,7 +105,7 @@ fn test_banner_renders_all_types() {
             msg_type
         );
         assert!(
-            harness.query_by_label("x").is_some(),
+            harness.query_by_label("\u{274C}").is_some(),
             "Missing dismiss button for {:?}",
             msg_type
         );
@@ -267,7 +267,7 @@ fn test_instance_banner_rendering() {
         });
     harness.run();
     assert!(harness.query_by_label("Instance error").is_some());
-    assert!(harness.query_by_label("x").is_some());
+    assert!(harness.query_by_label("\u{274C}").is_some());
 }
 
 /// Test that Component::show() returns None status when no message is set.
@@ -286,7 +286,7 @@ fn test_instance_banner_empty_status() {
         });
     harness.run();
     // Empty banner renders nothing
-    assert!(harness.query_by_label("x").is_none());
+    assert!(harness.query_by_label("\u{274C}").is_none());
 }
 
 /// Test that current_value() returns Visible when message is set, None otherwise.
@@ -319,7 +319,7 @@ fn test_multiple_banners_render() {
     assert!(harness.query_by_label("Warning one").is_some());
     assert!(harness.query_by_label("Success one").is_some());
     // Each banner has its own dismiss button
-    assert_eq!(harness.get_all_by_label("x").count(), 3);
+    assert_eq!(harness.get_all_by_label("\u{274C}").count(), 3);
 }
 
 /// Test BannerHandle::clear() removes the banner.


### PR DESCRIPTION
## Summary
- Changed error icon from ❌ to ⛔ to avoid confusion with the dismiss button
- Repurposed ❌ as a styled dismiss button (clickable label with pointer cursor) replacing the unstyled `small_button("x")`
- Fixed success (✅) and info (💬) icons to render correctly in Noto Sans font
- Long banner text now wraps at word boundaries instead of overflowing outside the window
- Removed duplicate error display in `AddNewIdentityScreen` — errors now only show via the global `MessageBanner`

## Test plan
- [ ] Trigger an error (e.g., load non-existent identity) — verify single ⛔ banner with ❌ dismiss, no duplicate
- [ ] Trigger a success message — verify ✅ icon renders correctly
- [ ] Trigger an info message — verify 💬 icon renders correctly
- [ ] Resize window to be narrow — verify long error text wraps instead of overflowing
- [ ] Verify dismiss button shows pointer cursor on hover and dismisses the banner on click
- [ ] Try to register an identity with invalid input — verify validation error shows via global banner (no local duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned message banner layout for improved wrapping and visibility.
  * Updated message-type icons to new emoji symbols and replaced the dismiss button with an emoji glyph plus hover cursor.

* **Refactor**
  * Centralized error reporting to a global message banner instead of per-component error blocks.

* **Tests**
  * Updated UI tests to expect the new emoji icons and dismiss glyph.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->