### PR TITLE
ci: skip draft PRs and remove disk space cleanup

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,7 @@
 reviews:
   auto_review:
     enabled: true
+    drafts: false
     base_branches:
       - master
       - v1.0-dev

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "v*-dev"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,33 +17,10 @@ env:
 jobs:
   clippy:
     name: Clippy
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
 
     steps:
-      - name: Free disk space
-        run: |
-          echo "=== Disk space before cleanup ==="
-          df -h
-          # Remove large unnecessary directories
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /opt/hostedtoolcache/node
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/graalvm
-          sudo rm -rf /usr/local/.ghcup
-          # Clean docker
-          sudo docker image prune --all --force || true
-          sudo docker system prune --all --force || true
-          # Clean apt cache
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          echo "=== Disk space after cleanup ==="
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,31 +42,6 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-      - name: Free disk space
-        if: ${{ runner.os == 'Linux' }}
-        run: |
-          echo "=== Disk space before cleanup ==="
-          df -h
-          # Remove large unnecessary directories
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /opt/hostedtoolcache/node
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/graalvm
-          sudo rm -rf /usr/local/.ghcup
-          # Clean docker
-          sudo docker image prune --all --force || true
-          sudo docker system prune --all --force || true
-          # Clean apt cache
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          echo "=== Disk space after cleanup ==="
-          df -h
-
       - name: Check out code
         uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
       - main
       - "v*-dev"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,33 +17,10 @@ env:
 jobs:
   test:
     name: Test Suite
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
 
     steps:
-      - name: Free disk space
-        run: |
-          echo "=== Disk space before cleanup ==="
-          df -h
-          # Remove large unnecessary directories
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/go
-          sudo rm -rf /opt/hostedtoolcache/node
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/graalvm
-          sudo rm -rf /usr/local/.ghcup
-          # Clean docker
-          sudo docker image prune --all --force || true
-          sudo docker system prune --all --force || true
-          # Clean apt cache
-          sudo apt-get clean
-          sudo rm -rf /var/lib/apt/lists/*
-          echo "=== Disk space after cleanup ==="
-          df -h
-
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Skip CI (tests + clippy) on draft PRs via `if: github.event.pull_request.draft != true`
- Remove "Free disk space" step from tests, clippy, and release workflows — unnecessary in CI

## Test plan
- Non-functional CI-only change, no manual test scenarios needed
- Verify workflows still trigger on push to `v*-dev` branches and non-draft PRs
- Verify draft PRs do not trigger tests/clippy workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code) by [Claudius the Magnificent](https://github.com/lklimek/claudius)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows updated to skip automated linting and testing for draft pull requests.
  * Removed disk cleanup steps from automated workflows to streamline pipelines.
  * Auto-review configuration updated to explicitly treat draft submissions as excluded from automatic reviews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->