### PR TITLE
fix(wallet): preserve nonces on platform address refresh

### DIFF
--- a/docs/ai-design/2026-03-03-fix-nonce-reset-on-refresh/manual-test-scenarios.md
+++ b/docs/ai-design/2026-03-03-fix-nonce-reset-on-refresh/manual-test-scenarios.md
@@ -1,0 +1,61 @@
+# Manual Test Scenarios: Fix Nonce Reset on Refresh (#652)
+
+## Prerequisites
+- Dash Evo Tool running and connected to a network (Testnet or Devnet)
+- An HD wallet with at least one Platform Payment address that has been used (nonce > 0)
+- If no address has nonce > 0, perform a Platform transaction first (e.g., transfer credits)
+
+## Test Scenario 1: Refresh All preserves nonces (default mode)
+
+**Steps:**
+1. Open Wallets screen
+2. Select an HD wallet
+3. Navigate to Platform Payment addresses (click the Platform account)
+4. Note the nonce values for addresses with nonce > 0
+5. Click the Refresh button (default "Core + Platform" mode)
+6. Wait for refresh to complete
+
+**Expected:** All nonce values remain unchanged after refresh. Addresses that had nonce > 0 still show the same nonce.
+
+## Test Scenario 2: Platform Only refresh preserves nonces
+
+**Steps:**
+1. Open Wallets screen and select an HD wallet
+2. Navigate to Platform Payment addresses
+3. Note the nonce values
+4. Switch refresh mode to "Platform Only" (dev mode dropdown)
+5. Click Refresh
+6. Wait for refresh to complete
+
+**Expected:** Nonce values remain unchanged. Balances may update if changed on-chain.
+
+## Test Scenario 3: Nonce updates correctly after new transaction
+
+**Steps:**
+1. Open Wallets screen and note current nonce for a Platform address
+2. Perform a Platform transaction using that address (e.g., transfer credits)
+3. After transaction completes, note the updated nonce
+4. Click Refresh
+5. Wait for refresh to complete
+
+**Expected:** Nonce reflects the post-transaction value both before and after refresh.
+
+## Test Scenario 4: Zero-balance addresses retain nonces
+
+**Steps:**
+1. Have a Platform address that was previously funded (nonce > 0) but now has 0 balance (credits were withdrawn or transferred out)
+2. Navigate to Platform Payment addresses
+3. Enable "Show zero-balance addresses" if the address is hidden
+4. Note the nonce value
+5. Click Refresh
+
+**Expected:** The address retains its nonce value even though balance is 0.
+
+## Test Scenario 5: Locked wallet shows error on refresh
+
+**Steps:**
+1. Open a password-protected wallet
+2. Lock the wallet
+3. Attempt to click Refresh for Platform sync
+
+**Expected:** Error message indicating wallet must be unlocked. Nonces from before locking are unchanged.

--- a/src/backend_task/wallet/fetch_platform_address_balances.rs
+++ b/src/backend_task/wallet/fetch_platform_address_balances.rs
@@ -152,11 +152,16 @@ impl AppContext {
                 }
             }
 
-            // Return balances for result
-            provider
-                .found_balances()
+            // Return the wallet's complete platform_address_info, not just
+            // found_balances.  The SDK's incremental sync only reports addresses
+            // whose balance changed; unchanged addresses are absent from
+            // found_balances but still have valid nonces in the wallet.
+            // Returning only found_balances would cause the UI to lose nonce
+            // values for stable-balance addresses (issue #652).
+            wallet
+                .platform_address_info
                 .iter()
-                .map(|(addr, funds)| (addr.clone(), (funds.balance, funds.nonce)))
+                .map(|(addr, info)| (addr.clone(), (info.balance, info.nonce)))
                 .collect()
         };
 


### PR DESCRIPTION
## Issue being fixed

Closes #652 — Refresh button resets the nonces in address table

### User Story

Imagine you are managing a Dash wallet with Platform Payment addresses. You've made several transactions, so your addresses show nonces > 0. You click Refresh to update balances — and suddenly all nonces reset to 0, making it look like your transaction history was wiped. With this fix, nonces are correctly preserved across refreshes.

## What was done?

The `fetch_platform_address_balances()` function previously returned only `provider.found_balances()` — addresses the SDK explicitly reported via `on_address_found` during sync. The SDK's incremental sync only reports addresses whose *balance changed*; addresses with stable balances (but non-zero nonces) were excluded from the result map.

The fix returns the wallet's complete `platform_address_info` after applying sync results, ensuring ALL known platform addresses — including those unchanged during incremental sync — are included with their correct nonces.

**Changed:** `src/backend_task/wallet/fetch_platform_address_balances.rs` — return full `wallet.platform_address_info` instead of `provider.found_balances()`

## How has this been tested?

- `cargo test --all-features --workspace` — 42 passed
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- Manual test scenarios in `docs/ai-design/2026-03-03-fix-nonce-reset-on-refresh/manual-test-scenarios.md`

## Test plan

- [ ] [Manual test scenarios](docs/ai-design/2026-03-03-fix-nonce-reset-on-refresh/manual-test-scenarios.md)

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nonce values being incorrectly lost for platform addresses with unchanged balances during wallet refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->