### PR TITLE
fix(spv): notify wallet after broadcast to update balance immediately

### DIFF
--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -993,6 +993,10 @@ impl SpvManager {
     ) {
         tracing::info!("SPV request handler started");
         let network_manager = Arc::clone(&self.network_manager);
+        // TODO(workaround): Remove wallet + reconcile_tx captures once
+        // dashpay/rust-dashcore#487 is fixed upstream.
+        let wallet = Arc::clone(&self.wallet);
+        let reconcile_tx = self.reconcile_tx.lock().ok().and_then(|g| g.clone());
         self.subtasks.spawn_sync("spv_request_handler", async move {
             loop {
                 tokio::select! {
@@ -1031,6 +1035,19 @@ impl SpvManager {
                                         Err("SPV network manager not available".to_string())
                                     }
                                 };
+                                // TODO(workaround): Remove once dashpay/rust-dashcore#487
+                                // is fixed. Upstream broadcast does not call
+                                // process_mempool_transaction(), so the wallet doesn't
+                                // know about its own outgoing tx until a block is mined.
+                                if result.is_ok() {
+                                    notify_wallet_after_broadcast(
+                                        &wallet,
+                                        &tx,
+                                        reconcile_tx.as_ref(),
+                                    )
+                                    .await;
+                                }
+
                                 let _ = response_tx.send(result);
                             }
                             None => {
@@ -1427,6 +1444,28 @@ fn build_spv_data_dir(network: Network, config: &NetworkConfig) -> Result<PathBu
     };
 
     Ok(base.join(network_dir))
+}
+
+/// Workaround for [dashpay/rust-dashcore#487]: upstream `broadcast_transaction()` does not
+/// call `process_mempool_transaction()` on the local wallet, so spent UTXOs stay unmarked
+/// and the balance is stale until a block is mined.
+///
+/// Remove this function once the upstream fix lands.
+///
+/// [dashpay/rust-dashcore#487]: https://github.com/dashpay/rust-dashcore/issues/487
+async fn notify_wallet_after_broadcast(
+    wallet: &Arc<AsyncRwLock<WalletManager<ManagedWalletInfo>>>,
+    tx: &Transaction,
+    reconcile_tx: Option<&mpsc::Sender<()>>,
+) {
+    {
+        let mut wm = wallet.write().await;
+        wm.process_mempool_transaction(tx).await;
+    }
+    if let Some(ch) = reconcile_tx {
+        let _ = ch.try_send(());
+    }
+    tracing::debug!("Notified wallet about broadcast tx {}", tx.txid());
 }
 
 impl fmt::Debug for SpvManager {


### PR DESCRIPTION
## Summary

- After SPV broadcast, call `process_mempool_transaction()` on the local wallet manager so spent UTXOs are marked immediately and balance updates in the UI without waiting for a block (~2.5 min)
- Workaround for upstream bug [dashpay/rust-dashcore#487](https://github.com/dashpay/rust-dashcore/issues/487) — clearly marked with `TODO(workaround)` for easy removal once fixed upstream

## Details

When broadcasting a transaction in SPV mode, the upstream `dash-spv` client sends the tx to P2P peers but does **not** notify its own `WalletManager`. The sending peer won't receive its own tx back via relay, so the wallet only discovers the transaction when it appears in a mined block.

This adds a self-contained workaround:
- **`notify_wallet_after_broadcast()`** free function — calls `wallet.process_mempool_transaction(&tx)` and fires a reconcile signal
- Called from `spawn_request_handler` after successful broadcast
- 3 TODO comments reference the upstream issue for tracking

## Test plan

- [ ] Send core-to-core transaction in SPV mode
- [ ] Verify wallet balance updates immediately after broadcast (not after block)
- [ ] Verify receiving wallet shows incoming tx after block confirmation
- [ ] Verify no duplicate balance updates when the tx later appears in a block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet state synchronization following successful transaction broadcasts. The wallet now properly updates mempool information and reconciliation data, ensuring accurate account balances and transaction history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->