### PR TITLE
ci: reduce wasted turns in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,9 +64,9 @@ jobs:
             Base branch: ${{ github.event.pull_request.base.ref }}
             Head branch: ${{ github.event.pull_request.head.ref }}
             PR title: ${{ github.event.pull_request.title }}
-            Run each bash command individually — never chain with && or ;.
 
             MemCan is NOT available in CI — skip memcan:recall, memcan:lessons-learned, and all mcp__plugin_memcan_brain__* tools.
+            When spawning agents, instruct them to not use memcan tools.
 
             FIRST, before anything else, probe GitHub MCP availability by calling
             mcp__plugin_claudius_github__get_me (no arguments). If it succeeds, use MCP tools
@@ -75,7 +75,7 @@ jobs:
             always include "GitHub MCP is available" or "GitHub MCP is NOT available — use gh CLI
             for all GitHub operations" in their prompts so they don't waste turns rediscovering this.
 
-            Load /claudash:dash-platform for Dash Platform domain context.
+            Load /claudash:dash-platform for Dash Platform domain context, and instruct agents to also do this.
             Sub-agents have no conversation history —
             pass all relevant PR context explicitly when spawning them.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,9 +68,15 @@ jobs:
 
             MemCan is NOT available in CI — skip memcan:recall, memcan:lessons-learned, and all mcp__plugin_memcan_brain__* tools.
 
+            FIRST, before anything else, probe GitHub MCP availability by calling
+            mcp__plugin_claudius_github__get_me (no arguments). If it succeeds, use MCP tools
+            for GitHub API operations. If it fails or is denied, set GITHUB_MCP_AVAILABLE=false
+            mentally and use gh CLI for all GitHub operations instead. When spawning sub-agents,
+            always include "GitHub MCP is available" or "GitHub MCP is NOT available — use gh CLI
+            for all GitHub operations" in their prompts so they don't waste turns rediscovering this.
+
             Load /claudash:dash-platform for Dash Platform domain context.
-            Use GitHub MCP tools for GitHub API operations (changed files, comments, reviews).
-            Fall back to gh CLI if MCP tools fail. Sub-agents have no conversation history —
+            Sub-agents have no conversation history —
             pass all relevant PR context explicitly when spawning them.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ github.token }}
         with:
           use_sticky_comment: true
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
@@ -58,10 +60,17 @@ jobs:
           show_full_output: true
           trigger_phrase: ""
           prompt: |
+            You are reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+            Base branch: ${{ github.event.pull_request.base.ref }}
+            Head branch: ${{ github.event.pull_request.head.ref }}
+            PR title: ${{ github.event.pull_request.title }}
+            Run each bash command individually — never chain with && or ;.
+
+            MemCan is NOT available in CI — skip memcan:recall, memcan:lessons-learned, and all mcp__plugin_memcan_brain__* tools.
+
             Load /claudash:dash-platform for Dash Platform domain context.
-            Prefer GitHub MCP tools over gh CLI commands.
-            Use MCP GitHub tools (not env vars or gh CLI) to retrieve PR context: PR number,
-            base branch, head branch, changed files. Sub-agents have no conversation history —
+            Use GitHub MCP tools for GitHub API operations (changed files, comments, reviews).
+            Fall back to gh CLI if MCP tools fail. Sub-agents have no conversation history —
             pass all relevant PR context explicitly when spawning them.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.
@@ -78,7 +87,7 @@ jobs:
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 150
-            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(cat *),Bash(python3 *),Bash(bash *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
+            --allowedTools "mcp__*,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(git status),Bash(git status *),Bash(git remote *),Bash(git merge-base *),Bash(cat *),Bash(python3 *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
 
       - name: Remove claudius-review label
         if: success()


### PR DESCRIPTION
## Summary

- **A1**: Expose `GH_TOKEN` to the review step so the claudius MCP server can authenticate GitHub API calls (was causing permission-denied errors that stalled the entire review)
- **A2**: Add missing `Bash(git status/remote/merge-base)` patterns to `allowedTools`; remove overly broad `Bash(bash *)` wildcard
- **A3**: Inject PR context (number, repo, base/head branches, title) directly into the prompt — eliminates 3-5 wasted turns of the agent discovering what it's reviewing
- **A5**: Disable MemCan tools (unavailable in CI) to prevent wasted MCP calls
- Bonus: replace rigid "prefer MCP, never use gh CLI" with resilient "use MCP, fall back to gh CLI" guidance; instruct agent not to chain bash commands

**Estimated savings**: ~8-13 API turns per review session, plus fixing the MCP auth failure that was killing sessions entirely.

## Test plan

- Non-functional CI change — no manual test scenarios needed
- Validate by applying `claudius-review` label to a test PR and confirming the review completes without permission errors

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code review workflow with improved PR context handling, including PR metadata integration.
  * Expanded tool configuration for more comprehensive automated review capabilities and optimized CI/CD reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->