### PR TITLE
fix: async graceful shutdown to prevent UI hang on window close

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -101,6 +101,9 @@ pub struct AppState {
     /// Async shutdown receiver. `Some` while a graceful shutdown is in progress;
     /// the viewport is closed once the receiver resolves.
     shutdown_receiver: Option<tokio::sync::oneshot::Receiver<()>>,
+    /// Timestamp when the async shutdown was initiated, used as a hard deadline
+    /// to force-close the viewport if the shutdown task stalls.
+    shutdown_started: Option<std::time::Instant>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -718,6 +721,7 @@ impl AppState {
             previous_connection_state: None,
             connection_banner_handle: None,
             shutdown_receiver: None,
+            shutdown_started: None,
         };
 
         // Initialize welcome screen if needed (after mainnet_app_context is owned by the struct)
@@ -1023,15 +1027,38 @@ impl App for AppState {
         // we issue Close ourselves.
         if let Some(rx) = &mut self.shutdown_receiver {
             // Shutdown already in progress — check if it's done.
-            match rx.try_recv() {
-                Ok(()) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+            let should_close = match rx.try_recv() {
+                Ok(()) => {
                     tracing::debug!("Async shutdown finished, closing viewport");
-                    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                    true
+                }
+                Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                    // Sender dropped without sending — shutdown task likely panicked.
+                    tracing::trace!("Shutdown channel closed unexpectedly (possible panic)");
+                    true
                 }
                 Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    // Still waiting — request another repaint so we keep polling.
-                    ctx.request_repaint();
+                    // Still waiting — check hard deadline to prevent infinite loop.
+                    if let Some(started) = self.shutdown_started {
+                        let grace = crate::utils::tasks::SHUTDOWN_TIMEOUT
+                            + std::time::Duration::from_secs(5);
+                        if started.elapsed() > grace {
+                            tracing::trace!(
+                                "Shutdown hard deadline exceeded, force-closing viewport"
+                            );
+                            true
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    }
                 }
+            };
+            if should_close {
+                ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+            } else {
+                ctx.request_repaint();
             }
             // Render a minimal UI that shows the shutdown banner.
             crate::ui::theme::apply_theme(ctx, self.theme_preference);
@@ -1049,6 +1076,7 @@ impl App for AppState {
             );
             tracing::debug!("Close requested, starting async shutdown");
             self.shutdown_receiver = Some(self.subtasks.shutdown_async());
+            self.shutdown_started = Some(std::time::Instant::now());
             ctx.request_repaint();
             return;
         }
@@ -1408,12 +1436,12 @@ impl App for AppState {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        // Normally the async shutdown path (initiated in update()) has already
-        // completed by the time we reach on_exit(). This blocking fallback only
-        // triggers if the window was force-closed without going through update()
-        // (e.g., OS-level kill, alt-F4 on some platforms).
+        // If shutdown_receiver is Some, the async shutdown was already initiated
+        // in update(). Skip the blocking fallback to avoid double-shutdown.
+        // The blocking path only runs when the window was force-closed without
+        // going through update() (e.g., OS-level kill, alt-F4 on some platforms).
         if self.shutdown_receiver.is_some() {
-            tracing::debug!("on_exit: async shutdown already completed");
+            tracing::debug!("on_exit: async shutdown was initiated, skipping blocking fallback");
             return;
         }
         tracing::debug!("on_exit: fallback blocking shutdown");

--- a/src/app.rs
+++ b/src/app.rs
@@ -1034,7 +1034,7 @@ impl App for AppState {
                 }
                 Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
                     // Sender dropped without sending — shutdown task likely panicked.
-                    tracing::trace!("Shutdown channel closed unexpectedly (possible panic)");
+                    tracing::warn!("Shutdown channel closed unexpectedly (possible panic)");
                     true
                 }
                 Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
@@ -1043,7 +1043,7 @@ impl App for AppState {
                         let grace = crate::utils::tasks::SHUTDOWN_TIMEOUT
                             + std::time::Duration::from_secs(5);
                         if started.elapsed() > grace {
-                            tracing::trace!(
+                            tracing::warn!(
                                 "Shutdown hard deadline exceeded, force-closing viewport"
                             );
                             true

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,6 +98,9 @@ pub struct AppState {
     previous_connection_state: Option<OverallConnectionState>,
     /// Handle to the current connection status banner, if one is displayed
     connection_banner_handle: Option<BannerHandle>,
+    /// Async shutdown receiver. `Some` while a graceful shutdown is in progress;
+    /// the viewport is closed once the receiver resolves.
+    shutdown_receiver: Option<tokio::sync::oneshot::Receiver<()>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -714,6 +717,7 @@ impl AppState {
             welcome_screen: None,
             previous_connection_state: None,
             connection_banner_handle: None,
+            shutdown_receiver: None,
         };
 
         // Initialize welcome screen if needed (after mainnet_app_context is owned by the struct)
@@ -1013,6 +1017,42 @@ impl AppState {
 
 impl App for AppState {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // ── Graceful shutdown: intercept window close so the UI stays responsive ──
+        // When the user closes the window we cancel the native close, show a banner,
+        // and start an async shutdown. Once all tasks have finished (or timed out)
+        // we issue Close ourselves.
+        if let Some(rx) = &mut self.shutdown_receiver {
+            // Shutdown already in progress — check if it's done.
+            match rx.try_recv() {
+                Ok(()) | Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                    tracing::debug!("Async shutdown finished, closing viewport");
+                    ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+                }
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                    // Still waiting — request another repaint so we keep polling.
+                    ctx.request_repaint();
+                }
+            }
+            // Render a minimal UI that shows the shutdown banner.
+            crate::ui::theme::apply_theme(ctx, self.theme_preference);
+            crate::ui::components::styled::island_central_panel(ctx, |_ui| {});
+            return;
+        }
+
+        if ctx.input(|i| i.viewport().close_requested()) {
+            // Prevent the window from closing immediately.
+            ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
+            MessageBanner::set_global(
+                ctx,
+                "Shutting down background tasks — please wait…",
+                MessageType::Warning,
+            );
+            tracing::debug!("Close requested, starting async shutdown");
+            self.shutdown_receiver = Some(self.subtasks.shutdown_async());
+            ctx.request_repaint();
+            return;
+        }
+
         // Apply Dash theme with user preference
         crate::ui::theme::apply_theme(ctx, self.theme_preference);
 
@@ -1368,10 +1408,15 @@ impl App for AppState {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
-        // Gracefully shutdown all background tasks, waiting for them to complete
-        // This ensures tasks like the dash-qt handler have time to check their settings
-        // and decide whether to terminate the process or leave it running
-        tracing::debug!("App received on_exit event, initiating graceful shutdown");
+        // Normally the async shutdown path (initiated in update()) has already
+        // completed by the time we reach on_exit(). This blocking fallback only
+        // triggers if the window was force-closed without going through update()
+        // (e.g., OS-level kill, alt-F4 on some platforms).
+        if self.shutdown_receiver.is_some() {
+            tracing::debug!("on_exit: async shutdown already completed");
+            return;
+        }
+        tracing::debug!("on_exit: fallback blocking shutdown");
         if let Err(e) = self.subtasks.shutdown() {
             tracing::error!("Error during task shutdown: {}", e);
         }

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -1,5 +1,7 @@
 use crate::app_dir::{app_user_data_file_path, create_dash_core_config_if_not_exists};
 use crate::context::AppContext;
+use crate::ui::MessageType;
+use crate::ui::components::MessageBanner;
 use crate::utils::path::format_path_for_display;
 use dash_sdk::dpp::dashcore::Network;
 use std::path::PathBuf;
@@ -67,8 +69,8 @@ impl AppContext {
         // Spawn a task to wait for the Dash-Qt process to exit
         let cancel = self.subtasks.cancellation_token.clone();
         let db = Arc::clone(&self.db);
+        let egui_ctx = self.egui_ctx().clone();
         self.subtasks.spawn_sync("dash_qt_watcher", async move {
-
             // Wait for the process to exit or current task to be cancelled
             tokio::select! {
                 exited = dash_qt.wait() => {
@@ -95,6 +97,7 @@ impl AppContext {
                     };
                     if should_close {
                         tracing::debug!("dash-qt process was cancelled, sending SIGTERM");
+                        MessageBanner::set_global(&egui_ctx, "Shutting down Dash-Qt...".to_string(), MessageType::Warning);
                         signal_term(&dash_qt)
                             .unwrap_or_else(|e| tracing::error!(error=?e, "Failed to send SIGTERM to dash-qt"));
                         let status = dash_qt.wait().await

--- a/src/backend_task/core/start_dash_qt.rs
+++ b/src/backend_task/core/start_dash_qt.rs
@@ -1,7 +1,5 @@
 use crate::app_dir::{app_user_data_file_path, create_dash_core_config_if_not_exists};
 use crate::context::AppContext;
-use crate::ui::MessageType;
-use crate::ui::components::MessageBanner;
 use crate::utils::path::format_path_for_display;
 use dash_sdk::dpp::dashcore::Network;
 use std::path::PathBuf;
@@ -69,7 +67,6 @@ impl AppContext {
         // Spawn a task to wait for the Dash-Qt process to exit
         let cancel = self.subtasks.cancellation_token.clone();
         let db = Arc::clone(&self.db);
-        let egui_ctx = self.egui_ctx().clone();
         self.subtasks.spawn_sync("dash_qt_watcher", async move {
             // Wait for the process to exit or current task to be cancelled
             tokio::select! {
@@ -97,7 +94,6 @@ impl AppContext {
                     };
                     if should_close {
                         tracing::debug!("dash-qt process was cancelled, sending SIGTERM");
-                        MessageBanner::set_global(&egui_ctx, "Shutting down Dash-Qt...".to_string(), MessageType::Warning);
                         signal_term(&dash_qt)
                             .unwrap_or_else(|e| tracing::error!(error=?e, "Failed to send SIGTERM to dash-qt"));
                         let status = dash_qt.wait().await

--- a/src/utils/tasks.rs
+++ b/src/utils/tasks.rs
@@ -41,9 +41,103 @@ impl TaskManager {
         tokio::spawn(spawn_subtask(subtasks, name, future));
     }
 
-    /// Shutdown all subtasks gracefully.
+    /// Start an asynchronous graceful shutdown of all subtasks.
+    ///
+    /// Cancels all tasks and returns a `oneshot::Receiver` that resolves when
+    /// shutdown is complete (or timed out). This does **not** block the calling
+    /// thread, so the UI can keep repainting while tasks wind down.
+    pub fn shutdown_async(&self) -> tokio::sync::oneshot::Receiver<()> {
+        let cancel = self.cancellation_token.clone();
+        let subtasks = self.tasks.clone();
+        let active_names = self.active_names.clone();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let completed = Arc::new(AtomicUsize::new(0));
+
+        let counter = completed.clone();
+        let counter_for_timeout = completed.clone();
+        tokio::task::spawn(async move {
+            tracing::trace!("shutdown_async: cancelling all tasks");
+            cancel.cancel();
+
+            let tasks_list = subtasks.clone();
+            let names_for_join = active_names.clone();
+            let timed_out = timeout(SHUTDOWN_TIMEOUT, async move {
+                let mut tasks = tasks_list.lock().await;
+                let total = tasks.len();
+                tracing::trace!(total, "shutdown_async: joining tasks");
+                let start = std::time::Instant::now();
+                while let Some(handle) = tasks.join_next().await {
+                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                    match &handle {
+                        Ok(name) => {
+                            if let Ok(mut names) = names_for_join.lock()
+                                && let Some(pos) = names.iter().position(|n| *n == *name)
+                            {
+                                names.swap_remove(pos);
+                            }
+                            tracing::trace!(
+                                task = name,
+                                task_num = i,
+                                total,
+                                elapsed_ms = start.elapsed().as_millis() as u64,
+                                "shutdown_async: task joined OK"
+                            );
+                        }
+                        Err(e) => tracing::trace!(
+                            task_num = i,
+                            total,
+                            elapsed_ms = start.elapsed().as_millis() as u64,
+                            error = %e,
+                            "shutdown_async: task joined with error"
+                        ),
+                    }
+                }
+            })
+            .await;
+
+            if timed_out.is_err() {
+                let done = counter_for_timeout.load(std::sync::atomic::Ordering::Relaxed);
+                let remaining: Vec<&str> =
+                    active_names.lock().map(|n| n.clone()).unwrap_or_default();
+                tracing::trace!(
+                    completed = done,
+                    remaining_count = remaining.len(),
+                    remaining_tasks = ?remaining,
+                    "shutdown_async: timed out, aborting remaining"
+                );
+
+                #[cfg(tokio_unstable)]
+                {
+                    let handle = tokio::runtime::Handle::current();
+                    let dump = handle.dump().await;
+                    for (i, task) in dump.tasks().iter().enumerate() {
+                        tracing::trace!(
+                            task_num = i,
+                            trace = %task.trace(),
+                            "shutdown_async: active tokio task"
+                        );
+                    }
+                }
+            }
+
+            subtasks.lock().await.shutdown().await;
+
+            tracing::debug!(
+                "Async shutdown complete, {} subtasks finished cleanly",
+                completed.load(std::sync::atomic::Ordering::Relaxed)
+            );
+
+            let _ = tx.send(());
+        });
+
+        rx
+    }
+
+    /// Shutdown all subtasks gracefully (blocking).
     ///
     /// Wait for all subtasks to finish within a specified timeout, and then abort them.
+    /// Blocks the calling thread. Prefer [`shutdown_async`] when the UI must stay responsive.
     ///
     /// This is an equivalent of `Runtime::shutdown_timeout` but for subtasks.
     pub fn shutdown(&self) -> Result<(), String> {

--- a/src/utils/tasks.rs
+++ b/src/utils/tasks.rs
@@ -52,80 +52,13 @@ impl TaskManager {
         let active_names = self.active_names.clone();
 
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-        let completed = Arc::new(AtomicUsize::new(0));
 
-        let counter = completed.clone();
-        let counter_for_timeout = completed.clone();
         tokio::task::spawn(async move {
-            tracing::trace!("shutdown_async: cancelling all tasks");
-            cancel.cancel();
-
-            let tasks_list = subtasks.clone();
-            let names_for_join = active_names.clone();
-            let timed_out = timeout(SHUTDOWN_TIMEOUT, async move {
-                let mut tasks = tasks_list.lock().await;
-                let total = tasks.len();
-                tracing::trace!(total, "shutdown_async: joining tasks");
-                let start = std::time::Instant::now();
-                while let Some(handle) = tasks.join_next().await {
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    match &handle {
-                        Ok(name) => {
-                            if let Ok(mut names) = names_for_join.lock()
-                                && let Some(pos) = names.iter().position(|n| *n == *name)
-                            {
-                                names.swap_remove(pos);
-                            }
-                            tracing::trace!(
-                                task = name,
-                                task_num = i,
-                                total,
-                                elapsed_ms = start.elapsed().as_millis() as u64,
-                                "shutdown_async: task joined OK"
-                            );
-                        }
-                        Err(e) => tracing::trace!(
-                            task_num = i,
-                            total,
-                            elapsed_ms = start.elapsed().as_millis() as u64,
-                            error = %e,
-                            "shutdown_async: task joined with error"
-                        ),
-                    }
-                }
-            })
-            .await;
-
-            if timed_out.is_err() {
-                let done = counter_for_timeout.load(std::sync::atomic::Ordering::Relaxed);
-                let remaining: Vec<&str> =
-                    active_names.lock().map(|n| n.clone()).unwrap_or_default();
-                tracing::trace!(
-                    completed = done,
-                    remaining_count = remaining.len(),
-                    remaining_tasks = ?remaining,
-                    "shutdown_async: timed out, aborting remaining"
-                );
-
-                #[cfg(tokio_unstable)]
-                {
-                    let handle = tokio::runtime::Handle::current();
-                    let dump = handle.dump().await;
-                    for (i, task) in dump.tasks().iter().enumerate() {
-                        tracing::trace!(
-                            task_num = i,
-                            trace = %task.trace(),
-                            "shutdown_async: active tokio task"
-                        );
-                    }
-                }
-            }
-
-            subtasks.lock().await.shutdown().await;
+            let completed = shutdown_inner(&cancel, &subtasks, &active_names, "async").await;
 
             tracing::debug!(
                 "Async shutdown complete, {} subtasks finished cleanly",
-                completed.load(std::sync::atomic::Ordering::Relaxed)
+                completed
             );
 
             let _ = tx.send(());
@@ -146,108 +79,117 @@ impl TaskManager {
         let active_names = self.active_names.clone();
 
         // a bit naive synchronization to wait for shutdown
-        let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
-        // counter for logging
-        let completed = Arc::new(AtomicUsize::new(0));
+        let (tx, mut rx) = tokio::sync::oneshot::channel::<usize>();
 
-        let counter = completed.clone();
-        let counter_for_timeout = completed.clone();
         // we need to run this task in separate task to avoid cancelling it during shutdown
         tokio::task::spawn(async move {
-            // Cancel all background tasks
-            tracing::trace!("shutdown: cancelling all tasks");
-            cancel.cancel();
-
-            // Wait for all subtasks to finish within SHUTDOWN_TIMEOUT
-
-            let tasks_list = subtasks.clone();
-            let names_for_join = active_names.clone();
-            let timed_out = timeout(SHUTDOWN_TIMEOUT, async move {
-                let mut tasks = tasks_list.lock().await;
-                let total = tasks.len();
-                tracing::trace!(total, "shutdown: joining tasks");
-                let start = std::time::Instant::now();
-                while let Some(handle) = tasks.join_next().await {
-                    let i = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
-                    match &handle {
-                        Ok(name) => {
-                            // Remove one instance of this name from active list
-                            if let Ok(mut names) = names_for_join.lock()
-                                && let Some(pos) = names.iter().position(|n| *n == *name)
-                            {
-                                names.swap_remove(pos);
-                            }
-                            tracing::trace!(
-                                task = name,
-                                task_num = i,
-                                total,
-                                elapsed_ms = start.elapsed().as_millis() as u64,
-                                "shutdown: task joined OK"
-                            );
-                        }
-                        Err(e) => tracing::trace!(
-                            task_num = i,
-                            total,
-                            elapsed_ms = start.elapsed().as_millis() as u64,
-                            error = %e,
-                            "shutdown: task joined with error"
-                        ),
-                    }
-                }
-            })
-            .await;
-
-            if timed_out.is_err() {
-                let done = counter_for_timeout.load(std::sync::atomic::Ordering::Relaxed);
-                let remaining: Vec<&str> =
-                    active_names.lock().map(|n| n.clone()).unwrap_or_default();
-                tracing::trace!(
-                    completed = done,
-                    remaining_count = remaining.len(),
-                    remaining_tasks = ?remaining,
-                    "shutdown: timed out waiting for tasks, aborting remaining"
-                );
-
-                #[cfg(tokio_unstable)]
-                {
-                    let handle = tokio::runtime::Handle::current();
-                    let dump = handle.dump().await;
-                    for (i, task) in dump.tasks().iter().enumerate() {
-                        tracing::trace!(
-                            task_num = i,
-                            trace = %task.trace(),
-                            "shutdown: active tokio task"
-                        );
-                    }
-                }
-            }
-
-            // now abort all tasks
-            subtasks.lock().await.shutdown().await;
+            let completed = shutdown_inner(&cancel, &subtasks, &active_names, "blocking").await;
 
             // notify that shutdown is complete
-            if tx.send(()).is_err() {
+            if tx.send(completed).is_err() {
                 tracing::error!("Failed to send shutdown completion signal");
             }
         });
 
         // wait for the shutdown task to finish
         const WAIT_TIME: Duration = Duration::from_millis(100);
+        let mut completed = 0;
         for _ in 0..SHUTDOWN_TIMEOUT.as_millis() / WAIT_TIME.as_millis() {
-            if rx.try_recv().is_ok() {
+            if let Ok(count) = rx.try_recv() {
+                completed = count;
                 break;
             }
             // wait for a short time to avoid busy waiting
             std::thread::sleep(WAIT_TIME);
         }
 
-        tracing::debug!(
-            "Shutdown complete, {} subtasks finished cleanly",
-            completed.load(std::sync::atomic::Ordering::Relaxed)
-        );
+        tracing::debug!("Shutdown complete, {} subtasks finished cleanly", completed);
 
         Ok(())
     }
+}
+
+/// Shared shutdown logic: cancel all tasks, join with timeout, abort remaining.
+///
+/// Returns the number of tasks that completed cleanly within the timeout.
+/// The `label` is used in log messages to distinguish async vs blocking callers.
+async fn shutdown_inner(
+    cancel: &CancellationToken,
+    subtasks: &Arc<tokio::sync::Mutex<tokio::task::JoinSet<&'static str>>>,
+    active_names: &Arc<Mutex<Vec<&'static str>>>,
+    label: &str,
+) -> usize {
+    tracing::trace!("{label}: cancelling all tasks");
+    cancel.cancel();
+
+    let completed = Arc::new(AtomicUsize::new(0));
+
+    let counter = completed.clone();
+    let tasks_list = subtasks.clone();
+    let names_for_join = active_names.clone();
+    let timed_out = timeout(SHUTDOWN_TIMEOUT, async move {
+        let mut tasks = tasks_list.lock().await;
+        let total = tasks.len();
+        tracing::trace!(total, "{label}: joining tasks");
+        let start = std::time::Instant::now();
+        while let Some(handle) = tasks.join_next().await {
+            let i = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+            match &handle {
+                Ok(name) => {
+                    // Remove one instance of this name from active list
+                    if let Ok(mut names) = names_for_join.lock()
+                        && let Some(pos) = names.iter().position(|n| *n == *name)
+                    {
+                        names.swap_remove(pos);
+                    }
+                    tracing::trace!(
+                        task = name,
+                        task_num = i,
+                        total,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        "{label}: task joined OK"
+                    );
+                }
+                Err(e) => tracing::trace!(
+                    task_num = i,
+                    total,
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    error = %e,
+                    "{label}: task joined with error"
+                ),
+            }
+        }
+    })
+    .await;
+
+    if timed_out.is_err() {
+        let done = completed.load(std::sync::atomic::Ordering::Relaxed);
+        let remaining: Vec<&str> = active_names.lock().map(|n| n.clone()).unwrap_or_default();
+        tracing::trace!(
+            completed = done,
+            remaining_count = remaining.len(),
+            remaining_tasks = ?remaining,
+            "{label}: timed out waiting for tasks, aborting remaining"
+        );
+
+        #[cfg(tokio_unstable)]
+        {
+            let handle = tokio::runtime::Handle::current();
+            let dump = handle.dump().await;
+            for (i, task) in dump.tasks().iter().enumerate() {
+                tracing::trace!(
+                    task_num = i,
+                    trace = %task.trace(),
+                    "{label}: active tokio task"
+                );
+            }
+        }
+    }
+
+    // Abort all remaining tasks
+    subtasks.lock().await.shutdown().await;
+
+    completed.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 #[inline(always)]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes UI freeze when closing the application window. Previously, `on_exit()` blocked the UI thread while waiting for background tasks (especially the dash-qt watcher) to shut down, causing the window to hang for up to 10 seconds.

### User Story

Imagine you are using Dash Evo Tool with Dash-Qt running in the background. You click the window close button and instead of the app closing smoothly, the window freezes — unresponsive, no feedback, just a blank hang until tasks finish. This PR replaces that with a smooth shutdown: you see a "Shutting down background tasks" banner while tasks wind down, and the window closes once everything is done.

## What was done?

**Async graceful shutdown** (commits `a7fa3402`, `b7530d04`):
- Intercept `close_requested()` in `update()` and cancel the native close via `CancelClose`
- Show a "Shutting down background tasks — please wait…" banner
- Start async shutdown via new `TaskManager::shutdown_async()` that returns a `oneshot::Receiver`
- Poll the receiver each frame; close the viewport once tasks finish (or timeout)
- Retain blocking `shutdown()` in `on_exit()` as fallback for force-close scenarios (OS kill, alt-F4)
- Remove dash-qt-specific shutdown banner (now covered by the global one)

**Fix: obtain change address once before fee retry loop** (commit `d67448d9`, PR #676):
- Move `get_change_address()` call out of the fee retry loop to avoid marking multiple addresses as used on failed attempts

**Fix: preserve nonces on platform address refresh** (commit `c1388bc8`, PR #677):
- Return full `platform_address_info` instead of just `found_balances` after sync
- Prevents nonce values from being lost for addresses whose balance didn't change

## How has this been tested?

- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- Manual test scenarios: `docs/ai-design/2026-03-03-fix-nonce-reset-on-refresh/manual-test-scenarios.md`

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced graceful shutdown experience with warning banner displayed during application close.
  * Improved shutdown timeout handling and minimal UI rendering to prevent accidental interactions during shutdown process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->