### PR TITLE
feat(security): add Secret type with zeroize-on-drop and PasswordInput component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "raw-cpuid",
  "rayon",
  "regex",
+ "region",
  "reqwest 0.13.2",
  "resvg",
  "rfd",
@@ -4660,6 +4661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6305,6 +6315,18 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "renderdoc-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tz-rs = { version = "0.7.0" }
 tempfile = "3.20.0"
 arc-swap = "1"
 urlencoding = "2"
+region = "3.0.2"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 zmq = "0.10.0"

--- a/docs/ai-design/2026-03-09-password-input/manual-test-scenarios.md
+++ b/docs/ai-design/2026-03-09-password-input/manual-test-scenarios.md
@@ -1,0 +1,445 @@
+# Manual Test Scenarios: Secret Type + PasswordInput Component
+
+**Date**: 2026-03-09
+**Feature**: Password masking with hold-to-reveal eye icon (Issues #705, #707)
+**Tester prerequisites**: A running Dash Evo Tool instance with at least one HD wallet and one single-key wallet loaded. Access to Testnet or a local Devnet. A known-valid WIF private key and hex private key for identity import tests.
+
+---
+
+## Group 1: PasswordInput Core Behavior
+
+### TC-1.1 Default masking on password fields
+
+**Preconditions**: Application is running. Navigate to any screen with a password field (e.g., Wallets > click a locked HD wallet to trigger unlock popup).
+
+**Steps**:
+1. Observe the password input field before typing anything.
+2. Type the characters `testpass123`.
+3. Observe the field contents while typing and after.
+
+**Expected results**:
+- Step 1: The field is empty and shows hint text (e.g., "Enter password") in a muted color. An eye icon with a diagonal slash is visible inside the field, right-aligned.
+- Step 2-3: Each typed character is immediately displayed as a bullet/dot character. The plaintext is never visible at any point during typing. The eye icon remains in the "closed" state (circle with slash).
+
+---
+
+### TC-1.2 Hold-to-reveal shows plaintext while held
+
+**Preconditions**: A password field contains typed text (e.g., continue from TC-1.1).
+
+**Steps**:
+1. Move the mouse pointer over the eye icon inside the password field.
+2. Observe the cursor and tooltip.
+3. Press and hold the primary mouse button on the eye icon.
+4. While holding, observe the field contents and the eye icon.
+5. Release the mouse button.
+6. Observe the field contents and eye icon after release.
+
+**Expected results**:
+- Step 1-2: The cursor changes to a pointing hand. The eye icon color changes to Dash blue (#008de4). A tooltip "Hold to reveal" appears.
+- Step 3-4: The field contents switch from dots to plaintext (the actual typed password is visible). The eye icon changes to "open" state (circle with filled pupil, no slash). The icon remains Dash blue.
+- Step 5-6: The field contents immediately switch back to dots/bullets. The eye icon returns to "closed" state (circle with slash). The color returns to muted gray (assuming the pointer moved off the icon).
+
+---
+
+### TC-1.3 Dragging pointer off eye icon re-masks immediately
+
+**Preconditions**: A password field contains typed text.
+
+**Steps**:
+1. Press and hold the primary mouse button on the eye icon (text reveals).
+2. While still holding the mouse button, drag the pointer outside the eye icon area (e.g., move left into the text area or away from the field entirely).
+3. Observe the field contents while the pointer is outside the icon area but the button is still held.
+4. Release the mouse button.
+
+**Expected results**:
+- Step 1: Text is revealed in plaintext while pointer is on the icon.
+- Step 2-3: As soon as the pointer leaves the eye icon rectangle, the text re-masks to dots immediately, even though the mouse button is still held down. The eye icon returns to closed state.
+- Step 4: Field remains masked. No change on button release.
+
+---
+
+### TC-1.4 Eye icon non-functional on empty field
+
+**Preconditions**: Navigate to any screen with a PasswordInput field. The field is empty.
+
+**Steps**:
+1. Observe that the eye icon is present even when the field is empty.
+2. Press and hold the eye icon.
+3. Release.
+
+**Expected results**:
+- Step 1: Eye icon is displayed in muted color. Hint text is visible.
+- Step 2: No crash or error. The field visually switches to "revealing" mode (open eye icon) but there is nothing to show since the field is empty.
+- Step 3: Returns to closed/masked state.
+
+---
+
+### TC-1.5 Error message display below input
+
+**Preconditions**: Navigate to a wallet unlock popup (click a locked wallet, or attempt an operation requiring unlock). Type an incorrect password.
+
+**Steps**:
+1. Enter an incorrect password in the unlock popup.
+2. Click "Unlock" (or equivalent submit action).
+3. Observe the area below the password input after the backend returns an error.
+4. Verify the eye icon still functions while an error is displayed.
+
+**Expected results**:
+- Step 2-3: An error message (e.g., "Incorrect password") appears below the input field in a warning/error color. The password field retains its content (dots visible).
+- Step 4: Pressing and holding the eye icon still reveals the typed (incorrect) password. The error message remains visible during reveal. The eye icon color and behavior are unchanged by the error state.
+
+---
+
+## Group 2: Wallet Unlock Flow
+
+### TC-2.1 HD wallet unlock popup uses PasswordInput
+
+**Preconditions**: At least one locked HD wallet exists.
+
+**Steps**:
+1. Navigate to the Wallets screen.
+2. Click on a locked HD wallet to trigger any operation that requires unlock (e.g., viewing private keys, sending funds).
+3. Observe the unlock popup that appears.
+4. Verify the password field is a PasswordInput (masked with eye icon).
+5. Type the correct wallet password.
+6. Hold the eye icon to verify the password is correct.
+7. Release the eye icon.
+8. Click "Unlock".
+
+**Expected results**:
+- Step 3-4: The popup contains a password field with dot masking and an eye icon. There is no separate "Show password" checkbox (the old pattern has been removed).
+- Step 5: Characters appear as dots.
+- Step 6: Plaintext password is visible while the eye is held.
+- Step 7: Password re-masks to dots.
+- Step 8: Wallet unlocks successfully. The popup closes.
+
+---
+
+### TC-2.2 Single-key wallet password entry
+
+**Preconditions**: A single-key wallet exists on the Wallets screen.
+
+**Steps**:
+1. Navigate to the Wallets screen.
+2. Locate the single-key wallet section.
+3. Observe the password input field for the single-key wallet.
+4. Type a password and verify it is masked.
+5. Use the hold-to-reveal eye icon to verify the password.
+
+**Expected results**:
+- Step 3: The password field uses PasswordInput with dot masking and an eye icon. No "Show password" checkbox is present.
+- Step 4-5: Masking and hold-to-reveal behave identically to TC-1.2.
+
+---
+
+## Group 3: Previously Unmasked Fields (Security Fixes)
+
+### TC-3.1 Add New Wallet screen masks password
+
+**Preconditions**: Application is running.
+
+**Steps**:
+1. Navigate to the Add New Wallet screen (e.g., Wallets > Add Wallet).
+2. Locate the password field.
+3. Type a password.
+4. Observe whether the field is masked.
+5. Use the eye icon to verify hold-to-reveal works.
+
+**Expected results**:
+- Step 2: The field has an eye icon and shows hint text (e.g., "Optional password").
+- Step 3-4: The password is displayed as dots, NOT plaintext. (Previously this field was unmasked -- this is a security fix.)
+- Step 5: Hold-to-reveal works as specified in TC-1.2.
+
+---
+
+### TC-3.2 Import Mnemonic screen masks password and private key
+
+**Preconditions**: Application is running.
+
+**Steps**:
+1. Navigate to the Import Mnemonic / Import Wallet screen.
+2. Locate the password field.
+3. Type a password and verify it is masked with dots.
+4. Locate any private key field (if applicable on this screen).
+5. Paste or type a private key value and verify it is masked.
+6. Use the eye icon on each field independently to verify reveal works.
+
+**Expected results**:
+- Step 2-3: Password field is masked. (Previously unmasked -- security fix.)
+- Step 4-5: Private key field is masked with dots and uses a monospace font. (Previously unmasked -- security fix.)
+- Step 6: Each field has its own independent eye icon. Holding one reveals only that field, not the other.
+
+---
+
+### TC-3.3 Add Existing Identity screen masks all private key fields
+
+**Preconditions**: Application is running.
+
+**Steps**:
+1. Navigate to the Add Existing Identity screen (Identities section).
+2. Locate the Voting Private Key, Owner Private Key, and Payout Address Private Key fields.
+3. Type or paste a WIF key into the Voting Private Key field.
+4. Observe that it is masked.
+5. Use the eye icon to reveal and verify the key text.
+6. Scroll down to the dynamic key list section.
+7. Add 2-3 additional private key entries using the "Add" button.
+8. Type values into each dynamic key field.
+9. Verify each dynamic key field is independently masked with its own eye icon.
+
+**Expected results**:
+- Step 2: All three static key fields use PasswordInput with eye icons. (Previously unmasked -- security fix.)
+- Step 3-4: The typed/pasted WIF key is shown as dots.
+- Step 5: Holding the eye reveals the key in monospace font.
+- Step 7-8: Each newly added key field is a PasswordInput with its own eye icon.
+- Step 9: Holding the eye on one dynamic key field reveals only that field. Other fields remain masked.
+
+---
+
+### TC-3.4 Network Chooser screen masks RPC password
+
+**Preconditions**: Application is running with access to network settings.
+
+**Steps**:
+1. Navigate to the Network Chooser / Network Configuration screen.
+2. Locate the Dashmate / Core RPC password field.
+3. Type or paste an RPC password.
+4. Observe masking behavior.
+5. Use the eye icon to verify the password.
+
+**Expected results**:
+- Step 2: The RPC password field uses PasswordInput with an eye icon and hint text "Core RPC password". (Previously unmasked -- security fix.)
+- Step 3-4: The password is displayed as dots.
+- Step 5: Hold-to-reveal works correctly.
+
+---
+
+## Group 4: Private Key Display (WIF in Popups and Info Screens)
+
+### TC-4.1 Private key dialog in Wallets screen
+
+**Preconditions**: An unlocked HD wallet with at least one derived address.
+
+**Steps**:
+1. Navigate to the Wallets screen.
+2. Select an unlocked HD wallet.
+3. Trigger the "Show Private Key" action for a specific address (e.g., via context menu or a key icon button).
+4. Observe the private key dialog/popup that appears.
+5. Look for the WIF private key display.
+6. Close the dialog.
+
+**Expected results**:
+- Step 4-5: The WIF private key is displayed. If there is a copy button, it copies the WIF value. The display uses the Secret type internally (no sensitive data in Debug output if logged).
+- Step 6: After closing the dialog, the WIF value should be cleared from the dialog state. Reopening the dialog for the same address should re-derive the key, not reuse stale data.
+
+---
+
+### TC-4.2 Key Info screen private key input and WIF display
+
+**Preconditions**: An identity with at least one key exists.
+
+**Steps**:
+1. Navigate to the Key Info screen for an identity key.
+2. Locate the private key input field.
+3. Verify it uses PasswordInput with masking and an eye icon.
+4. Type or paste a valid private key (hex format, 64 characters).
+5. Hold the eye icon to verify.
+6. If a WIF display is shown after key validation, verify it uses monospace font and the Secret type.
+
+**Expected results**:
+- Step 2-3: Private key input is a PasswordInput with monospace font, masked by default.
+- Step 4: Characters are shown as dots.
+- Step 5: Plaintext is revealed in monospace while holding the eye icon.
+- Step 6: WIF values are displayed using the Secret wrapper. If a copy button is present, it copies the WIF correctly.
+
+---
+
+### TC-4.3 Add Key screen private key input
+
+**Preconditions**: An identity exists where keys can be added.
+
+**Steps**:
+1. Navigate to the Add Key screen for an identity.
+2. Locate the private key input field.
+3. Type or paste a WIF private key (51-52 characters).
+4. Verify masking and hold-to-reveal.
+
+**Expected results**:
+- Step 2: The field uses PasswordInput with eye icon and monospace font.
+- Step 3-4: Key is masked as dots. Hold-to-reveal shows the WIF in monospace. Release re-masks.
+
+---
+
+### TC-4.4 Asset Lock screens password masking
+
+**Preconditions**: Navigate to an asset lock detail screen or create asset lock screen that requires wallet unlock.
+
+**Steps**:
+1. Trigger the wallet password field on the Asset Lock Detail screen or Create Asset Lock screen.
+2. Type a password.
+3. Verify masking with eye icon.
+4. On the Asset Lock Detail screen, if a private key WIF is displayed, verify it uses the Secret type.
+
+**Expected results**:
+- Step 2-3: Password field is masked with hold-to-reveal eye icon. No "Show password" checkbox.
+- Step 4: WIF display, if present, is wrapped in Secret (monospace, proper handling).
+
+---
+
+## Group 5: Secret Type Behavior
+
+### TC-5.1 Debug output does not leak secrets
+
+**Preconditions**: Application is running with logging enabled (debug level).
+
+**Steps**:
+1. Perform any operation that involves a Secret value (e.g., unlock a wallet, view a private key).
+2. Check the application log output (stdout/stderr or log file).
+3. Search for the actual password or key text in the logs.
+4. Search for "Secret(***)" in the logs to confirm redaction is present.
+
+**Expected results**:
+- Step 2-3: The actual secret value (password text, WIF key, hex key) does NOT appear anywhere in the log output.
+- Step 4: If the Secret type's Debug representation is logged, it shows `Secret(***)` instead of the actual value.
+
+---
+
+### TC-5.2 Password field clears after failed unlock attempt
+
+**Preconditions**: A locked wallet exists.
+
+**Steps**:
+1. Trigger the unlock popup for a locked wallet.
+2. Enter an incorrect password.
+3. Submit the unlock attempt.
+4. Observe whether the password field is cleared after the error is shown, or if the user can retry with the same text.
+5. If the field is not auto-cleared, close the popup and reopen it.
+6. Verify the field is empty on reopen.
+
+**Expected results**:
+- Step 3-4: The behavior depends on the screen implementation. The field may retain text for retry or may be cleared. Either is acceptable as long as the error message is shown.
+- Step 5-6: When the popup is closed and reopened, the password field MUST be empty. The Secret backing the previous input should have been zeroized.
+
+---
+
+### TC-5.3 Private key fields clear on screen navigation
+
+**Preconditions**: Navigate to the Add Existing Identity screen.
+
+**Steps**:
+1. Type private keys into the Voting, Owner, and Payout Address fields.
+2. Navigate away from the screen (e.g., go to Wallets, then back).
+3. Check whether the private key fields are empty or still contain the previous values.
+
+**Expected results**:
+- Step 3: Behavior depends on whether the screen instance is recreated on navigation. If the screen persists (root screen), the fields may retain values. If the screen is a modal that is popped from the stack, the fields and their Secret-wrapped values should be dropped and zeroized.
+
+---
+
+## Group 6: Theme and Visual Consistency
+
+### TC-6.1 Eye icon appearance in light mode
+
+**Preconditions**: Application is set to light mode.
+
+**Steps**:
+1. Navigate to any screen with a PasswordInput field.
+2. Observe the eye icon color in default state (not hovered).
+3. Hover over the eye icon and observe color change.
+4. Hold the eye icon and observe the "open eye" state.
+
+**Expected results**:
+- Step 2: Eye icon is drawn in a muted/secondary text color (visible but not prominent).
+- Step 3: Eye icon color changes to Dash blue (#008de4).
+- Step 4: Open eye (circle + filled pupil) in Dash blue. Text is revealed in plaintext.
+
+---
+
+### TC-6.2 Eye icon appearance in dark mode
+
+**Preconditions**: Application is set to dark mode.
+
+**Steps**:
+1. Repeat all steps from TC-6.1 in dark mode.
+
+**Expected results**:
+- Same behavior as TC-6.1 but with dark mode secondary text color for the default icon state. Dash blue hover/active color remains the same. The icon must have sufficient contrast against the dark input background.
+
+---
+
+### TC-6.3 Monospace font for private key fields
+
+**Preconditions**: Navigate to any screen with a private key PasswordInput (e.g., Add Existing Identity, Key Info).
+
+**Steps**:
+1. Type a hex string or WIF key into the private key field.
+2. Hold the eye icon to reveal the text.
+3. Compare the font to a regular password field (e.g., wallet unlock).
+
+**Expected results**:
+- Step 2-3: The revealed text in a private key field uses a monospace font. A regular password field uses the default proportional font. The difference should be visually obvious (equal character widths in monospace).
+
+---
+
+## Group 7: Edge Cases
+
+### TC-7.1 Very long password handling
+
+**Preconditions**: Any PasswordInput field.
+
+**Steps**:
+1. Type or paste a very long string (200+ characters) into the password field.
+2. Observe that the field scrolls or truncates visually but accepts all characters.
+3. Hold the eye icon to reveal.
+4. Verify all characters are present.
+
+**Expected results**:
+- Step 2: The field accepts the full string. Dots may overflow the visible area (horizontal scrolling within the field).
+- Step 3-4: Revealing shows the full plaintext (may require scrolling within the field). No truncation or data loss.
+
+---
+
+### TC-7.2 Paste into masked field
+
+**Preconditions**: Copy a known string to the clipboard (e.g., "pastedSecret123").
+
+**Steps**:
+1. Click into any PasswordInput field to focus it.
+2. Paste from clipboard (Ctrl+V / Cmd+V).
+3. Observe that dots appear (not plaintext).
+4. Hold the eye to reveal and confirm the pasted value matches the clipboard content.
+
+**Expected results**:
+- Step 2-3: Pasted text is immediately masked as dots.
+- Step 4: The revealed text matches the original clipboard content exactly.
+
+---
+
+### TC-7.3 Multiple PasswordInput fields on one screen
+
+**Preconditions**: Navigate to the Add Existing Identity screen (which has 3+ PasswordInput fields plus dynamic key list).
+
+**Steps**:
+1. Type different values into each of the three static key fields (Voting, Owner, Payout).
+2. Add two dynamic key entries and type values into them.
+3. Hold the eye icon on the Voting key field -- verify only that field reveals.
+4. Release. Hold the eye on a dynamic key field -- verify only that field reveals.
+5. Verify all other fields remain masked during each reveal.
+
+**Expected results**:
+- Step 3: Only the Voting key field shows plaintext. Owner, Payout, and dynamic fields show dots.
+- Step 4: Only the targeted dynamic field reveals. All others remain masked.
+- Step 5: Each eye icon operates independently. No cross-field reveal.
+
+---
+
+### TC-7.4 Rapid click on eye icon (not hold)
+
+**Preconditions**: A password field with text entered.
+
+**Steps**:
+1. Quickly click (press and release immediately) the eye icon.
+2. Observe whether the password flashes briefly or stays masked.
+
+**Expected results**:
+- Step 1-2: A very brief click may cause a single-frame flash of plaintext (since the reveal state is based on pointer-down). This is acceptable -- the text re-masks immediately on release. The field should NOT toggle to a persistent revealed state. After the click, the field must be fully masked.

--- a/docs/ai-design/2026-03-09-password-input/ux-spec.md
+++ b/docs/ai-design/2026-03-09-password-input/ux-spec.md
@@ -1,0 +1,467 @@
+# PasswordInput Component -- UX Design Specification
+
+**Date**: 2026-03-09
+**Component**: `PasswordInput`
+**Location**: `src/ui/components/password_input.rs`
+
+---
+
+## 1. Persona Walkthrough
+
+### Alex Torres (Everyday User)
+Alex unlocks wallets to send Dash. He types a password, sees dots, and needs a quick way to verify he typed it right before hitting "Unlock." The hold-to-peek eye icon is intuitive -- he has seen it in banking apps. He holds the eye, confirms his password visually, releases, and submits. He never thinks about it twice.
+
+### Priya Nakamura (Power User)
+Priya manages multiple wallets and pastes long private keys. She needs to verify the pasted key is correct before submitting. The hold-to-reveal works identically for private keys as for passwords. She also uses the RPC password field when configuring nodes -- same component, same muscle memory.
+
+### Jordan Kim (Platform Developer)
+Jordan enters private keys in hex and WIF format on the Add Existing Identity screen. The dynamic list of key inputs (add/remove) must each have their own eye icon. Jordan works fast and appreciates that the component handles masking, reveal, and styling consistently without boilerplate.
+
+**Validation**: All three personas understand the eye icon immediately. The hold-to-reveal pattern is familiar from mobile banking and password managers. No persona needs instructions.
+
+---
+
+## 2. Visual Layout
+
+```
+[Label]                                    (external, above input)
++--------------------------------------------------+
+|  * * * * * * * * * * * * * *          [eye_icon]  |
++--------------------------------------------------+
+[Error message]                            (below, inline)
+```
+
+### Eye Icon Placement
+- **Inside the text field**, right-aligned, vertically centered.
+- The icon occupies a 24x24px logical area within the input's right padding.
+- The text field has `right_margin` of 32px (24px icon + 8px padding) to prevent text from overlapping the icon.
+- The icon is rendered as an overlay on top of the text field background using `ui.painter()`, not as a separate widget beside the field.
+
+### Dimensions
+- Input height: matches existing `TextEdit::singleline` height (typically ~28-30px with default egui style).
+- Eye icon clickable area: 24x24px (meets WCAG AA 32x32 minimum when combined with vertical input padding that extends the hit area to at least 32px tall).
+- Gap between text content and eye icon: 8px (SM spacing).
+
+---
+
+## 3. Eye Icon Geometry (painter primitives)
+
+The icon is drawn with `ui.painter()` calls, following the same pattern as `info_icon_button`. Two states:
+
+### Closed Eye (default -- password masked)
+
+Drawn at 16x16px logical size within the 24x24px hit area, centered.
+
+```
+Geometry:
+1. Eye outline: A single quadratic bezier arc (upper lid).
+   - Left point:  (cx - 7, cy)
+   - Control:     (cx, cy - 5)
+   - Right point: (cx + 7, cy)
+   Stroke: 1.5px, color from state.
+
+2. Lower lid: Mirror arc below.
+   - Left point:  (cx - 7, cy)
+   - Control:     (cx, cy + 5)
+   - Right point: (cx + 7, cy)
+   Stroke: 1.5px, same color.
+
+3. Slash line (indicates "hidden"):
+   - From (cx - 5, cy - 5) to (cx + 5, cy + 5)
+   Stroke: 1.5px, same color.
+```
+
+Implementation note: egui's `PathShape` with `QuadraticBezierShape` or approximate with small line segments forming the arc. Alternatively, use `painter.add(Shape::QuadraticBezier(...))`.
+
+### Open Eye (pressed -- password revealed)
+
+Same as closed eye but WITHOUT the slash line, and WITH a filled pupil circle:
+
+```
+Geometry:
+1. Upper lid arc (same as closed eye).
+2. Lower lid arc (same as closed eye).
+3. Pupil: filled circle at (cx, cy), radius 2.5px.
+   Fill: same color as stroke.
+```
+
+### Simplified Alternative (if bezier is too complex)
+
+If quadratic beziers prove awkward in egui's painter API, use this circle-based approach:
+
+```
+Closed eye:
+1. Circle outline: center (cx, cy), radius 6px, stroke 1.5px.
+   (Represents the eye)
+2. Slash: line from (cx-5, cy-5) to (cx+5, cy+5), stroke 1.5px.
+
+Open eye:
+1. Circle outline: same as above.
+2. Pupil: filled circle at (cx, cy), radius 2.5px.
+```
+
+This is less visually refined but unambiguous and trivial to implement.
+
+---
+
+## 4. Hold-to-Reveal Interaction
+
+### Trigger: Mouse down on eye icon area
+- When the user presses the primary mouse button while the pointer is over the eye icon's 24x24px rect, the password is revealed (`.password(false)` on the TextEdit).
+- The eye icon switches to the "open" variant.
+
+### Hide: Mouse up OR pointer leaves the eye icon rect
+- When the primary mouse button is released (anywhere), the password is re-masked.
+- When the pointer moves outside the eye icon rect while the button is held, the password is re-masked immediately. This prevents "drag-to-keep-revealed" accidents and matches the user's stated requirement: "when mouse is moved or button released, password hides again."
+- The eye icon switches back to the "closed" variant.
+
+### Implementation in egui
+```rust
+// Allocate the eye icon rect inside the text field's right area
+let eye_sense = egui::Sense::click_and_drag(); // need drag to detect held state
+let (eye_rect, eye_response) = ui.allocate_exact_size(vec2(24.0, 24.0), eye_sense);
+
+// Reveal only while pointer is over the icon AND primary button is held
+let revealing = eye_response.is_pointer_button_down_on() && eye_response.hovered();
+```
+
+The key egui API: `Response::is_pointer_button_down_on()` returns true if the pointer initially pressed on this widget and the button is still held. Combined with `hovered()` (pointer is currently over the rect), this gives exact hold-to-reveal-while-over behavior.
+
+### Keyboard Accessibility
+- No keyboard toggle. egui has limited keyboard/focus support for custom-painted widgets. The eye icon is a mouse-only affordance.
+- Rationale: Hold-to-reveal is inherently a pointer interaction. A keyboard equivalent would need to be a toggle (press to reveal, press again to hide), which contradicts the security model of hold-to-reveal. Since egui lacks ARIA/screen-reader support anyway, this is an acceptable limitation.
+- If keyboard reveal is ever needed in the future, a separate `with_keyboard_reveal(Key)` builder method can be added.
+
+### Cursor
+- Hovering over the eye icon: `CursorIcon::PointingHand`.
+- While held/revealing: `CursorIcon::PointingHand` (no change).
+
+---
+
+## 5. Component States
+
+### 5.1 Default (masked, eye closed)
+- Text field shows dots/bullets (egui's `.password(true)` rendering).
+- Eye icon drawn in "closed" variant.
+- Eye icon color: `DashColors::text_secondary(dark_mode)` (muted, not distracting).
+- Border: 1px, `DashColors::border(dark_mode)`.
+
+### 5.2 Hover over Eye Icon
+- Eye icon color changes to `DashColors::DASH_BLUE` (#008de4).
+- Cursor: `PointingHand`.
+- Tooltip: "Hold to reveal" (via `.on_hover_text()`).
+- Text field appearance unchanged.
+
+### 5.3 Pressed/Held (revealing)
+- Text shown in plain text (`.password(false)`).
+- Eye icon drawn in "open" variant.
+- Eye icon color: `DashColors::DASH_BLUE`.
+- Border: unchanged from current focus/unfocus state.
+
+### 5.4 Focused (input has keyboard focus)
+- Border: 2px, `DashColors::DASH_BLUE`.
+- Eye icon appearance unchanged from default (unless also hovered).
+- Standard egui focus ring behavior.
+
+### 5.5 Error (validation failed)
+- Border: 2px, `DashColors::ERROR` (#eb5757).
+- Error text shown below the input in `DashColors::VALIDATION_WARNING` color, `Typography::SCALE_SM` (14px).
+- Eye icon remains functional and unchanged in color.
+
+### 5.6 Disabled
+- Text field: `ui.add_enabled(false, ...)`.
+- Eye icon: drawn in `DashColors::text_disabled(dark_mode)`, no hover effect, no interaction.
+- Cursor: default (no PointingHand).
+
+### 5.7 Empty with Hint Text
+- Hint text shown in `DashColors::text_secondary(dark_mode)`.
+- Eye icon shown but muted (same as default state).
+- Hint text examples: "Enter password", "Enter private key (WIF or hex)".
+
+---
+
+## 6. Component API
+
+### Struct
+
+```rust
+pub struct PasswordInput {
+    // Internal state
+    text: String,          // The actual password/key text
+    revealing: bool,       // Transient: true only while eye is held
+
+    // Configuration (set via builder)
+    label: Option<String>,
+    hint_text: String,
+    desired_width: Option<f32>,
+    error_message: Option<String>,
+    monospace: bool,       // For private keys (hex/WIF)
+}
+```
+
+### Constructor
+
+```rust
+impl PasswordInput {
+    pub fn new() -> Self { ... }
+}
+```
+
+### Builder Methods
+
+```rust
+impl PasswordInput {
+    /// Label rendered above the input. If None, no label is rendered.
+    /// For cases where the caller renders the label externally (e.g., Grid layout),
+    /// omit this.
+    pub fn with_label(mut self, label: impl Into<String>) -> Self;
+
+    /// Hint text shown when the input is empty.
+    pub fn with_hint_text(mut self, hint: impl Into<String>) -> Self;
+
+    /// Fixed width for the input. If None, uses available width.
+    pub fn with_desired_width(mut self, width: f32) -> Self;
+
+    /// Use monospace font (for private keys, hex strings).
+    pub fn with_monospace(mut self) -> Self;
+}
+```
+
+### Show Method
+
+```rust
+impl Component for PasswordInput {
+    type Response = PasswordInputResponse;
+
+    fn show(&mut self, ui: &mut Ui) -> InnerResponse<PasswordInputResponse>;
+}
+```
+
+### Response
+
+```rust
+pub struct PasswordInputResponse {
+    pub response: Response,
+    pub changed: bool,
+    pub error_message: Option<String>,
+    pub value: Option<String>,  // Some(text) when non-empty, None when empty
+}
+
+impl ComponentResponse for PasswordInputResponse {
+    type DomainType = String;
+    // ... standard trait methods
+}
+```
+
+### External Error Injection
+
+Callers can set validation errors externally (e.g., "Wrong password" from backend):
+
+```rust
+// After show(), caller can set error for next frame:
+password_input.set_error(Some("Incorrect password"));
+
+// Or clear it:
+password_input.set_error(None);
+```
+
+This is needed because password validation happens asynchronously (backend task), not at input time.
+
+### Text Access
+
+```rust
+impl PasswordInput {
+    /// Get the current text value (for reading before submission).
+    pub fn text(&self) -> &str;
+
+    /// Clear the input (e.g., after failed unlock attempt or screen reset).
+    pub fn clear(&mut self);
+}
+```
+
+### Label Handling Decision
+
+The component supports an **optional built-in label** via `with_label()`. Rationale:
+- Most password fields need a label ("Password:", "Private Key:").
+- The label is always above the input (per project convention).
+- In `Grid` layouts where the label is in a separate column (like add_existing_identity_screen), callers omit `with_label()` and render the label themselves.
+
+---
+
+## 7. Usage Patterns
+
+### 7.1 Wallet Unlock (simple)
+
+```rust
+struct MyScreen {
+    password: Option<String>,
+    password_widget: Option<PasswordInput>,
+}
+
+// In show():
+let widget = self.password_widget.get_or_insert_with(|| {
+    PasswordInput::new()
+        .with_label("Password")
+        .with_hint_text("Enter wallet password")
+});
+let response = widget.show(ui);
+response.inner.update(&mut self.password);
+```
+
+### 7.2 Private Key Input (monospace)
+
+```rust
+let widget = self.key_widget.get_or_insert_with(|| {
+    PasswordInput::new()
+        .with_label("Private Key")
+        .with_hint_text("WIF (51-52 chars) or hex (64 chars)")
+        .with_monospace()
+});
+```
+
+### 7.3 Dynamic List of Keys (add_existing_identity_screen)
+
+The `Vec<String>` keys_input pattern does NOT use lazy-init `Option<PasswordInput>` because the list is dynamic (add/remove). Instead, use a `Vec<PasswordInput>` that is kept in sync with the data:
+
+```rust
+struct AddExistingIdentityScreen {
+    keys_input: Vec<PasswordInput>,  // replaces Vec<String>
+}
+
+// Adding a key:
+self.keys_input.push(
+    PasswordInput::new()
+        .with_hint_text("Private key (hex or WIF)")
+        .with_monospace()
+);
+
+// In show() loop:
+for (i, key_input) in self.keys_input.iter_mut().enumerate() {
+    ui.label(format!("Private Key {}:", i + 1));
+    key_input.show(ui);
+}
+
+// Collecting values for submission:
+let keys: Vec<String> = self.keys_input.iter()
+    .map(|w| w.text().to_string())
+    .collect();
+```
+
+### 7.4 RPC Password (network config)
+
+```rust
+let widget = self.rpc_password_widget.get_or_insert_with(|| {
+    PasswordInput::new()
+        .with_hint_text("Core RPC password")
+});
+// No label -- rendered by external Grid column
+```
+
+---
+
+## 8. Rendering Implementation Notes
+
+### Eye Icon as Overlay
+
+The eye icon is NOT a separate widget placed beside the TextEdit. It is painted as an overlay on top of the TextEdit's allocated rect. This approach:
+
+1. Keeps the component as a single `ui.add()` call.
+2. Avoids layout issues with horizontal grouping.
+3. Matches how egui's built-in widgets handle internal icons.
+
+Implementation sketch:
+
+```rust
+fn show(&mut self, ui: &mut Ui) -> InnerResponse<PasswordInputResponse> {
+    // 1. Render label if configured
+    if let Some(label) = &self.label {
+        ui.label(label);
+    }
+
+    // 2. Build and add the TextEdit
+    let text_edit = TextEdit::singleline(&mut self.text)
+        .password(!self.revealing)
+        .hint_text(&self.hint_text)
+        .desired_width(self.desired_width.unwrap_or(f32::INFINITY))
+        .margin(Margin { right: 32.0, ..Default::default() }); // Reserve space for icon
+
+    let text_response = ui.add(text_edit);
+
+    // 3. Calculate eye icon rect (right side of text field)
+    let eye_rect = Rect::from_center_size(
+        pos2(text_response.rect.right() - 16.0, text_response.rect.center().y),
+        vec2(24.0, 24.0),
+    );
+
+    // 4. Sense interaction on eye rect
+    let eye_id = text_response.id.with("eye");
+    let eye_response = ui.interact(eye_rect, eye_id, Sense::click_and_drag());
+
+    // 5. Update revealing state
+    self.revealing = eye_response.is_pointer_button_down_on() && eye_response.hovered();
+
+    // 6. Draw eye icon
+    self.paint_eye_icon(ui, eye_rect, &eye_response);
+
+    // 7. Show error below
+    if let Some(err) = &self.error_message {
+        ui.colored_label(DashColors::VALIDATION_WARNING, err);
+    }
+
+    // 8. Request repaint if revealing (to re-mask on release)
+    if self.revealing {
+        ui.ctx().request_repaint();
+    }
+
+    // ... build and return response
+}
+```
+
+### Repaint on Reveal
+
+When revealing, the component must call `ui.ctx().request_repaint()` each frame to ensure the UI updates immediately when the mouse button is released. Without this, there could be a frame delay before re-masking.
+
+---
+
+## 9. Accessibility
+
+- **Min click target**: 24x24px icon within input that extends to at least 32px vertically due to input height. Meets WCAG AA.
+- **Hover tooltip**: "Hold to reveal" on the eye icon.
+- **No keyboard shortcut**: Acceptable limitation given egui's accessibility constraints. The password can still be typed and submitted without ever using the eye icon.
+- **Color contrast**: Eye icon uses `text_secondary` (muted gray) by default and `DASH_BLUE` on hover/press. Both meet 3:1 contrast ratio against input background in both light and dark themes.
+- **No ARIA**: egui does not support ARIA roles. Not applicable.
+
+---
+
+## 10. Migration Checklist
+
+Replace all existing password/key input patterns with `PasswordInput`:
+
+| Location | Current Pattern | Notes |
+|---|---|---|
+| `wallet_unlock_popup.rs` | `TextEdit + .password(!show) + StyledCheckbox` | Remove `show_password` field, checkbox |
+| `wallet_unlock.rs` (trait) | `TextEdit + .password(!show) + StyledCheckbox` | Remove `show_password()` / `show_password_mut()` from trait |
+| `single_key_send_screen.rs` | `TextEdit + .password(true) + checkbox "Show"` | Remove `show_password` field |
+| `wallets_screen/mod.rs` | `TextEdit + .password(!show) + checkbox` | Remove `sk_show_password` field |
+| `create_asset_lock_screen.rs` | `TextEdit + .password(!show)` via unlock trait | Remove `show_password` field |
+| `asset_lock_detail_screen.rs` | `TextEdit + .password(!show)` via unlock trait | Remove `show_password` field |
+| `import_mnemonic_screen.rs` | `TextEdit.password(true)` (no toggle) | Add reveal capability |
+| `add_new_wallet_screen.rs` | `ui.text_edit_singleline` (NO masking!) | Fix security issue |
+| `import_mnemonic_screen.rs` (password) | `ui.text_edit_singleline` (NO masking!) | Fix security issue |
+| `add_existing_identity_screen.rs` (keys) | `ui.text_edit_singleline` (NO masking!) | Fix security issue, use Vec<PasswordInput> |
+| `add_existing_identity_screen.rs` (voting/owner keys) | `ui.text_edit_singleline` (NO masking!) | Fix security issue |
+| `network_chooser_screen.rs` (RPC password) | `ui.text_edit_singleline` (NO masking!) | Fix security issue |
+
+---
+
+## 11. Design Decisions and Rationale
+
+**Hold-to-reveal vs toggle**: The user explicitly requested hold-to-reveal. This is more secure than a persistent toggle because the password is never left visible accidentally. It matches mobile banking patterns (e.g., Chase, Revolut).
+
+**Eye inside vs adjacent**: Inside the field reduces horizontal space usage and is the dominant pattern in web/mobile UIs. Users expect the eye icon inside the input.
+
+**No separate label widget**: The component optionally renders its own label to reduce boilerplate. Callers in Grid layouts skip the built-in label and render their own.
+
+**Single component for passwords AND private keys**: Both are sensitive text that should be masked. The only difference is monospace font for keys. The `with_monospace()` builder handles this without needing a separate `PrivateKeyInput` component.
+
+**No strength indicator**: Wallet passwords in Dash Evo Tool are user-chosen and not validated for strength. Adding a strength meter would be scope creep and is not requested.

--- a/docs/ai-design/2026-03-09-password-input/wireframe.html
+++ b/docs/ai-design/2026-03-09-password-input/wireframe.html
@@ -1,0 +1,836 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PasswordInput Component -- Interactive Wireframe</title>
+<style>
+  :root {
+    /* Dash Evo Tool design tokens */
+    --dash-blue: #008de4;
+    --dash-blue-hover: #0079c4;
+    --error: #eb5757;
+    --success: #27ae60;
+    --warning: #f1c40f;
+
+    /* Light mode */
+    --bg: #f5f5f5;
+    --surface: #ffffff;
+    --input-bg: #f8f9fa;
+    --text-primary: #1a1a2e;
+    --text-secondary: #6b7280;
+    --text-disabled: #b0b0b0;
+    --border: #d1d5db;
+    --border-focus: var(--dash-blue);
+    --validation-warning: #eb5757;
+
+    /* Spacing */
+    --sp-xxs: 2px;
+    --sp-xs: 4px;
+    --sp-sm: 8px;
+    --sp-md: 16px;
+    --sp-lg: 24px;
+    --sp-xl: 32px;
+
+    /* Typography */
+    --font-sm: 14px;
+    --font-base: 16px;
+    --font-xs: 12px;
+
+    /* Borders */
+    --radius-sm: 6px;
+    --radius-md: 12px;
+  }
+
+  .dark-mode {
+    --bg: #1a1a2e;
+    --surface: #262640;
+    --input-bg: #2a2a44;
+    --text-primary: #e8e8f0;
+    --text-secondary: #8888a0;
+    --text-disabled: #555566;
+    --border: #3a3a55;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Noto Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg);
+    color: var(--text-primary);
+    padding: 32px;
+    transition: background 0.2s, color 0.2s;
+  }
+
+  h1 {
+    font-size: 24px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+  }
+
+  h2 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: var(--text-primary);
+  }
+
+  h3 {
+    font-size: var(--font-base);
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--text-secondary);
+  }
+
+  .subtitle {
+    font-size: var(--font-sm);
+    color: var(--text-secondary);
+    margin-bottom: 32px;
+  }
+
+  .theme-toggle {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font-size: var(--font-sm);
+    z-index: 100;
+  }
+
+  .theme-toggle:hover {
+    border-color: var(--dash-blue);
+  }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--sp-lg);
+    margin-bottom: var(--sp-lg);
+  }
+
+  /* Password Input Component */
+  .password-input-group {
+    margin-bottom: var(--sp-md);
+  }
+
+  .password-label {
+    display: block;
+    font-size: var(--font-sm);
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: var(--sp-xs);
+  }
+
+  .password-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .password-input {
+    width: 100%;
+    height: 32px;
+    padding: 4px 40px 4px 8px; /* 40px right padding for eye icon */
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--input-bg);
+    color: var(--text-primary);
+    font-size: var(--font-base);
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s, border-width 0.05s;
+    letter-spacing: 0;
+  }
+
+  .password-input::placeholder {
+    color: var(--text-secondary);
+    letter-spacing: 0;
+  }
+
+  .password-input:focus {
+    border: 2px solid var(--border-focus);
+    padding: 3px 39px 3px 7px; /* Adjust padding to compensate for 2px border */
+  }
+
+  .password-input.error {
+    border: 2px solid var(--error);
+    padding: 3px 39px 3px 7px;
+  }
+
+  .password-input.monospace {
+    font-family: 'Noto Sans Mono', 'Courier New', monospace;
+    font-size: var(--font-sm);
+  }
+
+  .password-input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    background: var(--input-bg);
+  }
+
+  /* Eye icon button */
+  .eye-icon-btn {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    padding: 0;
+    border-radius: 4px;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  .eye-icon-btn:hover .eye-icon {
+    color: var(--dash-blue);
+  }
+
+  .eye-icon-btn:active .eye-icon {
+    color: var(--dash-blue);
+  }
+
+  .eye-icon-btn.disabled {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .eye-icon-btn.disabled .eye-icon {
+    color: var(--text-disabled);
+  }
+
+  .eye-icon {
+    color: var(--text-secondary);
+    transition: color 0.1s;
+    display: block;
+  }
+
+  .eye-icon svg {
+    width: 16px;
+    height: 16px;
+    display: block;
+  }
+
+  /* Error message below input */
+  .error-message {
+    font-size: var(--font-sm);
+    color: var(--validation-warning);
+    margin-top: var(--sp-xs);
+  }
+
+  /* Demo sections */
+  .demo-section {
+    margin-bottom: 32px;
+  }
+
+  .demo-row {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+  }
+
+  .demo-item {
+    flex: 1;
+    min-width: 280px;
+    max-width: 400px;
+  }
+
+  .state-label {
+    font-size: var(--font-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+
+  .section-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 32px 0;
+  }
+
+  /* Eye icon geometry annotation */
+  .icon-spec {
+    display: flex;
+    gap: 32px;
+    align-items: center;
+    padding: 16px;
+  }
+
+  .icon-large {
+    width: 64px;
+    height: 64px;
+    border: 1px dashed var(--border);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .icon-large svg {
+    width: 48px;
+    height: 48px;
+  }
+
+  .icon-description {
+    font-size: var(--font-sm);
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .icon-description code {
+    background: var(--input-bg);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: var(--font-xs);
+    font-family: 'Courier New', monospace;
+  }
+
+  /* Dynamic list demo */
+  .key-list-item {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .key-list-item .password-input-group {
+    flex: 1;
+    margin-bottom: 0;
+  }
+
+  .remove-btn {
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .remove-btn:hover {
+    border-color: var(--error);
+    color: var(--error);
+  }
+
+  .add-key-btn {
+    background: transparent;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--dash-blue);
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: var(--font-sm);
+    font-family: inherit;
+  }
+
+  .add-key-btn:hover {
+    border-color: var(--dash-blue);
+    background: rgba(0, 141, 228, 0.05);
+  }
+
+  .instructions {
+    background: var(--input-bg);
+    border-radius: var(--radius-sm);
+    padding: 12px 16px;
+    margin-bottom: 24px;
+    font-size: var(--font-sm);
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  .instructions strong {
+    color: var(--text-primary);
+  }
+</style>
+</head>
+<body>
+
+<button class="theme-toggle" onclick="toggleTheme()">Toggle Dark/Light</button>
+
+<h1>PasswordInput Component</h1>
+<p class="subtitle">Interactive wireframe -- Dash Evo Tool design system</p>
+
+<div class="instructions">
+  <strong>How to interact:</strong> Hold down the mouse button on the eye icon to reveal the password.
+  Release the mouse button or move the cursor away from the icon to re-mask.
+  This is a hold-to-reveal pattern, not a toggle.
+</div>
+
+<!-- SECTION 1: Basic States -->
+<div class="card">
+  <h2>1. All Component States</h2>
+
+  <div class="demo-row">
+    <div class="demo-item">
+      <div class="state-label">Default (empty with hint)</div>
+      <div class="password-input-group">
+        <label class="password-label">Password</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input" placeholder="Enter wallet password" data-pw="true">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-item">
+      <div class="state-label">With value (masked)</div>
+      <div class="password-input-group">
+        <label class="password-label">Password</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input" value="mySecretPassword123" data-pw="true" data-real="mySecretPassword123">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-row">
+    <div class="demo-item">
+      <div class="state-label">Error state</div>
+      <div class="password-input-group">
+        <label class="password-label">Password</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input error" value="wrongpassword" data-pw="true" data-real="wrongpassword">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+        <div class="error-message">Incorrect password</div>
+      </div>
+    </div>
+
+    <div class="demo-item">
+      <div class="state-label">Disabled</div>
+      <div class="password-input-group">
+        <label class="password-label">Password</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input" value="disabled" disabled data-pw="true">
+          <button class="eye-icon-btn disabled" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr class="section-divider">
+
+<!-- SECTION 2: Use Cases -->
+<div class="card">
+  <h2>2. Use Case: Wallet Unlock</h2>
+  <p class="subtitle" style="margin-bottom: 16px;">Persona: Alex (everyday user) unlocking a wallet to send Dash.</p>
+
+  <div class="demo-item" style="max-width: 400px;">
+    <div class="password-input-group">
+      <label class="password-label">Wallet Password</label>
+      <div class="password-input-wrapper">
+        <input type="password" class="password-input" placeholder="Enter password" data-pw="true">
+        <button class="eye-icon-btn" title="Hold to reveal">
+          <span class="eye-icon">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <path d="M1 8 Q8 3 15 8"/>
+              <path d="M1 8 Q8 13 15 8"/>
+              <line x1="3" y1="3" x2="13" y2="13"/>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <h2>3. Use Case: Private Key Input (monospace)</h2>
+  <p class="subtitle" style="margin-bottom: 16px;">Persona: Priya (power user) importing a private key in WIF format.</p>
+
+  <div class="demo-item" style="max-width: 500px;">
+    <div class="password-input-group">
+      <label class="password-label">Private Key</label>
+      <div class="password-input-wrapper">
+        <input type="password" class="password-input monospace" placeholder="WIF (51-52 chars) or hex (64 chars)" data-pw="true" data-real="5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ" value="5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ">
+        <button class="eye-icon-btn" title="Hold to reveal">
+          <span class="eye-icon">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+              <path d="M1 8 Q8 3 15 8"/>
+              <path d="M1 8 Q8 13 15 8"/>
+              <line x1="3" y1="3" x2="13" y2="13"/>
+            </svg>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="card">
+  <h2>4. Use Case: Dynamic Key List (Add Existing Identity)</h2>
+  <p class="subtitle" style="margin-bottom: 16px;">Persona: Jordan (developer) adding multiple private keys to an identity. Each key input has its own eye icon.</p>
+
+  <div id="key-list" style="max-width: 500px;">
+    <div class="key-list-item">
+      <div class="password-input-group">
+        <label class="password-label">Private Key 1 (Hex or WIF)</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input monospace" placeholder="Enter private key" data-pw="true" data-real="cVBZ3AhXkebe2JDBBnE8PqZmQPYZAhQrJxNSTSvPvBCqxh3vA6PK" value="cVBZ3AhXkebe2JDBBnE8PqZmQPYZAhQrJxNSTSvPvBCqxh3vA6PK">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <button class="remove-btn" onclick="removeKey(this)" title="Remove key">-</button>
+    </div>
+    <div class="key-list-item">
+      <div class="password-input-group">
+        <label class="password-label">Private Key 2 (Hex or WIF)</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input monospace" placeholder="Enter private key" data-pw="true">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <button class="remove-btn" onclick="removeKey(this)" title="Remove key">-</button>
+    </div>
+  </div>
+  <button class="add-key-btn" onclick="addKey()" style="margin-top: 8px;">+ Add key manually</button>
+</div>
+
+<hr class="section-divider">
+
+<!-- SECTION 3: Eye Icon Specification -->
+<div class="card">
+  <h2>5. Eye Icon Geometry (painter primitives)</h2>
+  <p class="subtitle" style="margin-bottom: 16px;">Both icons are drawn with egui's ui.painter() using quadratic bezier arcs and lines. No image assets.</p>
+
+  <div class="icon-spec">
+    <div class="icon-large">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="color: var(--text-secondary);">
+        <path d="M1 8 Q8 3 15 8"/>
+        <path d="M1 8 Q8 13 15 8"/>
+        <line x1="3" y1="3" x2="13" y2="13"/>
+      </svg>
+    </div>
+    <div class="icon-description">
+      <strong>Closed Eye (masked, default)</strong><br>
+      Upper lid: quadratic bezier from <code>(1, 8)</code> to <code>(15, 8)</code> with control point <code>(8, 3)</code><br>
+      Lower lid: quadratic bezier from <code>(1, 8)</code> to <code>(15, 8)</code> with control point <code>(8, 13)</code><br>
+      Slash: diagonal line from <code>(3, 3)</code> to <code>(13, 13)</code><br>
+      Stroke: 1.5px, <code>text_secondary</code> color (hover: <code>DASH_BLUE</code>)
+    </div>
+  </div>
+
+  <div class="icon-spec" style="margin-top: 16px;">
+    <div class="icon-large">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="color: var(--dash-blue);">
+        <path d="M1 8 Q8 3 15 8"/>
+        <path d="M1 8 Q8 13 15 8"/>
+        <circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none"/>
+      </svg>
+    </div>
+    <div class="icon-description">
+      <strong>Open Eye (revealed, while held)</strong><br>
+      Upper lid: same bezier arc as closed<br>
+      Lower lid: same bezier arc as closed<br>
+      Pupil: filled circle at <code>(8, 8)</code>, radius <code>2.5</code><br>
+      No slash line<br>
+      Color: <code>DASH_BLUE</code> (#008de4)
+    </div>
+  </div>
+
+  <div class="icon-spec" style="margin-top: 16px; border-top: 1px solid var(--border); padding-top: 16px;">
+    <div class="icon-large">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="color: var(--text-secondary);">
+        <circle cx="8" cy="8" r="6"/>
+        <line x1="3" y1="3" x2="13" y2="13"/>
+      </svg>
+    </div>
+    <div class="icon-description">
+      <strong>Simplified Alternative: Closed (circle + slash)</strong><br>
+      If bezier curves are awkward in egui's painter API.<br>
+      Circle outline: center <code>(8, 8)</code>, radius <code>6</code>, stroke 1.5px<br>
+      Slash: line from <code>(3, 3)</code> to <code>(13, 13)</code>
+    </div>
+  </div>
+
+  <div class="icon-spec" style="margin-top: 8px;">
+    <div class="icon-large">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="color: var(--dash-blue);">
+        <circle cx="8" cy="8" r="6"/>
+        <circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none"/>
+      </svg>
+    </div>
+    <div class="icon-description">
+      <strong>Simplified Alternative: Open (circle + pupil)</strong><br>
+      Circle outline: same as above<br>
+      Pupil: filled circle at <code>(8, 8)</code>, radius <code>2.5</code><br>
+      No slash line
+    </div>
+  </div>
+</div>
+
+<hr class="section-divider">
+
+<!-- SECTION 4: Interaction diagram -->
+<div class="card">
+  <h2>6. Interaction State Machine</h2>
+  <pre style="font-family: 'Courier New', monospace; font-size: 13px; color: var(--text-secondary); line-height: 1.6; overflow-x: auto;">
+  +-------------------+
+  |  DEFAULT (masked)  |
+  |  eye = closed      |
+  |  color = secondary |
+  +--------+----------+
+           |
+    pointer enters eye rect
+           |
+           v
+  +-------------------+
+  |  HOVER             |
+  |  eye = closed      |
+  |  color = DASH_BLUE |
+  |  cursor = pointer  |
+  |  tooltip shown     |
+  +--------+----------+
+           |
+    mouse button down on eye
+           |
+           v
+  +-------------------+
+  |  REVEALING         |
+  |  eye = open        |
+  |  color = DASH_BLUE |
+  |  text = plain      |
+  +--------+----------+
+           |
+    mouse up OR pointer leaves eye rect
+           |
+           v
+  +-------------------+
+  |  DEFAULT (masked)  |  (returns to start)
+  +-------------------+
+  </pre>
+</div>
+
+<script>
+  // Theme toggle
+  function toggleTheme() {
+    document.body.classList.toggle('dark-mode');
+  }
+
+  // Hold-to-reveal interaction for all password inputs
+  document.querySelectorAll('.eye-icon-btn:not(.disabled)').forEach(btn => {
+    const wrapper = btn.closest('.password-input-wrapper');
+    const input = wrapper.querySelector('.password-input');
+    const iconSpan = btn.querySelector('.eye-icon');
+
+    const closedSVG = `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+      <path d="M1 8 Q8 3 15 8"/>
+      <path d="M1 8 Q8 13 15 8"/>
+      <line x1="3" y1="3" x2="13" y2="13"/>
+    </svg>`;
+
+    const openSVG = `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+      <path d="M1 8 Q8 3 15 8"/>
+      <path d="M1 8 Q8 13 15 8"/>
+      <circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none"/>
+    </svg>`;
+
+    function reveal() {
+      input.type = 'text';
+      iconSpan.innerHTML = openSVG;
+      iconSpan.style.color = 'var(--dash-blue)';
+    }
+
+    function mask() {
+      input.type = 'password';
+      iconSpan.innerHTML = closedSVG;
+      iconSpan.style.color = '';
+    }
+
+    // Mouse down on eye = reveal
+    btn.addEventListener('mousedown', (e) => {
+      e.preventDefault(); // prevent focus steal from input
+      reveal();
+    });
+
+    // Mouse up anywhere = mask
+    document.addEventListener('mouseup', () => {
+      mask();
+    });
+
+    // Mouse leaves eye icon while held = mask
+    btn.addEventListener('mouseleave', () => {
+      mask();
+    });
+
+    // Hover color
+    btn.addEventListener('mouseenter', () => {
+      if (input.type === 'password') {
+        iconSpan.style.color = 'var(--dash-blue)';
+      }
+    });
+
+    btn.addEventListener('mouseleave', () => {
+      if (input.type === 'password') {
+        iconSpan.style.color = '';
+      }
+    });
+
+    // Prevent context menu on long press
+    btn.addEventListener('contextmenu', (e) => e.preventDefault());
+  });
+
+  // Dynamic key list
+  let keyCount = 2;
+
+  function addKey() {
+    keyCount++;
+    const list = document.getElementById('key-list');
+    const item = document.createElement('div');
+    item.className = 'key-list-item';
+    item.innerHTML = `
+      <div class="password-input-group">
+        <label class="password-label">Private Key ${keyCount} (Hex or WIF)</label>
+        <div class="password-input-wrapper">
+          <input type="password" class="password-input monospace" placeholder="Enter private key" data-pw="true">
+          <button class="eye-icon-btn" title="Hold to reveal">
+            <span class="eye-icon">
+              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+                <path d="M1 8 Q8 3 15 8"/>
+                <path d="M1 8 Q8 13 15 8"/>
+                <line x1="3" y1="3" x2="13" y2="13"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+      <button class="remove-btn" onclick="removeKey(this)" title="Remove key">-</button>
+    `;
+    list.appendChild(item);
+
+    // Re-bind the eye icon interaction for the new item
+    bindEyeIcon(item.querySelector('.eye-icon-btn'));
+  }
+
+  function removeKey(btn) {
+    const item = btn.closest('.key-list-item');
+    item.remove();
+    // Re-number labels
+    document.querySelectorAll('#key-list .key-list-item').forEach((item, i) => {
+      item.querySelector('.password-label').textContent = `Private Key ${i + 1} (Hex or WIF)`;
+    });
+    keyCount = document.querySelectorAll('#key-list .key-list-item').length;
+  }
+
+  function bindEyeIcon(btn) {
+    const wrapper = btn.closest('.password-input-wrapper');
+    const input = wrapper.querySelector('.password-input');
+    const iconSpan = btn.querySelector('.eye-icon');
+
+    const closedSVG = `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+      <path d="M1 8 Q8 3 15 8"/>
+      <path d="M1 8 Q8 13 15 8"/>
+      <line x1="3" y1="3" x2="13" y2="13"/>
+    </svg>`;
+
+    const openSVG = `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+      <path d="M1 8 Q8 3 15 8"/>
+      <path d="M1 8 Q8 13 15 8"/>
+      <circle cx="8" cy="8" r="2.5" fill="currentColor" stroke="none"/>
+    </svg>`;
+
+    function reveal() {
+      input.type = 'text';
+      iconSpan.innerHTML = openSVG;
+      iconSpan.style.color = 'var(--dash-blue)';
+    }
+
+    function mask() {
+      input.type = 'password';
+      iconSpan.innerHTML = closedSVG;
+      iconSpan.style.color = '';
+    }
+
+    btn.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      reveal();
+    });
+
+    document.addEventListener('mouseup', () => { mask(); });
+    btn.addEventListener('mouseleave', () => { mask(); });
+
+    btn.addEventListener('mouseenter', () => {
+      if (input.type === 'password') iconSpan.style.color = 'var(--dash-blue)';
+    });
+    btn.addEventListener('mouseleave', () => {
+      if (input.type === 'password') iconSpan.style.color = '';
+    });
+    btn.addEventListener('contextmenu', (e) => e.preventDefault());
+  }
+</script>
+
+</body>
+</html>

--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -17,6 +17,7 @@ use crate::context::AppContext;
 use crate::model::qualified_identity::encrypted_key_storage::{KeyStorage, WalletDerivationPath};
 use crate::model::qualified_identity::qualified_identity_public_key::QualifiedIdentityPublicKey;
 use crate::model::qualified_identity::{IdentityType, PrivateKeyTarget, QualifiedIdentity};
+use crate::model::secret::Secret;
 use crate::model::wallet::{Wallet, WalletArcRef, WalletSeedHash};
 use dash_sdk::Sdk;
 use dash_sdk::dashcore_rpc::dashcore::key::Secp256k1;
@@ -42,10 +43,10 @@ pub struct IdentityInputToLoad {
     pub identity_id_input: String,
     pub identity_type: IdentityType,
     pub alias_input: String,
-    pub voting_private_key_input: String,
-    pub owner_private_key_input: String,
-    pub payout_address_private_key_input: String,
-    pub keys_input: Vec<String>,
+    pub voting_private_key_input: Secret,
+    pub owner_private_key_input: Secret,
+    pub payout_address_private_key_input: Secret,
+    pub keys_input: Vec<Secret>,
     pub derive_keys_from_wallets: bool,
     pub selected_wallet_seed_hash: Option<WalletSeedHash>,
 }
@@ -349,10 +350,10 @@ pub enum IdentityTask {
 }
 
 fn verify_key_input(
-    untrimmed_private_key: String,
+    untrimmed_private_key: Secret,
     type_key: &str,
 ) -> Result<Option<[u8; 32]>, String> {
-    let private_key = untrimmed_private_key.trim().to_string();
+    let private_key = untrimmed_private_key.expose_secret().trim().to_string();
     match private_key.len() {
         64 => {
             // hex

--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -353,11 +353,11 @@ fn verify_key_input(
     untrimmed_private_key: Secret,
     type_key: &str,
 ) -> Result<Option<[u8; 32]>, String> {
-    let private_key = untrimmed_private_key.expose_secret().trim().to_string();
+    let private_key = untrimmed_private_key.expose_secret().trim();
     match private_key.len() {
         64 => {
             // hex
-            match hex::decode(private_key.as_str()) {
+            match hex::decode(private_key) {
                 Ok(decoded) => Ok(Some(decoded.try_into().unwrap())),
                 Err(_) => Err(format!(
                     "{} key is the size of a hex key but isn't hex",
@@ -367,7 +367,7 @@ fn verify_key_input(
         }
         51 | 52 => {
             // wif
-            match PrivateKey::from_wif(private_key.as_str()) {
+            match PrivateKey::from_wif(private_key) {
                 Ok(key) => Ok(Some(key.inner.secret_bytes())),
                 Err(_) => Err(format!(
                     "{} key is the length of a WIF key but is invalid",

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,5 +6,6 @@ pub mod password_info;
 pub mod proof_log_item;
 pub mod qualified_contract;
 pub mod qualified_identity;
+pub mod secret;
 pub mod settings;
 pub mod wallet;

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -1,6 +1,9 @@
+use std::any::TypeId;
 use std::fmt;
+use std::ops::Range;
 
-use zeroize::Zeroizing;
+use egui::TextBuffer;
+use zeroize::{Zeroize, Zeroizing};
 
 /// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).
 ///
@@ -8,39 +11,60 @@ use zeroize::Zeroizing;
 /// being swapped to disk. The lock is released automatically when the value is dropped.
 ///
 /// `Display`, `Deref`, and `DerefMut` are intentionally **not** implemented to
-/// prevent accidental leakage. Use [`expose_secret`](Self::expose_secret) or
-/// [`expose_secret_mut`](Self::expose_secret_mut) for explicit access.
+/// prevent accidental leakage. Use [`expose_secret`](Self::expose_secret) for
+/// explicit read access, or pass `&mut Secret` directly to `TextEdit::singleline`
+/// (via the [`TextBuffer`] impl) for mutable editing.
 pub struct Secret {
     /// Dropped first -- zeroes the bytes.
     inner: Zeroizing<String>,
     /// Dropped second -- unlocks the page.
     _lock: Option<region::LockGuard>,
+    /// Tracks the heap pointer so we can re-lock after reallocation.
+    locked_ptr: *const u8,
 }
+
+// SAFETY: `locked_ptr` is only used for pointer comparison (never dereferenced).
+// The actual data lives in `inner` (Send+Sync via Zeroizing<String>) and `_lock`
+// (Send+Sync via region::LockGuard's unsafe impls).
+unsafe impl Send for Secret {}
+unsafe impl Sync for Secret {}
 
 impl Secret {
     /// Wrap a string in a `Secret`, locking its backing memory on a best-effort basis.
     pub fn new(s: impl Into<String>) -> Self {
         let mut s: String = s.into();
-        // Pre-allocate so later pushes are less likely to reallocate (which would
-        // leave copies of the secret in freed pages).
         let target_cap = s.len().max(128);
         if s.capacity() < target_cap {
             s.reserve(target_cap - s.capacity());
         }
-        let lock = region::lock(s.as_ptr(), s.capacity()).ok();
+        let lock = region::lock(s.as_ptr(), s.capacity())
+            .map_err(|e| {
+                tracing::debug!("mlock failed for Secret: {e}");
+                e
+            })
+            .ok();
+        let locked_ptr = s.as_ptr();
         Self {
             inner: Zeroizing::new(s),
             _lock: lock,
+            locked_ptr,
         }
     }
 
     /// Create an empty `Secret` with a pre-allocated, locked buffer.
     pub fn with_capacity(cap: usize) -> Self {
         let s = String::with_capacity(cap);
-        let lock = region::lock(s.as_ptr(), s.capacity()).ok();
+        let lock = region::lock(s.as_ptr(), s.capacity())
+            .map_err(|e| {
+                tracing::debug!("mlock failed for Secret: {e}");
+                e
+            })
+            .ok();
+        let locked_ptr = s.as_ptr();
         Self {
             inner: Zeroizing::new(s),
             _lock: lock,
+            locked_ptr,
         }
     }
 
@@ -54,14 +78,65 @@ impl Secret {
         &self.inner
     }
 
-    /// Mutably borrow the backing `String` (needed for egui `TextEdit` binding).
-    pub fn expose_secret_mut(&mut self) -> &mut String {
-        &mut self.inner
-    }
-
     /// Whether the secret is empty.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+
+    /// If the backing allocation moved (e.g. after a `String` reallocation),
+    /// drop the old mlock guard and create a new one for the current buffer.
+    fn relock_if_moved(&mut self) {
+        if self.inner.as_ptr() != self.locked_ptr {
+            self._lock = region::lock(self.inner.as_ptr(), self.inner.capacity())
+                .map_err(|e| {
+                    tracing::debug!("mlock re-lock failed after reallocation: {e}");
+                    e
+                })
+                .ok();
+            self.locked_ptr = self.inner.as_ptr();
+        }
+    }
+}
+
+// -- TextBuffer impl (allows `TextEdit::singleline(&mut secret)`) -----------
+
+impl TextBuffer for Secret {
+    fn is_mutable(&self) -> bool {
+        true
+    }
+
+    fn as_str(&self) -> &str {
+        self.inner.as_str()
+    }
+
+    fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
+        let n = <String as TextBuffer>::insert_text(&mut *self.inner, text, char_index);
+        self.relock_if_moved();
+        n
+    }
+
+    fn delete_char_range(&mut self, char_range: Range<usize>) {
+        <String as TextBuffer>::delete_char_range(&mut *self.inner, char_range);
+    }
+
+    fn clear(&mut self) {
+        Zeroize::zeroize(&mut *self.inner);
+    }
+
+    fn replace_with(&mut self, text: &str) {
+        Zeroize::zeroize(&mut *self.inner);
+        self.inner.push_str(text);
+        self.relock_if_moved();
+    }
+
+    fn take(&mut self) -> String {
+        let copy = self.inner.to_string();
+        Zeroize::zeroize(&mut *self.inner);
+        copy
+    }
+
+    fn type_id(&self) -> TypeId {
+        TypeId::of::<Self>()
     }
 }
 
@@ -69,7 +144,22 @@ impl Secret {
 
 impl Clone for Secret {
     fn clone(&self) -> Self {
-        Self::new(self.inner.as_str().to_string())
+        let src = self.inner.as_str();
+        let cap = src.len().max(128);
+        let mut s = String::with_capacity(cap);
+        s.push_str(src);
+        let lock = region::lock(s.as_ptr(), s.capacity())
+            .map_err(|e| {
+                tracing::debug!("mlock failed for cloned Secret: {e}");
+                e
+            })
+            .ok();
+        let locked_ptr = s.as_ptr();
+        Self {
+            inner: Zeroizing::new(s),
+            _lock: lock,
+            locked_ptr,
+        }
     }
 }
 
@@ -86,14 +176,15 @@ impl fmt::Debug for Secret {
 }
 
 impl PartialEq for Secret {
-    /// Constant-time comparison to prevent timing side-channel attacks (CWE-208).
+    /// Best-effort timing-resistant comparison. Note: length differences cause
+    /// an early return, which leaks length information through timing. Acceptable
+    /// for this application's local threat model.
     fn eq(&self, other: &Self) -> bool {
         let a = self.expose_secret().as_bytes();
         let b = other.expose_secret().as_bytes();
         if a.len() != b.len() {
             return false;
         }
-        // XOR all bytes; any difference sets bits in `diff`.
         let diff = a
             .iter()
             .zip(b.iter())
@@ -112,7 +203,21 @@ impl From<String> for Secret {
 
 impl From<&str> for Secret {
     fn from(s: &str) -> Self {
-        Self::new(s.to_string())
+        let cap = s.len().max(128);
+        let mut buf = String::with_capacity(cap);
+        buf.push_str(s);
+        let lock = region::lock(buf.as_ptr(), buf.capacity())
+            .map_err(|e| {
+                tracing::debug!("mlock failed for Secret: {e}");
+                e
+            })
+            .ok();
+        let locked_ptr = buf.as_ptr();
+        Self {
+            inner: Zeroizing::new(buf),
+            _lock: lock,
+            locked_ptr,
+        }
     }
 }
 
@@ -140,10 +245,40 @@ mod tests {
     }
 
     #[test]
-    fn test_expose_secret_mut() {
+    fn test_text_buffer_insert_and_delete() {
         let mut secret = Secret::new("hello");
-        secret.expose_secret_mut().push_str(" world");
+
+        // insert_text appends " world"
+        let inserted = secret.insert_text(" world", 5);
+        assert_eq!(inserted, 6);
         assert_eq!(secret.expose_secret(), "hello world");
+
+        // delete_char_range removes " world"
+        secret.delete_char_range(5..11);
+        assert_eq!(secret.expose_secret(), "hello");
+    }
+
+    #[test]
+    fn test_text_buffer_clear() {
+        let mut secret = Secret::new("sensitive");
+        TextBuffer::clear(&mut secret);
+        assert!(secret.is_empty());
+        assert_eq!(secret.expose_secret(), "");
+    }
+
+    #[test]
+    fn test_text_buffer_replace_with() {
+        let mut secret = Secret::new("old content");
+        secret.replace_with("new content");
+        assert_eq!(secret.expose_secret(), "new content");
+    }
+
+    #[test]
+    fn test_text_buffer_take() {
+        let mut secret = Secret::new("take me");
+        let taken = TextBuffer::take(&mut secret);
+        assert_eq!(taken, "take me");
+        assert!(secret.is_empty());
     }
 
     #[test]

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -5,17 +5,17 @@ use std::ops::Range;
 use egui::TextBuffer;
 use zeroize::{Zeroize, Zeroizing};
 
-/// Default pre-allocation size for `Secret` buffers.
+/// Default pre-allocation capacity for `Secret` buffers.
 ///
-/// Set to one memory page (4096 bytes on most platforms) because:
+/// Set to 4096 bytes because:
 /// - `mlock` operates on page granularity — locking less than a page still
 ///   locks the entire page, so smaller buffers waste no memory.
-/// - A full page is large enough for any human-entered password or WIF key,
+/// - 4096 bytes is large enough for any human-entered password or WIF key,
 ///   making `String` reallocation virtually impossible during normal use.
 /// - When reallocation *does* happen, the old buffer is freed by the system
 ///   allocator without zeroing — a residual leak we cannot prevent without
-///   a custom allocator. Pre-allocating one page avoids this entirely.
-const PAGE_SIZE: usize = 4096;
+///   a custom allocator. Pre-allocating avoids this entirely.
+const DEFAULT_CAPACITY: usize = 4096;
 
 /// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).
 ///
@@ -52,7 +52,7 @@ impl Secret {
     /// Wrap a string in a `Secret`, locking its backing memory on a best-effort basis.
     pub fn new(s: impl Into<String>) -> Self {
         let mut source: String = s.into();
-        let cap = source.len().max(PAGE_SIZE);
+        let cap = source.len().max(DEFAULT_CAPACITY);
         let mut buf = String::with_capacity(cap);
         buf.push_str(&source);
         // Zeroize the original string before it's freed
@@ -73,7 +73,7 @@ impl Secret {
 
     /// Create an empty `Secret` with a pre-allocated, locked buffer.
     pub fn with_capacity(cap: usize) -> Self {
-        let cap = cap.max(PAGE_SIZE);
+        let cap = cap.max(DEFAULT_CAPACITY);
         let s = String::with_capacity(cap);
         let lock = region::lock(s.as_ptr(), s.capacity())
             .map_err(|e| {
@@ -128,13 +128,14 @@ impl Drop for Secret {
     fn drop(&mut self) {
         // Zero the full capacity, including bytes beyond len that
         // Zeroize for String would miss (it only zeros 0..len).
+        // Use zeroize crate semantics (volatile/fence-guarded) to prevent
+        // the compiler from optimizing the wipe away.
         let ptr = self.inner.as_mut_ptr();
         let cap = self.inner.capacity();
         if cap > 0 {
             // SAFETY: ptr is valid for cap bytes (String allocation guarantee).
-            unsafe {
-                std::ptr::write_bytes(ptr, 0, cap);
-            }
+            let slice = unsafe { std::slice::from_raw_parts_mut(ptr, cap) };
+            slice.zeroize();
         }
         // After this, Rust drops fields in order: inner (Zeroizing re-zeroes 0..len, harmless),
         // then _lock (unlocks the page), then locked_ptr (no-op).
@@ -204,7 +205,7 @@ impl Clone for Secret {
 
 impl Default for Secret {
     fn default() -> Self {
-        Self::with_capacity(PAGE_SIZE)
+        Self::with_capacity(DEFAULT_CAPACITY)
     }
 }
 
@@ -354,12 +355,12 @@ mod tests {
         let secret = Secret::with_capacity(256);
         assert!(secret.is_empty());
         assert_eq!(secret.expose_secret(), "");
-        // Capacity must be at least PAGE_SIZE
+        // Capacity must be at least DEFAULT_CAPACITY
         assert!(
-            secret.inner.capacity() >= PAGE_SIZE,
-            "capacity {} must be >= PAGE_SIZE {}",
+            secret.inner.capacity() >= DEFAULT_CAPACITY,
+            "capacity {} must be >= DEFAULT_CAPACITY {}",
             secret.inner.capacity(),
-            PAGE_SIZE,
+            DEFAULT_CAPACITY,
         );
     }
 

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -99,6 +99,11 @@ impl Secret {
         &self.inner
     }
 
+    /// The length of the secret in bytes.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
     /// Whether the secret is empty.
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -17,6 +17,27 @@ use zeroize::{Zeroize, Zeroizing};
 ///   a custom allocator. Pre-allocating avoids this entirely.
 const DEFAULT_CAPACITY: usize = 4096;
 
+/// A raw pointer used only for equality comparison, never dereferenced.
+/// Encapsulates the Send/Sync safety invariant so `Secret` itself does not
+/// need manual unsafe trait impls.
+#[derive(Clone, Copy)]
+struct CompareOnlyPtr(*const u8);
+
+// SAFETY: CompareOnlyPtr is never dereferenced — only compared via addr_eq().
+// The pointed-to memory is managed by the String inside Zeroizing.
+unsafe impl Send for CompareOnlyPtr {}
+unsafe impl Sync for CompareOnlyPtr {}
+
+impl CompareOnlyPtr {
+    fn new(ptr: *const u8) -> Self {
+        Self(ptr)
+    }
+
+    fn addr_eq(self, other: *const u8) -> bool {
+        std::ptr::eq(self.0, other)
+    }
+}
+
 /// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).
 ///
 /// Debug output is redacted. Best-effort `mlock` prevents the backing memory from
@@ -39,14 +60,8 @@ pub struct Secret {
     /// Dropped second -- unlocks the page.
     _lock: Option<region::LockGuard>,
     /// Tracks the heap pointer so we can re-lock after reallocation.
-    locked_ptr: *const u8,
+    locked_ptr: CompareOnlyPtr,
 }
-
-// SAFETY: `locked_ptr` is only used for pointer comparison (never dereferenced).
-// The actual data lives in `inner` (Send+Sync via Zeroizing<String>) and `_lock`
-// (Send+Sync via region::LockGuard's unsafe impls).
-unsafe impl Send for Secret {}
-unsafe impl Sync for Secret {}
 
 impl Secret {
     /// Wrap a string in a `Secret`, locking its backing memory on a best-effort basis.
@@ -63,7 +78,7 @@ impl Secret {
                 e
             })
             .ok();
-        let locked_ptr = buf.as_ptr();
+        let locked_ptr = CompareOnlyPtr::new(buf.as_ptr());
         Self {
             inner: Zeroizing::new(buf),
             _lock: lock,
@@ -81,7 +96,7 @@ impl Secret {
                 e
             })
             .ok();
-        let locked_ptr = s.as_ptr();
+        let locked_ptr = CompareOnlyPtr::new(s.as_ptr());
         Self {
             inner: Zeroizing::new(s),
             _lock: lock,
@@ -109,17 +124,24 @@ impl Secret {
         self.inner.is_empty()
     }
 
+    /// Returns a new `Secret` containing the trimmed content.
+    /// Keeps the data within the secure wrapper unlike `text().trim()`
+    /// which returns a borrowed `&str`.
+    pub fn trimmed(&self) -> Self {
+        Self::new(self.inner.trim().to_string())
+    }
+
     /// If the backing allocation moved (e.g. after a `String` reallocation),
     /// drop the old mlock guard and create a new one for the current buffer.
     fn relock_if_moved(&mut self) {
-        if self.inner.as_ptr() != self.locked_ptr {
+        if !self.locked_ptr.addr_eq(self.inner.as_ptr()) {
             self._lock = region::lock(self.inner.as_ptr(), self.inner.capacity())
                 .map_err(|e| {
                     tracing::debug!("mlock re-lock failed after reallocation: {e}");
                     e
                 })
                 .ok();
-            self.locked_ptr = self.inner.as_ptr();
+            self.locked_ptr = CompareOnlyPtr::new(self.inner.as_ptr());
         }
     }
 }
@@ -168,9 +190,7 @@ impl TextBuffer for Secret {
         if cap > len {
             // SAFETY: ptr is valid for cap bytes (String's allocation guarantee),
             // and we only write to the unused portion [len..cap).
-            unsafe {
-                std::ptr::write_bytes(ptr.add(len), 0, cap - len);
-            }
+            unsafe { std::slice::from_raw_parts_mut(ptr.add(len), cap - len) }.zeroize();
         }
     }
 
@@ -185,6 +205,9 @@ impl TextBuffer for Secret {
     }
 
     fn take(&mut self) -> String {
+        // INTENTIONAL(SEC-003): Returns unprotected String — required by egui TextBuffer trait.
+        // The undoer is disabled in PasswordInput, limiting the call paths. Accepted as
+        // inherent limitation of the egui framework for the desktop GUI threat model.
         let copy = self.inner.to_string();
         Zeroize::zeroize(&mut *self.inner);
         copy
@@ -199,7 +222,7 @@ impl TextBuffer for Secret {
 
 impl Clone for Secret {
     fn clone(&self) -> Self {
-        Self::new(self.inner.to_string())
+        Self::new((*self.inner).clone())
     }
 }
 
@@ -365,6 +388,20 @@ mod tests {
     }
 
     #[test]
+    fn test_trimmed() {
+        let secret = Secret::new("  hello world  ");
+        let trimmed = secret.trimmed();
+        assert_eq!(trimmed.expose_secret(), "hello world");
+    }
+
+    #[test]
+    fn test_trimmed_empty() {
+        let secret = Secret::new("   ");
+        let trimmed = secret.trimmed();
+        assert!(trimmed.is_empty());
+    }
+
+    #[test]
     fn test_delete_char_range_zeroes_trailing() {
         let mut secret = Secret::new("abcdef");
         secret.delete_char_range(3..6);
@@ -384,5 +421,49 @@ mod tests {
         assert_eq!(secret.expose_secret(), "drop me safely");
         drop(secret);
         // If we get here, drop didn't panic
+    }
+
+    // Compile-time assertion that Secret has a Drop impl (not trivially droppable).
+    const _: () = {
+        assert!(std::mem::needs_drop::<Secret>());
+    };
+
+    /// Best-effort test that Drop zeroes the full capacity.
+    ///
+    /// Reads freed memory after drop — technically UB and may fail if the
+    /// allocator reuses the page between drop and inspection (common during
+    /// parallel test execution). Run manually with `--ignored` in a single
+    /// thread for reliable results:
+    ///
+    /// ```sh
+    /// cargo test --lib -- test_drop_zeroes_full_capacity --ignored --test-threads=1
+    /// ```
+    ///
+    /// The compile-time assertion (`needs_drop`) above is the primary regression
+    /// guard; this test provides supplementary runtime verification.
+    #[test]
+    #[ignore]
+    fn test_drop_zeroes_full_capacity() {
+        let ptr: *const u8;
+        let cap: usize;
+        {
+            let secret = Secret::new("sensitive_data_here".to_string());
+            ptr = secret.inner.as_ptr();
+            cap = secret.inner.capacity();
+            // Verify data is present before drop
+            let slice = unsafe { std::slice::from_raw_parts(ptr, cap) };
+            assert!(
+                slice.iter().any(|&b| b != 0),
+                "Expected non-zero bytes before drop"
+            );
+            // secret drops here — Drop zeros 0..cap via zeroize
+        }
+        // SAFETY: Reading freed memory. Best-effort: allocator is unlikely to
+        // reuse this page immediately when running single-threaded.
+        let post = unsafe { std::slice::from_raw_parts(ptr, cap) };
+        assert!(
+            post.iter().all(|&b| b == 0),
+            "Memory was not zeroed after drop"
+        );
     }
 }

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -5,8 +5,16 @@ use std::ops::Range;
 use egui::TextBuffer;
 use zeroize::{Zeroize, Zeroizing};
 
-/// Default pre-allocation size for `Secret` buffers. Set to one memory page
-/// to minimize reallocations (which would leak the old buffer contents).
+/// Default pre-allocation size for `Secret` buffers.
+///
+/// Set to one memory page (4096 bytes on most platforms) because:
+/// - `mlock` operates on page granularity — locking less than a page still
+///   locks the entire page, so smaller buffers waste no memory.
+/// - A full page is large enough for any human-entered password or WIF key,
+///   making `String` reallocation virtually impossible during normal use.
+/// - When reallocation *does* happen, the old buffer is freed by the system
+///   allocator without zeroing — a residual leak we cannot prevent without
+///   a custom allocator. Pre-allocating one page avoids this entirely.
 const PAGE_SIZE: usize = 4096;
 
 /// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -1,0 +1,198 @@
+use std::fmt;
+
+use zeroize::Zeroizing;
+
+/// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).
+///
+/// Debug output is redacted. Best-effort `mlock` prevents the backing memory from
+/// being swapped to disk. The lock is released automatically when the value is dropped.
+///
+/// `Display`, `Deref`, and `DerefMut` are intentionally **not** implemented to
+/// prevent accidental leakage. Use [`expose_secret`](Self::expose_secret) or
+/// [`expose_secret_mut`](Self::expose_secret_mut) for explicit access.
+pub struct Secret {
+    /// Dropped first -- zeroes the bytes.
+    inner: Zeroizing<String>,
+    /// Dropped second -- unlocks the page.
+    _lock: Option<region::LockGuard>,
+}
+
+impl Secret {
+    /// Wrap a string in a `Secret`, locking its backing memory on a best-effort basis.
+    pub fn new(s: impl Into<String>) -> Self {
+        let mut s: String = s.into();
+        // Pre-allocate so later pushes are less likely to reallocate (which would
+        // leave copies of the secret in freed pages).
+        let target_cap = s.len().max(128);
+        if s.capacity() < target_cap {
+            s.reserve(target_cap - s.capacity());
+        }
+        let lock = region::lock(s.as_ptr(), s.capacity()).ok();
+        Self {
+            inner: Zeroizing::new(s),
+            _lock: lock,
+        }
+    }
+
+    /// Create an empty `Secret` with a pre-allocated, locked buffer.
+    pub fn with_capacity(cap: usize) -> Self {
+        let s = String::with_capacity(cap);
+        let lock = region::lock(s.as_ptr(), s.capacity()).ok();
+        Self {
+            inner: Zeroizing::new(s),
+            _lock: lock,
+        }
+    }
+
+    /// Create an empty `Secret` with a pre-allocated, locked buffer.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Borrow the plaintext.
+    pub fn expose_secret(&self) -> &str {
+        &self.inner
+    }
+
+    /// Mutably borrow the backing `String` (needed for egui `TextEdit` binding).
+    pub fn expose_secret_mut(&mut self) -> &mut String {
+        &mut self.inner
+    }
+
+    /// Whether the secret is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+}
+
+// -- Trait impls -------------------------------------------------------------
+
+impl Clone for Secret {
+    fn clone(&self) -> Self {
+        Self::new(self.inner.as_str().to_string())
+    }
+}
+
+impl Default for Secret {
+    fn default() -> Self {
+        Self::with_capacity(128)
+    }
+}
+
+impl fmt::Debug for Secret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Secret(***)")
+    }
+}
+
+impl PartialEq for Secret {
+    /// Constant-time comparison to prevent timing side-channel attacks (CWE-208).
+    fn eq(&self, other: &Self) -> bool {
+        let a = self.expose_secret().as_bytes();
+        let b = other.expose_secret().as_bytes();
+        if a.len() != b.len() {
+            return false;
+        }
+        // XOR all bytes; any difference sets bits in `diff`.
+        let diff = a
+            .iter()
+            .zip(b.iter())
+            .fold(0u8, |acc, (x, y)| acc | (x ^ y));
+        diff == 0
+    }
+}
+
+impl Eq for Secret {}
+
+impl From<String> for Secret {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<&str> for Secret {
+    fn from(s: &str) -> Self {
+        Self::new(s.to_string())
+    }
+}
+
+// -- Tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_redacted() {
+        let secret = Secret::new("hunter2");
+        let debug = format!("{:?}", secret);
+        assert!(debug.contains("***"), "debug output must be redacted");
+        assert!(
+            !debug.contains("hunter2"),
+            "debug output must not contain the actual value"
+        );
+    }
+
+    #[test]
+    fn test_expose_secret() {
+        let secret = Secret::new("hello");
+        assert_eq!(secret.expose_secret(), "hello");
+    }
+
+    #[test]
+    fn test_expose_secret_mut() {
+        let mut secret = Secret::new("hello");
+        secret.expose_secret_mut().push_str(" world");
+        assert_eq!(secret.expose_secret(), "hello world");
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(Secret::empty().is_empty());
+        assert!(Secret::default().is_empty());
+        assert!(!Secret::new("x").is_empty());
+    }
+
+    #[test]
+    fn test_partial_eq() {
+        let a = Secret::new("same");
+        let b = Secret::new("same");
+        let c = Secret::new("different");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_from_string() {
+        let s = String::from("owned");
+        let secret: Secret = s.into();
+        assert_eq!(secret.expose_secret(), "owned");
+    }
+
+    #[test]
+    fn test_from_str() {
+        let secret: Secret = "borrowed".into();
+        assert_eq!(secret.expose_secret(), "borrowed");
+    }
+
+    #[test]
+    fn test_default_is_empty() {
+        let secret = Secret::default();
+        assert!(secret.is_empty());
+        assert_eq!(secret.expose_secret(), "");
+    }
+
+    #[test]
+    fn test_clone() {
+        let original = Secret::new("clone me");
+        let cloned = original.clone();
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let secret = Secret::with_capacity(256);
+        assert!(secret.is_empty());
+        assert_eq!(secret.expose_secret(), "");
+    }
+}

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -5,6 +5,10 @@ use std::ops::Range;
 use egui::TextBuffer;
 use zeroize::{Zeroize, Zeroizing};
 
+/// Default pre-allocation size for `Secret` buffers. Set to one memory page
+/// to minimize reallocations (which would leak the old buffer contents).
+const PAGE_SIZE: usize = 4096;
+
 /// Zeroize-on-drop wrapper for sensitive strings (passwords, WIF keys, private key inputs).
 ///
 /// Debug output is redacted. Best-effort `mlock` prevents the backing memory from
@@ -14,6 +18,13 @@ use zeroize::{Zeroize, Zeroizing};
 /// prevent accidental leakage. Use [`expose_secret`](Self::expose_secret) for
 /// explicit read access, or pass `&mut Secret` directly to `TextEdit::singleline`
 /// (via the [`TextBuffer`] impl) for mutable editing.
+///
+/// # Security: TextEdit usage
+///
+/// When using `Secret` with `TextEdit::singleline`, you **must** set
+/// `.password(true)`. Without it, plaintext leaks to egui's layout system,
+/// widget info, and accessibility events. Use [`PasswordInput`] to ensure
+/// this is always enforced.
 pub struct Secret {
     /// Dropped first -- zeroes the bytes.
     inner: Zeroizing<String>,
@@ -32,20 +43,21 @@ unsafe impl Sync for Secret {}
 impl Secret {
     /// Wrap a string in a `Secret`, locking its backing memory on a best-effort basis.
     pub fn new(s: impl Into<String>) -> Self {
-        let mut s: String = s.into();
-        let target_cap = s.len().max(128);
-        if s.capacity() < target_cap {
-            s.reserve(target_cap - s.capacity());
-        }
-        let lock = region::lock(s.as_ptr(), s.capacity())
+        let mut source: String = s.into();
+        let cap = source.len().max(PAGE_SIZE);
+        let mut buf = String::with_capacity(cap);
+        buf.push_str(&source);
+        // Zeroize the original string before it's freed
+        source.zeroize();
+        let lock = region::lock(buf.as_ptr(), buf.capacity())
             .map_err(|e| {
                 tracing::debug!("mlock failed for Secret: {e}");
                 e
             })
             .ok();
-        let locked_ptr = s.as_ptr();
+        let locked_ptr = buf.as_ptr();
         Self {
-            inner: Zeroizing::new(s),
+            inner: Zeroizing::new(buf),
             _lock: lock,
             locked_ptr,
         }
@@ -53,6 +65,7 @@ impl Secret {
 
     /// Create an empty `Secret` with a pre-allocated, locked buffer.
     pub fn with_capacity(cap: usize) -> Self {
+        let cap = cap.max(PAGE_SIZE);
         let s = String::with_capacity(cap);
         let lock = region::lock(s.as_ptr(), s.capacity())
             .map_err(|e| {
@@ -98,6 +111,23 @@ impl Secret {
     }
 }
 
+impl Drop for Secret {
+    fn drop(&mut self) {
+        // Zero the full capacity, including bytes beyond len that
+        // Zeroize for String would miss (it only zeros 0..len).
+        let ptr = self.inner.as_mut_ptr();
+        let cap = self.inner.capacity();
+        if cap > 0 {
+            // SAFETY: ptr is valid for cap bytes (String allocation guarantee).
+            unsafe {
+                std::ptr::write_bytes(ptr, 0, cap);
+            }
+        }
+        // After this, Rust drops fields in order: inner (Zeroizing re-zeroes 0..len, harmless),
+        // then _lock (unlocks the page), then locked_ptr (no-op).
+    }
+}
+
 // -- TextBuffer impl (allows `TextEdit::singleline(&mut secret)`) -----------
 
 impl TextBuffer for Secret {
@@ -117,6 +147,17 @@ impl TextBuffer for Secret {
 
     fn delete_char_range(&mut self, char_range: Range<usize>) {
         <String as TextBuffer>::delete_char_range(&mut *self.inner, char_range);
+        // Zero deleted bytes in trailing capacity [len..capacity)
+        let ptr = self.inner.as_mut_ptr();
+        let len = self.inner.len();
+        let cap = self.inner.capacity();
+        if cap > len {
+            // SAFETY: ptr is valid for cap bytes (String's allocation guarantee),
+            // and we only write to the unused portion [len..cap).
+            unsafe {
+                std::ptr::write_bytes(ptr.add(len), 0, cap - len);
+            }
+        }
     }
 
     fn clear(&mut self) {
@@ -144,28 +185,13 @@ impl TextBuffer for Secret {
 
 impl Clone for Secret {
     fn clone(&self) -> Self {
-        let src = self.inner.as_str();
-        let cap = src.len().max(128);
-        let mut s = String::with_capacity(cap);
-        s.push_str(src);
-        let lock = region::lock(s.as_ptr(), s.capacity())
-            .map_err(|e| {
-                tracing::debug!("mlock failed for cloned Secret: {e}");
-                e
-            })
-            .ok();
-        let locked_ptr = s.as_ptr();
-        Self {
-            inner: Zeroizing::new(s),
-            _lock: lock,
-            locked_ptr,
-        }
+        Self::new(self.inner.to_string())
     }
 }
 
 impl Default for Secret {
     fn default() -> Self {
-        Self::with_capacity(128)
+        Self::with_capacity(PAGE_SIZE)
     }
 }
 
@@ -203,21 +229,7 @@ impl From<String> for Secret {
 
 impl From<&str> for Secret {
     fn from(s: &str) -> Self {
-        let cap = s.len().max(128);
-        let mut buf = String::with_capacity(cap);
-        buf.push_str(s);
-        let lock = region::lock(buf.as_ptr(), buf.capacity())
-            .map_err(|e| {
-                tracing::debug!("mlock failed for Secret: {e}");
-                e
-            })
-            .ok();
-        let locked_ptr = buf.as_ptr();
-        Self {
-            inner: Zeroizing::new(buf),
-            _lock: lock,
-            locked_ptr,
-        }
+        Self::new(s.to_string())
     }
 }
 
@@ -329,5 +341,34 @@ mod tests {
         let secret = Secret::with_capacity(256);
         assert!(secret.is_empty());
         assert_eq!(secret.expose_secret(), "");
+        // Capacity must be at least PAGE_SIZE
+        assert!(
+            secret.inner.capacity() >= PAGE_SIZE,
+            "capacity {} must be >= PAGE_SIZE {}",
+            secret.inner.capacity(),
+            PAGE_SIZE,
+        );
+    }
+
+    #[test]
+    fn test_delete_char_range_zeroes_trailing() {
+        let mut secret = Secret::new("abcdef");
+        secret.delete_char_range(3..6);
+        assert_eq!(secret.expose_secret(), "abc");
+        // Trailing capacity bytes (after len) should be zeroed
+        let len = secret.inner.len();
+        let cap = secret.inner.capacity();
+        let bytes = secret.inner.as_bytes();
+        // We can only inspect up to len via safe API, but the content is correct
+        assert_eq!(bytes, b"abc");
+        assert!(cap > len, "buffer should have trailing capacity");
+    }
+
+    #[test]
+    fn test_drop_does_not_panic() {
+        let secret = Secret::new("drop me safely");
+        assert_eq!(secret.expose_secret(), "drop me safely");
+        drop(secret);
+        // If we get here, drop didn't panic
     }
 }

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -10,6 +10,7 @@ pub mod info_popup;
 pub mod left_panel;
 pub mod left_wallet_panel;
 pub mod message_banner;
+pub mod password_input;
 pub mod selection_dialog;
 pub mod styled;
 pub mod tokens_subscreen_chooser_panel;

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -3,7 +3,11 @@ use egui::{Rect, Response, Sense, Stroke, Ui, pos2, vec2};
 use crate::model::secret::Secret;
 use crate::ui::theme::DashColors;
 
-/// Response from a [`PasswordInput`] widget.
+/// Response from [`PasswordInput::show`].
+///
+/// Intentionally does NOT implement `ComponentResponse` — exposing the `Secret`
+/// through a generic trait would undermine the security model.
+// INTENTIONAL(PROJ-001): Custom response type instead of ComponentResponse.
 pub struct PasswordInputResponse {
     /// The underlying `TextEdit` response.
     pub response: Response,
@@ -83,7 +87,7 @@ impl PasswordInput {
 
     /// Replace the secret with new content.
     pub fn set_text(&mut self, s: impl Into<String>) {
-        self.secret = Secret::new(s.into());
+        self.secret = Secret::new(s);
     }
 
     /// Zeroize and reset the secret to empty.
@@ -118,6 +122,8 @@ impl PasswordInput {
         let dark_mode = ui.ctx().style().visuals.dark_mode;
 
         // -- TextEdit --------------------------------------------------------
+        // INTENTIONAL(SEC-005): Egui TextEdit may cache plaintext in layout galleys and
+        // accessibility state. Accepted as inherent framework limitation for desktop GUI threat model.
         let mut text_edit = egui::TextEdit::singleline(&mut self.secret)
             .password(!self.revealing)
             .hint_text(&self.hint_text)

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -118,7 +118,7 @@ impl PasswordInput {
         let dark_mode = ui.ctx().style().visuals.dark_mode;
 
         // -- TextEdit --------------------------------------------------------
-        let mut text_edit = egui::TextEdit::singleline(self.secret.expose_secret_mut())
+        let mut text_edit = egui::TextEdit::singleline(&mut self.secret)
             .password(!self.revealing)
             .hint_text(&self.hint_text)
             .margin(egui::Margin {

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -165,7 +165,10 @@ impl PasswordInput {
         let eye_response = ui.interact(eye_rect, eye_id, Sense::click_and_drag());
 
         // Update for NEXT frame.
-        self.revealing = eye_response.is_pointer_button_down_on() && eye_response.hovered();
+        let next_revealing =
+            eye_response.is_pointer_button_down_on() && eye_response.hovered();
+        let reveal_changed = next_revealing != self.revealing;
+        self.revealing = next_revealing;
 
         let icon_color = if eye_response.hovered() || self.revealing {
             DashColors::DASH_BLUE
@@ -195,7 +198,7 @@ impl PasswordInput {
         }
         eye_response.on_hover_text("Hold to reveal");
 
-        if self.revealing {
+        if self.revealing || reveal_changed {
             ui.ctx().request_repaint();
         }
 

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -137,6 +137,20 @@ impl PasswordInput {
         }
 
         let text_response = ui.add(text_edit);
+
+        // SEC-001: Disable egui's Undoer to prevent plaintext undo history.
+        if let Some(mut state) =
+            egui::widgets::text_edit::TextEditState::load(ui.ctx(), text_response.id)
+        {
+            state.set_undoer(egui::util::undoer::Undoer::with_settings(
+                egui::util::undoer::Settings {
+                    max_undos: 0,
+                    ..Default::default()
+                },
+            ));
+            state.store(ui.ctx(), text_response.id);
+        }
+
         let changed = text_response.changed();
 
         // -- Eye icon --------------------------------------------------------

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -165,8 +165,7 @@ impl PasswordInput {
         let eye_response = ui.interact(eye_rect, eye_id, Sense::click_and_drag());
 
         // Update for NEXT frame.
-        let next_revealing =
-            eye_response.is_pointer_button_down_on() && eye_response.hovered();
+        let next_revealing = eye_response.is_pointer_button_down_on() && eye_response.hovered();
         let reveal_changed = next_revealing != self.revealing;
         self.revealing = next_revealing;
 

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -1,0 +1,204 @@
+use egui::{Rect, Response, Sense, Stroke, Ui, pos2, vec2};
+
+use crate::model::secret::Secret;
+use crate::ui::theme::DashColors;
+
+/// Response from a [`PasswordInput`] widget.
+pub struct PasswordInputResponse {
+    /// The underlying `TextEdit` response.
+    pub response: Response,
+    /// Whether the text changed this frame.
+    pub changed: bool,
+}
+
+/// A masked text input with a hold-to-reveal eye icon.
+///
+/// The backing buffer is a [`Secret`] that is zeroized on drop.
+/// The eye icon uses a press-and-hold gesture: the plaintext is visible
+/// only while the pointer is held down on the icon, and re-masked
+/// immediately on release.
+///
+/// # Usage
+///
+/// Store as `Option<PasswordInput>` for lazy initialization:
+///
+/// ```rust,ignore
+/// let pw = self.password.get_or_insert_with(|| {
+///     PasswordInput::new()
+///         .with_hint_text("Wallet password")
+///         .with_desired_width(300.0)
+/// });
+/// let resp = pw.show(ui);
+/// if resp.changed { /* validate */ }
+/// ```
+pub struct PasswordInput {
+    secret: Secret,
+    hint_text: String,
+    desired_width: Option<f32>,
+    error_message: Option<String>,
+    monospace: bool,
+    /// Carry-over from the previous frame (see module-level note on timing).
+    revealing: bool,
+}
+
+impl PasswordInput {
+    /// Create a new empty password input with default hint text.
+    pub fn new() -> Self {
+        Self {
+            secret: Secret::default(),
+            hint_text: "Enter password".to_string(),
+            desired_width: None,
+            error_message: None,
+            monospace: false,
+            revealing: false,
+        }
+    }
+
+    // -- Builder methods (consuming self) ------------------------------------
+
+    /// Override the hint / placeholder text.
+    pub fn with_hint_text(mut self, hint: impl Into<String>) -> Self {
+        self.hint_text = hint.into();
+        self
+    }
+
+    /// Set the desired width of the text field.
+    pub fn with_desired_width(mut self, width: f32) -> Self {
+        self.desired_width = Some(width);
+        self
+    }
+
+    /// Render the text in a monospace font (useful for WIF keys).
+    pub fn with_monospace(mut self) -> Self {
+        self.monospace = true;
+        self
+    }
+
+    // -- Access methods ------------------------------------------------------
+
+    /// Borrow the plaintext.
+    pub fn text(&self) -> &str {
+        self.secret.expose_secret()
+    }
+
+    /// Replace the secret with new content.
+    pub fn set_text(&mut self, s: impl Into<String>) {
+        self.secret = Secret::new(s.into());
+    }
+
+    /// Zeroize and reset the secret to empty.
+    pub fn clear(&mut self) {
+        self.secret = Secret::default();
+    }
+
+    /// Whether the secret is empty.
+    pub fn is_empty(&self) -> bool {
+        self.secret.is_empty()
+    }
+
+    /// Set or clear an external error message shown below the input.
+    pub fn set_error(&mut self, err: Option<String>) {
+        self.error_message = err;
+    }
+
+    /// Borrow the underlying [`Secret`].
+    pub fn secret(&self) -> &Secret {
+        &self.secret
+    }
+
+    /// Take the secret, replacing it with an empty one.
+    pub fn take_secret(&mut self) -> Secret {
+        std::mem::take(&mut self.secret)
+    }
+
+    // -- Rendering -----------------------------------------------------------
+
+    /// Render the password input. Returns a [`PasswordInputResponse`].
+    pub fn show(&mut self, ui: &mut Ui) -> PasswordInputResponse {
+        let dark_mode = ui.ctx().style().visuals.dark_mode;
+
+        // -- TextEdit --------------------------------------------------------
+        let mut text_edit = egui::TextEdit::singleline(self.secret.expose_secret_mut())
+            .password(!self.revealing)
+            .hint_text(&self.hint_text)
+            .margin(egui::Margin {
+                right: 28,
+                ..egui::Margin::same(4)
+            });
+
+        if self.monospace {
+            text_edit = text_edit.font(egui::TextStyle::Monospace);
+        }
+
+        if let Some(width) = self.desired_width {
+            text_edit = text_edit.desired_width(width);
+        } else {
+            text_edit = text_edit.desired_width(ui.available_width());
+        }
+
+        let text_response = ui.add(text_edit);
+        let changed = text_response.changed();
+
+        // -- Eye icon --------------------------------------------------------
+        let eye_size = vec2(24.0, 24.0);
+        let eye_center = pos2(
+            text_response.rect.right() - 16.0,
+            text_response.rect.center().y,
+        );
+        let eye_rect = Rect::from_center_size(eye_center, eye_size);
+
+        let eye_id = text_response.id.with("eye");
+        let eye_response = ui.interact(eye_rect, eye_id, Sense::click_and_drag());
+
+        // Update for NEXT frame.
+        self.revealing = eye_response.is_pointer_button_down_on() && eye_response.hovered();
+
+        let icon_color = if eye_response.hovered() || self.revealing {
+            DashColors::DASH_BLUE
+        } else {
+            DashColors::text_secondary(dark_mode)
+        };
+
+        let painter = ui.painter();
+        let cx = eye_center.x;
+        let cy = eye_center.y;
+
+        if self.revealing {
+            // Open eye: circle outline + filled pupil.
+            painter.circle_stroke(eye_center, 6.0, Stroke::new(1.5, icon_color));
+            painter.circle_filled(eye_center, 2.5, icon_color);
+        } else {
+            // Closed eye: circle outline + diagonal slash.
+            painter.circle_stroke(eye_center, 6.0, Stroke::new(1.5, icon_color));
+            painter.line_segment(
+                [pos2(cx - 5.0, cy - 5.0), pos2(cx + 5.0, cy + 5.0)],
+                Stroke::new(1.5, icon_color),
+            );
+        }
+
+        if eye_response.hovered() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        }
+        eye_response.on_hover_text("Hold to reveal");
+
+        if self.revealing {
+            ui.ctx().request_repaint();
+        }
+
+        // -- Error label -----------------------------------------------------
+        if let Some(err) = &self.error_message {
+            ui.colored_label(DashColors::VALIDATION_WARNING, err);
+        }
+
+        PasswordInputResponse {
+            response: text_response,
+            changed,
+        }
+    }
+}
+
+impl Default for PasswordInput {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/ui/components/wallet_unlock.rs
+++ b/src/ui/components/wallet_unlock.rs
@@ -67,9 +67,7 @@ pub trait ScreenWithWalletUnlock {
                 let unlock_clicked = ui.button("Unlock").clicked();
 
                 if enter_pressed || unlock_clicked {
-                    let password_text = self.password_input().text().to_string();
-
-                    let unlock_result = wallet.wallet_seed.open(&password_text);
+                    let unlock_result = wallet.wallet_seed.open(self.password_input().text());
 
                     match unlock_result {
                         Ok(_) => {

--- a/src/ui/components/wallet_unlock.rs
+++ b/src/ui/components/wallet_unlock.rs
@@ -2,22 +2,13 @@ use crate::context::AppContext;
 use crate::model::wallet::Wallet;
 use crate::ui::MessageType;
 use crate::ui::components::MessageBanner;
-use crate::ui::components::styled::StyledCheckbox;
-use crate::ui::theme::DashColors;
+use crate::ui::components::password_input::PasswordInput;
 use egui::Ui;
 use std::sync::{Arc, RwLock};
-use zeroize::Zeroize;
 
 pub trait ScreenWithWalletUnlock {
     fn selected_wallet_ref(&self) -> &Option<Arc<RwLock<Wallet>>>;
-    // Allow dead_code: This method provides read-only access to wallet passwords,
-    // useful for password validation and UI state management
-    #[allow(dead_code)]
-    fn wallet_password_ref(&self) -> &String;
-    fn wallet_password_mut(&mut self) -> &mut String;
-    fn show_password(&self) -> bool;
-    fn show_password_mut(&mut self) -> &mut bool;
-
+    fn password_input(&mut self) -> &mut PasswordInput;
     fn app_context(&self) -> Arc<AppContext>;
 
     fn should_ask_for_password(&mut self) -> bool {
@@ -54,7 +45,6 @@ pub trait ScreenWithWalletUnlock {
         if let Some(wallet_guard) = self.selected_wallet_ref().clone() {
             let mut wallet = wallet_guard.write().unwrap();
 
-            // Only render the unlock prompt if the wallet requires a password and is locked
             if wallet.uses_password && !wallet.is_open() {
                 if let Some(alias) = &wallet.alias {
                     ui.label(format!(
@@ -67,45 +57,19 @@ pub trait ScreenWithWalletUnlock {
 
                 ui.add_space(5.0);
 
-                // Capture necessary values before the closure
-                let show_password = self.show_password();
-                let mut local_show_password = show_password;
-                let wallet_password_mut = self.wallet_password_mut();
+                let pw_response = self.password_input().show(ui);
 
-                let mut attempt_unlock = false;
-
-                ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
-                    let password_input = ui.add(
-                        egui::TextEdit::singleline(wallet_password_mut)
-                            .password(!local_show_password)
-                            .hint_text("Enter password")
-                            .text_color(DashColors::text_primary(dark_mode))
-                            .background_color(DashColors::input_background(dark_mode)),
-                    );
-
-                    if password_input.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter))
-                    {
-                        attempt_unlock = true;
-                    }
-
-                    ui.add_space(5.0);
-
-                    // Checkbox to toggle password visibility
-                    StyledCheckbox::new(&mut local_show_password, "Show Password").show(ui);
-                });
+                let enter_pressed = pw_response.response.lost_focus()
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter));
 
                 ui.add_space(5.0);
 
-                if ui.button("Unlock").clicked() {
-                    attempt_unlock = true;
-                }
+                let unlock_clicked = ui.button("Unlock").clicked();
 
-                if attempt_unlock {
-                    // Use the password from wallet_password_mut
-                    let wallet_password_ref = &*wallet_password_mut;
+                if enter_pressed || unlock_clicked {
+                    let password_text = self.password_input().text().to_string();
 
-                    let unlock_result = wallet.wallet_seed.open(wallet_password_ref);
+                    let unlock_result = wallet.wallet_seed.open(&password_text);
 
                     match unlock_result {
                         Ok(_) => {
@@ -121,13 +85,9 @@ pub trait ScreenWithWalletUnlock {
                                 .with_auto_dismiss(std::time::Duration::from_secs(10));
                         }
                     }
-                    // Clear the password field after submission
-                    wallet_password_mut.zeroize();
-                }
 
-                // Update `show_password` after the closure
-                *self.show_password_mut() = local_show_password;
-                // Error display is handled by the global MessageBanner
+                    self.password_input().clear();
+                }
             }
         }
 

--- a/src/ui/components/wallet_unlock_popup.rs
+++ b/src/ui/components/wallet_unlock_popup.rs
@@ -1,10 +1,9 @@
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
-use crate::ui::components::styled::StyledCheckbox;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::theme::{ComponentStyles, DashColors, Shape};
 use egui;
 use std::sync::{Arc, RwLock};
-use zeroize::Zeroize;
 
 /// Result of showing the wallet unlock popup
 #[derive(Debug, Clone, PartialEq)]
@@ -21,8 +20,7 @@ pub enum WalletUnlockResult {
 /// Similar to InfoPopup and ConfirmationDialog but specialized for wallet unlock flow
 pub struct WalletUnlockPopup {
     is_open: bool,
-    password: String,
-    show_password: bool,
+    password_input: PasswordInput,
     error_message: Option<String>,
 }
 
@@ -37,8 +35,7 @@ impl WalletUnlockPopup {
     pub fn new() -> Self {
         Self {
             is_open: false,
-            password: String::new(),
-            show_password: false,
+            password_input: PasswordInput::new().with_hint_text("Enter password"),
             error_message: None,
         }
     }
@@ -46,14 +43,14 @@ impl WalletUnlockPopup {
     /// Open the popup
     pub fn open(&mut self) {
         self.is_open = true;
-        self.password.clear();
+        self.password_input.clear();
         self.error_message = None;
     }
 
     /// Close the popup
     pub fn close(&mut self) {
         self.is_open = false;
-        self.password.zeroize();
+        self.password_input.clear();
         self.error_message = None;
     }
 
@@ -128,31 +125,19 @@ impl WalletUnlockPopup {
                 // Password input
                 let mut attempt_unlock = false;
 
-                let password_response = ui.add(
-                    egui::TextEdit::singleline(&mut self.password)
-                        .password(!self.show_password)
-                        .hint_text("Enter password")
-                        .desired_width(f32::INFINITY)
-                        .text_color(DashColors::text_primary(dark_mode))
-                        .background_color(DashColors::input_background(dark_mode)),
-                );
+                let pw_response = self.password_input.show(ui);
 
                 // Focus the password field when popup opens
-                if password_response.gained_focus() || self.password.is_empty() {
-                    password_response.request_focus();
+                if pw_response.response.gained_focus() || self.password_input.is_empty() {
+                    pw_response.response.request_focus();
                 }
 
                 // Check for Enter key
-                if password_response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                if pw_response.response.lost_focus()
+                    && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                {
                     attempt_unlock = true;
                 }
-
-                ui.add_space(8.0);
-
-                // Show password checkbox
-                ui.horizontal(|ui| {
-                    StyledCheckbox::new(&mut self.show_password, "Show password").show(ui);
-                });
 
                 // Error message
                 if let Some(error) = &self.error_message {
@@ -208,7 +193,7 @@ impl WalletUnlockPopup {
                 // Attempt unlock if requested
                 if attempt_unlock {
                     let mut wallet_guard = wallet.write().unwrap();
-                    match wallet_guard.wallet_seed.open(&self.password) {
+                    match wallet_guard.wallet_seed.open(self.password_input.text()) {
                         Ok(_) => {
                             // Notify app context that wallet was unlocked
                             drop(wallet_guard); // Release write lock before calling handle_wallet_unlocked
@@ -224,7 +209,7 @@ impl WalletUnlockPopup {
                             } else {
                                 self.error_message = Some("Incorrect password".to_string());
                             }
-                            self.password.zeroize();
+                            self.password_input.clear();
                         }
                     }
                 }

--- a/src/ui/components/wallet_unlock_popup.rs
+++ b/src/ui/components/wallet_unlock_popup.rs
@@ -23,6 +23,7 @@ pub struct WalletUnlockPopup {
     is_open: bool,
     password_input: PasswordInput,
     error_message: Option<String>,
+    focus_requested: bool,
 }
 
 impl Default for WalletUnlockPopup {
@@ -38,6 +39,7 @@ impl WalletUnlockPopup {
             is_open: false,
             password_input: PasswordInput::new().with_hint_text("Enter password"),
             error_message: None,
+            focus_requested: false,
         }
     }
 
@@ -46,6 +48,7 @@ impl WalletUnlockPopup {
         self.is_open = true;
         self.password_input.clear();
         self.error_message = None;
+        self.focus_requested = false;
     }
 
     /// Close the popup
@@ -127,9 +130,10 @@ impl WalletUnlockPopup {
 
                 let pw_response = self.password_input.show(ui);
 
-                // Focus the password field when popup opens
-                if pw_response.response.gained_focus() || self.password_input.is_empty() {
+                // Focus the password field once when popup opens
+                if !self.focus_requested {
                     pw_response.response.request_focus();
+                    self.focus_requested = true;
                 }
 
                 // Check for Enter key

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -3,9 +3,11 @@ use crate::backend_task::identity::{IdentityInputToLoad, IdentityTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
 use crate::model::qualified_identity::IdentityType;
+use crate::model::secret::Secret;
 use crate::model::wallet::Wallet;
 use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock_popup::{
@@ -94,10 +96,10 @@ pub struct AddExistingIdentityScreen {
     identity_id_input: String,
     pub identity_type: IdentityType,
     alias_input: String,
-    voting_private_key_input: String,
-    owner_private_key_input: String,
-    payout_address_private_key_input: String,
-    keys_input: Vec<String>,
+    voting_private_key_input: PasswordInput,
+    owner_private_key_input: PasswordInput,
+    payout_address_private_key_input: PasswordInput,
+    keys_input: Vec<PasswordInput>,
     add_identity_status: AddIdentityStatus,
     testnet_loaded_nodes: Option<TestnetNodes>,
     selected_wallet: Option<Arc<RwLock<Wallet>>>,
@@ -134,9 +136,15 @@ impl AddExistingIdentityScreen {
             identity_id_input: String::new(),
             identity_type: IdentityType::User,
             alias_input: String::new(),
-            voting_private_key_input: String::new(),
-            owner_private_key_input: String::new(),
-            payout_address_private_key_input: String::new(),
+            voting_private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (WIF or hex)")
+                .with_monospace(),
+            owner_private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (WIF or hex)")
+                .with_monospace(),
+            payout_address_private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (WIF or hex)")
+                .with_monospace(),
             keys_input: vec![],
             add_identity_status: AddIdentityStatus::NotStarted,
             testnet_loaded_nodes,
@@ -384,28 +392,23 @@ impl AddExistingIdentityScreen {
                 if self.show_advanced_options {
                     match self.identity_type {
                         IdentityType::Masternode | IdentityType::Evonode => {
-                            let voting_private_key_input = &mut self.voting_private_key_input;
-                            let owner_private_key_input = &mut self.owner_private_key_input;
-                            let payout_address_private_key_input =
-                                &mut self.payout_address_private_key_input;
-
                             ui.label("Voting Private Key:");
-                            ui.text_edit_singleline(voting_private_key_input);
+                            self.voting_private_key_input.show(ui);
                             ui.end_row();
 
                             ui.label("Owner Private Key:");
-                            ui.text_edit_singleline(owner_private_key_input);
+                            self.owner_private_key_input.show(ui);
                             ui.end_row();
 
                             ui.label("Payout Address Private Key:");
-                            ui.text_edit_singleline(payout_address_private_key_input);
+                            self.payout_address_private_key_input.show(ui);
                             ui.end_row();
                         }
                         IdentityType::User => {
                             // Manual key inputs for User type
                             let mut keys_to_remove = vec![];
 
-                            for (i, key) in self.keys_input.iter_mut().enumerate() {
+                            for (i, key_input) in self.keys_input.iter_mut().enumerate() {
                                 ui.horizontal(|ui| {
                                     ui.label(format!("Private Key {} (Hex or WIF):", i + 1));
 
@@ -422,7 +425,7 @@ impl AddExistingIdentityScreen {
                                     }
                                 });
 
-                                ui.text_edit_singleline(key);
+                                key_input.show(ui);
 
                                 if ui.button("-").clicked() {
                                     keys_to_remove.push(i);
@@ -443,7 +446,11 @@ impl AddExistingIdentityScreen {
         if self.show_advanced_options && self.identity_type == IdentityType::User {
             ui.add_space(10.0);
             if ui.button("+ Add key manually").clicked() {
-                self.keys_input.push(String::new());
+                self.keys_input.push(
+                    PasswordInput::new()
+                        .with_hint_text("Private key (WIF or hex)")
+                        .with_monospace(),
+                );
             }
         }
 
@@ -891,10 +898,16 @@ impl AddExistingIdentityScreen {
             identity_id_input: self.identity_id_input.trim().to_string(),
             identity_type: self.identity_type,
             alias_input: self.alias_input.clone(),
-            voting_private_key_input: self.voting_private_key_input.clone(),
-            owner_private_key_input: self.owner_private_key_input.clone(),
-            payout_address_private_key_input: self.payout_address_private_key_input.clone(),
-            keys_input: self.keys_input.clone(),
+            voting_private_key_input: Secret::new(self.voting_private_key_input.text().to_string()),
+            owner_private_key_input: Secret::new(self.owner_private_key_input.text().to_string()),
+            payout_address_private_key_input: Secret::new(
+                self.payout_address_private_key_input.text().to_string(),
+            ),
+            keys_input: self
+                .keys_input
+                .iter()
+                .map(|k| Secret::new(k.text().to_string()))
+                .collect(),
             derive_keys_from_wallets: self.identity_associated_with_wallet,
             selected_wallet_seed_hash,
         };
@@ -912,9 +925,12 @@ impl AddExistingIdentityScreen {
             self.identity_id_input = hpmn.protx_tx_hash.clone();
             self.identity_type = IdentityType::Evonode;
             self.alias_input = name.clone();
-            self.voting_private_key_input = hpmn.voter.private_key.clone();
-            self.owner_private_key_input = hpmn.owner.private_key.clone();
-            self.payout_address_private_key_input = hpmn.payout.private_key.clone();
+            self.voting_private_key_input
+                .set_text(hpmn.voter.private_key.clone());
+            self.owner_private_key_input
+                .set_text(hpmn.owner.private_key.clone());
+            self.payout_address_private_key_input
+                .set_text(hpmn.payout.private_key.clone());
         }
     }
 
@@ -927,8 +943,10 @@ impl AddExistingIdentityScreen {
             self.identity_id_input = masternode.pro_tx_hash.clone();
             self.identity_type = IdentityType::Masternode;
             self.alias_input = name.clone();
-            self.voting_private_key_input = masternode.voter.private_key.clone();
-            self.owner_private_key_input = masternode.owner.private_key.clone();
+            self.voting_private_key_input
+                .set_text(masternode.voter.private_key.clone());
+            self.owner_private_key_input
+                .set_text(masternode.owner.private_key.clone());
         }
     }
 
@@ -962,7 +980,17 @@ impl AddExistingIdentityScreen {
             self.voting_private_key_input.clear();
             self.owner_private_key_input.clear();
             self.payout_address_private_key_input.clear();
-            self.keys_input = vec![String::new(), String::new(), String::new()];
+            self.keys_input = vec![
+                PasswordInput::new()
+                    .with_hint_text("Private key (WIF or hex)")
+                    .with_monospace(),
+                PasswordInput::new()
+                    .with_hint_text("Private key (WIF or hex)")
+                    .with_monospace(),
+                PasswordInput::new()
+                    .with_hint_text("Private key (WIF or hex)")
+                    .with_monospace(),
+            ];
             self.identity_index_input.clear();
             self.dpns_name_input.clear();
             self.show_pop_up_info = None;

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -3,7 +3,6 @@ use crate::backend_task::identity::{IdentityInputToLoad, IdentityTask};
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
 use crate::model::qualified_identity::IdentityType;
-use crate::model::secret::Secret;
 use crate::model::wallet::Wallet;
 use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
@@ -898,15 +897,13 @@ impl AddExistingIdentityScreen {
             identity_id_input: self.identity_id_input.trim().to_string(),
             identity_type: self.identity_type,
             alias_input: self.alias_input.clone(),
-            voting_private_key_input: Secret::new(self.voting_private_key_input.text().to_string()),
-            owner_private_key_input: Secret::new(self.owner_private_key_input.text().to_string()),
-            payout_address_private_key_input: Secret::new(
-                self.payout_address_private_key_input.text().to_string(),
-            ),
+            voting_private_key_input: self.voting_private_key_input.take_secret(),
+            owner_private_key_input: self.owner_private_key_input.take_secret(),
+            payout_address_private_key_input: self.payout_address_private_key_input.take_secret(),
             keys_input: self
                 .keys_input
-                .iter()
-                .map(|k| Secret::new(k.text().to_string()))
+                .iter_mut()
+                .map(|k| k.take_secret())
                 .collect(),
             derive_keys_from_wallets: self.identity_associated_with_wallet,
             selected_wallet_seed_hash,

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -11,6 +11,7 @@ use crate::backend_task::identity::{
 };
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult, FeeResult};
 use crate::context::AppContext;
+use crate::model::secret::Secret;
 use crate::model::wallet::Wallet;
 use crate::ui::components::MessageBanner;
 use crate::ui::components::info_popup::InfoPopup;
@@ -619,7 +620,8 @@ impl AddNewIdentityScreen {
                                 ui.label("Master Key");
                             });
                             row.col(|ui| {
-                                ui.label(master_key.to_wif());
+                                let wif = Secret::new(master_key.to_wif());
+                                ui.label(wif.expose_secret());
                             });
                             row.col(|_ui| {
                                 // No purpose for master key
@@ -663,7 +665,8 @@ impl AddNewIdentityScreen {
                                 ui.label(format!("Key {}", i + 1));
                             });
                             row.col(|ui| {
-                                ui.label(key.to_wif());
+                                let wif = Secret::new(key.to_wif());
+                                ui.label(wif.expose_secret());
                             });
                             row.col(|ui| {
                                 ui.vertical(|ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -621,6 +621,8 @@ impl AddNewIdentityScreen {
                             });
                             row.col(|ui| {
                                 let wif = Secret::new(master_key.to_wif());
+                                // INTENTIONAL(CODE-003): WIF displayed as plaintext label — user-initiated key view.
+                                // Secret wrapper provides zeroize-on-drop for the Rust-side variable.
                                 ui.label(wif.expose_secret());
                             });
                             row.col(|_ui| {
@@ -666,6 +668,8 @@ impl AddNewIdentityScreen {
                             });
                             row.col(|ui| {
                                 let wif = Secret::new(key.to_wif());
+                                // INTENTIONAL(CODE-003): WIF displayed as plaintext label — user-initiated key view.
+                                // Secret wrapper provides zeroize-on-drop for the Rust-side variable.
                                 ui.label(wif.expose_secret());
                             });
                             row.col(|ui| {

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -7,6 +7,7 @@ use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::qualified_identity::qualified_identity_public_key::QualifiedIdentityPublicKey;
 use crate::model::wallet::Wallet;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock_popup::{
@@ -41,7 +42,7 @@ pub enum AddKeyStatus {
 pub struct AddKeyScreen {
     pub identity: QualifiedIdentity,
     pub app_context: Arc<AppContext>,
-    private_key_input: String,
+    private_key_input: PasswordInput,
     key_type: KeyType,
     purpose: Purpose,
     security_level: SecurityLevel,
@@ -73,7 +74,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
-            private_key_input: String::new(),
+            private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (hex)")
+                .with_monospace(),
             key_type: KeyType::ECDSA_SECP256K1,
             purpose: Purpose::AUTHENTICATION,
             security_level: SecurityLevel::HIGH,
@@ -114,7 +117,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
-            private_key_input: String::new(),
+            private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (hex)")
+                .with_monospace(),
             key_type: KeyType::ECDSA_SECP256K1,
             purpose: Purpose::ENCRYPTION,
             security_level: SecurityLevel::MEDIUM,
@@ -155,7 +160,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
-            private_key_input: String::new(),
+            private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (hex)")
+                .with_monospace(),
             key_type: KeyType::ECDSA_SECP256K1,
             purpose: Purpose::DECRYPTION,
             security_level: SecurityLevel::MEDIUM,
@@ -174,7 +181,7 @@ impl AddKeyScreen {
     fn validate_and_add_key(&mut self) -> AppAction {
         let mut app_action = AppAction::None;
         // Convert the input string to bytes (hex decoding)
-        match hex::decode(&self.private_key_input) {
+        match hex::decode(self.private_key_input.text()) {
             Ok(private_key_bytes_vec) if private_key_bytes_vec.len() == 32 => {
                 let private_key_bytes = private_key_bytes_vec.try_into().unwrap();
                 let public_key_data_result = self.key_type.public_key_data_from_private_key_data(
@@ -290,7 +297,8 @@ impl AddKeyScreen {
             .key_type
             .random_public_and_private_key_data(&mut rng, self.app_context.platform_version())
         {
-            self.private_key_input = hex::encode(private_key_bytes);
+            self.private_key_input
+                .set_text(hex::encode(private_key_bytes));
         } else {
             self.add_key_status = AddKeyStatus::Error;
             MessageBanner::set_global(
@@ -322,7 +330,7 @@ impl AddKeyScreen {
         if let AppAction::Custom(ref s) = action
             && s == "add_another"
         {
-            self.private_key_input = String::new();
+            self.private_key_input.clear();
             self.contract_id_input = String::new();
             self.document_type_input = String::new();
             self.enable_contract_bounds = false;
@@ -597,7 +605,7 @@ impl ScreenLike for AddKeyScreen {
 
                     // Private Key Input
                     ui.label("Private Key:");
-                    ui.text_edit_singleline(&mut self.private_key_input);
+                    self.private_key_input.show(ui);
                     if ui.button("Generate Random").clicked() {
                         self.generate_random_private_key();
                     }

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -316,6 +316,8 @@ impl ScreenLike for KeyInfoScreen {
                                                 .color(ui.visuals().text_color()),
                                         );
                                         let wif = Secret::new(private_key.to_wif());
+                                        // INTENTIONAL(CODE-003): WIF displayed as plaintext label — user-initiated key view.
+                                        // Secret wrapper provides zeroize-on-drop for the Rust-side variable.
                                         ui.label(
                                             RichText::new(wif.expose_secret())
                                                 .color(ui.visuals().text_color()),
@@ -329,6 +331,8 @@ impl ScreenLike for KeyInfoScreen {
                                             .color(ui.visuals().text_color()),
                                     );
                                     let private_key_hex = Secret::new(hex::encode(clear));
+                                    // INTENTIONAL(CODE-003): WIF displayed as plaintext label — user-initiated key view.
+                                    // Secret wrapper provides zeroize-on-drop for the Rust-side variable.
                                     ui.label(
                                         RichText::new(private_key_hex.expose_secret())
                                             .color(ui.visuals().text_color()),

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -4,10 +4,12 @@ use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::qualified_identity::encrypted_key_storage::{
     PrivateKeyData, WalletDerivationPath,
 };
+use crate::model::secret::Secret;
 use crate::model::wallet::Wallet;
 use crate::ui::components::MessageBanner;
 use crate::ui::components::info_popup::InfoPopup;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock_popup::{
@@ -40,7 +42,7 @@ pub struct KeyInfoScreen {
     pub private_key_data: Option<(PrivateKeyData, Option<WalletDerivationPath>)>,
     pub decrypted_private_key: Option<RPCPrivateKey>,
     pub app_context: Arc<AppContext>,
-    private_key_input: String,
+    private_key_input: PasswordInput,
     selected_wallet: Option<Arc<RwLock<Wallet>>>,
     wallet_unlock_popup: WalletUnlockPopup,
     wallet_open_attempted: bool,
@@ -312,8 +314,9 @@ impl ScreenLike for KeyInfoScreen {
                                                 .strong()
                                                 .color(ui.visuals().text_color()),
                                         );
+                                        let wif = Secret::new(private_key.to_wif());
                                         ui.label(
-                                            RichText::new(private_key.to_wif())
+                                            RichText::new(wif.expose_secret())
                                                 .color(ui.visuals().text_color()),
                                         );
                                         ui.end_row();
@@ -324,9 +327,9 @@ impl ScreenLike for KeyInfoScreen {
                                             .strong()
                                             .color(ui.visuals().text_color()),
                                     );
-                                    let private_key_hex = hex::encode(clear);
+                                    let private_key_hex = Secret::new(hex::encode(clear));
                                     ui.label(
-                                        RichText::new(private_key_hex)
+                                        RichText::new(private_key_hex.expose_secret())
                                             .color(ui.visuals().text_color()),
                                     );
                                     ui.end_row();
@@ -358,9 +361,9 @@ impl ScreenLike for KeyInfoScreen {
                                                     .strong()
                                                     .color(ui.visuals().text_color()),
                                             );
-                                            let private_key_wif = private_key.to_wif();
+                                            let wif = Secret::new(private_key.to_wif());
                                             ui.label(
-                                                RichText::new(private_key_wif)
+                                                RichText::new(wif.expose_secret())
                                                     .color(ui.visuals().text_color()),
                                             );
                                             ui.end_row();
@@ -370,10 +373,11 @@ impl ScreenLike for KeyInfoScreen {
                                                     .strong()
                                                     .color(ui.visuals().text_color()),
                                             );
-                                            let private_key_hex =
-                                                hex::encode(private_key.inner.secret_bytes());
+                                            let private_key_hex = Secret::new(hex::encode(
+                                                private_key.inner.secret_bytes(),
+                                            ));
                                             ui.label(
-                                                RichText::new(private_key_hex)
+                                                RichText::new(private_key_hex.expose_secret())
                                                     .color(ui.visuals().text_color()),
                                             );
                                             ui.end_row();
@@ -395,9 +399,9 @@ impl ScreenLike for KeyInfoScreen {
                                                             .strong()
                                                             .color(ui.visuals().text_color()),
                                                     );
-                                                    let private_key_wif = private_key.to_wif();
+                                                    let wif = Secret::new(private_key.to_wif());
                                                     ui.label(
-                                                        RichText::new(private_key_wif)
+                                                        RichText::new(wif.expose_secret())
                                                             .color(ui.visuals().text_color()),
                                                     );
                                                     ui.end_row();
@@ -407,12 +411,14 @@ impl ScreenLike for KeyInfoScreen {
                                                             .strong()
                                                             .color(ui.visuals().text_color()),
                                                     );
-                                                    let private_key_hex = hex::encode(
+                                                    let private_key_hex = Secret::new(hex::encode(
                                                         private_key.inner.secret_bytes(),
-                                                    );
+                                                    ));
                                                     ui.label(
-                                                        RichText::new(private_key_hex)
-                                                            .color(ui.visuals().text_color()),
+                                                        RichText::new(
+                                                            private_key_hex.expose_secret(),
+                                                        )
+                                                        .color(ui.visuals().text_color()),
                                                     );
                                                     ui.end_row();
                                                 });
@@ -451,9 +457,9 @@ impl ScreenLike for KeyInfoScreen {
                                                             .strong()
                                                             .color(ui.visuals().text_color()),
                                                     );
-                                                    let private_key_wif = private_key.to_wif();
+                                                    let wif = Secret::new(private_key.to_wif());
                                                     ui.label(
-                                                        RichText::new(private_key_wif)
+                                                        RichText::new(wif.expose_secret())
                                                             .color(ui.visuals().text_color()),
                                                     );
                                                     ui.end_row();
@@ -463,12 +469,14 @@ impl ScreenLike for KeyInfoScreen {
                                                             .strong()
                                                             .color(ui.visuals().text_color()),
                                                     );
-                                                    let private_key_hex = hex::encode(
+                                                    let private_key_hex = Secret::new(hex::encode(
                                                         private_key.inner.secret_bytes(),
-                                                    );
+                                                    ));
                                                     ui.label(
-                                                        RichText::new(private_key_hex)
-                                                            .color(ui.visuals().text_color()),
+                                                        RichText::new(
+                                                            private_key_hex.expose_secret(),
+                                                        )
+                                                        .color(ui.visuals().text_color()),
                                                     );
                                                     ui.end_row();
                                                 });
@@ -499,7 +507,7 @@ impl ScreenLike for KeyInfoScreen {
                     }
                 } else {
                     ui.label(RichText::new("Enter Private Key:").color(text_primary));
-                    ui.text_edit_singleline(&mut self.private_key_input);
+                    self.private_key_input.show(ui);
 
                     if ui.button("Add Private Key").clicked() {
                         self.validate_and_store_private_key();
@@ -592,7 +600,9 @@ impl KeyInfoScreen {
             private_key_data,
             decrypted_private_key: None,
             app_context: app_context.clone(),
-            private_key_input: String::new(),
+            private_key_input: PasswordInput::new()
+                .with_hint_text("Private key (WIF or hex)")
+                .with_monospace(),
             selected_wallet,
             wallet_unlock_popup: WalletUnlockPopup::new(),
             wallet_open_attempted: false,
@@ -608,7 +618,7 @@ impl KeyInfoScreen {
 
     fn validate_and_store_private_key(&mut self) {
         // Convert the input string to bytes (hex decoding)
-        let private_key_bytes = match hex::decode(&self.private_key_input) {
+        let private_key_bytes = match hex::decode(self.private_key_input.text()) {
             Ok(private_key_bytes_vec) if private_key_bytes_vec.len() == 32 => {
                 private_key_bytes_vec.try_into().unwrap()
             }
@@ -620,7 +630,7 @@ impl KeyInfoScreen {
                 );
                 return;
             }
-            Err(_) => match PrivateKey::from_wif(&self.private_key_input) {
+            Err(_) => match PrivateKey::from_wif(self.private_key_input.text()) {
                 Ok(key) => key.inner.secret_bytes(),
                 Err(_) => {
                     MessageBanner::set_global(

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -87,7 +87,7 @@ pub struct NetworkChooserScreen {
     pub testnet_app_context: Option<Arc<AppContext>>,
     pub devnet_app_context: Option<Arc<AppContext>>,
     pub local_app_context: Option<Arc<AppContext>>,
-    pub dashmate_password_input: PasswordInput,
+    dashmate_password_input: PasswordInput,
     pub current_network: Network,
     pub recheck_time: Option<TimestampMillis>,
     custom_dash_qt_path: Option<PathBuf>,

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -10,6 +10,7 @@ use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
 use crate::ui::components::MessageBanner;
 use crate::ui::components::component_trait::Component;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::{
     ConfirmationDialog, ConfirmationStatus, StyledCard, StyledCheckbox, island_central_panel,
 };
@@ -86,7 +87,7 @@ pub struct NetworkChooserScreen {
     pub testnet_app_context: Option<Arc<AppContext>>,
     pub devnet_app_context: Option<Arc<AppContext>>,
     pub local_app_context: Option<Arc<AppContext>>,
-    pub local_network_dashmate_password: String,
+    pub dashmate_password_input: PasswordInput,
     pub current_network: Network,
     pub recheck_time: Option<TimestampMillis>,
     custom_dash_qt_path: Option<PathBuf>,
@@ -120,15 +121,12 @@ impl NetworkChooserScreen {
         current_network: Network,
         overwrite_dash_conf: bool,
     ) -> Self {
-        let local_network_dashmate_password = if let Ok(config) = Config::load() {
-            if let Some(local_config) = config.config_for_network(Network::Regtest) {
-                local_config.core_rpc_password.clone()
-            } else {
-                "".to_string()
-            }
-        } else {
-            "".to_string()
-        };
+        let mut dashmate_password_input = PasswordInput::new().with_hint_text("Core RPC password");
+        if let Ok(config) = Config::load()
+            && let Some(local_config) = config.config_for_network(Network::Regtest)
+        {
+            dashmate_password_input.set_text(local_config.core_rpc_password.clone());
+        }
 
         let current_context = match current_network {
             Network::Dash => mainnet_app_context,
@@ -184,7 +182,7 @@ impl NetworkChooserScreen {
             testnet_app_context: testnet_app_context.cloned(),
             devnet_app_context: devnet_app_context.cloned(),
             local_app_context: local_app_context.cloned(),
-            local_network_dashmate_password,
+            dashmate_password_input,
             current_network,
             recheck_time: None,
             custom_dash_qt_path,
@@ -444,7 +442,7 @@ impl NetworkChooserScreen {
                 ui.add_space(8.0);
 
                 ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut self.local_network_dashmate_password);
+                    self.dashmate_password_input.show(ui);
 
                     let save_clicked = ui.button("Save").clicked();
 
@@ -452,7 +450,7 @@ impl NetworkChooserScreen {
                     if ui.button("Auto Update").clicked() {
                         match read_dashmate_rpc_password("local_seed") {
                             Ok(password) => {
-                                self.local_network_dashmate_password = password;
+                                self.dashmate_password_input.set_text(password);
                                 auto_update_succeeded = true;
                             }
                             Err(e) => {
@@ -466,8 +464,9 @@ impl NetworkChooserScreen {
                         && let Ok(mut config) = Config::load()
                         && let Some(local_cfg) = config.config_for_network(Network::Regtest).clone()
                     {
-                        let updated_local_config = local_cfg
-                            .update_core_rpc_password(self.local_network_dashmate_password.clone());
+                        let updated_local_config = local_cfg.update_core_rpc_password(
+                            self.dashmate_password_input.text().to_string(),
+                        );
                         config.update_config_for_network(
                             Network::Regtest,
                             updated_local_config.clone(),

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -7,6 +7,7 @@ use crate::model::wallet::{
 };
 use crate::ui::components::entropy_grid::U256EntropyGrid;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
@@ -82,7 +83,7 @@ impl WordCount {
 
 pub struct AddNewWalletScreen {
     seed_phrase: Option<Mnemonic>,
-    password: String,
+    password_input: PasswordInput,
     entropy_grid: U256EntropyGrid,
     selected_language: Language,
     selected_word_count: WordCount,
@@ -111,7 +112,7 @@ impl AddNewWalletScreen {
     pub fn new(app_context: &Arc<AppContext>) -> Self {
         Self {
             seed_phrase: None,
-            password: String::new(),
+            password_input: PasswordInput::new().with_hint_text("Optional password"),
             entropy_grid: U256EntropyGrid::new(),
             selected_language: Language::English,
             selected_word_count: WordCount::Words24, // Default to 24 words for maximum security
@@ -152,15 +153,15 @@ impl AddNewWalletScreen {
         if let Some(mnemonic) = &self.seed_phrase {
             let seed = mnemonic.to_seed("");
 
-            let (encrypted_seed, salt, nonce, uses_password) = if self.password.is_empty() {
+            let (encrypted_seed, salt, nonce, uses_password) = if self.password_input.is_empty() {
                 (seed.to_vec(), vec![], vec![], false)
             } else {
                 // Encrypt the seed to obtain encrypted_seed, salt, and nonce
                 let (encrypted_seed, salt, nonce) =
-                    ClosedKeyItem::encrypt_seed(&seed, self.password.as_str())?;
+                    ClosedKeyItem::encrypt_seed(&seed, self.password_input.text())?;
                 if self.use_password_for_app {
                     let (encrypted_message, salt, nonce) =
-                        encrypt_message(DASH_SECRET_MESSAGE, self.password.as_str())?;
+                        encrypt_message(DASH_SECRET_MESSAGE, self.password_input.text())?;
                     self.app_context
                         .update_main_password(&salt, &nonce, &encrypted_message)
                         .map_err(|e| e.to_string())?;
@@ -811,9 +812,10 @@ impl ScreenLike for AddNewWalletScreen {
 
                     ui.horizontal(|ui| {
                         ui.label("Optional Password:");
-                        if ui.text_edit_singleline(&mut self.password).changed() {
-                            if !self.password.is_empty() {
-                                let estimate = zxcvbn(&self.password, &[]);
+                        let pw_response = self.password_input.show(ui);
+                        if pw_response.changed {
+                            if !self.password_input.is_empty() {
+                                let estimate = zxcvbn(self.password_input.text(), &[]);
 
                                 // Convert Score to u8
                                 let score_u8 = u8::from(estimate.score());

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -352,7 +352,7 @@ impl ScreenLike for AssetLockDetailScreen {
 
                     ui.label("Private Key (WIF):");
                     if let Some(ref wif) = self.private_key_wif {
-                        ui.add(egui::TextEdit::multiline(&mut wif.expose_secret().to_owned().as_str())
+                        ui.add(egui::TextEdit::multiline(&mut wif.expose_secret())
                             .font(egui::FontId::monospace(12.0))
                             .desired_width(f32::INFINITY)
                             .desired_rows(1));
@@ -366,6 +366,7 @@ impl ScreenLike for AssetLockDetailScreen {
                         if ComponentStyles::add_primary_button(ui, "Copy").clicked()
                             && let Some(ref wif) = self.private_key_wif
                         {
+                            // SECURITY: clipboard copy inherently exposes plaintext — user-initiated action
                             ui.ctx().copy_text(wif.expose_secret().to_string());
                             MessageBanner::set_global(ctx, "Private key copied to clipboard", MessageType::Success);
                         }

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -1,8 +1,10 @@
 use crate::app::AppAction;
 use crate::context::AppContext;
+use crate::model::secret::Secret;
 use crate::model::wallet::Wallet;
 use crate::ui::components::MessageBanner;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
@@ -20,10 +22,9 @@ pub struct AssetLockDetailScreen {
     pub asset_lock_index: usize,
     pub app_context: Arc<AppContext>,
     wallet: Option<Arc<RwLock<Wallet>>>,
-    wallet_password: String,
-    show_password: bool,
+    password_input: PasswordInput,
     show_private_key_popup: bool,
-    private_key_wif: Option<String>,
+    private_key_wif: Option<Secret>,
 }
 
 impl AssetLockDetailScreen {
@@ -46,8 +47,7 @@ impl AssetLockDetailScreen {
             asset_lock_index,
             app_context: app_context.clone(),
             wallet,
-            wallet_password: String::new(),
-            show_password: false,
+            password_input: PasswordInput::new().with_hint_text("Enter password"),
             show_private_key_popup: false,
             private_key_wif: None,
         }
@@ -227,7 +227,7 @@ impl AssetLockDetailScreen {
                                         let wallet = wallet_arc.write().unwrap();
                                         match wallet.private_key_at_derivation_path(&derivation_path, self.app_context.network) {
                                             Ok(private_key) => {
-                                                self.private_key_wif = Some(private_key.to_wif());
+                                                self.private_key_wif = Some(Secret::new(private_key.to_wif()));
                                                 self.show_private_key_popup = true;
                                             }
                                             Err(e) => {
@@ -265,20 +265,8 @@ impl ScreenWithWalletUnlock for AssetLockDetailScreen {
         &self.wallet
     }
 
-    fn wallet_password_ref(&self) -> &String {
-        &self.wallet_password
-    }
-
-    fn wallet_password_mut(&mut self) -> &mut String {
-        &mut self.wallet_password
-    }
-
-    fn show_password(&self) -> bool {
-        self.show_password
-    }
-
-    fn show_password_mut(&mut self) -> &mut bool {
-        &mut self.show_password
+    fn password_input(&mut self) -> &mut PasswordInput {
+        &mut self.password_input
     }
 
     fn app_context(&self) -> Arc<AppContext> {
@@ -363,17 +351,18 @@ impl ScreenLike for AssetLockDetailScreen {
                     ui.add_space(15.0);
 
                     ui.label("Private Key (WIF):");
-                    if let Some(wif) = self.private_key_wif.clone() {
-                        ui.add(egui::TextEdit::multiline(&mut wif.as_str())
+                    if let Some(wif) = &self.private_key_wif {
+                        ui.add(egui::TextEdit::multiline(&mut wif.expose_secret().to_owned().as_str())
                             .font(egui::FontId::monospace(12.0))
                             .desired_width(f32::INFINITY)
                             .desired_rows(1));
 
                         ui.add_space(10.0);
 
+                        let wif_copy = wif.expose_secret().to_string();
                         ui.horizontal(|ui| {
                             if ui.button("Copy").clicked() {
-                                ui.ctx().copy_text(wif.clone());
+                                ui.ctx().copy_text(wif_copy);
                                 MessageBanner::set_global(ctx, "Private key copied to clipboard", MessageType::Success);
                             }
                             if ui.button("Close").clicked() {

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -11,6 +11,7 @@ use crate::ui::components::MessageBanner;
 use crate::ui::components::amount_input::AmountInput;
 use crate::ui::components::identity_selector::IdentitySelector;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::wallet_unlock::ScreenWithWalletUnlock;
@@ -35,8 +36,7 @@ pub struct CreateAssetLockScreen {
     pub wallet: Arc<RwLock<Wallet>>,
     selected_wallet: Option<Arc<RwLock<Wallet>>>,
     pub app_context: Arc<AppContext>,
-    wallet_password: String,
-    show_password: bool,
+    password_input: PasswordInput,
     // Asset lock creation fields
     step: Arc<RwLock<WalletFundedScreenStep>>,
     amount_input: Option<AmountInput>,
@@ -75,8 +75,7 @@ impl CreateAssetLockScreen {
             wallet,
             selected_wallet,
             app_context: app_context.clone(),
-            wallet_password: String::new(),
-            show_password: false,
+            password_input: PasswordInput::new().with_hint_text("Enter password"),
             step: Arc::new(RwLock::new(WalletFundedScreenStep::WaitingOnFunds)),
             amount_input: Some(
                 AmountInput::new(Amount::new_dash(0.5))
@@ -237,20 +236,8 @@ impl ScreenWithWalletUnlock for CreateAssetLockScreen {
         &self.selected_wallet
     }
 
-    fn wallet_password_ref(&self) -> &String {
-        &self.wallet_password
-    }
-
-    fn wallet_password_mut(&mut self) -> &mut String {
-        &mut self.wallet_password
-    }
-
-    fn show_password(&self) -> bool {
-        self.show_password
-    }
-
-    fn show_password_mut(&mut self) -> &mut bool {
-        &mut self.show_password
+    fn password_input(&mut self) -> &mut PasswordInput {
+        &mut self.password_input
     }
 
     fn app_context(&self) -> Arc<AppContext> {

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -100,7 +100,7 @@ impl ImportMnemonicScreen {
     }
 
     fn try_parse_private_key(&mut self) {
-        let input = self.private_key_input.text().trim().to_string();
+        let input = self.private_key_input.text().trim();
         if input.is_empty() {
             self.parsed_single_key_wallet = None;
             self.error = None;
@@ -108,8 +108,8 @@ impl ImportMnemonicScreen {
         }
 
         // Try to parse as WIF first, then as hex
-        let result = SingleKeyWallet::from_wif(&input, None, None)
-            .or_else(|_| SingleKeyWallet::from_hex(&input, self.app_context.network, None, None));
+        let result = SingleKeyWallet::from_wif(input, None, None)
+            .or_else(|_| SingleKeyWallet::from_hex(input, self.app_context.network, None, None));
 
         match result {
             Ok(wallet) => {
@@ -124,7 +124,7 @@ impl ImportMnemonicScreen {
     }
 
     fn save_private_key_wallet(&mut self) -> Result<AppAction, String> {
-        let input = self.private_key_input.text().trim().to_string();
+        let input = self.private_key_input.text().trim();
         if input.is_empty() {
             return Err("Please enter a private key".to_string());
         }
@@ -151,8 +151,8 @@ impl ImportMnemonicScreen {
 
         // Try WIF first, then hex
         let mut wallet =
-            SingleKeyWallet::from_wif(&input, password, alias.clone()).or_else(|_| {
-                SingleKeyWallet::from_hex(&input, self.app_context.network, password, alias)
+            SingleKeyWallet::from_wif(input, password, alias.clone()).or_else(|_| {
+                SingleKeyWallet::from_hex(input, self.app_context.network, password, alias)
             })?;
 
         wallet.core_wallet_name = self

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -24,6 +24,7 @@ use dash_sdk::dpp::key_wallet::bip32::{ExtendedPrivKey, ExtendedPubKey};
 use egui::{ComboBox, Grid, RichText, Ui, Vec2};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
+use zeroize::Zeroize;
 use zxcvbn::zxcvbn;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -355,6 +356,9 @@ impl ImportMnemonicScreen {
             && s == "import_another_wallet"
         {
             // Reset mnemonic fields
+            for w in &mut self.seed_phrase_words {
+                w.zeroize();
+            }
             self.seed_phrase_words = vec!["".to_string(); 24];
             self.selected_seed_phrase_length = 12;
             self.seed_phrase = None;
@@ -507,6 +511,14 @@ impl ImportMnemonicScreen {
                 "Private Key (Single Address)",
             );
         });
+    }
+}
+
+impl Drop for ImportMnemonicScreen {
+    fn drop(&mut self) {
+        for w in &mut self.seed_phrase_words {
+            w.zeroize();
+        }
     }
 }
 

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -11,6 +11,7 @@ use eframe::egui::Context;
 
 use crate::model::wallet::encryption::{DASH_SECRET_MESSAGE, encrypt_message};
 use crate::model::wallet::{ClosedKeyItem, OpenWalletSeed, Wallet, WalletSeed};
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::theme::DashColors;
 use crate::ui::wallets::add_new_wallet_screen::{
     DASH_BIP44_ACCOUNT_0_PATH_MAINNET, DASH_BIP44_ACCOUNT_0_PATH_TESTNET,
@@ -34,7 +35,7 @@ pub enum ImportType {
 pub struct ImportMnemonicScreen {
     // Common fields
     import_type: ImportType,
-    password: String,
+    password_input: PasswordInput,
     alias_input: String,
     password_strength: f64,
     estimated_time_to_crack: String,
@@ -50,7 +51,7 @@ pub struct ImportMnemonicScreen {
     seed_phrase: Option<Mnemonic>,
 
     // Private key-specific fields
-    private_key_input: String,
+    private_key_input: PasswordInput,
     parsed_single_key_wallet: Option<SingleKeyWallet>,
 
     // Identity discovery options
@@ -67,7 +68,7 @@ impl ImportMnemonicScreen {
         Self {
             // Common fields
             import_type: ImportType::Mnemonic,
-            password: String::new(),
+            password_input: PasswordInput::new().with_hint_text("Optional password"),
             alias_input: String::new(),
             password_strength: 0.0,
             estimated_time_to_crack: String::new(),
@@ -83,7 +84,9 @@ impl ImportMnemonicScreen {
             seed_phrase: None,
 
             // Private key-specific fields
-            private_key_input: String::new(),
+            private_key_input: PasswordInput::new()
+                .with_hint_text("Enter private key (WIF: 51-52 chars, or hex: 64 chars)")
+                .with_monospace(),
             parsed_single_key_wallet: None,
 
             // Identity discovery options
@@ -97,7 +100,7 @@ impl ImportMnemonicScreen {
     }
 
     fn try_parse_private_key(&mut self) {
-        let input = self.private_key_input.trim();
+        let input = self.private_key_input.text().trim().to_string();
         if input.is_empty() {
             self.parsed_single_key_wallet = None;
             self.error = None;
@@ -105,8 +108,8 @@ impl ImportMnemonicScreen {
         }
 
         // Try to parse as WIF first, then as hex
-        let result = SingleKeyWallet::from_wif(input, None, None)
-            .or_else(|_| SingleKeyWallet::from_hex(input, self.app_context.network, None, None));
+        let result = SingleKeyWallet::from_wif(&input, None, None)
+            .or_else(|_| SingleKeyWallet::from_hex(&input, self.app_context.network, None, None));
 
         match result {
             Ok(wallet) => {
@@ -121,16 +124,16 @@ impl ImportMnemonicScreen {
     }
 
     fn save_private_key_wallet(&mut self) -> Result<AppAction, String> {
-        let input = self.private_key_input.trim();
+        let input = self.private_key_input.text().trim().to_string();
         if input.is_empty() {
             return Err("Please enter a private key".to_string());
         }
 
         // Parse the key with password and alias
-        let password = if self.password.is_empty() {
+        let password = if self.password_input.is_empty() {
             None
         } else {
-            Some(self.password.as_str())
+            Some(self.password_input.text())
         };
 
         // Generate default wallet name if none provided
@@ -148,8 +151,8 @@ impl ImportMnemonicScreen {
 
         // Try WIF first, then hex
         let mut wallet =
-            SingleKeyWallet::from_wif(input, password, alias.clone()).or_else(|_| {
-                SingleKeyWallet::from_hex(input, self.app_context.network, password, alias)
+            SingleKeyWallet::from_wif(&input, password, alias.clone()).or_else(|_| {
+                SingleKeyWallet::from_hex(&input, self.app_context.network, password, alias)
             })?;
 
         wallet.core_wallet_name = self
@@ -186,15 +189,15 @@ impl ImportMnemonicScreen {
         if let Some(mnemonic) = &self.seed_phrase {
             let seed = mnemonic.to_seed("");
 
-            let (encrypted_seed, salt, nonce, uses_password) = if self.password.is_empty() {
+            let (encrypted_seed, salt, nonce, uses_password) = if self.password_input.is_empty() {
                 (seed.to_vec(), vec![], vec![], false)
             } else {
                 // Encrypt the seed to obtain encrypted_seed, salt, and nonce
                 let (encrypted_seed, salt, nonce) =
-                    ClosedKeyItem::encrypt_seed(&seed, self.password.as_str())?;
+                    ClosedKeyItem::encrypt_seed(&seed, self.password_input.text())?;
                 if self.use_password_for_app {
                     let (encrypted_message, salt, nonce) =
-                        encrypt_message(DASH_SECRET_MESSAGE, self.password.as_str())?;
+                        encrypt_message(DASH_SECRET_MESSAGE, self.password_input.text())?;
                     self.app_context
                         .update_main_password(&salt, &nonce, &encrypted_message)
                         .map_err(|e| e.to_string())?;
@@ -357,11 +360,11 @@ impl ImportMnemonicScreen {
             self.seed_phrase = None;
 
             // Reset private key fields
-            self.private_key_input = String::new();
+            self.private_key_input.clear();
             self.parsed_single_key_wallet = None;
 
             // Reset common fields
-            self.password = String::new();
+            self.password_input.clear();
             self.alias_input = String::new();
             self.password_strength = 0.0;
             self.estimated_time_to_crack = String::new();
@@ -464,17 +467,9 @@ impl ImportMnemonicScreen {
         ));
         ui.add_space(8.0);
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
-        let response = ui.add_sized(
-            Vec2::new(ui.available_width() - 20.0, 40.0),
-            egui::TextEdit::singleline(&mut self.private_key_input)
-                .hint_text("Enter private key (WIF: 51-52 chars, or hex: 64 chars)")
-                .text_color(DashColors::text_primary(dark_mode))
-                .background_color(DashColors::input_background(dark_mode))
-                .password(true),
-        );
+        let response = self.private_key_input.show(ui);
 
-        if response.changed() {
+        if response.changed {
             self.try_parse_private_key();
         }
 
@@ -666,9 +661,10 @@ impl ScreenLike for ImportMnemonicScreen {
 
                     ui.horizontal(|ui| {
                         ui.label("Optional Password:");
-                        if ui.text_edit_singleline(&mut self.password).changed() {
-                            if !self.password.is_empty() {
-                                let estimate = zxcvbn(&self.password, &[]);
+                        let pw_response = self.password_input.show(ui);
+                        if pw_response.changed {
+                            if !self.password_input.is_empty() {
+                                let estimate = zxcvbn(self.password_input.text(), &[]);
 
                                 // Convert Score to u8
                                 let score_u8 = u8::from(estimate.score());

--- a/src/ui/wallets/single_key_send_screen.rs
+++ b/src/ui/wallets/single_key_send_screen.rs
@@ -8,6 +8,7 @@ use crate::model::amount::{Amount, DASH_DECIMAL_PLACES};
 use crate::model::wallet::single_key::SingleKeyWallet;
 use crate::ui::components::MessageBanner;
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::theme::DashColors;
@@ -62,8 +63,7 @@ pub struct SingleKeyWalletSendScreen {
     sending: bool,
 
     // Wallet unlock
-    wallet_password: String,
-    show_password: bool,
+    password_input: PasswordInput,
 
     // Fee confirmation dialog
     fee_dialog: FeeConfirmationDialog,
@@ -82,8 +82,7 @@ impl SingleKeyWalletSendScreen {
             subtract_fee: false,
             memo: String::new(),
             sending: false,
-            wallet_password: String::new(),
-            show_password: false,
+            password_input: PasswordInput::new().with_hint_text("Enter password"),
             fee_dialog: FeeConfirmationDialog::default(),
             show_advanced_options: false,
         }
@@ -761,14 +760,7 @@ impl SingleKeyWalletSendScreen {
                     );
                     ui.add_space(5.0);
 
-                    let password_field = if self.show_password {
-                        egui::TextEdit::singleline(&mut self.wallet_password)
-                    } else {
-                        egui::TextEdit::singleline(&mut self.wallet_password).password(true)
-                    };
-                    ui.add(password_field.desired_width(200.0));
-
-                    ui.checkbox(&mut self.show_password, "Show");
+                    self.password_input.show(ui);
 
                     ui.add_space(10.0);
 
@@ -777,9 +769,9 @@ impl SingleKeyWalletSendScreen {
                     {
                         match wallet.write() {
                             Ok(mut wallet_guard) => {
-                                match wallet_guard.open(&self.wallet_password) {
+                                match wallet_guard.open(self.password_input.text()) {
                                     Ok(_) => {
-                                        self.wallet_password.clear();
+                                        self.password_input.clear();
                                     }
                                     Err(e) => {
                                         MessageBanner::set_global(

--- a/src/ui/wallets/wallets_screen/address_table.rs
+++ b/src/ui/wallets/wallets_screen/address_table.rs
@@ -446,8 +446,7 @@ impl WalletsBalancesScreen {
                                         Ok(key) => {
                                             self.private_key_dialog.is_open = true;
                                             self.private_key_dialog.address = display_address;
-                                            self.private_key_dialog.private_key_wif =
-                                                zeroize::Zeroizing::new(key);
+                                            self.private_key_dialog.private_key_wif = key;
                                             self.private_key_dialog.show_key = false;
                                         }
                                         Err(err) => {

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -95,6 +95,7 @@ pub(super) struct MineDialogState {
 }
 
 /// State for the Private Key dialog
+#[derive(Default)]
 pub(super) struct PrivateKeyDialogState {
     pub is_open: bool,
     /// The address being displayed
@@ -107,19 +108,6 @@ pub(super) struct PrivateKeyDialogState {
     pub pending_derivation_path: Option<DerivationPath>,
     /// Pending address string (when wallet needs unlock first)
     pub pending_address: Option<String>,
-}
-
-impl Default for PrivateKeyDialogState {
-    fn default() -> Self {
-        Self {
-            is_open: false,
-            address: String::new(),
-            private_key_wif: Secret::new(String::new()),
-            show_key: false,
-            pending_derivation_path: None,
-            pending_address: None,
-        }
-    }
 }
 
 impl WalletsBalancesScreen {

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -3,6 +3,7 @@ use crate::backend_task::BackendTask;
 use crate::backend_task::core::{CoreTask, PaymentRecipient, WalletPaymentRequest};
 use crate::backend_task::wallet::WalletTask;
 use crate::model::amount::Amount;
+use crate::model::secret::Secret;
 use crate::model::wallet::{DerivationPathHelpers, Wallet};
 use crate::ui::MessageType;
 use crate::ui::components::MessageBanner;
@@ -99,7 +100,7 @@ pub(super) struct PrivateKeyDialogState {
     /// The address being displayed
     pub address: String,
     /// The private key in WIF format
-    pub private_key_wif: String,
+    pub private_key_wif: Secret,
     /// Whether to show the private key (hidden by default)
     pub show_key: bool,
     /// Pending derivation path (when wallet needs unlock first)
@@ -896,7 +897,7 @@ impl WalletsBalancesScreen {
                     // Private key value (hidden by default)
                     if self.private_key_dialog.show_key {
                         ui.label(
-                            RichText::new(&self.private_key_dialog.private_key_wif)
+                            RichText::new(self.private_key_dialog.private_key_wif.expose_secret())
                                 .monospace()
                                 .color(DashColors::text_primary(dark_mode)),
                         );
@@ -924,8 +925,9 @@ impl WalletsBalancesScreen {
                         }
 
                         if ui.button("Copy Key").clicked() {
-                            let _ =
-                                copy_text_to_clipboard(&self.private_key_dialog.private_key_wif);
+                            let _ = copy_text_to_clipboard(
+                                self.private_key_dialog.private_key_wif.expose_secret(),
+                            );
                         }
                     });
 
@@ -1224,7 +1226,7 @@ impl WalletsBalancesScreen {
         }
     }
 
-    pub(super) fn derive_private_key_wif(&self, path: &DerivationPath) -> Result<String, String> {
+    pub(super) fn derive_private_key_wif(&self, path: &DerivationPath) -> Result<Secret, String> {
         let wallet_arc = self
             .selected_wallet
             .clone()
@@ -1234,7 +1236,7 @@ impl WalletsBalancesScreen {
             return Err("Unlock this wallet to view private keys.".to_string());
         }
         let private_key = wallet.private_key_at_derivation_path(path, self.app_context.network)?;
-        Ok(private_key.to_wif())
+        Ok(Secret::new(private_key.to_wif()))
     }
 
     pub(super) fn open_mine_dialog(&mut self) {

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -35,7 +35,6 @@ use eframe::egui::{self, ComboBox, Context, Ui};
 use egui::{Color32, Frame, Margin, RichText};
 use egui_extras::{Column, TableBuilder};
 use std::sync::{Arc, RwLock};
-use zeroize::{Zeroize, Zeroizing};
 
 use crate::model::wallet::single_key::SingleKeyWallet;
 use address_table::{SortColumn, SortOrder};
@@ -1797,7 +1796,7 @@ impl ScreenLike for WalletsBalancesScreen {
                             Ok(key) => {
                                 self.private_key_dialog.is_open = true;
                                 self.private_key_dialog.address = address;
-                                self.private_key_dialog.private_key_wif = Zeroizing::new(key);
+                                self.private_key_dialog.private_key_wif = key;
                                 self.private_key_dialog.show_key = false;
                             }
                             Err(err) => {
@@ -1895,6 +1894,7 @@ impl ScreenLike for WalletsBalancesScreen {
                         ui.add_space(10.0);
 
                         ui.horizontal(|ui| {
+                            let dark_mode = ui.ctx().style().visuals.dark_mode;
                             if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode)
                                 .clicked()
                             {

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -15,6 +15,7 @@ use crate::spv::{CoreBackendMode, SpvStatus};
 use crate::ui::components::component_trait::Component;
 use crate::ui::components::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};
 use crate::ui::components::left_panel::add_left_panel;
+use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::selection_dialog::{SelectionDialog, SelectionStatus};
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
@@ -82,8 +83,7 @@ pub struct WalletsBalancesScreen {
     rename_input: String,
     wallet_unlock_popup: WalletUnlockPopup,
     show_sk_unlock_dialog: bool,
-    sk_wallet_password: String,
-    sk_show_password: bool,
+    sk_password_input: PasswordInput,
     remove_wallet_dialog: Option<ConfirmationDialog>,
     pending_wallet_removal: Option<WalletSeedHash>,
     pending_wallet_removal_alias: Option<String>,
@@ -192,8 +192,7 @@ impl WalletsBalancesScreen {
             rename_input: String::new(),
             wallet_unlock_popup: WalletUnlockPopup::new(),
             show_sk_unlock_dialog: false,
-            sk_wallet_password: String::new(),
-            sk_show_password: false,
+            sk_password_input: PasswordInput::new().with_hint_text("Enter password"),
             remove_wallet_dialog: None,
             pending_wallet_removal: None,
             pending_wallet_removal_alias: None,
@@ -1867,29 +1866,15 @@ impl ScreenLike for WalletsBalancesScreen {
 
                         ui.add_space(10.0);
 
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
                         let mut attempt_unlock = false;
 
-                        ui.horizontal(|ui| {
-                            let password_input = ui.add(
-                                egui::TextEdit::singleline(&mut self.sk_wallet_password)
-                                    .password(!self.sk_show_password)
-                                    .hint_text("Enter password")
-                                    .desired_width(250.0)
-                                    .text_color(DashColors::text_primary(dark_mode))
-                                    .background_color(DashColors::input_background(dark_mode)),
-                            );
+                        let pw_response = self.sk_password_input.show(ui);
 
-                            if password_input.lost_focus()
-                                && ui.input(|i| i.key_pressed(egui::Key::Enter))
-                            {
-                                attempt_unlock = true;
-                            }
-                        });
-
-                        ui.add_space(5.0);
-
-                        ui.checkbox(&mut self.sk_show_password, "Show Password");
+                        if pw_response.response.lost_focus()
+                            && ui.input(|i| i.key_pressed(egui::Key::Enter))
+                        {
+                            attempt_unlock = true;
+                        }
 
                         ui.add_space(10.0);
 
@@ -1906,7 +1891,7 @@ impl ScreenLike for WalletsBalancesScreen {
                         if attempt_unlock {
                             if let Some(wallet_arc) = &self.selected_single_key_wallet {
                                 let mut wallet = wallet_arc.write().unwrap();
-                                let unlock_result = wallet.open(&self.sk_wallet_password);
+                                let unlock_result = wallet.open(self.sk_password_input.text());
 
                                 match unlock_result {
                                     Ok(_) => {
@@ -1917,7 +1902,7 @@ impl ScreenLike for WalletsBalancesScreen {
                                     }
                                 }
                             }
-                            self.sk_wallet_password.clear();
+                            self.sk_password_input.clear();
                         }
 
                         // Error display is handled by the global MessageBanner.
@@ -1926,7 +1911,7 @@ impl ScreenLike for WalletsBalancesScreen {
 
             if close_dialog {
                 self.show_sk_unlock_dialog = false;
-                self.sk_wallet_password.clear();
+                self.sk_password_input.clear();
                 // Check if we were trying to refresh the SK wallet
                 if self.pending_refresh_after_unlock {
                     self.pending_refresh_after_unlock = false;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Closes #705 — Sensitive strings (passwords, WIF private keys) stored as plain `String` without memory zeroing
Closes #707 — Reusable password input component with hold-to-reveal

### User Story

Imagine you are managing your Dash wallets and identities. Previously, when you typed a password or private key, it was displayed in plaintext on screen — anyone watching could read it. And even after you navigated away, the sensitive data lingered in memory, potentially accessible to malware or memory dumps.

Now, all password and private key fields are masked by default with a small eye icon — hold the eye to peek at what you typed, release to re-mask. Behind the scenes, all sensitive strings are automatically zeroed when no longer needed, and their memory pages are locked to prevent swapping to disk.

## What was done?

### New types and components
- **`Secret` type** (`src/model/secret.rs`) — Zeroize-on-drop wrapper with best-effort `mlock` via `region` crate. Redacted `Debug`, constant-time `PartialEq`, no `Display`/`Deref` (explicit `expose_secret()` access)
- **`PasswordInput` component** (`src/ui/components/password_input.rs`) — Masked text input with hold-to-reveal eye icon, builder API, error display

### Security fixes
- **5 screens had passwords/keys displayed in plaintext** (no masking at all): Add New Wallet, Import Mnemonic, Add Existing Identity, Key Info, Network Chooser — all now masked
- All WIF private key display values wrapped in `Secret` for zeroize-on-drop
- `ScreenWithWalletUnlock` trait simplified from 4 methods to 1
- Manual `.zeroize()` calls removed (Secret handles it automatically)

### Migration scope
- 12+ screens migrated to `PasswordInput` and/or `Secret`
- 19 files modified, 4 new files, net reduction in code lines
- `IdentityInputToLoad` backend struct fields migrated to `Secret`

## How has this been tested?

- `cargo build --all-features` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — zero warnings
- `cargo +nightly fmt --all` — clean
- `cargo test --all-features --workspace` — 42 passed, 0 failed
- Security audit by specialist agent (1 MEDIUM fixed: constant-time PartialEq; 1 LOW fixed: default capacity)
- Security grep audit: no remaining unprotected password/key String fields in UI
- 27 manual test scenarios: `docs/ai-design/2026-03-09-password-input/manual-test-scenarios.md`

## Breaking Changes

None — all changes are internal. No public API changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant tests (10 unit tests for Secret type)
- [x] I have made corresponding changes to the documentation (UX spec, manual test scenarios)
- [x] Security audit completed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New secure PasswordInput widget: masked entry, hold-to-reveal eye, monospace option for keys, and automatic secret clearing.
  * New Secret type: memory-protected secret storage with zeroization, safe comparisons, and editing support.

* **Bug Fixes**
  * Replaced plaintext password/key fields across the UI with secure inputs to reduce leakage risk.

* **Documentation**
  * Added manual test scenarios, UX spec, and interactive wireframe for the password input.

* **Chores**
  * Added optional memory-locking support dependency and associated tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->