### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default code owners for all files
-* @PastaPastaPasta @lklimek


### PR DESCRIPTION
Remove the CODEOWNERS file as it is no longer needed.

## Validation

- CI passes (no code changes; file removal only)
- CODEOWNERS removal is intentional — the file is no longer needed per the PR description
- No alternate code ownership policy exists to replace it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
