### PR TITLE
refactor(spv): replace auto-stop with Connecting state and degraded warning

### DIFF
--- a/docs/ai-design/2025-02-25-spv-peer-rework/manual-tests.md
+++ b/docs/ai-design/2025-02-25-spv-peer-rework/manual-tests.md
@@ -60,9 +60,10 @@ These scenarios verify the reworked SPV peer connection lifecycle:
 ### Expected Results
 
 - **Step 3:** Orange indicator with fast pulse. Tooltip: "Connecting...\nSPV: Starting\nDAPI: Available (...)".
-- **Step 5:** After ~30s, tooltip adds: "\nHaving trouble finding peers...".
-- **Step 6:** SPV **remains running** (does NOT stop). Indicator stays orange. No error banner appears. SPV continues trying DNS lookups and peer discovery in the background.
+- **Step 5:** After ~30s, tooltip adds: "\nHaving trouble finding peers. Check your connection." A **warning banner** also appears with the same text.
+- **Step 6:** SPV **remains running** (does NOT stop). Indicator stays orange. SPV continues trying DNS lookups and peer discovery in the background.
 - **Critical:** Verify NO "SPV disconnected" error banner. Verify `stop_spv()` is NOT called (check logs -- no "stopping SPV" message).
+- **Recovery:** If you restore connectivity and peers connect, the warning banner **automatically clears** and the indicator transitions to Syncing/Synced.
 
 ---
 
@@ -170,6 +171,7 @@ These scenarios verify the reworked SPV peer connection lifecycle:
 | Syncing | >0 | Syncing | "Syncing" | "SPV: Headers: X / Y (Z%)" | Phase progress shown |
 | Syncing | 0 | Connecting | "Connecting..." | "SPV: <phase>" | After 30s: degraded warning |
 | Running | >0 | Synced | "Ready" | "SPV: Synced" | -- |
+| Running | 0 | Connecting | "Connecting..." | "SPV: Synced" | After 30s: degraded warning |
 | Stopping | 0 | Connecting | "Connecting..." | "SPV: Stopping" | -- |
 | Stopped | 0 | Disconnected | "Disconnected" | "SPV: Stopped" | -- |
 
@@ -187,10 +189,10 @@ These scenarios verify the reworked SPV peer connection lifecycle:
 
 ### Expected Results
 
-- Once peer count drops to 0, `refresh_state()` maps `Running` to `Synced` (Running always maps to Synced regardless of peer count -- it means sync is complete).
+- Once peer count drops to 0, `refresh_state()` maps active SPV with zero peers to `Connecting` (fast orange pulse).
 - **Wait** -- `Running` status means sync finished. The SPV library may transition to a different status internally if peers drop. Observe actual SpvStatus transitions.
-- If SPV stays `Running` with 0 peers: indicator stays **green** (Running = Synced in the state machine). The `spv_no_peers_since` timer starts but no stop_spv is called.
-- After 30s with 0 peers, degraded warning appears in tooltip.
+- If SPV stays `Running` with 0 peers: indicator should remain **orange** (`Connecting`), and the `spv_no_peers_since` timer continues without calling `stop_spv()`.
+- After 30s with 0 peers, degraded warning banner and tooltip appear.
 
 ---
 

