### PR TITLE
test: use in-memory database for e2e and kittest tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,9 @@ zeromq = "0.4.1"
 native-dialog = "0.9.0"
 raw-cpuid = "11.5.0"
 
+[features]
+testing = []
+
 [dev-dependencies]
 egui_kittest = { version = "0.33.3", features = ["eframe"] }
 
@@ -93,7 +96,7 @@ winres = "0.1"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"
-check-cfg = ["cfg(tokio_unstable)"]
+check-cfg = ["cfg(tokio_unstable)", "cfg(feature, values(\"testing\"))"]
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
-use crate::app_dir::{
-    app_user_data_file_path, copy_env_file_if_not_exists,
-    create_app_user_data_directory_if_not_exists,
-};
+#[cfg(not(feature = "testing"))]
+use crate::app_dir::app_user_data_file_path;
+use crate::app_dir::{copy_env_file_if_not_exists, create_app_user_data_directory_if_not_exists};
 use crate::backend_task::contested_names::ContestedResourceTask;
 use crate::backend_task::core::CoreItem;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
@@ -9,6 +8,7 @@ use crate::components::core_zmq_listener::{CoreZMQListener, ZMQMessage};
 use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
 use crate::database::Database;
+#[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
 use crate::ui::components::MessageBanner;
@@ -166,6 +166,12 @@ impl BitOrAssign for AppAction {
     }
 }
 impl AppState {
+    /// Creates a new `AppState` using the production database.
+    ///
+    /// This constructor is hidden when the `testing` feature is active to prevent
+    /// tests from accidentally using the production database. Use the `testing`
+    /// feature-gated `new()` variant instead.
+    #[cfg(not(feature = "testing"))]
     pub fn new(ctx: egui::Context) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         create_app_user_data_directory_if_not_exists()?;
         copy_env_file_if_not_exists();
@@ -173,7 +179,28 @@ impl AppState {
         let db_file_path = app_user_data_file_path("data.db")?;
         let db = Arc::new(Database::new(&db_file_path)?);
         db.initialize(&db_file_path)?;
+        Self::new_inner(ctx, db)
+    }
 
+    /// Creates a new `AppState` using an in-memory database for testing.
+    ///
+    /// Available only when the `testing` feature is active. This prevents tests
+    /// from reading or writing the production database.
+    #[cfg(feature = "testing")]
+    pub fn new(ctx: egui::Context) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        create_app_user_data_directory_if_not_exists()?;
+        copy_env_file_if_not_exists();
+        let db = Arc::new(
+            crate::database::test_helpers::create_test_database()
+                .map_err(|e| format!("Failed to create test database: {}", e))?,
+        );
+        Self::new_inner(ctx, db)
+    }
+
+    fn new_inner(
+        ctx: egui::Context,
+        db: Arc<Database>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let settings = db.get_settings()?.map(Settings::from).unwrap_or_default();
         let password_info = settings.password_info;
         let theme_preference = settings.theme_mode;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -9,7 +9,7 @@ mod proof_log;
 mod scheduled_votes;
 mod settings;
 mod single_key_wallet;
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;
 mod tokens;
 mod top_ups;


### PR DESCRIPTION
## Summary

Tests were using the production database (`~/.config/dash-evo-tool/data.db`), risking data corruption and creating implicit dependencies on prior app setup.

### Details
- Add `testing` feature flag to `Cargo.toml`
- Gate `AppState::new()` with `#[cfg(not(feature = "testing"))]` for production, and provide a `#[cfg(feature = "testing")]` variant that uses an in-memory SQLite database via the existing `create_test_database()` helper
- Widen `test_helpers` module visibility from `#[cfg(test)]` to `#[cfg(any(test, feature = "testing"))]`
- **Zero test file changes** — `--all-features` (already standard) enables the testing feature automatically

## Test plan
- [x] `cargo build` — production build works (no `testing` feature)
- [x] `cargo build --features testing` — compiles with testing feature
- [x] `cargo test --test e2e --all-features` — 10 tests pass with in-memory DB
- [x] `cargo test --test kittest --all-features` — 42 tests pass with in-memory DB
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean (without testing feature)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>