### PR TITLE
feat: remember SPV connection state across app restarts

### DIFF
--- a/docs/ai-design/2026-03-05-remember-spv-state/manual-test-scenarios.md
+++ b/docs/ai-design/2026-03-05-remember-spv-state/manual-test-scenarios.md
@@ -47,9 +47,10 @@
 
 1. Connect SPV
 2. Disable developer mode in settings
-3. Close and reopen app
-4. Re-enable developer mode
-5. Switch to SPV mode
+3. Verify SPV has stopped and auto-start checkbox is no longer visible
+4. Close and reopen app
+5. Re-enable developer mode
+6. Switch to SPV mode
 
 **Expected:** SPV does not auto-start (was cleared when dev mode was disabled).
 

--- a/docs/ai-design/2026-03-05-remember-spv-state/manual-test-scenarios.md
+++ b/docs/ai-design/2026-03-05-remember-spv-state/manual-test-scenarios.md
@@ -1,0 +1,61 @@
+# Manual Test Scenarios: Remember SPV State (#626)
+
+## Prerequisites
+- Developer mode enabled
+- Backend mode set to SPV
+
+## Scenario 1: SPV reconnects after restart
+
+1. Open Dash Evo Tool
+2. Go to Network Chooser, click **Connect** (SPV)
+3. Wait for SPV to reach Syncing or Running state
+4. Close the app
+5. Reopen the app
+
+**Expected:** SPV automatically starts syncing/connecting on launch.
+
+## Scenario 2: SPV stays idle after manual disconnect + restart
+
+1. Open Dash Evo Tool
+2. Connect SPV (wait for Syncing/Running)
+3. Click **Disconnect**
+4. Close the app
+5. Reopen the app
+
+**Expected:** SPV is idle (no auto-start).
+
+## Scenario 3: Checkbox reflects connect/disconnect state
+
+1. Open Dash Evo Tool
+2. Go to Network Chooser settings, verify "Auto-start SPV on startup" is unchecked
+3. Click **Connect** (SPV)
+4. Scroll to settings, verify checkbox is now **checked**
+5. Click **Disconnect**
+6. Verify checkbox is now **unchecked**
+
+## Scenario 4: Backend mode switch clears auto-start
+
+1. Connect SPV (verify checkbox is checked)
+2. Switch backend mode from SPV to Dash Core RPC
+3. Verify checkbox is unchecked
+4. Close and reopen app
+5. Switch back to SPV mode
+
+**Expected:** SPV does not auto-start (was cleared when switching to RPC).
+
+## Scenario 5: Developer mode disable clears auto-start
+
+1. Connect SPV
+2. Disable developer mode in settings
+3. Close and reopen app
+4. Re-enable developer mode
+5. Switch to SPV mode
+
+**Expected:** SPV does not auto-start (was cleared when dev mode was disabled).
+
+## Scenario 6: Manual checkbox override still works
+
+1. Without connecting SPV, manually check "Auto-start SPV on startup"
+2. Close and reopen app
+
+**Expected:** SPV auto-starts on launch (manual checkbox override respected).

