### PR TITLE
fix(ui): prevent overlapping banner details when multiple expanded

### DIFF
--- a/docs/ai-design/2026-03-05-banner-details-overlap/manual-test.md
+++ b/docs/ai-design/2026-03-05-banner-details-overlap/manual-test.md
@@ -1,0 +1,24 @@
+# Manual Test: Banner Details Overlap Fix (#681)
+
+## Prerequisites
+- Developer mode enabled (to see "Show details" links on error banners)
+- Ability to trigger multiple backend errors (e.g., invalid network config, expired identity operations)
+
+## Test Scenario: Multiple Expanded Details
+
+1. Trigger 2+ error banners that include technical details (e.g., attempt operations on a disconnected network, or perform actions that produce different errors in sequence)
+2. Verify all banners appear stacked vertically without overlap
+3. Click "Show details" on the **first** banner — verify the details section expands inline, pushing subsequent banners down
+4. Click "Show details" on the **second** banner — verify its details section also expands without overlapping the first
+5. Scroll within each details section independently — verify scroll positions are independent (no shared state)
+6. Click "Hide details" on one banner — verify only that banner's details collapse; the other remains expanded
+7. Dismiss one banner — verify remaining banners reflow correctly
+
+## Expected Result
+- Each banner's details section occupies its own vertical space
+- No visual overlap between expanded details of different banners
+- Scroll areas within each details section are independent
+
+## Regression Check
+- Single banner with "Show details" still works as before
+- Banners without details are unaffected

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -548,6 +548,7 @@ fn process_banner(ui: &mut egui::Ui, state: &mut BannerState) -> BannerStatus {
         state.suggestion.as_deref(),
         state.details.as_deref(),
         &mut state.details_expanded,
+        state.key,
     ) {
         return BannerStatus::Dismissed;
     }
@@ -559,6 +560,7 @@ fn process_banner(ui: &mut egui::Ui, state: &mut BannerState) -> BannerStatus {
 
 /// Shared rendering logic for both global and per-instance banners.
 /// Returns `true` if the dismiss button was clicked.
+#[allow(clippy::too_many_arguments)]
 fn render_banner(
     ui: &mut egui::Ui,
     text: &str,
@@ -567,6 +569,7 @@ fn render_banner(
     suggestion: Option<&str>,
     details: Option<&str>,
     details_expanded: &mut bool,
+    banner_key: u64,
 ) -> bool {
     let dark_mode = ui.ctx().style().visuals.dark_mode;
     let fg_color = DashColors::message_color(message_type, dark_mode);
@@ -679,6 +682,7 @@ fn render_banner(
                         .corner_radius(Shape::RADIUS_SM as f32)
                         .show(ui, |ui| {
                             egui::ScrollArea::vertical()
+                                .id_salt(banner_key)
                                 .max_height(DETAILS_MAX_HEIGHT)
                                 .show(ui, |ui| {
                                     ui.add(


### PR DESCRIPTION
## Issue being fixed

Closes #681

### User Story

Imagine you are a developer using Dash Evo Tool and you encounter multiple errors at once. You click "Show details" on each error banner to see the technical information — but the expanded details sections overlap each other, making them unreadable. After this fix, each banner's details section properly takes its own vertical space, so you can read and compare errors side by side.

## What was done?

Added unique `id_salt(banner_key)` to the `ScrollArea` inside `render_banner()`, so each banner's expanded details section gets its own egui widget ID. Previously, multiple expanded `ScrollArea`s without explicit IDs caused egui ID collisions, leading to visual overlap.

**Changes:**
- Added `banner_key: u64` parameter to `render_banner()` function
- Added `.id_salt(banner_key)` to `ScrollArea::vertical()` in the details section
- Passed `state.key` at the call site in `process_banner()`

## How has this been tested?

- All 42 kittest UI tests pass
- Clippy clean, formatter clean
- Manual test scenario: `docs/ai-design/2026-03-05-banner-details-overlap/manual-test.md`

## Test plan

- [docs/ai-design/2026-03-05-banner-details-overlap/manual-test.md](docs/ai-design/2026-03-05-banner-details-overlap/manual-test.md)

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant tests
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where banner details would overlap when multiple banners are expanded simultaneously.

* **Documentation**
  * Added comprehensive manual testing documentation for banner details behavior, scrolling independence, and reflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->