### PR TITLE
ci: add Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,5 @@
 ---
-name: Claude Code Review
+name: "Claude Code Review (add claudius-review label to trigger)"
 
 "on":
   pull_request:
@@ -14,8 +14,8 @@ jobs:
     if: >
       github.event.pull_request.draft == false &&
       (
-        (github.event.action == 'labeled' && github.event.label.name == 'claude review') ||
-        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude review'))
+        (github.event.action == 'labeled' && github.event.label.name == 'claudius-review') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claudius-review'))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -60,7 +60,7 @@ jobs:
             2. For each inline comment thread that IS fixed in code but NOT yet resolved:
                reply with a short description of how it was resolved, then resolve the thread.
             3. If ALL previous comments are now resolved, approve the PR and
-               remove the "claude review" label.
+               remove the "claudius-review" label.
             4. If unresolved comments remain OR this is the first review, run /claudius:grumpy-review
                and publish new findings as inline PR comments.
           claude_args: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,9 +66,16 @@ jobs:
                and resolve the thread.
             2. Run /claudius:grumpy-review to perform a fresh code review.
             3. Post only MEDIUM severity and higher findings as new inline PR comments.
-            4. Remove the "claudius-review" label (review is human-triggered each time).
-            5. If no unresolved comments remain after the full flow, approve the PR.
+            4. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
+
+      - name: Remove claudius-review label
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --remove-label "claudius-review" 2>/dev/null || true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,7 @@ jobs:
           HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK != '' }}
         run: |
           if [ "$HAS_TOKEN" != "true" ]; then
-            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret not configured."
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret not configured. Configure the CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret in your repository or organization settings."
             exit 1
           fi
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      issues: write
       pull-requests: write
       id-token: write
     env:
@@ -31,7 +32,7 @@ jobs:
           HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK != '' }}
         run: |
           if [ "$HAS_TOKEN" != "true" ]; then
-            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret not configured — skipping review."
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret not configured."
             exit 1
           fi
 
@@ -58,13 +59,15 @@ jobs:
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.
 
-            1. Run /claudius:check-pr-comments to verify if previous review comments are addressed.
-            2. For each inline comment thread that IS fixed in code but NOT yet resolved:
-               reply with a short description of how it was resolved, then resolve the thread.
-            3. If ALL previous comments are now resolved, approve the PR and
-               remove the "claudius-review" label.
-            4. If unresolved comments remain OR this is the first review, run /claudius:grumpy-review
-               and publish new findings as inline PR comments.
+            Follow this review flow in order:
+
+            1. Run /claudius:check-pr-comments to check if previous review comments are addressed.
+               For each thread that IS fixed but NOT yet resolved, reply describing the fix
+               and resolve the thread.
+            2. Run /claudius:grumpy-review to perform a fresh code review.
+            3. Post only MEDIUM severity and higher findings as new inline PR comments.
+            4. Remove the "claudius-review" label (review is human-triggered each time).
+            5. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,68 @@
+---
+name: Claude Code Review
+
+"on":
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >
+      github.event.pull_request.draft == false &&
+      (
+        (github.event.action == 'labeled' && github.event.label.name == 'claude review') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude review'))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    env:
+      CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'opus' }}
+    steps:
+      - name: Check for OAuth token
+        env:
+          HAS_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK != '' }}
+        run: |
+          if [ "$HAS_TOKEN" != "true" ]; then
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK secret not configured — skipping review."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Configure git to use HTTPS instead of SSH
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          use_sticky_comment: true
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
+          plugin_marketplaces: "https://github.com/lklimek/agents.git"
+          plugins: "claudius@lklimek"
+          show_full_output: true
+          trigger_phrase: ""
+          prompt: |
+            Prefer GitHub MCP tools over gh CLI commands.
+
+            1. Run /claudius:check-pr-comments to verify if previous review comments are addressed.
+            2. For each inline comment thread that IS fixed in code but NOT yet resolved:
+               reply with a short description of how it was resolved, then resolve the thread.
+            3. If ALL previous comments are now resolved, approve the PR and
+               remove the "claude review" label.
+            4. If unresolved comments remain OR this is the first review, run /claudius:grumpy-review
+               and publish new findings as inline PR comments.
+          claude_args: |
+            --model ${{ env.CLAUDE_MODEL }}
+            --max-turns 30

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,5 @@
 ---
-name: "Claude Code Review (add claudius-review label to trigger)"
+name: "Claude (label: claudius-review)"
 
 "on":
   pull_request:
@@ -55,6 +55,8 @@ jobs:
           trigger_phrase: ""
           prompt: |
             Prefer GitHub MCP tools over gh CLI commands.
+            Write all PR comments in Claudius persona — witty, confident, subtly snarky,
+            but always respectful and genuinely helpful, as if advising a trusted colleague.
 
             1. Run /claudius:check-pr-comments to verify if previous review comments are addressed.
             2. For each inline comment thread that IS fixed in code but NOT yet resolved:
@@ -64,5 +66,6 @@ jobs:
             4. If unresolved comments remain OR this is the first review, run /claudius:grumpy-review
                and publish new findings as inline PR comments.
           claude_args: |
+            --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,7 @@ jobs:
             --max-turns 30
 
       - name: Remove claudius-review label
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary

- Adds automated code review workflow triggered by `claudius-review` PR label
- Uses `--agent claudius:claudius` with `grumpy-review` and `check-pr-comments` skills via GitHub MCP
- Review flow: check existing threads → resolve fixed ones → fresh review → post MEDIUM+ findings → remove label → approve if clean
- Label is always removed after review (human-triggered each time)
- Defaults to Opus model, configurable via `CLAUDE_MODEL` repo variable
- Fails the job when `CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK` secret is missing (intentional — visible failure, not silent skip)

## Prerequisites

1. `CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK` secret configured (already exists)
2. Create `claudius-review` label in GitHub → Issues → Labels

## Test plan

- [ ] Add `claudius-review` label to a test PR → verify workflow triggers and produces review comments
- [ ] Push new commits to labeled PR → verify workflow re-runs on synchronize
- [ ] Address all review comments, re-label → verify threads get resolved and PR is approved
- [ ] Remove secret temporarily → verify workflow fails with warning (red, not green)
- [ ] Verify workflow does NOT trigger on unlabeled PRs or draft PRs
- [ ] Verify only MEDIUM+ findings are posted as inline comments

Non-functional CI change — no manual test scenario file needed.

🤖 Generated with [Claude Code](https://claude.ai/code) · Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated code review workflow for pull requests to streamline the review process and maintain code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->