### PR TITLE
ci: fix Claude review workflow tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,7 +71,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
-            --allowedTools "mcp__*,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(python3 *),Bash(bash *),Read,Glob,Grep,Agent,Skill"
+            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(cat *),Bash(python3 *),Bash(bash *)"
 
       - name: Remove claudius-review label
         if: success()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,7 +71,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
-            --allowedTools "mcp__*,Bash(gh *),Bash(python3 *),Bash(bash *),Bash(cat *),Bash(git *),Bash(jq *),Read,Glob,Grep,Agent,Skill"
+            --allowedTools "mcp__*,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(python3 *),Bash(bash *),Read,Glob,Grep,Agent,Skill"
 
       - name: Remove claudius-review label
         if: success()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -71,6 +71,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
+            --allowedTools "mcp__*,Bash(gh *),Bash(python3 *),Bash(bash *),Bash(cat *),Bash(git *),Bash(jq *),Read,Glob,Grep,Agent,Skill"
 
       - name: Remove claudius-review label
         if: success()


### PR DESCRIPTION
## Summary

- Fix Claude Code review workflow failing due to missing tool permissions in CI
- Add `--allowedTools` whitelist matching what `grumpy-review` and `check-pr-comments` skills require

## Allowed tools

| Tool | Purpose |
|---|---|
| `Bash(gh pr/api *)` | GitHub CLI for PR ops and GraphQL thread resolution |
| `Bash(git diff/log/fetch/branch/show/rev-parse *)` | Repo inspection and comparison base |
| `Bash(python3/bash/cat *)` | Skill scripts, report validation, schema reading |
| `Read, Write, Edit, Glob, Grep` | Code reading and report generation |
| `Task*, SendMessage, Agent, Skill` | Sub-agent spawning and orchestration |
| `mcp__*` | GitHub MCP tools |

## Test plan

- [ ] Apply `claudius-review` label to a test PR → verify workflow completes successfully
- [ ] Verify sub-agents can spawn, write reports, and post inline comments

Non-functional CI fix — no manual test scenario file needed.

🤖 Generated with [Claude Code](https://claude.ai/code) · Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius)