### PR TITLE
fix: handle ContractNotFound and TokenNotFound in add token screen

### DIFF
--- a/docs/ai-design/2026-05-13-add-token-not-found/manual-test-scenarios.md
+++ b/docs/ai-design/2026-05-13-add-token-not-found/manual-test-scenarios.md
@@ -1,0 +1,42 @@
+# Add Token Not-Found Fallback Manual Test Scenarios
+
+## Scope
+
+Validate the add-token-by-ID lookup state machine when a contract ID is missing, when a token ID is used as fallback, and when stale state could otherwise be reused.
+
+## Scenario 1: Missing contract falls back to token ID lookup
+
+1. Open `Tokens` -> `Add Token`.
+2. Enter a valid base58 identifier that is not a contract ID but is a real token ID.
+3. Click `Search`.
+4. Verify the screen does not show an error after the first `ContractNotFound` result.
+5. Verify the screen automatically performs the token-ID lookup and resolves to the token or contract result.
+
+## Scenario 2: Token not found shows terminal error
+
+1. Open `Tokens` -> `Add Token`.
+2. Enter a valid base58 identifier that is neither a contract ID nor a token ID.
+3. Click `Search`.
+4. Verify the lookup ends with an error banner saying no contract or token was found.
+5. Verify the screen does not loop or retry indefinitely.
+
+## Scenario 3: Token found but backing contract missing
+
+1. Open `Tokens` -> `Add Token`.
+2. Enter a valid base58 token ID whose token record resolves but whose data contract is unavailable.
+3. Click `Search`.
+4. Verify the final banner says the token was found but its data contract could not be fetched.
+5. Verify the screen stays in an error state and does not retry again.
+
+## Scenario 4: New search clears stale add-token state
+
+1. Resolve a token so the `Add Token` button becomes available.
+2. Without adding it, enter a different identifier and click `Search`.
+3. Verify the previous token selection and fetched contract are cleared immediately.
+4. Verify the old `Add Token` action is no longer available unless the new lookup succeeds.
+
+## Scenario 5: Search button is disabled during active lookup
+
+1. Enter any valid identifier and click `Search`.
+2. While the status line shows `Searching...`, verify the `Search` button is disabled.
+3. Verify only one lookup result sequence is processed for that search attempt.

--- a/src/ui/tokens/add_token_by_id_screen.rs
+++ b/src/ui/tokens/add_token_by_id_screen.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 /// UI state during the add-token flow.
-#[derive(PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 enum AddTokenStatus {
     Idle,
     Searching(u32),