--- a/src/app.rs
+++ b/src/app.rs
@@ -734,7 +734,16 @@ impl AppState {
             // TODO: SPV auto-start is gated behind developer mode while SPV is in development.
             // Remove the is_developer_mode() check once SPV is production-ready.
             let current_context = app_state.current_app_context();
-            let auto_start_spv = db.get_auto_start_spv().unwrap_or(false);
+            let auto_start_spv = db.get_auto_start_spv().unwrap_or_else(|e| {
+                tracing::debug!("Failed to read auto_start_spv setting: {}", e);
+                false
+            });
+            // Clear auto_start_spv at startup so that if the app crashes during SPV
+            // startup, the next launch won't create a crash loop. The flag will be
+            // re-enabled by start_spv() if SPV successfully begins connecting.
+            if auto_start_spv && let Err(e) = db.update_auto_start_spv(false) {
+                tracing::debug!("Failed to clear auto_start_spv at startup: {}", e);
+            }
             if auto_start_spv
                 && current_context.is_developer_mode()
                 && current_context.core_backend_mode() == crate::spv::CoreBackendMode::Spv
@@ -804,15 +813,23 @@ impl AppState {
 
     /// Persist SPV running state so the app auto-starts SPV on next launch
     /// if it was active when the user closed the window.
+    ///
+    /// This is a safety-net for abnormal shutdowns. During normal operation,
+    /// `start_spv()` and `stop_spv()` eagerly persist the state on every
+    /// connect/disconnect.
     fn save_spv_running_state(&self) {
         let ctx = self.current_app_context();
-        if ctx.core_backend_mode() != CoreBackendMode::Spv {
-            return;
-        }
-        let spv_active = matches!(
-            ctx.spv_manager().status().status,
-            SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Running
-        );
+        // In non-SPV modes, save false as defence-in-depth. Mode-switch already
+        // persists false via stop_spv(), but this ensures consistency even if
+        // that path was somehow skipped.
+        let spv_active = if ctx.core_backend_mode() != CoreBackendMode::Spv {
+            false
+        } else {
+            matches!(
+                ctx.spv_manager().status().status,
+                SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Running
+            )
+        };
         if let Err(e) = ctx.db.update_auto_start_spv(spv_active) {
             tracing::warn!("Failed to save SPV running state: {}", e);
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ use crate::database::Database;
 #[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
 use crate::model::settings::Settings;
-use crate::spv::CoreBackendMode;
+use crate::spv::{CoreBackendMode, SpvStatus};
 use crate::ui::components::{BannerHandle, MessageBanner};
 use crate::ui::contracts_documents::contracts_documents_screen::DocumentQueryScreen;
 use crate::ui::dashpay::{DashPayScreen, DashPaySubscreen, ProfileSearchScreen};
@@ -802,6 +802,24 @@ impl AppState {
         }
     }
 
+    /// Persist SPV running state so the app auto-starts SPV on next launch
+    /// if it was active when the user closed the window.
+    fn save_spv_running_state(&self) {
+        let ctx = self.current_app_context();
+        if ctx.core_backend_mode() != CoreBackendMode::Spv {
+            return;
+        }
+        let spv_active = matches!(
+            ctx.spv_manager().status().status,
+            SpvStatus::Starting | SpvStatus::Syncing | SpvStatus::Running
+        );
+        if let Err(e) = ctx.db.update_auto_start_spv(spv_active) {
+            tracing::warn!("Failed to save SPV running state: {}", e);
+        } else {
+            tracing::debug!("Saved SPV running state: auto_start_spv={}", spv_active);
+        }
+    }
+
     fn context_available_for_network(&self, network: Network) -> bool {
         match network {
             Network::Dash => true, // Mainnet is always available
@@ -1075,6 +1093,10 @@ impl App for AppState {
                 MessageType::Warning,
             );
             tracing::debug!("Close requested, starting async shutdown");
+
+            // Remember SPV running state so it auto-starts on next launch.
+            self.save_spv_running_state();
+
             self.shutdown_receiver = Some(self.subtasks.shutdown_async());
             self.shutdown_started = Some(std::time::Instant::now());
             ctx.request_repaint();
@@ -1445,6 +1467,7 @@ impl App for AppState {
             return;
         }
         tracing::debug!("on_exit: fallback blocking shutdown");
+        self.save_spv_running_state();
         if let Err(e) = self.subtasks.shutdown() {
             tracing::error!("Error during task shutdown: {}", e);
         }

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -799,7 +799,10 @@ impl AppContext {
         // at 200ms intervals and picks up the Stopped transition quickly.
         self.connection_status.reset_timer();
 
-        // Remember that SPV was stopped so it doesn't auto-start on next launch.
+        // Note: stop_spv() must not be called from the shutdown path.
+        // During shutdown, save_spv_running_state() in app.rs handles persistence
+        // based on the current SPV status. Calling stop_spv() during shutdown would
+        // overwrite that state with false.
         if let Err(e) = self.db.update_auto_start_spv(false) {
             tracing::warn!("Failed to save auto_start_spv: {}", e);
         }

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -77,6 +77,12 @@ impl AppContext {
         self.connection_status
             .set_spv_status(self.spv_manager.status().status);
         self.connection_status.refresh_state();
+
+        // Remember that SPV was started so it auto-starts on next launch.
+        if let Err(e) = self.db.update_auto_start_spv(true) {
+            tracing::warn!("Failed to save auto_start_spv: {}", e);
+        }
+
         Ok(())
     }
 
@@ -792,5 +798,10 @@ impl AppContext {
         // Reset the throttle timer so trigger_refresh() starts polling
         // at 200ms intervals and picks up the Stopped transition quickly.
         self.connection_status.reset_timer();
+
+        // Remember that SPV was stopped so it doesn't auto-start on next launch.
+        if let Err(e) = self.db.update_auto_start_spv(false) {
+            tracing::warn!("Failed to save auto_start_spv: {}", e);
+        }
     }
 }

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -1303,10 +1303,13 @@ impl NetworkChooserScreen {
                             .clicked()
                         {
                             // Save to database
-                            let _ = self
+                            if let Err(e) = self
                                 .mainnet_app_context
                                 .db
-                                .update_auto_start_spv(self.auto_start_spv);
+                                .update_auto_start_spv(self.auto_start_spv)
+                            {
+                                tracing::warn!("Failed to save auto_start_spv: {}", e);
+                            }
                         }
                         ui.label(
                             egui::RichText::new(if self.auto_start_spv {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -308,6 +308,7 @@ impl NetworkChooserScreen {
                                     let ctx = self.current_app_context();
                                     ctx.set_core_backend_mode(CoreBackendMode::Rpc);
                                     ctx.stop_spv();
+                                    self.auto_start_spv = false;
                                 }
                             });
 
@@ -549,6 +550,7 @@ impl NetworkChooserScreen {
                             .clicked()
                         {
                             self.current_app_context().stop_spv();
+                            self.auto_start_spv = false;
                         }
 
                         // Show sync status next to button
@@ -616,6 +618,8 @@ impl NetworkChooserScreen {
                                 if let Err(err) = self.current_app_context().start_spv() {
                                     app_action =
                                         AppAction::Custom(format!("Failed to start SPV: {}", err));
+                                } else {
+                                    self.auto_start_spv = true;
                                 }
                             } else {
                                 // Core mode connect
@@ -1084,6 +1088,8 @@ impl NetworkChooserScreen {
                                 }
                                 self.backend_modes.insert(Network::Regtest, CoreBackendMode::Rpc);
                             }
+                            // stop_spv() already persisted auto_start_spv=false; sync the UI field.
+                            self.auto_start_spv = false;
                         }
                     }
                     ui.label(


### PR DESCRIPTION
## Issue being fixed or feature implemented

Closes #626

### User Story

Imagine you are a Dash Evo Tool user who regularly uses SPV mode. You connect to the network, sync your wallet, and everything works great. Then you close the app for the night. The next morning you open it again — and SPV is sitting idle. You have to manually click Connect every single time. Now, the app remembers whether SPV was running when you closed it and automatically reconnects on the next launch.

## What was done?

Reused the existing `auto_start_spv` database setting to automatically track SPV connection state:

- **`start_spv()`** now saves `auto_start_spv=true` to the database
- **`stop_spv()`** now saves `auto_start_spv=false` to the database
- **Shutdown handler** (`save_spv_running_state()`) persists the current SPV state as a safety net (e.g., crash without calling `stop_spv`)
- **UI checkbox** ("Auto-start SPV on startup") stays in sync with connect/disconnect/mode-switch actions

No new database columns — this leverages the existing `auto_start_spv` column and the existing auto-start logic on app launch.

### Files changed

| File | Change |
|------|--------|
| `src/context/wallet_lifecycle.rs` | `start_spv()` → save true; `stop_spv()` → save false |
| `src/app.rs` | Added `save_spv_running_state()`, called on both shutdown paths |
| `src/ui/network_chooser_screen.rs` | Sync checkbox on connect/disconnect/mode-switch/dev-mode-disable |

## How has this been tested?

- All 42 existing tests pass
- `cargo clippy` — zero warnings
- Manual test scenarios: `docs/ai-design/2026-03-05-remember-spv-state/manual-test-scenarios.md`

## Test plan

- [ ] Connect SPV → close app → reopen → SPV auto-reconnects
- [ ] Disconnect SPV → close app → reopen → SPV stays idle
- [ ] Checkbox reflects connect/disconnect state changes
- [ ] Backend mode switch (SPV→RPC) clears auto-start
- [ ] Developer mode disable clears auto-start
- [ ] Manual checkbox override still works

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPV auto-start preference now persists across restarts and is saved on shutdown/startup to respect user choice.

* **Bug Fixes**
  * UI checkbox reliably reflects and controls SPV auto-start state.
  * Auto-start flag is cleared when switching backend modes or manually disconnecting to prevent unwanted auto-start.
  * Startup handling improved to avoid erroneous auto-starts and reduce crash-loop risk.

* **Documentation**
  * Added six manual test scenarios for validating SPV state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->