--- a/docs/ai-design/2025-02-25-spv-peer-rework/manual-tests.md
+++ b/docs/ai-design/2025-02-25-spv-peer-rework/manual-tests.md
@@ -1,0 +1,252 @@
+# Manual Test Scenarios: SPV Peer Status Rework
+
+**Feature:** Replace SPV auto-stop with Connecting state and degraded-state warning
+**Branch:** `fix/spv-peer-timeout`
+**Date:** 2025-02-25
+
+## Overview
+
+These scenarios verify the reworked SPV peer connection lifecycle:
+
+- SPV **no longer auto-stops** on peer timeout -- it keeps running and retrying peer discovery.
+- New **four-state** connection indicator: Red (Disconnected), Orange/fast-pulse (Connecting), Orange/slow-pulse (Syncing), Green (Synced).
+- After ~30 seconds with zero peers, a **degraded warning** appears in the tooltip ("Having trouble finding peers...") but SPV stays running.
+
+---
+
+## Global Preconditions
+
+1. Dash Evo Tool is installed and launches successfully.
+2. The application is configured for **SPV mode** unless stated otherwise.
+3. At least one network (Testnet or Mainnet) is configured with valid DAPI endpoints.
+4. Tester has access to network controls (firewall rules, VPN toggle) to simulate peer availability.
+
+---
+
+## Scenario 1: Fresh SPV Start on Good Network
+
+**Goal:** Verify the Connecting -> Syncing -> Synced progression.
+
+### Steps
+
+1. Launch the application with normal network connectivity.
+2. Observe the connection indicator immediately after SPV starts.
+3. Hover over the indicator to read the tooltip.
+4. Wait for peers to connect (usually within a few seconds).
+5. Observe the indicator transition during sync phases.
+6. Wait for sync to complete.
+
+### Expected Results
+
+- **Step 2:** Orange circle with **fast pulse** (`time * 2.5`). Tooltip header: "Connecting...".
+- **Step 4:** Once peers connect, indicator remains orange but pulse slows (`time * 1.2`). Tooltip header changes to "Syncing". SPV label shows phase progress (e.g., "SPV: Headers: 12345 / 27000 (45%)").
+- **Step 6:** Indicator turns **green** with normal pulse. Tooltip: "Ready\nSPV: Synced\nDAPI: Available (N unbanned / M total endpoints)".
+
+---
+
+## Scenario 2: Fresh SPV Start on Bad Network (No Peers)
+
+**Goal:** Verify SPV stays running and shows degraded warning instead of stopping.
+
+### Steps
+
+1. Block outbound P2P peer connections (firewall on port 9999/19999).
+2. Launch the application. Ensure DAPI endpoints are reachable.
+3. Observe the indicator -- should show orange (Connecting).
+4. Wait approximately 30 seconds.
+5. Hover over the indicator to read the tooltip.
+6. Continue waiting 1-2 minutes.
+
+### Expected Results
+
+- **Step 3:** Orange indicator with fast pulse. Tooltip: "Connecting...\nSPV: Starting\nDAPI: Available (...)".
+- **Step 5:** After ~30s, tooltip adds: "\nHaving trouble finding peers...".
+- **Step 6:** SPV **remains running** (does NOT stop). Indicator stays orange. No error banner appears. SPV continues trying DNS lookups and peer discovery in the background.
+- **Critical:** Verify NO "SPV disconnected" error banner. Verify `stop_spv()` is NOT called (check logs -- no "stopping SPV" message).
+
+---
+
+## Scenario 3: Peers Disconnect Mid-Sync
+
+**Goal:** Verify state transitions back to Connecting (not Disconnected) when peers drop.
+
+### Steps
+
+1. Start SPV and wait for it to begin syncing with peers (orange, slow pulse).
+2. Block all peer connections via firewall.
+3. Observe the indicator over the next 5-10 seconds.
+
+### Expected Results
+
+- **Step 2:** Peer count drops to 0. The `spv_no_peers_since` timer starts.
+- **Step 3:** Indicator changes from slow-pulse orange (Syncing) to **fast-pulse orange (Connecting)**. SPV status remains `Syncing` but with 0 peers, `refresh_state()` maps this to `Connecting`.
+- SPV does NOT stop. No error banner.
+- After 30s of no peers, tooltip adds "Having trouble finding peers...".
+
+---
+
+## Scenario 4: Peers Reconnect After Disconnect
+
+**Goal:** Verify seamless recovery when peers become available again.
+
+### Steps
+
+1. Complete Scenario 3 (SPV is in Connecting state, no peers).
+2. Restore network connectivity (remove firewall rule).
+3. Observe the indicator.
+
+### Expected Results
+
+- **Step 2-3:** Peers reconnect via SPV's internal discovery. `spv_no_peers_since` is cleared (`peers > 0` resets to `None`).
+- Indicator transitions from fast-pulse orange (Connecting) to slow-pulse orange (Syncing) as peers connect and sync resumes.
+- Eventually reaches green (Synced) once sync completes.
+- No manual restart needed -- SPV recovered on its own.
+
+---
+
+## Scenario 5: Network Switch
+
+**Goal:** Verify connection state resets cleanly on network switch.
+
+### Steps
+
+1. Confirm SPV is synced on current network (green indicator).
+2. Switch to a different network via the network chooser.
+3. Observe the indicator immediately after switch.
+4. Wait for SPV to start on the new network.
+
+### Expected Results
+
+- **Step 2:** `ConnectionStatus::reset()` clears all state: `spv_status` -> Idle, `spv_connected_peers` -> 0, `spv_no_peers_since` -> None, `overall_state` -> Disconnected.
+- **Step 3:** Indicator turns **red** momentarily.
+- **Step 4:** Transitions to orange/Connecting, then Syncing, then green/Synced.
+
+---
+
+## Scenario 6: All DAPI Endpoints Banned
+
+**Goal:** Verify that losing DAPI forces Disconnected even with SPV peers.
+
+### Steps
+
+1. Confirm SPV is synced (green indicator).
+2. Cause all DAPI endpoints to become banned.
+3. Observe the indicator after the next refresh cycle (within 1-4 seconds).
+
+### Expected Results
+
+- `refresh_state()` returns `Disconnected` because `dapi_available()` is false.
+- Indicator turns **red**, regardless of SPV peer status.
+- Tooltip: "Disconnected\nSPV: Synced\nDAPI: All M endpoints banned".
+
+---
+
+## Scenario 7: Connection Indicator Visual States
+
+**Goal:** Verify all four visual states render correctly.
+
+### Expected Results
+
+| State | Color | Pulse | Background glow |
+|---|---|---|---|
+| Disconnected | Red (`error_color`) | None (`scale = 1.0`) | Same radius as main circle |
+| Connecting | Orange (`warning_color`) | Fast pulse (`1.0 + 0.2 * sin(t*2.5)`) | Pulsating with 0.3 opacity |
+| Syncing | Orange (`warning_color`) | Slow pulse (`1.0 + 0.15 * sin(t*1.2)`) | Pulsating with 0.3 opacity |
+| Synced | Green (`success_color`) | Normal pulse (`1.0 + 0.2 * sin(t*2.0)`) | Pulsating with 0.3 opacity |
+
+- Connecting and Syncing use the same orange color but differ in pulse rate.
+- Only Disconnected does NOT call `repaint_animation`.
+
+---
+
+## Scenario 8: Tooltip Text for Each State
+
+**Goal:** Verify tooltip accuracy across all SPV states.
+
+| SPV Status | Peers | Overall State | Tooltip line 1 | Tooltip line 2 | Extra |
+|---|---|---|---|---|---|
+| Idle | 0 | Disconnected | "Disconnected" | "SPV: Idle" | -- |
+| Starting | 0 | Connecting | "Connecting..." | "SPV: Starting" | After 30s: "Having trouble finding peers..." |
+| Syncing | >0 | Syncing | "Syncing" | "SPV: Headers: X / Y (Z%)" | Phase progress shown |
+| Syncing | 0 | Connecting | "Connecting..." | "SPV: <phase>" | After 30s: degraded warning |
+| Running | >0 | Synced | "Ready" | "SPV: Synced" | -- |
+| Stopping | 0 | Connecting | "Connecting..." | "SPV: Stopping" | -- |
+| Stopped | 0 | Disconnected | "Disconnected" | "SPV: Stopped" | -- |
+
+---
+
+## Scenario 9: Running State with Peers Dropping to Zero
+
+**Goal:** Verify Running (Synced) transitions correctly when peers vanish.
+
+### Steps
+
+1. Confirm green indicator (SPV Running, peers connected).
+2. Block peer connections.
+3. Observe the indicator over 30+ seconds.
+
+### Expected Results
+
+- Once peer count drops to 0, `refresh_state()` maps `Running` to `Synced` (Running always maps to Synced regardless of peer count -- it means sync is complete).
+- **Wait** -- `Running` status means sync finished. The SPV library may transition to a different status internally if peers drop. Observe actual SpvStatus transitions.
+- If SPV stays `Running` with 0 peers: indicator stays **green** (Running = Synced in the state machine). The `spv_no_peers_since` timer starts but no stop_spv is called.
+- After 30s with 0 peers, degraded warning appears in tooltip.
+
+---
+
+## Scenario 10: Long-Running Stability
+
+**Goal:** Verify no resource leaks from peer tracking.
+
+### Steps
+
+1. Launch and sync SPV fully.
+2. Note memory usage (RSS).
+3. Run for 1+ hour with occasional peer churn (toggle connectivity 2-3 times).
+4. Check memory every 15 minutes.
+
+### Expected Results
+
+- Memory stable (no unbounded growth).
+- `spv_no_peers_since` is `Option<Instant>` (fixed size), `spv_connected_peers` is `AtomicU16`.
+- After peer churn, returns to Synced without stale state.
+- No Mutex poisoning or deadlock warnings in logs.
+
+---
+
+## Scenario 11: RPC Mode Unaffected
+
+**Goal:** Verify SPV peer logic doesn't interfere with RPC mode.
+
+### Steps
+
+1. Launch in RPC mode (Dash Core wallet connected).
+2. Verify indicator follows RPC/ZMQ status.
+3. Stop Dash Core.
+4. Observe indicator.
+
+### Expected Results
+
+- No SPV timeout logic is involved.
+- Green when RPC online + ZMQ connected + DAPI available; red otherwise.
+- Tooltip shows RPC-specific content.
+- No "Having trouble finding peers..." or SPV-related messages.
+
+---
+
+## Scenario 12: Connecting State vs Syncing Pulse Differentiation
+
+**Goal:** Verify the visual difference between Connecting and Syncing is noticeable.
+
+### Steps
+
+1. Start SPV with peers blocked -- observe Connecting state pulse.
+2. Unblock peers -- observe transition to Syncing state pulse.
+3. Compare the two pulse rates side by side (or record video).
+
+### Expected Results
+
+- **Connecting** pulse is noticeably faster (2.5 Hz base) with slightly larger amplitude.
+- **Syncing** pulse is calmer (1.2 Hz base) with smaller amplitude.
+- Both are orange -- the pulse rate is the primary visual differentiator.
+- Transition between states should be smooth (no flicker or jump).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1156,6 +1156,19 @@ impl App for AppState {
                 .trigger_refresh(active_context.as_ref()),
         );
 
