### PR TITLE
ci: add path filters to clippy and tests workflows

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,8 +5,18 @@ on:
     branches:
       - main
       - "v*-dev"
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/clippy.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/clippy.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/clippy.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -16,6 +17,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/clippy.yml"
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/tests.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -16,6 +17,7 @@ on:
       - "**/*.rs"
       - "**/Cargo.toml"
       - "Cargo.lock"
+      - ".cargo/config.toml"
       - ".github/workflows/tests.yml"
 
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,18 @@ on:
     branches:
       - main
       - "v*-dev"
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/tests.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/tests.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Issue being fixed or feature implemented

CI workflows (clippy, tests) run on every push and PR regardless of what changed, wasting runner minutes on non-Rust changes.

## What was done?

Added `paths` filters to both `push` and `pull_request` triggers in `clippy.yml` and `tests.yml`. Workflows now only trigger when:
- `**/*.rs` — any Rust source file
- `**/Cargo.toml` — any Cargo manifest
- `Cargo.lock` — dependency lockfile
- `.github/workflows/<self>.yml` — the workflow file itself

## How has this been tested?

Verified YAML syntax. Non-functional CI change — no manual test scenarios needed.

## Breaking Changes

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>