@@ -36,6 +36,32 @@ enum AddTokenStatus {
     FoundMultiple(Vec<TokenInfo>),
     Error,
     Complete,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ContractNotFoundResolution {
+    RetryWithTokenIdLookup,
+    Error(&'static str),
+}
+
+const NO_CONTRACT_OR_TOKEN_FOUND_MESSAGE: &str = "No contract or token found for the given identifier. Verify the ID, check the selected network, and try again.";
+const TOKEN_CONTRACT_MISSING_MESSAGE: &str = "Token was found, but its data contract could not be fetched. Check the selected network and try again.";
+
+fn resolve_contract_not_found(
+    input: &str,
+    tried_token_id_lookup: bool,
+) -> ContractNotFoundResolution {
+    if tried_token_id_lookup {
+        ContractNotFoundResolution::Error(TOKEN_CONTRACT_MISSING_MESSAGE)
+    } else if Identifier::from_string(input, Encoding::Base58).is_ok() {
+        ContractNotFoundResolution::RetryWithTokenIdLookup
+    } else {
+        ContractNotFoundResolution::Error(NO_CONTRACT_OR_TOKEN_FOUND_MESSAGE)
+    }
+}
+
+fn token_not_found_error_message() -> &'static str {
+    NO_CONTRACT_OR_TOKEN_FOUND_MESSAGE
 }
 
 pub struct AddTokenByIdScreen {
@@ -48,6 +74,7 @@ pub struct AddTokenByIdScreen {
     selected_token: Option<TokenInfo>,
 
     try_token_id_next: bool,
+    tried_token_id_lookup: bool,
 }
 
 impl AddTokenByIdScreen {
@@ -59,45 +86,56 @@ impl AddTokenByIdScreen {
             status: AddTokenStatus::Idle,
             selected_token: None,
             try_token_id_next: false,
+            tried_token_id_lookup: false,
         }
+    }
+
+    fn begin_lookup(&mut self, start_time: u32) {
+        self.status = AddTokenStatus::Searching(start_time);
+        self.fetched_contract = None;
+        self.selected_token = None;
+        self.try_token_id_next = false;
+        self.tried_token_id_lookup = false;
     }
 
     fn render_search_inputs(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
+        let is_searching = matches!(self.status, AddTokenStatus::Searching(_));
 
         ui.horizontal(|ui| {
             ui.label("Contract or Token ID:");
-            ui.text_edit_singleline(&mut self.contract_or_token_id_input);
+            ui.add_enabled(
+                !is_searching,
+                egui::TextEdit::singleline(&mut self.contract_or_token_id_input),
+            );
         });
 
         ui.add_space(10.0);
         if ui
             .add_enabled(
-                !self.contract_or_token_id_input.is_empty(),
+                !self.contract_or_token_id_input.is_empty() && !is_searching,
                 egui::Button::new("Search"),
             )
             .clicked()
         {
             let now = Utc::now().timestamp() as u32;
-            self.status = AddTokenStatus::Searching(now);
+            self.begin_lookup(now);
 
-            if !self.contract_or_token_id_input.is_empty() {
-                // Try to parse as identifier
-                if let Ok(identifier) =
-                    Identifier::from_string(&self.contract_or_token_id_input, Encoding::Base58)
-                {
-                    // First try as contract ID
-                    action = AppAction::BackendTask(BackendTask::TokenTask(Box::new(
-                        TokenTask::FetchTokenByContractId(identifier),
-                    )));
-                } else {
-                    MessageBanner::set_global(
-                        self.app_context.egui_ctx(),
-                        "Invalid identifier format",
-                        MessageType::Error,
-                    );
-                    self.status = AddTokenStatus::Error;
-                }
+            // Try to parse as identifier
+            if let Ok(identifier) =
+                Identifier::from_string(&self.contract_or_token_id_input, Encoding::Base58)
+            {
+                // First try as contract ID
+                action = AppAction::BackendTask(BackendTask::TokenTask(Box::new(
+                    TokenTask::FetchTokenByContractId(identifier),
+                )));
+            } else {
+                MessageBanner::set_global(
+                    self.app_context.egui_ctx(),
+                    "Invalid identifier format",
+                    MessageType::Error,
+                );
+                self.status = AddTokenStatus::Error;
             }
         }
 
@@ -183,10 +221,30 @@ impl AddTokenByIdScreen {
             self.fetched_contract = None;
             self.selected_token = None;
             self.try_token_id_next = false;
+            self.tried_token_id_lookup = false;
             return AppAction::None;
         }
 
         action
+    }
+
+    /// Handles contract-not-found by attempting a one-time fallback to token ID lookup.
+    /// Used by both `display_message` and `display_task_result`.
+    fn handle_contract_not_found(&mut self) {
+        match resolve_contract_not_found(
+            &self.contract_or_token_id_input,
+            self.tried_token_id_lookup,
+        ) {
+            ContractNotFoundResolution::RetryWithTokenIdLookup => {
+                self.try_token_id_next = true;
+                self.tried_token_id_lookup = true;
+            }
+            ContractNotFoundResolution::Error(message) => {
+                self.try_token_id_next = false;
+                MessageBanner::set_global(self.app_context.egui_ctx(), message, MessageType::Error);
+                self.status = AddTokenStatus::Error;
+            }
+        }
     }
 
     fn handle_fetched_contract(
@@ -265,19 +323,7 @@ impl ScreenLike for AddTokenByIdScreen {
             MessageType::Success => {
                 if msg.contains("DataContract successfully saved") {
                     self.status = AddTokenStatus::Complete;
-                } else if msg.contains("Contract not found") {
-                    // Contract not found, try as token ID
-                    if let Ok(_identifier) =
-                        Identifier::from_string(&self.contract_or_token_id_input, Encoding::Base58)
-                    {
-                        // We'll initiate a token ID search
-                        self.try_token_id_next = true;
-                    } else {
-                        self.status = AddTokenStatus::Error;
-                    }
-                } else if msg.contains("Token not found")
-                    || msg.contains("Error fetching contracts")
-                {
+                } else if msg.contains("Error fetching contracts") {
                     self.status = AddTokenStatus::Error;
                 }
             }
@@ -298,6 +344,17 @@ impl ScreenLike for AddTokenByIdScreen {
                 token_position,
             ) => {
                 self.handle_fetched_contract(contract, Some(token_position));
+            }
+            BackendTaskSuccessResult::ContractNotFound => {
+                self.handle_contract_not_found();
+            }
+            BackendTaskSuccessResult::TokenNotFound => {
+                MessageBanner::set_global(
+                    self.app_context.egui_ctx(),
+                    token_not_found_error_message(),
+                    MessageType::Error,
+                );
+                self.status = AddTokenStatus::Error;
             }
             _ => {}
         }
@@ -385,5 +442,156 @@ impl ScreenLike for AddTokenByIdScreen {
         });
 
         action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::{Arc, Once};
+
+    use dash_sdk::dpp::dashcore::Network;
+
+    use crate::app_dir::copy_env_file_if_not_exists;
+    use crate::context::AppContext;
+    use crate::database::Database;
+    use crate::ui::ScreenLike;
+
+    use super::{
+        AddTokenByIdScreen, AddTokenStatus, ContractNotFoundResolution,
+        NO_CONTRACT_OR_TOKEN_FOUND_MESSAGE, TOKEN_CONTRACT_MISSING_MESSAGE,
+        resolve_contract_not_found, token_not_found_error_message,
+    };
+    use crate::backend_task::BackendTaskSuccessResult;
+
+    fn ensure_test_env() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            copy_env_file_if_not_exists();
+
+            unsafe {
+                std::env::set_var("MAINNET_dapi_addresses", "http://127.0.0.1:1443");
+                std::env::set_var("MAINNET_core_host", "127.0.0.1");
+                std::env::set_var("MAINNET_core_rpc_port", "9998");
+                std::env::set_var("MAINNET_core_rpc_user", "dashrpc");
+                std::env::set_var("MAINNET_core_rpc_password", "password");
+
+                std::env::set_var("LOCAL_dapi_addresses", "http://127.0.0.1:2443");
+                std::env::set_var("LOCAL_core_host", "127.0.0.1");
+                std::env::set_var("LOCAL_core_rpc_port", "20302");
+                std::env::set_var("LOCAL_core_rpc_user", "dashmate");
+                std::env::set_var("LOCAL_core_rpc_password", "password");
+            }
+        });
+    }
+
+    fn test_screen(test_name: &str) -> AddTokenByIdScreen {
+        ensure_test_env();
+
+        let db_file_path = format!("test_db_add_token_by_id_screen_{test_name}");
+        let _ = std::fs::remove_file(&db_file_path);
+        let db = Arc::new(Database::new(&db_file_path).unwrap());
+        db.initialize(Path::new(&db_file_path)).unwrap();
+
+        let app_context = AppContext::new(
+            crate::app_dir::app_user_data_dir_path().unwrap(),
+            Network::Regtest,
+            db,
+            None,
+            Default::default(),
+            Default::default(),
+            egui::Context::default(),
+        )
+        .expect("Expected to create AppContext");
+        let screen = AddTokenByIdScreen::new(&app_context);
+
+        let _ = std::fs::remove_file(&db_file_path);
+        screen
+    }
+
+    #[test]
+    fn first_contract_not_found_retries_with_token_id_lookup() {
+        let resolution =
+            resolve_contract_not_found("7guyd1YceqT5S8xqA4UY9fZPpQn2J39GQJ4j3Nf7wV6H", false);
+
+        assert_eq!(
+            resolution,
+            ContractNotFoundResolution::RetryWithTokenIdLookup
+        );
+    }
+
+    #[test]
+    fn second_contract_not_found_becomes_error() {
+        let resolution =
+            resolve_contract_not_found("7guyd1YceqT5S8xqA4UY9fZPpQn2J39GQJ4j3Nf7wV6H", true);
+
+        assert_eq!(
+            resolution,
+            ContractNotFoundResolution::Error(TOKEN_CONTRACT_MISSING_MESSAGE)
+        );
+    }
+
+    #[test]
+    fn contract_not_found_retries_with_token_id_when_base58_is_valid() {
+        let mut screen = test_screen("contract_not_found_retries");
+        screen.contract_or_token_id_input =
+            "7guyd1YceqT5S8xqA4UY9fZPpQn2J39GQJ4j3Nf7wV6H".to_string();
+        screen.status = AddTokenStatus::Searching(42);
+        screen.tried_token_id_lookup = false;
+
+        screen.display_task_result(BackendTaskSuccessResult::ContractNotFound);
+
+        assert_eq!(screen.status, AddTokenStatus::Searching(42));
+        assert!(screen.try_token_id_next);
+        assert!(screen.tried_token_id_lookup);
+    }
+
+    #[test]
+    fn contract_not_found_errors_when_base58_is_invalid() {
+        let mut screen = test_screen("contract_not_found_invalid");
+        screen.contract_or_token_id_input = "not-base58".to_string();
+        screen.status = AddTokenStatus::Searching(42);
+        screen.tried_token_id_lookup = false;
+
+        screen.display_task_result(BackendTaskSuccessResult::ContractNotFound);
+
+        assert_eq!(screen.status, AddTokenStatus::Error);
+        assert!(!screen.try_token_id_next);
+        assert!(!screen.tried_token_id_lookup);
+    }
+
+    #[test]
+    fn contract_not_found_errors_after_token_id_lookup_was_tried() {
+        let mut screen = test_screen("contract_not_found_second_pass");
+        screen.contract_or_token_id_input =
+            "7guyd1YceqT5S8xqA4UY9fZPpQn2J39GQJ4j3Nf7wV6H".to_string();
+        screen.status = AddTokenStatus::Searching(42);
+        screen.tried_token_id_lookup = true;
+
+        screen.display_task_result(BackendTaskSuccessResult::ContractNotFound);
+
+        assert_eq!(screen.status, AddTokenStatus::Error);
+        assert!(!screen.try_token_id_next);
+        assert!(screen.tried_token_id_lookup);
+    }
+
+    #[test]
+    fn token_not_found_while_searching_sets_error_status() {
+        let mut screen = test_screen("token_not_found");
+        screen.status = AddTokenStatus::Searching(42);
+
+        screen.display_task_result(BackendTaskSuccessResult::TokenNotFound);
+
+        assert_eq!(screen.status, AddTokenStatus::Error);
+        assert!(!screen.try_token_id_next);
+        assert!(!screen.tried_token_id_lookup);
+    }
+
+    #[test]
+    fn token_not_found_maps_to_error_message() {
+        assert_eq!(
+            token_not_found_error_message(),
+            NO_CONTRACT_OR_TOKEN_FOUND_MESSAGE
+        );
     }
 }


