### PR TITLE
fix: SpvProvider missing dashpay contract + extract shared lookup

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -353,27 +353,16 @@ impl AppContext {
             return None;
         }
 
-        // If defaulting to RPC is desired, swap provider after binding.
-        if app_context.core_backend_mode() == CoreBackendMode::Rpc {
-            if let Err(e) = app_context
+        // If defaulting to RPC, rebind the RPC provider (overrides SPV registration above).
+        if app_context.core_backend_mode() == CoreBackendMode::Rpc
+            && let Err(e) = app_context
                 .rpc_context_provider
                 .read()
                 .map_err(|_| "RPC provider lock poisoned".to_string())
                 .and_then(|provider| provider.bind_app_context(app_context.clone()))
-            {
-                tracing::error!("Failed to bind RPC provider: {}", e);
-                return None;
-            }
-        } else {
-            // Ensure SDK uses the SPV provider
-            let provider = match app_context.spv_context_provider.read() {
-                Ok(p) => p.clone(),
-                Err(_) => {
-                    tracing::error!("SPV provider lock poisoned");
-                    return None;
-                }
-            };
-            app_context.sdk.load().set_context_provider(provider);
+        {
+            tracing::error!("Failed to bind RPC provider: {}", e);
+            return None;
         }
 
         app_context.bootstrap_loaded_wallets();
@@ -419,22 +408,16 @@ impl AppContext {
         // Switch SDK context provider to match the selected backend
         match mode {
             CoreBackendMode::Spv => {
-                // Clone the SPV provider and bind app context on the clone
-                let provider = match self.spv_context_provider.read() {
-                    Ok(p) => p.clone(),
-                    Err(_) => {
-                        tracing::error!("SPV provider lock poisoned");
-                        return;
-                    }
-                };
-                if let Err(e) = provider.bind_app_context(Arc::clone(self)) {
+                if let Err(e) = self
+                    .spv_context_provider
+                    .read()
+                    .map_err(|_| "SPV provider lock poisoned".to_string())
+                    .and_then(|provider| provider.bind_app_context(Arc::clone(self)))
+                {
                     tracing::error!("Failed to bind SPV provider: {}", e);
-                    return;
                 }
-                self.sdk.load().set_context_provider(provider);
             }
             CoreBackendMode::Rpc => {
-                // RPC provider binding also sets itself on the SDK
                 if let Err(e) = self
                     .rpc_context_provider
                     .read()
@@ -558,7 +541,9 @@ impl AppContext {
         }
         self.sdk.store(Arc::new(new_sdk));
 
-        // Rebind providers to ensure they hold the new AppContext reference
+        // Rebind providers to ensure they hold the new AppContext reference.
+        // bind_app_context also registers the provider with the SDK, so the
+        // active provider (last bound) wins.
         self.spv_context_provider
             .read()
             .map_err(|_| "SPV provider lock poisoned".to_string())?
@@ -568,13 +553,6 @@ impl AppContext {
                 .read()
                 .map_err(|_| "RPC provider lock poisoned".to_string())?
                 .bind_app_context(self.clone())?;
-        } else {
-            let provider = self
-                .spv_context_provider
-                .read()
-                .map_err(|_| "SPV provider lock poisoned".to_string())?
-                .clone();
-            self.sdk.load().set_context_provider(provider);
         }
 
         Ok(())

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -405,7 +405,10 @@ impl AppContext {
             tracing::error!("Failed to persist core backend mode: {}", e);
         }
 
-        // Switch SDK context provider to match the selected backend
+        // Switch SDK context provider to match the selected backend.
+        // Early returns are defensive: if code is added after this match, a failed
+        // bind should not proceed with a stale provider.
+        #[allow(clippy::needless_return)]
         match mode {
             CoreBackendMode::Spv => {
                 if let Err(e) = self
@@ -415,6 +418,7 @@ impl AppContext {
                     .and_then(|provider| provider.bind_app_context(Arc::clone(self)))
                 {
                     tracing::error!("Failed to bind SPV provider: {}", e);
+                    return;
                 }
             }
             CoreBackendMode::Rpc => {
@@ -425,6 +429,7 @@ impl AppContext {
                     .and_then(|provider| provider.bind_app_context(Arc::clone(self)))
                 {
                     tracing::error!("Failed to bind RPC provider: {}", e);
+                    return;
                 }
             }
         }

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -15,16 +15,25 @@ use std::sync::{Arc, Mutex};
 // Shared contract/token resolution used by both RPC and SPV providers.
 // ---------------------------------------------------------------------------
 
+/// Number of system contracts cached on [`AppContext`].
+/// Update this when adding a new system contract field.
+///
+/// The typed array size in [`resolve_data_contract`] must match — the compiler
+/// will reject a mismatch, catching forgotten additions at build time.
+pub(crate) const SYSTEM_CONTRACT_COUNT: usize = 5;
+
 /// Resolve a data contract by ID: check cached system contracts first, then DB.
 ///
-/// All system contracts are listed in `CACHED` — adding a new one is a single
+/// All system contracts are listed in `cached` — adding a new one is a single
 /// array edit, which prevents the two providers from drifting out of sync.
+/// The array size is tied to [`SYSTEM_CONTRACT_COUNT`] so the compiler enforces
+/// completeness.
 pub(crate) fn resolve_data_contract(
     app_ctx: &AppContext,
     db: &Database,
     data_contract_id: &Identifier,
 ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
-    let cached: [&Arc<DataContract>; 5] = [
+    let cached: [&Arc<DataContract>; SYSTEM_CONTRACT_COUNT] = [
         &app_ctx.dpns_contract,
         &app_ctx.dashpay_contract,
         &app_ctx.token_history_contract,
@@ -65,7 +74,7 @@ pub(crate) struct Provider {
 impl Provider {
     /// Create new ContextProvider.
     ///
-    /// Note that you have to bind it to app context using [Provider::set_app_context()].
+    /// Note that you have to bind it to app context using [`Provider::bind_app_context`].
     pub fn new(
         db: Arc<Database>,
         network: Network,
@@ -128,11 +137,13 @@ impl ContextProvider for Provider {
         let guard = self
             .app_context
             .lock()
-            .map_err(|_| ContextProviderError::Config("Provider lock poisoned".to_string()))?;
+            .map_err(|_| ContextProviderError::Config("RpcProvider lock poisoned".to_string()))?;
         let app_ctx = guard
             .as_ref()
-            .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-        resolve_data_contract(app_ctx, &self.db, data_contract_id)
+            .ok_or(ContextProviderError::Config("no app context".to_string()))?
+            .clone();
+        drop(guard);
+        resolve_data_contract(&app_ctx, &self.db, data_contract_id)
     }
 
     fn get_token_configuration(
@@ -143,11 +154,13 @@ impl ContextProvider for Provider {
         let guard = self
             .app_context
             .lock()
-            .map_err(|_| ContextProviderError::Config("Provider lock poisoned".to_string()))?;
+            .map_err(|_| ContextProviderError::Config("RpcProvider lock poisoned".to_string()))?;
         let app_ctx = guard
             .as_ref()
-            .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-        resolve_token_configuration(app_ctx, &self.db, token_id)
+            .ok_or(ContextProviderError::Config("no app context".to_string()))?
+            .clone();
+        drop(guard);
+        resolve_token_configuration(&app_ctx, &self.db, token_id)
     }
 
     fn get_quorum_public_key(

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -7,10 +7,54 @@ use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::error::ContextProviderError;
-use dash_sdk::platform::ContextProvider;
-use dash_sdk::platform::DataContract;
+use dash_sdk::platform::{ContextProvider, DataContract, Identifier};
 use rusqlite::Result;
 use std::sync::{Arc, Mutex};
+
+// ---------------------------------------------------------------------------
+// Shared contract/token resolution used by both RPC and SPV providers.
+// ---------------------------------------------------------------------------
+
+/// Resolve a data contract by ID: check cached system contracts first, then DB.
+///
+/// All system contracts are listed in `CACHED` — adding a new one is a single
+/// array edit, which prevents the two providers from drifting out of sync.
+pub(crate) fn resolve_data_contract(
+    app_ctx: &AppContext,
+    db: &Database,
+    data_contract_id: &Identifier,
+) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+    let cached: [&Arc<DataContract>; 5] = [
+        &app_ctx.dpns_contract,
+        &app_ctx.dashpay_contract,
+        &app_ctx.token_history_contract,
+        &app_ctx.withdraws_contract,
+        &app_ctx.keyword_search_contract,
+    ];
+
+    for contract in &cached {
+        if data_contract_id == &contract.id() {
+            return Ok(Some(Arc::clone(contract)));
+        }
+    }
+
+    // DB fallback for user-added / non-system contracts
+    let dc = db
+        .get_contract_by_id(*data_contract_id, app_ctx)
+        .map_err(|e| ContextProviderError::Generic(e.to_string()))?;
+
+    Ok(dc.map(|qc| Arc::new(qc.contract)))
+}
+
+/// Resolve a token configuration from the database.
+pub(crate) fn resolve_token_configuration(
+    app_ctx: &AppContext,
+    db: &Database,
+    token_id: &Identifier,
+) -> Result<Option<dash_sdk::dpp::data_contract::TokenConfiguration>, ContextProviderError> {
+    db.get_token_config_for_id(token_id, app_ctx)
+        .map_err(|e| ContextProviderError::Generic(e.to_string()))
+}
 
 pub(crate) struct Provider {
     db: Arc<Database>,
@@ -78,55 +122,32 @@ impl Provider {
 impl ContextProvider for Provider {
     fn get_data_contract(
         &self,
-        data_contract_id: &dash_sdk::platform::Identifier,
+        data_contract_id: &Identifier,
         _platform_version: &PlatformVersion,
-    ) -> Result<Option<Arc<DataContract>>, dash_sdk::error::ContextProviderError> {
-        let app_ctx_guard = self
+    ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+        let guard = self
             .app_context
             .lock()
             .map_err(|_| ContextProviderError::Config("Provider lock poisoned".to_string()))?;
-        let app_ctx = app_ctx_guard
+        let app_ctx = guard
             .as_ref()
             .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-
-        if data_contract_id == &app_ctx.dpns_contract.id() {
-            Ok(Some(app_ctx.dpns_contract.clone()))
-        } else if data_contract_id == &app_ctx.dashpay_contract.id() {
-            Ok(Some(app_ctx.dashpay_contract.clone()))
-        } else if data_contract_id == &app_ctx.token_history_contract.id() {
-            Ok(Some(app_ctx.token_history_contract.clone()))
-        } else if data_contract_id == &app_ctx.withdraws_contract.id() {
-            Ok(Some(app_ctx.withdraws_contract.clone()))
-        } else if data_contract_id == &app_ctx.keyword_search_contract.id() {
-            Ok(Some(app_ctx.keyword_search_contract.clone()))
-        } else {
-            let dc = self
-                .db
-                .get_contract_by_id(*data_contract_id, app_ctx.as_ref())
-                .map_err(|e| dash_sdk::error::ContextProviderError::Generic(e.to_string()))?;
-
-            drop(app_ctx_guard);
-
-            Ok(dc.map(|qc| Arc::new(qc.contract)))
-        }
+        resolve_data_contract(app_ctx, &self.db, data_contract_id)
     }
 
     fn get_token_configuration(
         &self,
-        token_id: &dash_sdk::platform::Identifier,
+        token_id: &Identifier,
     ) -> Result<Option<dash_sdk::dpp::data_contract::TokenConfiguration>, ContextProviderError>
     {
-        let app_ctx_guard = self
+        let guard = self
             .app_context
             .lock()
             .map_err(|_| ContextProviderError::Config("Provider lock poisoned".to_string()))?;
-        let app_ctx = app_ctx_guard
+        let app_ctx = guard
             .as_ref()
             .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-
-        self.db
-            .get_token_config_for_id(token_id, app_ctx)
-            .map_err(|e| dash_sdk::error::ContextProviderError::Generic(e.to_string()))
+        resolve_token_configuration(app_ctx, &self.db, token_id)
     }
 
     fn get_quorum_public_key(

--- a/src/context_provider_spv.rs
+++ b/src/context_provider_spv.rs
@@ -29,10 +29,14 @@ impl SpvProvider {
 
     /// Attach the `AppContext` and register this provider with the SDK.
     ///
-    /// Mirrors `RpcProvider::bind_app_context` — after this call, the SDK
+    /// Mirrors [`Provider::bind_app_context`](crate::context_provider::Provider::bind_app_context)
+    /// — after this call, the SDK
     /// uses this provider for proof verification and quorum key resolution.
     ///
     /// Returns an error if the lock is poisoned (indicates a prior panic).
+    ///
+    /// # Thread safety
+    /// Called during init and mode-switch only — not on hot paths.
     pub fn bind_app_context(&self, app_context: Arc<AppContext>) -> Result<(), String> {
         let cloned = app_context.clone();
         let mut ac = self
@@ -59,8 +63,10 @@ impl ContextProvider for SpvProvider {
             .map_err(|_| ContextProviderError::Config("SpvProvider lock poisoned".to_string()))?;
         let app_ctx = guard
             .as_ref()
-            .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-        resolve_data_contract(app_ctx, &self.db, data_contract_id)
+            .ok_or(ContextProviderError::Config("no app context".to_string()))?
+            .clone();
+        drop(guard);
+        resolve_data_contract(&app_ctx, &self.db, data_contract_id)
     }
 
     fn get_token_configuration(
@@ -74,8 +80,10 @@ impl ContextProvider for SpvProvider {
             .map_err(|_| ContextProviderError::Config("SpvProvider lock poisoned".to_string()))?;
         let app_ctx = guard
             .as_ref()
-            .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-        resolve_token_configuration(app_ctx, &self.db, token_id)
+            .ok_or(ContextProviderError::Config("no app context".to_string()))?
+            .clone();
+        drop(guard);
+        resolve_token_configuration(&app_ctx, &self.db, token_id)
     }
 
     fn get_quorum_public_key(

--- a/src/context_provider_spv.rs
+++ b/src/context_provider_spv.rs
@@ -1,10 +1,10 @@
 use crate::context::AppContext;
+use crate::context_provider::{resolve_data_contract, resolve_token_configuration};
 use crate::database::Database;
 use dash_sdk::dpp::dashcore::Network;
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::error::ContextProviderError;
-use dash_sdk::platform::{ContextProvider, DataContract};
+use dash_sdk::platform::{ContextProvider, DataContract, Identifier};
 use std::sync::{Arc, Mutex};
 
 /// SPV-based ContextProvider for the Dash SDK.
@@ -27,15 +27,22 @@ impl SpvProvider {
         })
     }
 
-    /// Attach the `AppContext` so we can access SpvManager and settings.
+    /// Attach the `AppContext` and register this provider with the SDK.
+    ///
+    /// Mirrors `RpcProvider::bind_app_context` — after this call, the SDK
+    /// uses this provider for proof verification and quorum key resolution.
     ///
     /// Returns an error if the lock is poisoned (indicates a prior panic).
     pub fn bind_app_context(&self, app_context: Arc<AppContext>) -> Result<(), String> {
+        let cloned = app_context.clone();
         let mut ac = self
             .app_context
             .lock()
             .map_err(|_| "SpvProvider app_context lock poisoned".to_string())?;
-        ac.replace(app_context);
+        ac.replace(cloned);
+        drop(ac);
+
+        app_context.sdk.load().set_context_provider(self.clone());
         Ok(())
     }
 }
@@ -43,53 +50,32 @@ impl SpvProvider {
 impl ContextProvider for SpvProvider {
     fn get_data_contract(
         &self,
-        data_contract_id: &dash_sdk::platform::Identifier,
+        data_contract_id: &Identifier,
         _platform_version: &PlatformVersion,
     ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
-        let app_ctx_guard = self
+        let guard = self
             .app_context
             .lock()
             .map_err(|_| ContextProviderError::Config("SpvProvider lock poisoned".to_string()))?;
-        let app_ctx = app_ctx_guard
+        let app_ctx = guard
             .as_ref()
             .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-
-        if data_contract_id == &app_ctx.dpns_contract.id() {
-            Ok(Some(app_ctx.dpns_contract.clone()))
-        } else if data_contract_id == &app_ctx.token_history_contract.id() {
-            Ok(Some(app_ctx.token_history_contract.clone()))
-        } else if data_contract_id == &app_ctx.withdraws_contract.id() {
-            Ok(Some(app_ctx.withdraws_contract.clone()))
-        } else if data_contract_id == &app_ctx.keyword_search_contract.id() {
-            Ok(Some(app_ctx.keyword_search_contract.clone()))
-        } else {
-            let dc = self
-                .db
-                .get_contract_by_id(*data_contract_id, app_ctx.as_ref())
-                .map_err(|e| ContextProviderError::Generic(e.to_string()))?;
-
-            drop(app_ctx_guard);
-
-            Ok(dc.map(|qc| Arc::new(qc.contract)))
-        }
+        resolve_data_contract(app_ctx, &self.db, data_contract_id)
     }
 
     fn get_token_configuration(
         &self,
-        token_id: &dash_sdk::platform::Identifier,
+        token_id: &Identifier,
     ) -> Result<Option<dash_sdk::dpp::data_contract::TokenConfiguration>, ContextProviderError>
     {
-        let app_ctx_guard = self
+        let guard = self
             .app_context
             .lock()
             .map_err(|_| ContextProviderError::Config("SpvProvider lock poisoned".to_string()))?;
-        let app_ctx = app_ctx_guard
+        let app_ctx = guard
             .as_ref()
             .ok_or(ContextProviderError::Config("no app context".to_string()))?;
-
-        self.db
-            .get_token_config_for_id(token_id, app_ctx)
-            .map_err(|e| ContextProviderError::Generic(e.to_string()))
+        resolve_token_configuration(app_ctx, &self.db, token_id)
     }
 
     fn get_quorum_public_key(

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -648,18 +648,19 @@ fn render_banner(
                 } else {
                     "Show details"
                 };
-                if ui
-                    .add(
-                        egui::Label::new(
-                            egui::RichText::new(toggle_text)
-                                .font(Typography::body_small())
-                                .color(DashColors::DASH_BLUE)
-                                .underline(),
-                        )
-                        .sense(egui::Sense::click()),
+                let toggle_response = ui.add(
+                    egui::Label::new(
+                        egui::RichText::new(toggle_text)
+                            .font(Typography::body_small())
+                            .color(DashColors::DASH_BLUE)
+                            .underline(),
                     )
-                    .clicked()
-                {
+                    .sense(egui::Sense::click()),
+                );
+                if toggle_response.hovered() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
+                if toggle_response.clicked() {
                     *details_expanded = !*details_expanded;
                 }
 

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -601,17 +601,16 @@ fn render_banner(
 
                 // Right-aligned: annotation + dismiss
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {
-                    let dismiss_response = ui.add(
-                        egui::Label::new(
-                            egui::RichText::new("\u{274C}")
-                                .color(fg_color)
-                                .font(Typography::body_small()),
+                    let dismiss_response = ui
+                        .add(
+                            egui::Label::new(
+                                egui::RichText::new("\u{274C}")
+                                    .color(fg_color)
+                                    .font(Typography::body_small()),
+                            )
+                            .sense(egui::Sense::click()),
                         )
-                        .sense(egui::Sense::click()),
-                    );
-                    if dismiss_response.hovered() {
-                        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-                    }
+                        .on_hover_cursor(egui::CursorIcon::PointingHand);
                     if dismiss_response.clicked() {
                         dismissed = true;
                     }
@@ -648,18 +647,17 @@ fn render_banner(
                 } else {
                     "Show details"
                 };
-                let toggle_response = ui.add(
-                    egui::Label::new(
-                        egui::RichText::new(toggle_text)
-                            .font(Typography::body_small())
-                            .color(DashColors::DASH_BLUE)
-                            .underline(),
+                let toggle_response = ui
+                    .add(
+                        egui::Label::new(
+                            egui::RichText::new(toggle_text)
+                                .font(Typography::body_small())
+                                .color(DashColors::DASH_BLUE)
+                                .underline(),
+                        )
+                        .sense(egui::Sense::click()),
                     )
-                    .sense(egui::Sense::click()),
-                );
-                if toggle_response.hovered() {
-                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
-                }
+                    .on_hover_cursor(egui::CursorIcon::PointingHand);
                 if toggle_response.clicked() {
                     *details_expanded = !*details_expanded;
                 }


### PR DESCRIPTION
## Summary

- **fix**: `SpvProvider::get_data_contract()` was missing the `dashpay_contract` branch, causing `UnknownContract` errors during proof verification in SPV mode (e.g., profile replace operations)
- **refactor**: Extract duplicated contract-lookup logic from both providers into shared `resolve_data_contract()` / `resolve_token_configuration()` free functions with array-based lookup — adding a new system contract is now a single-line edit
- **fix**: Make `SpvProvider::bind_app_context()` self-register with the SDK (matching `RpcProvider`), removing redundant `set_context_provider()` calls at 3 SPV activation sites
- **fix(ui)**: Add missing pointer cursor on banner "Show details" toggle

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test --all-features --workspace` — 42/42 pass
- [x] `cargo +nightly fmt --all` — clean
- [ ] Manual: trigger a profile update in SPV mode and verify no `UnknownContract` error
- [ ] Manual: verify "Show details" button in error banner shows pointer cursor on hover

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Message banner details toggle now shows pointer cursor and uses more consistent click handling for clearer interactions.

* **Bug Fixes / Stability**
  * Improved provider binding and contract/token resolution flow to reduce binding errors and improve stability when switching modes or reconnecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->