+        // Show a warning banner when SPV has been unable to find peers
+        // for an extended period. `set_global` deduplicates by text, so
+        // calling this every frame is safe — only one banner is shown.
+        if active_context.core_backend_mode() == crate::spv::CoreBackendMode::Spv
+            && active_context.connection_status().spv_peer_degraded()
+        {
+            MessageBanner::set_global(
+                ctx,
+                "Having trouble finding peers. Check your network connection.",
+                MessageType::Warning,
+            );
+        }
+
         for action in actions {
             match action {
                 AppAction::None => {}

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,11 +7,11 @@ use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::components::core_zmq_listener::{CoreZMQListener, ZMQMessage};
 use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
-use crate::spv::CoreBackendMode;
 use crate::database::Database;
 #[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
+use crate::spv::CoreBackendMode;
 use crate::ui::components::MessageBanner;
 use crate::ui::contracts_documents::contracts_documents_screen::DocumentQueryScreen;
 use crate::ui::dashpay::{DashPayScreen, DashPaySubscreen, ProfileSearchScreen};

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,6 @@ use crate::database::Database;
 #[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
-use crate::spv::{CoreBackendMode, SpvStatus};
 use crate::ui::components::MessageBanner;
 use crate::ui::contracts_documents::contracts_documents_screen::DocumentQueryScreen;
 use crate::ui::dashpay::{DashPayScreen, DashPaySubscreen, ProfileSearchScreen};
@@ -1156,27 +1155,6 @@ impl App for AppState {
                 .connection_status()
                 .trigger_refresh(active_context.as_ref()),
         );
-
-        // Auto-stop SPV if no peers connect within the timeout.
-        // Guard against repeated calls: once stop_spv() sets the status to
-        // Stopping, `is_active()` still returns true so `spv_no_peers_since`
-        // wouldn't be cleared, and the timeout check would fire again each
-        // frame until the manager finishes shutting down.
-        if active_context.core_backend_mode() == CoreBackendMode::Spv
-            && active_context.connection_status().spv_peer_timed_out()
-            && !matches!(
-                active_context.connection_status().spv_status(),
-                SpvStatus::Stopping | SpvStatus::Stopped
-            )
-        {
-            tracing::warn!("SPV peer timeout: no peers connected, stopping SPV");
-            active_context.stop_spv();
-            MessageBanner::set_global(
-                ctx,
-                "SPV disconnected: no peers found. Check your network connection.",
-                MessageType::Error,
-            );
-        }
 
         for action in actions {
             match action {

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::components::core_zmq_listener::{CoreZMQListener, ZMQMessage};
 use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
+use crate::spv::CoreBackendMode;
 use crate::database::Database;
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
@@ -1128,6 +1129,19 @@ impl App for AppState {
                 .connection_status()
                 .trigger_refresh(active_context.as_ref()),
         );
+
+        // Auto-stop SPV if no peers connect within the timeout.
+        if active_context.core_backend_mode() == CoreBackendMode::Spv
+            && active_context.connection_status().spv_peer_timed_out()
+        {
+            tracing::warn!("SPV peer timeout: no peers connected, stopping SPV");
+            active_context.stop_spv();
+            MessageBanner::set_global(
+                ctx,
+                "SPV disconnected: no peers found. Check your network connection.",
+                MessageType::Error,
+            );
+        }
 
         for action in actions {
             match action {

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::database::Database;
 #[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
-use crate::spv::CoreBackendMode;
+use crate::spv::{CoreBackendMode, SpvStatus};
 use crate::ui::components::MessageBanner;
 use crate::ui::contracts_documents::contracts_documents_screen::DocumentQueryScreen;
 use crate::ui::dashpay::{DashPayScreen, DashPaySubscreen, ProfileSearchScreen};
@@ -1158,8 +1158,16 @@ impl App for AppState {
         );
 
         // Auto-stop SPV if no peers connect within the timeout.
+        // Guard against repeated calls: once stop_spv() sets the status to
+        // Stopping, `is_active()` still returns true so `spv_no_peers_since`
+        // wouldn't be cleared, and the timeout check would fire again each
+        // frame until the manager finishes shutting down.
         if active_context.core_backend_mode() == CoreBackendMode::Spv
             && active_context.connection_status().spv_peer_timed_out()
+            && !matches!(
+                active_context.connection_status().spv_status(),
+                SpvStatus::Stopping | SpvStatus::Stopped
+            )
         {
             tracing::warn!("SPV peer timeout: no peers connected, stopping SPV");
             active_context.stop_spv();

--- a/src/app.rs
+++ b/src/app.rs
@@ -1157,16 +1157,14 @@ impl App for AppState {
         );
 
         // Show a warning banner when SPV has been unable to find peers
-        // for an extended period. `set_global` deduplicates by text, so
-        // calling this every frame is safe — only one banner is shown.
-        if active_context.core_backend_mode() == crate::spv::CoreBackendMode::Spv
-            && active_context.connection_status().spv_peer_degraded()
-        {
-            MessageBanner::set_global(
-                ctx,
-                "Having trouble finding peers. Check your network connection.",
-                MessageType::Warning,
-            );
+        // for an extended period.  Cleared as soon as the condition resolves.
+        const SPV_DEGRADED_BANNER: &str = "Having trouble finding peers. Check your connection.";
+        if active_context.core_backend_mode() == crate::spv::CoreBackendMode::Spv {
+            if active_context.connection_status().spv_peer_degraded() {
+                MessageBanner::set_global(ctx, SPV_DEGRADED_BANNER, MessageType::Warning);
+            } else {
+                MessageBanner::clear_global_message(ctx, SPV_DEGRADED_BANNER);
+            }
         }
 
         for action in actions {

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -392,7 +392,10 @@ impl ConnectionStatus {
         match backend_mode {
             CoreBackendMode::Spv => {
                 let snapshot = app_context.spv_manager().status();
-                tracing::trace!("ConnectionStatus: polled SPV status = {:?}", snapshot.status);
+                tracing::trace!(
+                    "ConnectionStatus: polled SPV status = {:?}",
+                    snapshot.status
+                );
                 self.set_spv_status(snapshot.status);
                 let peers = snapshot.connected_peers as u16;
                 self.spv_connected_peers.store(peers, Ordering::Relaxed);

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -506,3 +506,46 @@ impl Default for ConnectionStatus {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn spv_peer_timed_out_returns_false_when_none() {
+        let status = ConnectionStatus::new();
+        // Default state: spv_no_peers_since is None.
+        assert!(!status.spv_peer_timed_out());
+    }
+
+    #[test]
+    fn spv_peer_timed_out_returns_false_before_threshold() {
+        let status = ConnectionStatus::new();
+        // Set to "just now" — well within the timeout window.
+        *status.spv_no_peers_since.lock().unwrap() = Some(Instant::now());
+        assert!(!status.spv_peer_timed_out());
+    }
+
+    #[test]
+    fn spv_peer_timed_out_returns_true_after_threshold() {
+        let status = ConnectionStatus::new();
+        // Set to a point beyond the timeout threshold.
+        *status.spv_no_peers_since.lock().unwrap() =
+            Some(Instant::now() - SPV_PEER_TIMEOUT - Duration::from_millis(1));
+        assert!(status.spv_peer_timed_out());
+    }
+
+    #[test]
+    fn spv_peer_timed_out_clears_on_reset() {
+        let status = ConnectionStatus::new();
+        // Set to a point beyond the timeout threshold so it would fire.
+        *status.spv_no_peers_since.lock().unwrap() =
+            Some(Instant::now() - SPV_PEER_TIMEOUT - Duration::from_millis(1));
+        assert!(status.spv_peer_timed_out());
+
+        // After reset the timestamp should be cleared.
+        status.reset(CoreBackendMode::Spv);
+        assert!(!status.spv_peer_timed_out());
+    }
+}

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -193,7 +193,7 @@ impl ConnectionStatus {
     /// Returns `true` if SPV has been active with zero connected peers
     /// for longer than [`SPV_PEER_DEGRADED_TIMEOUT`].
     ///
-    /// Returns `false` if the mutex is poisoned (conservative default).
+    /// If the mutex is poisoned, recovers the inner value and evaluates it.
     pub fn spv_peer_degraded(&self) -> bool {
         self.spv_no_peers_since
             .lock()

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 const REFRESH_CONNECTED: Duration = Duration::from_secs(10);
 const REFRESH_DISCONNECTED: Duration = Duration::from_secs(2);
 
+const SPV_PEER_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Three-state connection indicator matching the UI's red/orange/green circle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -48,6 +50,10 @@ pub struct ConnectionStatus {
     disable_zmq: AtomicBool,
     overall_state: AtomicU8,
     last_update: Mutex<Instant>,
+    spv_connected_peers: AtomicU16,
+    /// When SPV first entered an active state (`Starting`/`Syncing`) with zero
+    /// peers.  Reset to `None` once peers connect or SPV stops.
+    spv_no_peers_since: Mutex<Option<Instant>>,
     dapi_total_endpoints: AtomicU16,
     dapi_available_endpoints: AtomicU16,
 }
@@ -62,6 +68,8 @@ impl ConnectionStatus {
             disable_zmq: AtomicBool::new(false),
             overall_state: AtomicU8::new(OverallConnectionState::Disconnected as u8),
             last_update: Mutex::new(Instant::now()),
+            spv_connected_peers: AtomicU16::new(0),
+            spv_no_peers_since: Mutex::new(None),
             dapi_total_endpoints: AtomicU16::new(0),
             dapi_available_endpoints: AtomicU16::new(0),
         }
@@ -82,6 +90,10 @@ impl ConnectionStatus {
         self.backend_mode
             .store(backend_mode.as_u8(), Ordering::Relaxed);
         self.disable_zmq.store(false, Ordering::Relaxed);
+        self.spv_connected_peers.store(0, Ordering::Relaxed);
+        if let Ok(mut since) = self.spv_no_peers_since.lock() {
+            *since = None;
+        }
         self.overall_state.store(
             OverallConnectionState::Disconnected as u8,
             Ordering::Relaxed,
@@ -173,6 +185,16 @@ impl ConnectionStatus {
         } else {
             format!("All {total} endpoints banned")
         }
+    }
+
+    /// Returns `true` if SPV has been active with zero connected peers
+    /// for longer than [`SPV_PEER_TIMEOUT`].
+    pub fn spv_peer_timed_out(&self) -> bool {
+        self.spv_no_peers_since
+            .lock()
+            .ok()
+            .and_then(|g| *g)
+            .is_some_and(|since| since.elapsed() >= SPV_PEER_TIMEOUT)
     }
 
     pub fn spv_connected(status: SpvStatus) -> bool {
@@ -353,10 +375,20 @@ impl ConnectionStatus {
 
         match backend_mode {
             CoreBackendMode::Spv => {
-                // SPV status is updated elsewhere
-                let spv_status = app_context.spv_manager().status().status;
-                tracing::trace!("ConnectionStatus: polled SPV status = {:?}", spv_status);
-                self.set_spv_status(spv_status);
+                let snapshot = app_context.spv_manager().status();
+                tracing::trace!("ConnectionStatus: polled SPV status = {:?}", snapshot.status);
+                self.set_spv_status(snapshot.status);
+                let peers = snapshot.connected_peers as u16;
+                self.spv_connected_peers.store(peers, Ordering::Relaxed);
+
+                // Track how long we've been active with zero peers.
+                if let Ok(mut since) = self.spv_no_peers_since.lock() {
+                    if peers > 0 || !snapshot.status.is_active() {
+                        *since = None;
+                    } else if since.is_none() {
+                        *since = Some(Instant::now());
+                    }
+                }
             }
             CoreBackendMode::Rpc => {
                 // Update ZMQ status if there's a new event

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -98,6 +98,7 @@ impl ConnectionStatus {
         if let Ok(mut since) = self.spv_no_peers_since.lock() {
             *since = None;
         }
+
         self.overall_state.store(
             OverallConnectionState::Disconnected as u8,
             Ordering::Relaxed,

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -95,18 +95,17 @@ impl ConnectionStatus {
             .store(backend_mode.as_u8(), Ordering::Relaxed);
         self.disable_zmq.store(false, Ordering::Relaxed);
         self.spv_connected_peers.store(0, Ordering::Relaxed);
-        if let Ok(mut since) = self.spv_no_peers_since.lock() {
-            *since = None;
-        }
-
+        *self
+            .spv_no_peers_since
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
         self.overall_state.store(
             OverallConnectionState::Disconnected as u8,
             Ordering::Relaxed,
         );
         // Set last_update to epoch so the next trigger_refresh fires immediately
-        if let Ok(mut last) = self.last_update.lock() {
-            *last = Instant::now() - REFRESH_CONNECTED;
-        }
+        *self.last_update.lock().unwrap_or_else(|e| e.into_inner()) =
+            Instant::now() - REFRESH_CONNECTED;
     }
 
     pub fn rpc_online(&self) -> bool {
@@ -156,9 +155,8 @@ impl ConnectionStatus {
 
     /// Reset the throttle timer so the next `trigger_refresh()` fires immediately.
     pub fn reset_timer(&self) {
-        if let Ok(mut last) = self.last_update.lock() {
-            *last = Instant::now() - REFRESH_CONNECTED;
-        }
+        *self.last_update.lock().unwrap_or_else(|e| e.into_inner()) =
+            Instant::now() - REFRESH_CONNECTED;
     }
 
     pub fn dapi_total_endpoints(&self) -> u16 {
@@ -194,11 +192,12 @@ impl ConnectionStatus {
 
     /// Returns `true` if SPV has been active with zero connected peers
     /// for longer than [`SPV_PEER_DEGRADED_TIMEOUT`].
+    ///
+    /// Returns `false` if the mutex is poisoned (conservative default).
     pub fn spv_peer_degraded(&self) -> bool {
         self.spv_no_peers_since
             .lock()
-            .ok()
-            .and_then(|g| *g)
+            .unwrap_or_else(|e| e.into_inner())
             .is_some_and(|since| since.elapsed() >= SPV_PEER_DEGRADED_TIMEOUT)
     }
 
@@ -210,6 +209,14 @@ impl ConnectionStatus {
         self.overall_state.load(Ordering::Relaxed).into()
     }
 
+    /// Recompute the overall connection state from the individual subsystem
+    /// flags.
+    ///
+    /// Each field is read with `Ordering::Relaxed` — there is no cross-field
+    /// synchronisation, so a single call may observe a mix of "old" and "new"
+    /// values.  This is acceptable because the function runs on every UI
+    /// frame (1-4 s cadence) and any transient inconsistency self-corrects on
+    /// the next poll.
     pub fn refresh_state(&self) {
         let backend_mode = self.backend_mode();
         let disable_zmq = self.disable_zmq();
@@ -231,8 +238,11 @@ impl ConnectionStatus {
                 } else {
                     let has_peers = self.spv_connected_peers.load(Ordering::Relaxed) > 0;
                     match spv_status {
-                        SpvStatus::Running => OverallConnectionState::Synced,
-                        SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Stopping => {
+                        SpvStatus::Running if has_peers => OverallConnectionState::Synced,
+                        SpvStatus::Running
+                        | SpvStatus::Starting
+                        | SpvStatus::Syncing
+                        | SpvStatus::Stopping => {
                             if has_peers {
                                 OverallConnectionState::Syncing
                             } else {
@@ -252,6 +262,8 @@ impl ConnectionStatus {
     /// In SPV mode, fetches sync progress from the [`SpvManager`] to display
     /// a detailed phase summary (e.g. `"SPV: Headers: 12345 / 27000 (45%)"`)
     /// instead of the bare `"SPV: Syncing"`.
+    // TODO: decouple from AppContext — accept a struct with the needed fields
+    // (spv_manager status, settings) instead of the full context reference.
     pub fn tooltip_text(&self, app_context: &crate::context::AppContext) -> String {
         let backend_mode = self.backend_mode();
         let disable_zmq = self.disable_zmq();
@@ -307,7 +319,7 @@ impl ConnectionStatus {
                         .unwrap_or_else(|| format!("SPV: {:?}", spv_status))
                 };
                 let degraded_warning = if self.spv_peer_degraded() {
-                    "\nHaving trouble finding peers..."
+                    "\nHaving trouble finding peers. Check your connection."
                 } else {
                     ""
                 };
@@ -414,16 +426,18 @@ impl ConnectionStatus {
                     snapshot.status
                 );
                 self.set_spv_status(snapshot.status);
-                let peers = snapshot.connected_peers as u16;
+                let peers = (snapshot.connected_peers).min(u16::MAX as usize) as u16;
                 self.spv_connected_peers.store(peers, Ordering::Relaxed);
 
                 // Track how long we've been active with zero peers.
-                if let Ok(mut since) = self.spv_no_peers_since.lock() {
-                    if peers > 0 || !snapshot.status.is_active() {
-                        *since = None;
-                    } else if since.is_none() {
-                        *since = Some(Instant::now());
-                    }
+                let mut since = self
+                    .spv_no_peers_since
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                if peers > 0 || !snapshot.status.is_active() {
+                    *since = None;
+                } else if since.is_none() {
+                    *since = Some(Instant::now());
                 }
             }
             CoreBackendMode::Rpc => {

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -14,25 +14,28 @@ use std::time::{Duration, Instant};
 const REFRESH_CONNECTED: Duration = Duration::from_secs(4);
 const REFRESH_DISCONNECTED: Duration = Duration::from_secs(1);
 
-const SPV_PEER_TIMEOUT: Duration = Duration::from_secs(10);
+const SPV_PEER_DEGRADED_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Three-state connection indicator matching the UI's red/orange/green circle.
+/// Four-state connection indicator matching the UI's red/orange/green circle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum OverallConnectionState {
     /// No connection at all — red indicator.
     Disconnected = 0,
+    /// SPV active but no peers connected yet — orange indicator (faster pulse).
+    Connecting = 1,
     /// All subsystems connected but still syncing data — orange indicator.
-    Syncing = 1,
+    Syncing = 2,
     /// Fully connected and operational — green indicator.
-    Synced = 2,
+    Synced = 3,
 }
 
 impl From<u8> for OverallConnectionState {
     fn from(v: u8) -> Self {
         match v {
-            1 => Self::Syncing,
-            2 => Self::Synced,
+            1 => Self::Connecting,
+            2 => Self::Syncing,
+            3 => Self::Synced,
             _ => Self::Disconnected,
         }
     }
@@ -189,13 +192,13 @@ impl ConnectionStatus {
     }
 
     /// Returns `true` if SPV has been active with zero connected peers
-    /// for longer than [`SPV_PEER_TIMEOUT`].
-    pub fn spv_peer_timed_out(&self) -> bool {
+    /// for longer than [`SPV_PEER_DEGRADED_TIMEOUT`].
+    pub fn spv_peer_degraded(&self) -> bool {
         self.spv_no_peers_since
             .lock()
             .ok()
             .and_then(|g| *g)
-            .is_some_and(|since| since.elapsed() >= SPV_PEER_TIMEOUT)
+            .is_some_and(|since| since.elapsed() >= SPV_PEER_DEGRADED_TIMEOUT)
     }
 
     pub fn spv_connected(status: SpvStatus) -> bool {
@@ -225,10 +228,15 @@ impl ConnectionStatus {
                 if !dapi_available {
                     OverallConnectionState::Disconnected
                 } else {
+                    let has_peers = self.spv_connected_peers.load(Ordering::Relaxed) > 0;
                     match spv_status {
                         SpvStatus::Running => OverallConnectionState::Synced,
                         SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Stopping => {
-                            OverallConnectionState::Syncing
+                            if has_peers {
+                                OverallConnectionState::Syncing
+                            } else {
+                                OverallConnectionState::Connecting
+                            }
                         }
                         _ => OverallConnectionState::Disconnected,
                     }
@@ -266,8 +274,10 @@ impl ConnectionStatus {
 
                 let header = match overall {
                     OverallConnectionState::Synced => "Connected to Dash Core Wallet",
-                    // RPC mode doesn't currently produce Syncing, but kept for forward-compat.
-                    OverallConnectionState::Syncing => "Syncing to Dash Core Wallet",
+                    // RPC mode doesn't currently produce Connecting/Syncing, but kept for forward-compat.
+                    OverallConnectionState::Connecting | OverallConnectionState::Syncing => {
+                        "Syncing to Dash Core Wallet"
+                    }
                     OverallConnectionState::Disconnected if self.rpc_online() => {
                         "Dash Core connection incomplete"
                     }
@@ -280,6 +290,7 @@ impl ConnectionStatus {
             CoreBackendMode::Spv => {
                 let header = match overall {
                     OverallConnectionState::Synced => "Ready",
+                    OverallConnectionState::Connecting => "Connecting...",
                     OverallConnectionState::Syncing => "Syncing",
                     OverallConnectionState::Disconnected => "Disconnected",
                 };
@@ -294,7 +305,12 @@ impl ConnectionStatus {
                         .map(|p| format!("SPV: {}", spv_phase_summary(p)))
                         .unwrap_or_else(|| format!("SPV: {:?}", spv_status))
                 };
-                format!("{header}\n{spv_label}\n{dapi_status}")
+                let degraded_warning = if self.spv_peer_degraded() {
+                    "\nHaving trouble finding peers..."
+                } else {
+                    ""
+                };
+                format!("{header}\n{spv_label}{degraded_warning}\n{dapi_status}")
             }
         }
     }
@@ -513,39 +529,39 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn spv_peer_timed_out_returns_false_when_none() {
+    fn spv_peer_degraded_returns_false_when_none() {
         let status = ConnectionStatus::new();
         // Default state: spv_no_peers_since is None.
-        assert!(!status.spv_peer_timed_out());
+        assert!(!status.spv_peer_degraded());
     }
 
     #[test]
-    fn spv_peer_timed_out_returns_false_before_threshold() {
+    fn spv_peer_degraded_returns_false_before_threshold() {
         let status = ConnectionStatus::new();
-        // Set to "just now" — well within the timeout window.
+        // Set to "just now" — well within the degraded window.
         *status.spv_no_peers_since.lock().unwrap() = Some(Instant::now());
-        assert!(!status.spv_peer_timed_out());
+        assert!(!status.spv_peer_degraded());
     }
 
     #[test]
-    fn spv_peer_timed_out_returns_true_after_threshold() {
+    fn spv_peer_degraded_returns_true_after_threshold() {
         let status = ConnectionStatus::new();
-        // Set to a point beyond the timeout threshold.
+        // Set to a point beyond the degraded threshold.
         *status.spv_no_peers_since.lock().unwrap() =
-            Some(Instant::now() - SPV_PEER_TIMEOUT - Duration::from_millis(1));
-        assert!(status.spv_peer_timed_out());
+            Some(Instant::now() - SPV_PEER_DEGRADED_TIMEOUT - Duration::from_millis(1));
+        assert!(status.spv_peer_degraded());
     }
 
     #[test]
-    fn spv_peer_timed_out_clears_on_reset() {
+    fn spv_peer_degraded_clears_on_reset() {
         let status = ConnectionStatus::new();
-        // Set to a point beyond the timeout threshold so it would fire.
+        // Set to a point beyond the degraded threshold so it would fire.
         *status.spv_no_peers_since.lock().unwrap() =
-            Some(Instant::now() - SPV_PEER_TIMEOUT - Duration::from_millis(1));
-        assert!(status.spv_peer_timed_out());
+            Some(Instant::now() - SPV_PEER_DEGRADED_TIMEOUT - Duration::from_millis(1));
+        assert!(status.spv_peer_degraded());
 
         // After reset the timestamp should be cleared.
         status.reset(CoreBackendMode::Spv);
-        assert!(!status.spv_peer_timed_out());
+        assert!(!status.spv_peer_degraded());
     }
 }

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -279,18 +279,26 @@ impl MessageBanner {
     // for another (e.g., replacing a generic "Success" with a specific one).
 
     /// Adds a global banner message if one with the same text does not already exist.
+    ///
+    /// **Idempotent**: if a banner with identical text is already displayed,
+    /// this is a no-op and the existing banner is returned unchanged
+    /// (timestamps, auto-dismiss timer, and `logged` flag are all preserved).
+    /// This makes it safe to call every frame without side-effects.
+    ///
+    /// To reset the auto-dismiss timer of an existing banner, use
+    /// [`replace_global`](Self::replace_global) with the same text for both
+    /// `old_text` and `new_text`, or store the returned [`BannerHandle`] and
+    /// call [`BannerHandle::with_auto_dismiss`].
+    ///
     /// Evicts the oldest message when the cap ([`MAX_BANNERS`]) is reached.
     ///
     /// Returns a [`BannerHandle`] for updating or clearing the banner later.
     pub fn set_global(ctx: &egui::Context, text: &str, message_type: MessageType) -> BannerHandle {
         let mut banners = get_banners(ctx);
-        if let Some(existing) = banners.iter_mut().find(|b| b.text == text) {
-            existing.reset_to(text.to_string(), message_type);
-            let key = existing.key;
-            set_banners(ctx, banners);
+        if let Some(existing) = banners.iter().find(|b| b.text == text) {
             return BannerHandle {
                 ctx: ctx.clone(),
-                key,
+                key: existing.key,
             };
         }
         let key = next_banner_key();

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -104,10 +104,12 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
     let dark_mode = ui.ctx().style().visuals.dark_mode;
     let circle_size = 14.0;
 
-    // Three-state color: green (synced), orange (syncing), red (disconnected)
+    // Four-state color: green (synced), orange (syncing/connecting), red (disconnected)
     let color = match overall {
         OverallConnectionState::Synced => DashColors::success_color(dark_mode),
-        OverallConnectionState::Syncing => DashColors::warning_color(dark_mode),
+        OverallConnectionState::Connecting | OverallConnectionState::Syncing => {
+            DashColors::warning_color(dark_mode)
+        }
         OverallConnectionState::Disconnected => DashColors::error_color(dark_mode),
     };
 
@@ -116,6 +118,7 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
 
     let pulse_scale = match overall {
         OverallConnectionState::Synced => 1.0 + 0.2 * (time * 2.0).sin(),
+        OverallConnectionState::Connecting => 1.0 + 0.2 * (time * 2.5).sin(),
         OverallConnectionState::Syncing => 1.0 + 0.15 * (time * 1.2).sin(),
         OverallConnectionState::Disconnected => 1.0, // No pulse when disconnected
     };


### PR DESCRIPTION
## Issue being fixed or feature implemented

When SPV starts and no peers connect, the old behavior was to auto-stop SPV after 10 seconds and show an error. This was counterproductive — SPV handles peer discovery and reconnection internally, so stopping it killed the very mechanism that would fix the problem.

### User Story

Imagine you're a user starting Dash Evo Tool in SPV mode on a slow or congested network. Previously, if peers took longer than 10 seconds to connect, SPV would abruptly stop and show a scary error banner, forcing you to manually restart. Now, the app shows a "Connecting..." state with a pulsing orange indicator while SPV keeps trying to find peers in the background. If it takes longer than 30 seconds, you get a gentle warning in the tooltip — but SPV stays running and will connect as soon as peers become available.

## What was done?

### Replaced auto-stop with graceful degraded state
- **Removed `stop_spv()` on peer timeout** from the main update loop in `app.rs`
- SPV now keeps running and retrying peer discovery when no peers are found

### Added four-state connection indicator
- `OverallConnectionState` now has `Disconnected`, `Connecting`, `Syncing`, `Synced`
- `Connecting` = SPV active but no peers yet (fast orange pulse at 2.5 Hz)
- `Syncing` = SPV active with peers (slow orange pulse at 1.2 Hz)
- Distinguished by peer count in `refresh_state()`

### Degraded-state warning
- After 30 seconds with zero peers (`SPV_PEER_DEGRADED_TIMEOUT`), a warning banner appears: "Having trouble finding peers. Check your network connection."
- SPV continues running — the warning is informational, not destructive

### Fixed MessageBanner::set_global idempotency
- `set_global` no longer resets timestamps when a banner with the same text already exists
- Safe to call from per-frame checks without side-effects

## How has this been tested?

- All 42 unit/integration tests pass
- Clippy clean with warnings-as-errors
- Manual test scenarios documented in `docs/ai-design/2025-02-25-spv-peer-rework/manual-tests.md`

## Breaking Changes

None

## Follow-up

- Event-driven peer status via `NetworkEvent` subscription (replaces polling): #659

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPV degraded-peer warning banner now appears when SPV has no peers for an extended period
  * Connection indicator expanded to four visible states (including a new "Connecting" state) with updated pulse behavior and tooltips

* **Bug Fixes**
  * Global banner handling made idempotent to avoid creating duplicate banner entries

* **Documentation**
  * Added manual test scenarios covering SPV connection states, degraded-warning behavior, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->