### PR DESCRIPTION
## Issue

Fixes https://github.com/dashpay/dash-evo-tool/issues/691

## Description

The Add/Search Token screen gets stuck searching indefinitely when a contract or token is not found on the network.

**Root cause:** `AddTokenByIdScreen::display_task_result` has a `_ => {}` wildcard that silently swallows `BackendTaskSuccessResult::ContractNotFound` and `BackendTaskSuccessResult::TokenNotFound`. When either variant is returned, the UI stays in `Searching(timestamp)` state forever with no user feedback.

**Fix:**
- **`ContractNotFound`** — falls back to interpreting the input as a Token ID (via the existing `try_token_id_next` mechanism), matching the existing fallback pattern elsewhere in the screen
- **`TokenNotFound`** — shows an error via `MessageBanner` and transitions to `Error` state
- Both paths use the unified `MessageBanner` system consistent with other error handling in the same file

## Validation

- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅
- Manual trace: confirmed `ContractNotFound` and `TokenNotFound` are returned by the backend task handlers in `src/backend_task/tokens/mod.rs` (lines 523, 549, 553) and were previously swallowed by the wildcard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a controlled, one-time fallback: when a contract lookup fails for a valid identifier, the app will automatically attempt a token-ID lookup.
  * Improved error handling and messaging for missing contracts/tokens, including consistent mapping for “token not found”.
  * Prevents infinite retry loops and properly resets lookup state after successful “Add Another” actions.
* **Documentation**
  * Added manual test scenarios for the Tokens → Add Token lookup flow.
* **Tests**
  * Expanded coverage for fallback behavior, invalid identifiers, and terminal error transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->