### PR TITLE
fix(ui): skip redundant details in MessageBanner

### DIFF
--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -208,6 +208,13 @@ impl BannerHandle {
         }
         let mut banners = get_banners(&self.ctx);
         let b = banners.iter_mut().find(|b| b.key == self.key)?;
+        // Skip if details would just repeat the primary text (exact match or
+        // Debug-quoted match, e.g. `"same text"` vs `same text`).
+        if details == b.text
+            || details.strip_prefix('"').and_then(|s| s.strip_suffix('"')) == Some(&b.text)
+        {
+            return Some(self);
+        }
         b.details = Some(details);
         set_banners(&self.ctx, banners);
         Some(self)

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -210,10 +210,16 @@ impl BannerHandle {
         let b = banners.iter_mut().find(|b| b.key == self.key)?;
         // Skip if details would just repeat the primary text (exact match or
         // Debug-quoted match, e.g. `"same text"` vs `same text`).
-        if details == b.text
-            || details.strip_prefix('"').and_then(|s| s.strip_suffix('"')) == Some(&b.text)
-        {
-            return Some(self);
+        let is_redundant = details == b.text
+            || details
+                .strip_prefix('"')
+                .and_then(|s| s.strip_suffix('"'))
+                == Some(b.text.as_str());
+
+        if is_redundant {
+            b.details = None;
+        } else {
+            b.details = Some(details);
         }
         b.details = Some(details);
         set_banners(&self.ctx, banners);

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -211,17 +211,13 @@ impl BannerHandle {
         // Skip if details would just repeat the primary text (exact match or
         // Debug-quoted match, e.g. `"same text"` vs `same text`).
         let is_redundant = details == b.text
-            || details
-                .strip_prefix('"')
-                .and_then(|s| s.strip_suffix('"'))
-                == Some(b.text.as_str());
+            || details.strip_prefix('"').and_then(|s| s.strip_suffix('"')) == Some(b.text.as_str());
 
         if is_redundant {
             b.details = None;
         } else {
             b.details = Some(details);
         }
-        b.details = Some(details);
         set_banners(&self.ctx, banners);
         Some(self)
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Closes #680 

`BannerHandle::with_details()` would set details even when they duplicated the primary banner text, creating a pointless collapsible section that just repeated the message.

### User Story

Imagine you are a user and an error banner appears. You expand the "Details" section hoping for more information, only to see the exact same text repeated. That's annoying and unhelpful.

## What was done?

Added a guard in `with_details()` that skips setting details when the text matches the primary banner message. Handles two cases:

- **Exact match** — `details == banner.text` (e.g., error types where `Debug` == `Display`)
- **Debug-quoted match** — strips surrounding quotes from `Debug`-formatted strings before comparing (e.g., `"error msg"` vs `error msg`)

## How has this been tested?

- Code review of all `with_details()` callsites confirmed no behavioral change for cases where details differ from the primary text
- `cargo +nightly fmt` and `cargo clippy` pass (pre-existing errors in other modules are unrelated)

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Banner details that exactly duplicate the main banner text (including simple formatted variants) are now suppressed, so users won't see repeated or redundant detail text beneath a banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->