### PR TITLE
fix(spv): clear stale SPV state and banner on backend mode switch

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1170,6 +1170,9 @@ impl App for AppState {
             } else {
                 MessageBanner::clear_global_message(ctx, SPV_DEGRADED_BANNER);
             }
+        } else {
+            // Ensure stale SPV banner is cleared after mode switch.
+            MessageBanner::clear_global_message(ctx, SPV_DEGRADED_BANNER);
         }
 
         for action in actions {

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -441,6 +441,10 @@ impl ConnectionStatus {
                 }
             }
             CoreBackendMode::Rpc => {
+                // Ensure stale SPV state is cleared when RPC backend is active.
+                self.spv_connected_peers.store(0, Ordering::Relaxed);
+                *self.spv_no_peers_since.lock().unwrap() = None;
+
                 // Update ZMQ status if there's a new event
                 let disable_zmq = app_context
                     .get_settings()


### PR DESCRIPTION
## Issue

When switching from SPV to RPC backend mode, two related issues could leave stale SPV state visible to the user:

1. **Stale SPV state leak (Medium):** `refresh_zmq_and_spv()` enters the `Rpc` branch but never clears `spv_no_peers_since` or `spv_connected_peers`. If the mode switch happens without a full `reset()`, the degraded peer timer persists.

2. **Banner not cleared on mode switch (Low-Medium):** The SPV degraded banner is only managed inside `if core_backend_mode() == Spv`. Switching away while the banner is showing leaves it stuck.

Found in code review of #658.

## Changes

- **`connection_status.rs`:** Clear `spv_connected_peers` and `spv_no_peers_since` at the top of the `Rpc` branch in `refresh_zmq_and_spv()`.
- **`app.rs`:** Add an `else` branch to unconditionally clear the SPV degraded banner when not in SPV mode.

## Testing

`cargo check` passes.
