### PR TITLE
ci: fix Claude Code review workflow context and history

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # We can diff so we need history
+          fetch-depth: 0
 
       - name: Configure git to use HTTPS instead of SSH
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
@@ -59,6 +60,9 @@ jobs:
           prompt: |
             Load /claudash:dash-platform for Dash Platform domain context.
             Prefer GitHub MCP tools over gh CLI commands.
+            Use MCP GitHub tools (not env vars or gh CLI) to retrieve PR context: PR number,
+            base branch, head branch, changed files. Sub-agents have no conversation history —
+            pass all relevant PR context explicitly when spawning them.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,9 @@ jobs:
           use_sticky_comment: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
           plugin_marketplaces: "https://github.com/lklimek/agents.git"
-          plugins: "claudius@lklimek"
+          plugins: |
+            claudius@lklimek
+            claudash@lklimek
           show_full_output: true
           trigger_phrase: ""
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,6 +57,7 @@ jobs:
           show_full_output: true
           trigger_phrase: ""
           prompt: |
+            Load /claudash:dash-platform for Dash Platform domain context.
             Prefer GitHub MCP tools over gh CLI commands.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,7 +77,7 @@ jobs:
           claude_args: |
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
-            --max-turns 30
+            --max-turns 150
             --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(cat *),Bash(python3 *),Bash(bash *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
 
       - name: Remove claudius-review label

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,7 +74,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
-            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git *),Bash(cat *),Bash(python3 *),Bash(bash *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
+            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(cat *),Bash(python3 *),Bash(bash *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
 
       - name: Remove claudius-review label
         if: success()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,7 +74,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 30
-            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(cat *),Bash(python3 *),Bash(bash *)"
+            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git *),Bash(cat *),Bash(python3 *),Bash(bash *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
 
       - name: Remove claudius-review label
         if: success()


### PR DESCRIPTION
## Summary
- **Full git history**: Changed `fetch-depth: 1` → `fetch-depth: 0` so `git diff`, `git log`, and `git merge-base` work correctly during review
- **MCP for PR context**: Agent now uses MCP GitHub tools (not env vars) to get PR number, branches, and changed files — avoids tool permission blocks on shell parameter substitution
- **Sub-agent context passing**: Prompt explicitly instructs agent to pass PR context to spawned sub-agents (they have no conversation history)
- Previous commits: tightened git allowedTools, added shell utils, loaded dash-platform skill, added claudash plugin

## Test plan
- [ ] Trigger `claudius-review` label on a test PR and verify the review completes without "command requires approval" errors
- [ ] Verify git history commands (diff, log, merge-base) succeed in the review log
- [ ] Confirm sub-agents receive PR context and can produce review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow to retain full git history, expand available review plugins, provide richer PR/context prompts, increase interaction limits, and broaden allowed command/tool access to support deeper, more flexible automated analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->