### PR TITLE
fix: wire up DashPay payment history to wallet transactions

### DIFF
--- a/src/backend_task/dashpay.rs
+++ b/src/backend_task/dashpay.rs
@@ -1,5 +1,7 @@
-use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::error::TaskError;
+use crate::backend_task::{
+    BackendTaskSuccessResult, DashPayPaymentHistoryEntry, DashPayPaymentHistoryResult,
+};
 use crate::context::AppContext;
 use dash_sdk::Sdk;
 use std::sync::Arc;
@@ -26,6 +28,8 @@ use crate::model::qualified_identity::QualifiedIdentity;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
+
+const PARTIAL_PAYMENT_HISTORY_WARNING: &str = "Some older DashPay payments may be missing. Unlock all associated wallets and refresh payment history to complete the backfill.";
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum DashPayTask {
@@ -171,6 +175,79 @@ impl AppContext {
             ),
             DashPayTask::LoadPaymentHistory { identity } => {
                 let identity_id = identity.identity.id();
+                let network_str = self.network.to_string();
+                let mut payment_history_warning = None;
+
+                // Retroactively scan wallet transactions for DashPay payments
+                // that may not yet be in the dashpay_payments table. Once a
+                // wallet has completed its full backfill scan we rely on the
+                // lifecycle reconcile path to handle deltas.
+                for (seed_hash, wallet_arc) in &identity.associated_wallets {
+                    let has_scan_marker = self.db.has_dashpay_wallet_tx_scan_marker(
+                        seed_hash,
+                        &identity_id,
+                        &network_str,
+                    )?;
+                    if has_scan_marker {
+                        continue;
+                    }
+
+                    let (wallet_txs, seed) = match wallet_arc.read() {
+                        Ok(guard) => {
+                            if guard.transactions.is_empty() {
+                                continue;
+                            }
+
+                            if !guard.is_open() {
+                                payment_history_warning =
+                                    Some(PARTIAL_PAYMENT_HISTORY_WARNING.to_string());
+                                continue;
+                            }
+
+                            let Ok(seed) = guard.seed_bytes() else {
+                                payment_history_warning =
+                                    Some(PARTIAL_PAYMENT_HISTORY_WARNING.to_string());
+                                continue;
+                            };
+
+                            (guard.transactions.clone(), *seed)
+                        }
+                        Err(_) => {
+                            return Err(TaskError::DashPayScan {
+                                source: incoming_payments::DashPayScanError::WalletLockPoisoned,
+                            });
+                        }
+                    };
+
+                    let scan_mode = incoming_payments::DashPayWalletScanMode::Full {
+                        active_seed_bytes: &seed,
+                        active_wallet: wallet_arc,
+                    };
+
+                    let scan_result =
+                        incoming_payments::scan_wallet_transactions_for_dashpay_payments(
+                            self,
+                            &identity_id,
+                            &wallet_txs,
+                            scan_mode,
+                        )
+                        .map_err(|source| TaskError::DashPayScan { source })?;
+
+                    if scan_result.mappings_available {
+                        self.db.mark_dashpay_wallet_tx_scan_complete(
+                            seed_hash,
+                            &identity_id,
+                            &network_str,
+                        )?;
+                    }
+                    if scan_result.saved_payments > 0 {
+                        tracing::info!(
+                            "Retroactively discovered {} DashPay payment(s) from wallet transactions",
+                            scan_result.saved_payments
+                        );
+                    }
+                }
+
                 let records = payments::load_payment_history(self, &identity_id, None)
                     .await
                     .map_err(
@@ -179,11 +256,10 @@ impl AppContext {
                         },
                     )?;
 
-                let network_str = self.network.to_string();
                 let contacts = self
                     .db
                     .load_dashpay_contacts(&identity_id, &network_str)
-                    .unwrap_or_default();
+                    .map_err(|source| TaskError::Database { source })?;
 
                 let results: Vec<_> = records
                     .into_iter()
@@ -208,17 +284,23 @@ impl AppContext {
                                 format!("Unknown ({})", &s[..s.len().min(8)])
                             });
 
-                        (
-                            rec.tx_id.unwrap_or_default(),
+                        DashPayPaymentHistoryEntry {
+                            tx_id: rec.tx_id.unwrap_or_default(),
                             contact_name,
-                            rec.amount,
+                            amount: rec.amount,
                             is_incoming,
-                            rec.memo.unwrap_or_default(),
-                        )
+                            memo: rec.memo.unwrap_or_default(),
+                            timestamp: rec.timestamp,
+                        }
                     })
                     .collect();
 
-                Ok(BackendTaskSuccessResult::DashPayPaymentHistory(results))
+                Ok(BackendTaskSuccessResult::DashPayPaymentHistory(
+                    DashPayPaymentHistoryResult {
+                        payments: results,
+                        warning: payment_history_warning,
+                    },
+                ))
             }
             DashPayTask::SendPaymentToContact {
                 identity,
@@ -258,11 +340,7 @@ impl AppContext {
                 let result =
                     incoming_payments::register_dashpay_addresses_for_identity(self, &identity)
                         .await
-                        .map_err(|e| {
-                            crate::backend_task::dashpay::errors::DashPayError::Internal {
-                                message: e,
-                            }
-                        })?;
+                        .map_err(|source| TaskError::DashPayScan { source })?;
 
                 Ok(BackendTaskSuccessResult::Message(format!(
                     "Registered {} DashPay addresses for {} contacts{}",

--- a/src/backend_task/dashpay/incoming_payments.rs
+++ b/src/backend_task/dashpay/incoming_payments.rs
@@ -1,12 +1,14 @@
 use super::hd_derivation::{derive_dashpay_incoming_xpub, derive_payment_address};
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
+use crate::model::wallet::{Wallet, WalletSeedHash};
 use dash_sdk::dpp::dashcore::{Address, Network};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::Identifier;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+use thiserror::Error;
 
 /// Default gap limit for DashPay address derivation
 const DASHPAY_GAP_LIMIT: u32 = 20;
@@ -26,6 +28,24 @@ pub struct DashPayAddressRegistrationResult {
     pub addresses_registered: usize,
     pub contacts_processed: usize,
     pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DashPayWalletScanResult {
+    pub saved_payments: usize,
+    pub mappings_available: bool,
+}
+
+#[derive(Clone, Copy)]
+pub enum DashPayWalletScanMode<'a> {
+    Full {
+        active_seed_bytes: &'a [u8; 64],
+        active_wallet: &'a Arc<std::sync::RwLock<Wallet>>,
+    },
+    Delta {
+        active_seed_bytes: Option<&'a [u8; 64]>,
+        active_wallet: Option<&'a Arc<std::sync::RwLock<Wallet>>>,
+    },
 }
 
 /// Derive the receiving addresses for a contact relationship
@@ -70,34 +90,23 @@ pub fn derive_receiving_addresses_for_contact(
 pub async fn register_dashpay_addresses_for_identity(
     app_context: &Arc<AppContext>,
     identity: &QualifiedIdentity,
-) -> Result<DashPayAddressRegistrationResult, String> {
+) -> Result<DashPayAddressRegistrationResult, DashPayScanError> {
+    register_dashpay_addresses_for_identity_impl(app_context, identity)
+}
+
+fn register_dashpay_addresses_for_identity_impl(
+    app_context: &AppContext,
+    identity: &QualifiedIdentity,
+) -> Result<DashPayAddressRegistrationResult, DashPayScanError> {
     let mut result = DashPayAddressRegistrationResult::default();
     let our_identity_id = identity.identity.id();
-
-    // Get the wallet seed
-    let wallet = identity
-        .associated_wallets
-        .values()
-        .next()
-        .ok_or("No wallet associated with identity")?;
-
-    let seed = {
-        let wallet_guard = wallet.read().map_err(|e| e.to_string())?;
-        if !wallet_guard.is_open() {
-            return Err("Wallet must be unlocked to register DashPay addresses".to_string());
-        }
-        wallet_guard
-            .seed_bytes()
-            .map_err(|e| format!("Wallet seed not available: {}", e))?
-            .to_vec()
-    };
 
     // Load all contacts for this identity from the database
     let network_str = app_context.network.to_string();
     let contacts = app_context
         .db
         .load_dashpay_contacts(&our_identity_id, &network_str)
-        .map_err(|e| format!("Failed to load contacts: {}", e))?;
+        .map_err(DashPayScanError::LoadContacts)?;
 
     if contacts.is_empty() {
         return Ok(result);
@@ -107,7 +116,7 @@ pub async fn register_dashpay_addresses_for_identity(
     let address_indices = app_context
         .db
         .get_all_contact_address_indices(&our_identity_id)
-        .map_err(|e| format!("Failed to load address indices: {}", e))?;
+        .map_err(DashPayScanError::LoadContactAddressIndices)?;
 
     // Create a map for quick lookup
     let indices_map: BTreeMap<Vec<u8>, _> = address_indices
@@ -116,6 +125,7 @@ pub async fn register_dashpay_addresses_for_identity(
         .collect();
 
     let network = app_context.network;
+    let wallet_seeds = collect_wallet_seeds(&identity.associated_wallets)?;
 
     for contact in contacts {
         let contact_id = match Identifier::from_bytes(&contact.contact_identity_id) {
@@ -150,102 +160,366 @@ pub async fn register_dashpay_addresses_for_identity(
 
         let start_index = bloom_registered;
         let count = target_count - bloom_registered;
+        let mut contact_registration_succeeded = true;
 
         // Derive the receiving addresses
-        match derive_receiving_addresses_for_contact(
-            &seed,
-            network,
-            &our_identity_id,
-            &contact_id,
-            start_index,
-            count,
-        ) {
-            Ok(addresses) => {
-                // Register each address with the wallet
-                for addr_info in &addresses {
-                    if let Err(e) = register_dashpay_address(
-                        app_context,
-                        wallet,
-                        &addr_info.address,
-                        &our_identity_id,
-                        &contact_id,
-                        addr_info.address_index,
-                    ) {
-                        result.errors.push(format!(
-                            "Failed to register address for contact {}: {}",
-                            contact_id.to_string(Encoding::Base58),
-                            e
-                        ));
-                    } else {
-                        result.addresses_registered += 1;
+        for wallet_seed in &wallet_seeds {
+            match derive_receiving_addresses_for_contact(
+                &wallet_seed.seed,
+                network,
+                &our_identity_id,
+                &contact_id,
+                start_index,
+                count,
+            ) {
+                Ok(addresses) => {
+                    for addr_info in &addresses {
+                        if let Err(e) = register_dashpay_address(
+                            app_context,
+                            &wallet_seed.wallet,
+                            &wallet_seed.seed_hash,
+                            &addr_info.address,
+                            &our_identity_id,
+                            &contact_id,
+                            addr_info.address_index,
+                        ) {
+                            result.errors.push(format!(
+                                "Failed to register address for contact {}: {}",
+                                contact_id.to_string(Encoding::Base58),
+                                e
+                            ));
+                            contact_registration_succeeded = false;
+                        } else {
+                            result.addresses_registered += 1;
+                        }
                     }
                 }
-
-                // Update the bloom_registered_count in database
-                if let Err(e) = app_context.db.update_bloom_registered_count(
-                    &our_identity_id,
-                    &contact_id,
-                    target_count,
-                ) {
+                Err(e) => {
                     result.errors.push(format!(
-                        "Failed to update bloom count for contact {}: {}",
+                        "Failed to derive addresses for contact {}: {}",
                         contact_id.to_string(Encoding::Base58),
                         e
                     ));
+                    contact_registration_succeeded = false;
                 }
-
-                result.contacts_processed += 1;
-            }
-            Err(e) => {
-                result.errors.push(format!(
-                    "Failed to derive addresses for contact {}: {}",
-                    contact_id.to_string(Encoding::Base58),
-                    e
-                ));
             }
         }
+
+        if contact_registration_succeeded
+            && let Err(e) = app_context.db.update_bloom_registered_count(
+                &our_identity_id,
+                &contact_id,
+                target_count,
+            )
+        {
+            result.errors.push(format!(
+                "Failed to update bloom count for contact {}: {}",
+                contact_id.to_string(Encoding::Base58),
+                e
+            ));
+        }
+
+        result.contacts_processed += 1;
     }
 
     Ok(result)
+}
+
+struct WalletSeedRegistration {
+    wallet: Arc<std::sync::RwLock<Wallet>>,
+    seed_hash: WalletSeedHash,
+    seed: [u8; 64],
+}
+
+fn collect_wallet_seeds(
+    wallets: &BTreeMap<WalletSeedHash, Arc<std::sync::RwLock<Wallet>>>,
+) -> Result<Vec<WalletSeedRegistration>, DashPayScanError> {
+    if wallets.is_empty() {
+        return Err(DashPayScanError::NoAssociatedWallet);
+    }
+
+    wallets
+        .values()
+        .map(|wallet| {
+            let wallet_guard = wallet
+                .read()
+                .map_err(|_| DashPayScanError::WalletLockPoisoned)?;
+            if !wallet_guard.is_open() {
+                return Err(DashPayScanError::WalletLocked);
+            }
+            let seed = *wallet_guard
+                .seed_bytes()
+                .map_err(|e| DashPayScanError::WalletSeedUnavailable(e.to_string()))?;
+            Ok(WalletSeedRegistration {
+                wallet: Arc::clone(wallet),
+                seed_hash: wallet_guard.seed_hash(),
+                seed,
+            })
+        })
+        .collect()
+}
+
+fn wallet_seed_hash(
+    wallet: &Arc<std::sync::RwLock<Wallet>>,
+) -> Result<WalletSeedHash, DashPayScanError> {
+    let guard = wallet
+        .read()
+        .map_err(|_| DashPayScanError::WalletLockPoisoned)?;
+    Ok(guard.seed_hash())
+}
+
+#[cfg(test)]
+fn compute_seed_hash(seed_bytes: &[u8; 64]) -> WalletSeedHash {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(seed_bytes);
+    hasher.finalize().into()
+}
+
+fn contacts_with_target_counts(
+    db: &crate::database::Database,
+    network: Network,
+    identity_id: &Identifier,
+) -> Result<Vec<(Identifier, u32)>, DashPayScanError> {
+    let network_str = network.to_string();
+    let contacts = db
+        .load_dashpay_contacts(identity_id, &network_str)
+        .map_err(DashPayScanError::LoadContacts)?;
+    if contacts.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let address_indices = db
+        .get_all_contact_address_indices(identity_id)
+        .map_err(DashPayScanError::LoadContactAddressIndices)?;
+    let indices_map: BTreeMap<Vec<u8>, _> = address_indices
+        .into_iter()
+        .map(|idx| (idx.contact_identity_id.clone(), idx))
+        .collect();
+
+    contacts
+        .into_iter()
+        .map(|contact| {
+            let contact_id = Identifier::from_bytes(&contact.contact_identity_id).map_err(|e| {
+                DashPayScanError::MalformedContactId {
+                    identity_id: *identity_id,
+                    details: e.to_string(),
+                }
+            })?;
+            let target_count = indices_map
+                .get(&contact.contact_identity_id)
+                .map(|idx| idx.highest_receive_index.saturating_add(DASHPAY_GAP_LIMIT))
+                .unwrap_or(DASHPAY_GAP_LIMIT);
+            Ok((contact_id, target_count))
+        })
+        .collect()
+}
+
+fn derive_dashpay_address_mappings_for_seed(
+    owner_identity_id: &Identifier,
+    active_seed_bytes: &[u8],
+    network: Network,
+    contacts: &[(Identifier, u32)],
+) -> Result<Vec<DashPayReceivingAddress>, DashPayScanError> {
+    let mut addresses = Vec::new();
+    for (contact_id, target_count) in contacts {
+        if *target_count == 0 {
+            continue;
+        }
+        addresses.extend(
+            derive_receiving_addresses_for_contact(
+                active_seed_bytes,
+                network,
+                owner_identity_id,
+                contact_id,
+                0,
+                *target_count,
+            )
+            .map_err(|details| DashPayScanError::DeriveReceivingAddresses {
+                contact_id: *contact_id,
+                details,
+            })?,
+        );
+    }
+    Ok(addresses)
+}
+
+fn ensure_dashpay_address_mappings_for_scan(
+    db: &crate::database::Database,
+    network: Network,
+    identity_id: &Identifier,
+    active_seed_hash: &WalletSeedHash,
+    active_seed_bytes: &[u8],
+    active_wallet: Option<&Arc<std::sync::RwLock<Wallet>>>,
+) -> Result<bool, DashPayScanError> {
+    let contacts = contacts_with_target_counts(db, network, identity_id)?;
+    if contacts.is_empty() {
+        return Ok(false);
+    }
+
+    let addresses = derive_dashpay_address_mappings_for_seed(
+        identity_id,
+        active_seed_bytes,
+        network,
+        &contacts,
+    )?;
+    if addresses.is_empty() {
+        return Ok(false);
+    }
+
+    for addr_info in addresses {
+        if let Some(active_wallet) = active_wallet {
+            db.save_dashpay_address_mapping(
+                identity_id,
+                &addr_info.contact_id,
+                active_seed_hash,
+                &addr_info.address,
+                addr_info.address_index,
+            )
+            .map_err(DashPayScanError::SaveAddressMapping)?;
+            register_dashpay_address_in_wallet(
+                active_wallet,
+                &addr_info.address,
+                identity_id,
+                &addr_info.contact_id,
+                addr_info.address_index,
+            )?;
+        } else {
+            db.save_dashpay_address_mapping(
+                identity_id,
+                &addr_info.contact_id,
+                active_seed_hash,
+                &addr_info.address,
+                addr_info.address_index,
+            )
+            .map_err(DashPayScanError::SaveAddressMapping)?;
+        }
+    }
+
+    Ok(true)
+}
+
+fn dashpay_address_mappings_cover_targets(
+    db: &crate::database::Database,
+    network: Network,
+    identity_id: &Identifier,
+    seed_hash: &WalletSeedHash,
+) -> Result<bool, DashPayScanError> {
+    let contacts = contacts_with_target_counts(db, network, identity_id)?;
+    if contacts.is_empty() {
+        return Ok(true);
+    }
+
+    let mappings = db
+        .get_dashpay_address_mappings_for_wallet(identity_id, seed_hash)
+        .map_err(DashPayScanError::LoadAddressMappings)?;
+    let mut coverage: HashMap<Identifier, HashSet<u32>> = HashMap::new();
+    for (_, contact_id, address_index) in mappings {
+        coverage
+            .entry(contact_id)
+            .or_default()
+            .insert(address_index);
+    }
+
+    Ok(contacts.into_iter().all(|(contact_id, target_count)| {
+        if target_count == 0 {
+            return true;
+        }
+
+        let Some(indices) = coverage.get(&contact_id) else {
+            return false;
+        };
+        (0..target_count).all(|index| indices.contains(&index))
+    }))
+}
+
+fn register_existing_dashpay_address_mappings_in_wallet(
+    db: &crate::database::Database,
+    network: Network,
+    identity_id: &Identifier,
+    seed_hash: &WalletSeedHash,
+    active_wallet: &Arc<std::sync::RwLock<Wallet>>,
+) -> Result<bool, DashPayScanError> {
+    use std::str::FromStr;
+
+    let mappings = db
+        .get_dashpay_address_mappings_for_wallet(identity_id, seed_hash)
+        .map_err(DashPayScanError::LoadAddressMappings)?;
+
+    if mappings.is_empty() {
+        return Ok(false);
+    }
+
+    for (address_str, contact_id, address_index) in mappings {
+        let address = Address::from_str(&address_str)
+            .map_err(|err| DashPayScanError::MalformedStoredAddressMapping {
+                address: address_str.clone(),
+                details: err.to_string(),
+            })?
+            .require_network(network)
+            .map_err(|err| DashPayScanError::MalformedStoredAddressMapping {
+                address: address_str,
+                details: err.to_string(),
+            })?;
+
+        register_dashpay_address_in_wallet(
+            active_wallet,
+            &address,
+            identity_id,
+            &contact_id,
+            address_index,
+        )?;
+    }
+
+    Ok(true)
 }
 
 /// Register a single DashPay address with the wallet
 fn register_dashpay_address(
     app_context: &AppContext,
     wallet: &Arc<std::sync::RwLock<crate::model::wallet::Wallet>>,
+    seed_hash: &WalletSeedHash,
     address: &Address,
     owner_id: &Identifier,
     contact_id: &Identifier,
     address_index: u32,
-) -> Result<(), String> {
+) -> Result<(), DashPayScanError> {
+    // Store the DashPay address mapping in the database
+    app_context
+        .db
+        .save_dashpay_address_mapping(owner_id, contact_id, seed_hash, address, address_index)
+        .map_err(DashPayScanError::SaveAddressMapping)?;
+
+    register_dashpay_address_in_wallet(wallet, address, owner_id, contact_id, address_index)
+}
+
+fn register_dashpay_address_in_wallet(
+    wallet: &Arc<std::sync::RwLock<crate::model::wallet::Wallet>>,
+    address: &Address,
+    owner_id: &Identifier,
+    contact_id: &Identifier,
+    address_index: u32,
+) -> Result<(), DashPayScanError> {
     use crate::model::wallet::{DerivationPathReference, DerivationPathType};
     use dash_sdk::dpp::key_wallet::bip32::{ChildNumber, DerivationPath};
 
-    // Create a derivation path representation for DashPay addresses
-    // m/9'/5'/15'/0'/<owner_hash>/<contact_hash>/<index>
-    // Note: We use a simplified representation since full 256-bit paths don't fit in standard BIP32
     let path = DerivationPath::from(vec![
-        ChildNumber::from_hardened_idx(9).unwrap(), // Feature purpose
-        ChildNumber::from_hardened_idx(5).unwrap(), // Coin type (Dash)
-        ChildNumber::from_hardened_idx(15).unwrap(), // DashPay feature
-        ChildNumber::from_hardened_idx(0).unwrap(), // Account
-        // For the identity indices, we use a hash to fit in u32
+        ChildNumber::from_hardened_idx(9).unwrap(),
+        ChildNumber::from_hardened_idx(5).unwrap(),
+        ChildNumber::from_hardened_idx(15).unwrap(),
+        ChildNumber::from_hardened_idx(0).unwrap(),
         ChildNumber::from_normal_idx(hash_identifier_to_u32(owner_id)).unwrap(),
         ChildNumber::from_normal_idx(hash_identifier_to_u32(contact_id)).unwrap(),
         ChildNumber::from_normal_idx(address_index).unwrap(),
     ]);
 
-    // Store the DashPay address mapping in the database
-    app_context
-        .db
-        .save_dashpay_address_mapping(owner_id, contact_id, address, address_index)
-        .map_err(|e| format!("Failed to save address mapping: {}", e))?;
-
-    // Register with the wallet's known addresses
-    let mut guard = wallet.write().map_err(|e| e.to_string())?;
+    let mut guard = wallet
+        .write()
+        .map_err(|_| DashPayScanError::WalletLockPoisoned)?;
 
     if guard.known_addresses.contains_key(address) {
-        return Ok(()); // Already registered
+        return Ok(());
     }
 
     guard.known_addresses.insert(address.clone(), path.clone());
@@ -274,12 +548,92 @@ fn hash_identifier_to_u32(id: &Identifier) -> u32 {
 pub fn match_transaction_to_contact(
     app_context: &AppContext,
     address: &Address,
-) -> Result<Option<(Identifier, Identifier, u32)>, String> {
+) -> Result<Option<(Identifier, Identifier, u32)>, DashPayScanError> {
     // Look up the address in the DashPay address mapping
     app_context
         .db
         .get_dashpay_address_mapping(address)
-        .map_err(|e| format!("Failed to lookup address: {}", e))
+        .map_err(DashPayScanError::LookupAddressMapping)
+}
+
+/// Record a single incoming DashPay payment in the database.
+///
+/// Saves the payment record and updates the highest receive index for the
+/// contact.  This is the shared core of [`process_incoming_payment`] (real-time
+/// SPV path) and [`scan_wallet_transactions_for_dashpay_payments`] (retroactive
+/// scan).
+#[derive(Debug, Error)]
+pub enum DashPayScanError {
+    #[error("failed to load identity for scan: {0}")]
+    LoadIdentity(#[source] rusqlite::Error),
+    #[error("identity not found for scan: {0}")]
+    IdentityNotFound(Identifier),
+    #[error("wallet lock was poisoned while preparing scan")]
+    WalletLockPoisoned,
+    #[error("wallet must be unlocked to scan DashPay payments")]
+    WalletLocked,
+    #[error("wallet seed not available: {0}")]
+    WalletSeedUnavailable(String),
+    #[error("no wallet associated with identity")]
+    NoAssociatedWallet,
+    #[error("failed to load DashPay contacts: {0}")]
+    LoadContacts(#[source] rusqlite::Error),
+    #[error("failed to load DashPay contact address indices: {0}")]
+    LoadContactAddressIndices(#[source] rusqlite::Error),
+    #[error("failed to load DashPay address mappings: {0}")]
+    LoadAddressMappings(#[source] rusqlite::Error),
+    #[error("failed to lookup DashPay address mapping: {0}")]
+    LookupAddressMapping(#[source] rusqlite::Error),
+    #[error("failed to save DashPay address mapping: {0}")]
+    SaveAddressMapping(#[source] rusqlite::Error),
+    #[error("stored DashPay address mapping is malformed for address {address}: {details}")]
+    MalformedStoredAddressMapping { address: String, details: String },
+    #[error("malformed contact identifier for owner {identity_id}: {details}")]
+    MalformedContactId {
+        identity_id: Identifier,
+        details: String,
+    },
+    #[error("failed to derive receiving addresses for contact {contact_id}: {details}")]
+    DeriveReceivingAddresses {
+        contact_id: Identifier,
+        details: String,
+    },
+    #[error("failed to save payment: {0}")]
+    SavePayment(#[source] rusqlite::Error),
+    #[error("failed to update receive index: {0}")]
+    UpdateReceiveIndex(#[source] rusqlite::Error),
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_incoming_payment(
+    db: &crate::database::Database,
+    tx_id: &str,
+    output_index: Option<u32>,
+    owner_id: &Identifier,
+    contact_id: &Identifier,
+    amount_duffs: u64,
+    address_index: u32,
+    created_at: Option<i64>,
+) -> Result<bool, DashPayScanError> {
+    let save_result = db
+        .save_payment_with_output_index(
+            tx_id,
+            output_index,
+            contact_id, // from contact
+            owner_id,   // to us
+            amount_duffs as i64,
+            None, // memo — not available for incoming
+            "received",
+            created_at,
+        )
+        .map_err(DashPayScanError::SavePayment)?;
+
+    if save_result.changed() {
+        db.update_highest_receive_index(owner_id, contact_id, address_index + 1)
+            .map_err(DashPayScanError::UpdateReceiveIndex)?;
+    }
+
+    Ok(save_result.changed())
 }
 
 /// Process an incoming transaction that was detected by SPV
@@ -289,7 +643,8 @@ pub async fn process_incoming_payment(
     tx_id: &str,
     address: &Address,
     amount_duffs: u64,
-) -> Result<Option<IncomingPaymentInfo>, String> {
+    output_index: Option<u32>,
+) -> Result<Option<IncomingPaymentInfo>, DashPayScanError> {
     // Check if this address belongs to a DashPay contact relationship
     let mapping = match match_transaction_to_contact(app_context, address)? {
         Some(m) => m,
@@ -298,31 +653,18 @@ pub async fn process_incoming_payment(
 
     let (owner_id, contact_id, address_index) = mapping;
 
-    // Update the highest receive index if needed
-    let current_indices = app_context
-        .db
-        .get_contact_address_indices(&owner_id, &contact_id)
-        .map_err(|e| format!("Failed to get address indices: {}", e))?;
-
-    if address_index >= current_indices.highest_receive_index {
-        app_context
-            .db
-            .update_highest_receive_index(&owner_id, &contact_id, address_index + 1)
-            .map_err(|e| format!("Failed to update receive index: {}", e))?;
-    }
-
-    // Save the payment record
-    app_context
-        .db
-        .save_payment(
-            tx_id,
-            &contact_id, // from contact
-            &owner_id,   // to us
-            amount_duffs as i64,
-            None, // memo - not available for incoming
-            "received",
-        )
-        .map_err(|e| format!("Failed to save payment: {}", e))?;
+    // Record the payment and update address index.
+    // Real-time path: pass None so created_at defaults to the current time.
+    record_incoming_payment(
+        &app_context.db,
+        tx_id,
+        output_index,
+        &owner_id,
+        &contact_id,
+        amount_duffs,
+        address_index,
+        None,
+    )?;
 
     Ok(Some(IncomingPaymentInfo {
         tx_id: tx_id.to_string(),
@@ -345,9 +687,222 @@ pub struct IncomingPaymentInfo {
     pub address_index: u32,
 }
 
+/// A payment match produced by scanning wallet transactions against the
+/// DashPay address mapping table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DashPayScanMatch {
+    tx_id: String,
+    output_index: u32,
+    contact_id: Identifier,
+    address_index: u32,
+    amount_duffs: u64,
+    /// Block/tx timestamp, used as the payment row's `created_at`.
+    timestamp: u64,
+}
+
+/// Pure matching logic for the retroactive DashPay scan.
+///
+/// Returns one match per output that hits a known DashPay receiving address.
+/// Returns an empty vector if the transaction should be skipped:
+/// - transaction is outgoing (address_map only contains receive-side addresses,
+///   so matching an output of an outgoing tx does NOT indicate a payment to a
+///   contact — it would likely be our own change address or unrelated),
+/// - no output matches a known DashPay receiving address.
+fn match_dashpay_payment_in_transaction(
+    wtx: &crate::model::wallet::WalletTransaction,
+    address_map: &std::collections::HashMap<String, (Identifier, u32)>,
+    network: Network,
+) -> Vec<DashPayScanMatch> {
+    if !wtx.is_incoming() {
+        return Vec::new();
+    }
+
+    let tx_id = wtx.txid.to_string();
+    let mut matches = Vec::new();
+    for (output_index, output) in wtx.transaction.output.iter().enumerate() {
+        let Ok(addr) = Address::from_script(&output.script_pubkey, network) else {
+            continue;
+        };
+        if let Some((contact_id, address_index)) = address_map.get(&addr.to_string()) {
+            matches.push(DashPayScanMatch {
+                tx_id: tx_id.clone(),
+                output_index: output_index as u32,
+                contact_id: *contact_id,
+                address_index: *address_index,
+                amount_duffs: output.value,
+                timestamp: wtx.timestamp,
+            });
+        }
+    }
+
+    matches
+}
+
+/// Scan wallet transactions against DashPay address mappings and save any
+/// matched payments to the `dashpay_payments` table.
+///
+/// This is the retroactive counterpart of [`process_incoming_payment`]: it
+/// iterates over *all* wallet transactions (already synced via SPV) and checks
+/// every output address against the stored address-mapping table. Calling this
+/// function repeatedly is safe and idempotent because inserts are keyed by
+/// transaction/contact/output identity and ignored on conflict.
+///
+/// It is designed to be called from:
+/// - the SPV reconcile flow (after wallet transactions are updated), and
+/// - the `LoadPaymentHistory` backend task (for immediate retroactive
+///   detection when the user opens the Payment History screen).
+pub fn scan_wallet_transactions_for_dashpay_payments(
+    app_context: &AppContext,
+    identity_id: &Identifier,
+    transactions: &[crate::model::wallet::WalletTransaction],
+    scan_mode: DashPayWalletScanMode<'_>,
+) -> Result<DashPayWalletScanResult, DashPayScanError> {
+    scan_wallet_transactions_for_dashpay_payments_impl(
+        &app_context.db,
+        app_context.network,
+        identity_id,
+        transactions,
+        scan_mode,
+    )
+}
+
+fn scan_wallet_transactions_for_dashpay_payments_impl(
+    db: &crate::database::Database,
+    network: Network,
+    identity_id: &Identifier,
+    transactions: &[crate::model::wallet::WalletTransaction],
+    scan_mode: DashPayWalletScanMode<'_>,
+) -> Result<DashPayWalletScanResult, DashPayScanError> {
+    let mappings_ensured = match scan_mode {
+        DashPayWalletScanMode::Full {
+            active_seed_bytes,
+            active_wallet,
+        } => ensure_dashpay_address_mappings_for_scan(
+            db,
+            network,
+            identity_id,
+            &wallet_seed_hash(active_wallet)?,
+            active_seed_bytes,
+            Some(active_wallet),
+        )?,
+        DashPayWalletScanMode::Delta {
+            active_seed_bytes,
+            active_wallet,
+        } => match active_wallet {
+            Some(active_wallet) => {
+                let active_seed_hash = wallet_seed_hash(active_wallet)?;
+                if dashpay_address_mappings_cover_targets(
+                    db,
+                    network,
+                    identity_id,
+                    &active_seed_hash,
+                )? {
+                    register_existing_dashpay_address_mappings_in_wallet(
+                        db,
+                        network,
+                        identity_id,
+                        &active_seed_hash,
+                        active_wallet,
+                    )?
+                } else if let Some(active_seed_bytes) = active_seed_bytes {
+                    ensure_dashpay_address_mappings_for_scan(
+                        db,
+                        network,
+                        identity_id,
+                        &active_seed_hash,
+                        active_seed_bytes,
+                        Some(active_wallet),
+                    )?
+                } else {
+                    false
+                }
+            }
+            None => false,
+        },
+    };
+
+    // Build a lookup set of addresses → (owner_id, contact_id, address_index)
+    let mappings = match scan_mode {
+        DashPayWalletScanMode::Full { active_wallet, .. } => db
+            .get_dashpay_address_mappings_for_wallet(identity_id, &wallet_seed_hash(active_wallet)?)
+            .map_err(DashPayScanError::LoadAddressMappings)?,
+        DashPayWalletScanMode::Delta {
+            active_wallet: Some(active_wallet),
+            ..
+        } => db
+            .get_dashpay_address_mappings_for_wallet(identity_id, &wallet_seed_hash(active_wallet)?)
+            .map_err(DashPayScanError::LoadAddressMappings)?,
+        DashPayWalletScanMode::Delta {
+            active_wallet: None,
+            ..
+        } => Vec::new(),
+    };
+
+    if mappings.is_empty() {
+        return Ok(DashPayWalletScanResult {
+            saved_payments: 0,
+            mappings_available: false,
+        });
+    }
+
+    // address string → (contact_id, address_index)
+    let address_map: HashMap<String, (Identifier, u32)> = mappings
+        .into_iter()
+        .map(|(addr_str, contact_id, idx)| (addr_str, (contact_id, idx)))
+        .collect();
+
+    let mut saved = 0usize;
+
+    for wtx in transactions {
+        for m in match_dashpay_payment_in_transaction(wtx, &address_map, network) {
+            let created_at = (m.timestamp != 0).then_some(m.timestamp as i64);
+            if record_incoming_payment(
+                db,
+                &m.tx_id,
+                Some(m.output_index),
+                identity_id,
+                &m.contact_id,
+                m.amount_duffs,
+                m.address_index,
+                created_at,
+            )? {
+                saved += 1;
+                tracing::info!(
+                    tx_id = %m.tx_id,
+                    vout = m.output_index,
+                    contact = %m.contact_id.to_string(Encoding::Base58),
+                    amount = m.amount_duffs,
+                    direction = "received",
+                    address_index = m.address_index,
+                    "Saved DashPay payment from wallet transaction scan"
+                );
+            }
+        }
+    }
+
+    if saved > 0 {
+        tracing::info!(
+            identity = %identity_id.to_string(Encoding::Base58),
+            new_payments = saved,
+            "DashPay wallet transaction scan complete"
+        );
+    }
+
+    Ok(DashPayWalletScanResult {
+        saved_payments: saved,
+        mappings_available: mappings_ensured || !address_map.is_empty(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::test_helpers::create_test_database;
+    use crate::model::wallet::{TransactionStatus, Wallet, WalletTransaction};
+    use dash_sdk::dpp::dashcore::hashes::Hash;
+    use dash_sdk::dpp::dashcore::{PublicKey, Transaction, TxOut, Txid};
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::{Arc, RwLock};
 
     #[test]
     fn test_hash_identifier_to_u32() {
@@ -355,5 +910,844 @@ mod tests {
         let hash = hash_identifier_to_u32(&id);
         // Should be less than 2^31 (non-hardened range)
         assert!(hash < 0x80000000);
+    }
+
+    fn address_from_seed(byte: u8) -> Address {
+        let pubkey_bytes = [byte; 33];
+        // Start from a valid compressed secp256k1 point header (0x02) and tweak
+        // the x coordinate. Fall back to bumping the byte if unlucky.
+        let mut attempt = pubkey_bytes;
+        attempt[0] = 0x02;
+        attempt[1] = byte;
+        loop {
+            if let Ok(pk) = PublicKey::from_slice(&attempt) {
+                return Address::p2pkh(&pk, Network::Testnet);
+            }
+            attempt[1] = attempt[1].wrapping_add(1);
+        }
+    }
+
+    fn make_wtx(
+        txid_byte: u8,
+        outputs: Vec<TxOut>,
+        net_amount: i64,
+        timestamp: u64,
+    ) -> WalletTransaction {
+        WalletTransaction {
+            txid: Txid::from_slice(&[txid_byte; 32]).unwrap(),
+            transaction: Transaction {
+                version: 2,
+                lock_time: 0,
+                input: vec![],
+                output: outputs,
+                special_transaction_payload: None,
+            },
+            timestamp,
+            height: Some(100),
+            block_hash: None,
+            net_amount,
+            fee: None,
+            label: None,
+            is_ours: true,
+            status: TransactionStatus::Confirmed,
+        }
+    }
+
+    fn wallet_from_seed(seed_byte: u8) -> Arc<RwLock<Wallet>> {
+        let wallet = Wallet::new_from_seed([seed_byte; 64], Network::Testnet, None, None)
+            .expect("wallet from seed");
+        Arc::new(RwLock::new(wallet))
+    }
+
+    fn seed_from_wallet(wallet: &Arc<RwLock<Wallet>>) -> [u8; 64] {
+        let guard = wallet.read().expect("wallet read");
+        *guard.seed_bytes().expect("seed bytes")
+    }
+
+    fn save_contact(
+        db: &crate::database::Database,
+        owner_id: &Identifier,
+        contact_id: &Identifier,
+    ) {
+        db.save_dashpay_contact(
+            owner_id,
+            contact_id,
+            &Network::Testnet.to_string(),
+            Some("contact"),
+            None,
+            None,
+            None,
+            "accepted",
+        )
+        .expect("save contact");
+    }
+
+    fn save_mappings_for_seed(
+        db: &crate::database::Database,
+        owner_id: &Identifier,
+        seed: &[u8; 64],
+        mappings: &[DashPayReceivingAddress],
+    ) {
+        let seed_hash = compute_seed_hash(seed);
+        for mapping in mappings {
+            db.save_dashpay_address_mapping(
+                owner_id,
+                &mapping.contact_id,
+                &seed_hash,
+                &mapping.address,
+                mapping.address_index,
+            )
+            .expect("save mapping");
+        }
+    }
+
+    #[test]
+    fn collect_wallet_seeds_returns_all_associated_wallets() {
+        let wallet_a = wallet_from_seed(0x21);
+        let wallet_b = wallet_from_seed(0x22);
+        let seed_a = seed_from_wallet(&wallet_a);
+        let seed_b = seed_from_wallet(&wallet_b);
+
+        let mut wallets = BTreeMap::new();
+        wallets.insert(
+            wallet_a.read().expect("wallet a").seed_hash(),
+            Arc::clone(&wallet_a),
+        );
+        wallets.insert(
+            wallet_b.read().expect("wallet b").seed_hash(),
+            Arc::clone(&wallet_b),
+        );
+
+        let collected = collect_wallet_seeds(&wallets).expect("collect wallet seeds");
+        assert_eq!(collected.len(), 2);
+        assert!(collected.iter().any(|entry| entry.seed == seed_a));
+        assert!(collected.iter().any(|entry| entry.seed == seed_b));
+        assert!(
+            collected
+                .iter()
+                .any(|entry| entry.seed_hash == compute_seed_hash(&seed_a))
+        );
+        assert!(
+            collected
+                .iter()
+                .any(|entry| entry.seed_hash == compute_seed_hash(&seed_b))
+        );
+    }
+
+    #[test]
+    fn ensure_mappings_for_scan_registers_wallet_known_and_watched_addresses() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let wallet = wallet_from_seed(0x31);
+        let initial_known = wallet.read().expect("wallet read").known_addresses.len();
+        let seed = seed_from_wallet(&wallet);
+
+        save_contact(&db, &owner_id, &contact_id);
+        db.update_highest_receive_index(&owner_id, &contact_id, 3)
+            .expect("seed receive index");
+
+        let ensured = ensure_dashpay_address_mappings_for_scan(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            &compute_seed_hash(&seed),
+            &seed,
+            Some(&wallet),
+        )
+        .expect("ensure mappings");
+        assert!(ensured);
+
+        let expected = derive_receiving_addresses_for_contact(
+            &seed,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            23,
+        )
+        .expect("derive expected addresses");
+        let stored = db
+            .get_all_dashpay_address_mappings(&owner_id)
+            .expect("load mappings");
+        assert_eq!(stored.len(), expected.len());
+
+        let guard = wallet.read().expect("wallet read");
+        assert_eq!(guard.known_addresses.len(), initial_known + expected.len());
+        for addr in &expected {
+            assert!(guard.known_addresses.contains_key(&addr.address));
+            assert!(
+                guard
+                    .watched_addresses
+                    .values()
+                    .any(|info| info.address == addr.address)
+            );
+        }
+    }
+
+    #[test]
+    fn delta_scan_with_seed_backfills_mappings_and_records_payment() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let wallet = wallet_from_seed(0x41);
+        let seed = seed_from_wallet(&wallet);
+
+        save_contact(&db, &owner_id, &contact_id);
+
+        let derived = derive_receiving_addresses_for_contact(
+            &seed,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            1,
+        )
+        .expect("derive one address");
+        let payment_address = derived[0].address.clone();
+        let wtx = make_wtx(
+            0x51,
+            vec![TxOut {
+                value: 42_000,
+                script_pubkey: payment_address.script_pubkey(),
+            }],
+            42_000,
+            1_700_000_123,
+        );
+
+        let result = scan_wallet_transactions_for_dashpay_payments_impl(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            std::slice::from_ref(&wtx),
+            DashPayWalletScanMode::Delta {
+                active_seed_bytes: Some(&seed),
+                active_wallet: Some(&wallet),
+            },
+        )
+        .expect("delta scan");
+
+        assert_eq!(result.saved_payments, 1);
+        assert!(result.mappings_available);
+        assert_eq!(
+            db.get_all_dashpay_address_mappings(&owner_id)
+                .expect("load mappings")
+                .len(),
+            DASHPAY_GAP_LIMIT as usize
+        );
+
+        let guard = wallet.read().expect("wallet read");
+        assert!(guard.known_addresses.contains_key(&payment_address));
+        assert!(
+            guard
+                .watched_addresses
+                .values()
+                .any(|info| info.address == payment_address)
+        );
+        drop(guard);
+
+        let payments = db
+            .load_payment_history(&owner_id, 10)
+            .expect("load payments");
+        assert_eq!(payments.len(), 1);
+        assert_eq!(payments[0].tx_id, wtx.txid.to_string());
+    }
+
+    #[test]
+    fn delta_scan_with_complete_db_mappings_re_registers_wallet_addresses() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let original_wallet = wallet_from_seed(0x42);
+        let original_seed = seed_from_wallet(&original_wallet);
+
+        save_contact(&db, &owner_id, &contact_id);
+        ensure_dashpay_address_mappings_for_scan(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            &compute_seed_hash(&original_seed),
+            &original_seed,
+            Some(&original_wallet),
+        )
+        .expect("seed mappings");
+
+        assert!(
+            dashpay_address_mappings_cover_targets(
+                &db,
+                Network::Testnet,
+                &owner_id,
+                &compute_seed_hash(&original_seed),
+            )
+            .expect("coverage check")
+        );
+
+        let mapping_count = db
+            .get_all_dashpay_address_mappings(&owner_id)
+            .expect("load mappings")
+            .len();
+        let fresh_wallet = wallet_from_seed(0x42);
+        let fresh_seed = seed_from_wallet(&fresh_wallet);
+        let fresh_wallet_known_before = fresh_wallet
+            .read()
+            .expect("wallet read")
+            .known_addresses
+            .len();
+
+        let payment_address = derive_receiving_addresses_for_contact(
+            &original_seed,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            1,
+        )
+        .expect("derive known payment address")[0]
+            .address
+            .clone();
+        let wtx = make_wtx(
+            0x52,
+            vec![TxOut {
+                value: 84_000,
+                script_pubkey: payment_address.script_pubkey(),
+            }],
+            84_000,
+            1_700_000_124,
+        );
+
+        let result = scan_wallet_transactions_for_dashpay_payments_impl(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            std::slice::from_ref(&wtx),
+            DashPayWalletScanMode::Delta {
+                active_seed_bytes: Some(&fresh_seed),
+                active_wallet: Some(&fresh_wallet),
+            },
+        )
+        .expect("delta scan with existing mappings");
+
+        assert_eq!(result.saved_payments, 1);
+        assert!(result.mappings_available);
+        assert_eq!(
+            db.get_all_dashpay_address_mappings(&owner_id)
+                .expect("reload mappings")
+                .len(),
+            mapping_count
+        );
+
+        let guard = fresh_wallet.read().expect("wallet read");
+        assert!(guard.known_addresses.len() > fresh_wallet_known_before);
+        assert!(guard.known_addresses.contains_key(&payment_address));
+        assert!(
+            guard
+                .watched_addresses
+                .values()
+                .any(|info| info.address == payment_address)
+        );
+    }
+
+    #[test]
+    fn delta_reregistration_only_imports_addresses_for_active_wallet_seed() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let wallet_a = wallet_from_seed(0x43);
+        let wallet_b = wallet_from_seed(0x44);
+        let seed_a = seed_from_wallet(&wallet_a);
+        let seed_b = seed_from_wallet(&wallet_b);
+
+        save_contact(&db, &owner_id, &contact_id);
+
+        let mappings_a = derive_receiving_addresses_for_contact(
+            &seed_a,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            DASHPAY_GAP_LIMIT,
+        )
+        .expect("derive wallet A mappings");
+        let mappings_b = derive_receiving_addresses_for_contact(
+            &seed_b,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            DASHPAY_GAP_LIMIT,
+        )
+        .expect("derive wallet B mappings");
+        save_mappings_for_seed(&db, &owner_id, &seed_a, &mappings_a);
+        save_mappings_for_seed(&db, &owner_id, &seed_b, &mappings_b);
+
+        let fresh_wallet_a = wallet_from_seed(0x43);
+        let result = scan_wallet_transactions_for_dashpay_payments_impl(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            &[],
+            DashPayWalletScanMode::Delta {
+                active_seed_bytes: Some(&seed_a),
+                active_wallet: Some(&fresh_wallet_a),
+            },
+        )
+        .expect("delta scan");
+
+        assert_eq!(result.saved_payments, 0);
+        assert!(result.mappings_available);
+
+        let guard = fresh_wallet_a.read().expect("wallet read");
+        assert!(
+            mappings_a
+                .iter()
+                .all(|mapping| guard.known_addresses.contains_key(&mapping.address))
+        );
+        assert!(
+            mappings_b
+                .iter()
+                .all(|mapping| !guard.known_addresses.contains_key(&mapping.address))
+        );
+    }
+
+    #[test]
+    fn delta_scan_without_seed_bytes_re_registers_existing_scoped_mappings() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let original_wallet = wallet_from_seed(0x45);
+        let seed = seed_from_wallet(&original_wallet);
+        let seed_hash = compute_seed_hash(&seed);
+
+        save_contact(&db, &owner_id, &contact_id);
+        ensure_dashpay_address_mappings_for_scan(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            &seed_hash,
+            &seed,
+            Some(&original_wallet),
+        )
+        .expect("seed mappings");
+
+        let fresh_wallet = wallet_from_seed(0x45);
+        let known_before = fresh_wallet
+            .read()
+            .expect("wallet read")
+            .known_addresses
+            .len();
+
+        let result = scan_wallet_transactions_for_dashpay_payments_impl(
+            &db,
+            Network::Testnet,
+            &owner_id,
+            &[],
+            DashPayWalletScanMode::Delta {
+                active_seed_bytes: None,
+                active_wallet: Some(&fresh_wallet),
+            },
+        )
+        .expect("delta scan");
+
+        assert_eq!(result.saved_payments, 0);
+        assert!(result.mappings_available);
+        assert!(
+            fresh_wallet
+                .read()
+                .expect("wallet read")
+                .known_addresses
+                .len()
+                > known_before
+        );
+    }
+
+    #[test]
+    fn coverage_check_is_scoped_to_the_active_wallet_seed() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let seed_a = [0x46; 64];
+        let seed_b = [0x47; 64];
+
+        save_contact(&db, &owner_id, &contact_id);
+
+        let mappings_b = derive_receiving_addresses_for_contact(
+            &seed_b,
+            Network::Testnet,
+            &owner_id,
+            &contact_id,
+            0,
+            DASHPAY_GAP_LIMIT,
+        )
+        .expect("derive wallet B mappings");
+        save_mappings_for_seed(&db, &owner_id, &seed_b, &mappings_b);
+
+        assert!(
+            !dashpay_address_mappings_cover_targets(
+                &db,
+                Network::Testnet,
+                &owner_id,
+                &compute_seed_hash(&seed_a),
+            )
+            .expect("wallet A coverage")
+        );
+        assert!(
+            dashpay_address_mappings_cover_targets(
+                &db,
+                Network::Testnet,
+                &owner_id,
+                &compute_seed_hash(&seed_b),
+            )
+            .expect("wallet B coverage")
+        );
+    }
+
+    #[test]
+    fn scan_helper_skips_outgoing_transactions() {
+        let addr = address_from_seed(1);
+        let contact_id = Identifier::random();
+        let mut address_map = HashMap::new();
+        address_map.insert(addr.to_string(), (contact_id, 5u32));
+
+        let output = TxOut {
+            value: 50_000,
+            script_pubkey: addr.script_pubkey(),
+        };
+        // net_amount < 0 → outgoing
+        let wtx = make_wtx(0x11, vec![output], -10_000, 1_700_000_000);
+
+        let result = match_dashpay_payment_in_transaction(&wtx, &address_map, Network::Testnet);
+        assert!(result.is_empty(), "outgoing transactions must be skipped");
+    }
+
+    #[test]
+    fn scan_helper_records_all_matching_outputs_per_tx() {
+        let addr1 = address_from_seed(3);
+        let addr2 = address_from_seed(4);
+        let contact_a = Identifier::random();
+        let contact_b = Identifier::random();
+
+        let mut address_map = HashMap::new();
+        address_map.insert(addr1.to_string(), (contact_a, 7u32));
+        address_map.insert(addr2.to_string(), (contact_b, 9u32));
+
+        let outputs = vec![
+            TxOut {
+                value: 11_111,
+                script_pubkey: addr1.script_pubkey(),
+            },
+            TxOut {
+                value: 22_222,
+                script_pubkey: addr2.script_pubkey(),
+            },
+        ];
+        let wtx = make_wtx(0x33, outputs, 33_333, 1_700_000_100);
+
+        let matches = match_dashpay_payment_in_transaction(&wtx, &address_map, Network::Testnet);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches[0].contact_id, contact_a);
+        assert_eq!(matches[0].output_index, 0);
+        assert_eq!(matches[0].address_index, 7);
+        assert_eq!(matches[0].amount_duffs, 11_111);
+        assert_eq!(matches[0].timestamp, 1_700_000_100);
+        assert_eq!(matches[1].contact_id, contact_b);
+        assert_eq!(matches[1].output_index, 1);
+        assert_eq!(matches[1].address_index, 9);
+        assert_eq!(matches[1].amount_duffs, 22_222);
+    }
+
+    #[test]
+    fn scan_helper_records_same_contact_multiple_outputs_per_tx() {
+        let addr1 = address_from_seed(5);
+        let addr2 = address_from_seed(6);
+        let contact_id = Identifier::random();
+
+        let mut address_map = HashMap::new();
+        address_map.insert(addr1.to_string(), (contact_id, 3u32));
+        address_map.insert(addr2.to_string(), (contact_id, 4u32));
+
+        let outputs = vec![
+            TxOut {
+                value: 40_000,
+                script_pubkey: addr1.script_pubkey(),
+            },
+            TxOut {
+                value: 60_000,
+                script_pubkey: addr2.script_pubkey(),
+            },
+        ];
+        let wtx = make_wtx(0x34, outputs, 100_000, 1_700_000_101);
+
+        let matches = match_dashpay_payment_in_transaction(&wtx, &address_map, Network::Testnet);
+        assert_eq!(matches.len(), 2);
+        assert_eq!(matches.iter().map(|m| m.amount_duffs).sum::<u64>(), 100_000);
+    }
+
+    #[test]
+    fn record_incoming_payment_advances_highest_receive_index() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+
+        // Record at index 3 → highest should become 4 (index + 1).
+        record_incoming_payment(
+            &db,
+            "txid_a",
+            Some(0),
+            &owner_id,
+            &contact_id,
+            1_000,
+            3,
+            Some(1_700_000_000),
+        )
+        .expect("record 1");
+        let indices = db
+            .get_contact_address_indices(&owner_id, &contact_id)
+            .expect("load indices");
+        assert_eq!(indices.highest_receive_index, 4);
+
+        // Record at a HIGHER index 10 → should advance to 11.
+        record_incoming_payment(
+            &db,
+            "txid_b",
+            Some(1),
+            &owner_id,
+            &contact_id,
+            2_000,
+            10,
+            Some(1_700_000_100),
+        )
+        .expect("record 2");
+        let indices = db
+            .get_contact_address_indices(&owner_id, &contact_id)
+            .expect("load indices");
+        assert_eq!(indices.highest_receive_index, 11);
+
+        // Record at a LOWER index 2 → must NOT regress (MAX semantics).
+        record_incoming_payment(
+            &db,
+            "txid_c",
+            Some(2),
+            &owner_id,
+            &contact_id,
+            3_000,
+            2,
+            Some(1_700_000_200),
+        )
+        .expect("record 3");
+        let indices = db
+            .get_contact_address_indices(&owner_id, &contact_id)
+            .expect("load indices");
+        assert_eq!(indices.highest_receive_index, 11);
+
+        // Backfilled payments should store the provided timestamp, not the scan time.
+        let payments = db
+            .load_payment_history(&owner_id, 10)
+            .expect("load payments");
+        let row_a = payments
+            .iter()
+            .find(|p| p.tx_id == "txid_a")
+            .expect("txid_a saved");
+        assert_eq!(row_a.created_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn record_incoming_payment_skips_duplicate_output_and_reports_false() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+
+        let inserted = record_incoming_payment(
+            &db,
+            "txid_dup",
+            Some(1),
+            &owner_id,
+            &contact_id,
+            5_000,
+            8,
+            Some(1_700_000_000),
+        )
+        .expect("first insert");
+        assert!(inserted);
+
+        let inserted_again = record_incoming_payment(
+            &db,
+            "txid_dup",
+            Some(1),
+            &owner_id,
+            &contact_id,
+            5_000,
+            8,
+            Some(1_700_000_000),
+        )
+        .expect("duplicate insert");
+        assert!(!inserted_again);
+
+        let payments = db
+            .load_payment_history(&owner_id, 10)
+            .expect("load payments");
+        assert_eq!(payments.len(), 1);
+
+        let indices = db
+            .get_contact_address_indices(&owner_id, &contact_id)
+            .expect("load indices");
+        assert_eq!(indices.highest_receive_index, 9);
+    }
+
+    #[test]
+    fn record_incoming_payment_upgrades_legacy_row_and_reports_true() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+
+        db.save_payment_with_output_index(
+            "txid_legacy",
+            None,
+            &contact_id,
+            &owner_id,
+            5_000,
+            Some("legacy memo"),
+            "received",
+            Some(1_700_000_000),
+        )
+        .expect("seed legacy row");
+
+        let changed = record_incoming_payment(
+            &db,
+            "txid_legacy",
+            Some(2),
+            &owner_id,
+            &contact_id,
+            5_000,
+            4,
+            Some(1_700_000_100),
+        )
+        .expect("upgrade legacy row");
+        assert!(changed);
+
+        let payments = db
+            .load_payment_history(&owner_id, 10)
+            .expect("load payments");
+        assert_eq!(payments.len(), 1);
+        assert_eq!(payments[0].output_index, 2);
+        assert_eq!(payments[0].memo.as_deref(), Some("legacy memo"));
+        assert_eq!(payments[0].created_at, 1_700_000_000);
+
+        let indices = db
+            .get_contact_address_indices(&owner_id, &contact_id)
+            .expect("load indices");
+        assert_eq!(indices.highest_receive_index, 5);
+    }
+
+    #[test]
+    fn record_incoming_payment_saves_multiple_outputs_from_same_transaction() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+
+        assert!(
+            record_incoming_payment(
+                &db,
+                "txid_multi",
+                Some(0),
+                &owner_id,
+                &contact_id,
+                40_000,
+                2,
+                Some(1_700_000_010),
+            )
+            .expect("first output")
+        );
+        assert!(
+            record_incoming_payment(
+                &db,
+                "txid_multi",
+                Some(1),
+                &owner_id,
+                &contact_id,
+                60_000,
+                3,
+                Some(1_700_000_010),
+            )
+            .expect("second output")
+        );
+
+        let payments = db
+            .load_payment_history(&owner_id, 10)
+            .expect("load payments");
+        assert_eq!(payments.len(), 2);
+        assert_eq!(
+            payments.iter().map(|payment| payment.amount).sum::<i64>(),
+            100_000
+        );
+    }
+
+    #[test]
+    fn record_incoming_payment_uses_db_default_timestamp_when_backfill_timestamp_is_zero() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+
+        record_incoming_payment(
+            &db,
+            "txid_zero_ts",
+            Some(0),
+            &owner_id,
+            &contact_id,
+            7_500,
+            1,
+            None,
+        )
+        .expect("insert");
+
+        let payment = db
+            .load_payment_history(&owner_id, 1)
+            .expect("load payments")
+            .into_iter()
+            .next()
+            .expect("payment row");
+        assert_ne!(payment.created_at, 0);
+    }
+
+    #[test]
+    fn full_scan_mappings_are_derived_per_active_wallet_seed() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let contacts = vec![(contact_id, DASHPAY_GAP_LIMIT)];
+        let seed_a = [7u8; 64];
+        let seed_b = [8u8; 64];
+
+        let mappings_a = derive_dashpay_address_mappings_for_seed(
+            &owner_id,
+            &seed_a,
+            Network::Testnet,
+            &contacts,
+        )
+        .expect("derive mappings for wallet A");
+        let mappings_b = derive_dashpay_address_mappings_for_seed(
+            &owner_id,
+            &seed_b,
+            Network::Testnet,
+            &contacts,
+        )
+        .expect("derive mappings for wallet B");
+
+        assert_eq!(mappings_a.len(), DASHPAY_GAP_LIMIT as usize);
+        assert_eq!(mappings_b.len(), DASHPAY_GAP_LIMIT as usize);
+        assert!(
+            mappings_a
+                .iter()
+                .zip(mappings_b.iter())
+                .all(|(a, b)| a.address != b.address),
+            "distinct wallet seeds must contribute distinct DashPay receive mappings"
+        );
+
+        save_mappings_for_seed(&db, &owner_id, &seed_a, &mappings_a);
+        save_mappings_for_seed(&db, &owner_id, &seed_b, &mappings_b);
+
+        let stored = db
+            .get_all_dashpay_address_mappings(&owner_id)
+            .expect("load mappings");
+        assert_eq!(stored.len(), (DASHPAY_GAP_LIMIT as usize) * 2);
     }
 }

--- a/src/backend_task/dashpay/payments.rs
+++ b/src/backend_task/dashpay/payments.rs
@@ -327,8 +327,10 @@ pub async fn send_payment_to_contact_impl(
         payment.amount
     );
 
-    // Save to database using the db interface - propagate errors
-    app_context.db.save_payment(
+    // Save to database. The payment is already broadcast on-chain at this point,
+    // so a local-history persistence failure must not fail the task — otherwise the
+    // UI would report failure and could prompt a duplicate retry. Log and continue.
+    if let Err(e) = app_context.db.save_payment(
         &txid,
         &from_identity.identity.id(),
         &to_contact_id,
@@ -336,7 +338,13 @@ pub async fn send_payment_to_contact_impl(
         memo.as_deref(),
         "sent",
         None,
-    )?;
+    ) {
+        tracing::error!(
+            "Failed to save DashPay payment history for broadcast txid {}: {:?}",
+            txid,
+            e
+        );
+    }
 
     // Convert to Dash for display
     let amount_dash = amount_duffs as f64 / 100_000_000.0;

--- a/src/backend_task/dashpay/payments.rs
+++ b/src/backend_task/dashpay/payments.rs
@@ -335,6 +335,7 @@ pub async fn send_payment_to_contact_impl(
         amount_duffs as i64,
         memo.as_deref(),
         "sent",
+        None,
     )?;
 
     // Convert to Dash for display

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -32,6 +32,13 @@ pub enum TaskError {
     #[error(transparent)]
     DashPay(#[from] crate::backend_task::dashpay::errors::DashPayError),
 
+    /// Retroactive DashPay wallet transaction scan failed.
+    #[error("Could not scan wallet transactions for DashPay payments. Please retry.")]
+    DashPayScan {
+        #[source]
+        source: crate::backend_task::dashpay::incoming_payments::DashPayScanError,
+    },
+
     /// Configuration errors.
     #[error(transparent)]
     Config(#[from] crate::config::ConfigError),

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -118,6 +118,22 @@ pub enum BackendTask {
 }
 
 #[derive(Debug, Clone)]
+pub struct DashPayPaymentHistoryEntry {
+    pub tx_id: String,
+    pub contact_name: String,
+    pub amount: u64,
+    pub is_incoming: bool,
+    pub memo: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct DashPayPaymentHistoryResult {
+    pub payments: Vec<DashPayPaymentHistoryEntry>,
+    pub warning: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum BackendTaskSuccessResult {
     // General results
@@ -193,7 +209,7 @@ pub enum BackendTaskSuccessResult {
     },
     DashPayContacts(Vec<Identifier>), // List of contact identity IDs
     DashPayContactsWithInfo(Vec<ContactData>), // List of contacts with metadata
-    DashPayPaymentHistory(Vec<(String, String, u64, bool, String)>), // (tx_id, contact_name, amount, is_incoming, memo)
+    DashPayPaymentHistory(DashPayPaymentHistoryResult),
     DashPayProfileUpdated(Identifier), // Identity ID of updated profile
     DashPayContactRequestSent(String), // Username or ID of recipient
     DashPayContactRequestAccepted(Identifier), // Request ID that was accepted

--- a/src/context/transaction_processing.rs
+++ b/src/context/transaction_processing.rs
@@ -9,6 +9,7 @@ use dash_sdk::dpp::dashcore::transaction::special_transaction::TransactionPayloa
 use dash_sdk::dpp::dashcore::{Address, InstantLock, OutPoint, Transaction, TxOut, Txid};
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::InstantAssetLockProof;
 use dash_sdk::dpp::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::{AssetLockProof, CoreBlockHeight};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
@@ -212,36 +213,100 @@ impl AppContext {
                 if let Ok(Some((owner_id, contact_id, address_index))) =
                     self.db.get_dashpay_address_mapping(&address)
                 {
+                    let txid_str = tx.txid().to_string();
+                    let owner_str = owner_id.to_string(Encoding::Base58);
+                    let contact_str = contact_id.to_string(Encoding::Base58);
+
                     // Update the highest receive index if needed
-                    if let Ok(indices) = self.db.get_contact_address_indices(&owner_id, &contact_id)
-                        && address_index >= indices.highest_receive_index
-                    {
-                        let _ = self.db.update_highest_receive_index(
-                            &owner_id,
-                            &contact_id,
-                            address_index + 1,
-                        );
+                    match self.db.get_contact_address_indices(&owner_id, &contact_id) {
+                        Ok(indices) if address_index >= indices.highest_receive_index => {
+                            if let Err(e) = self.db.update_highest_receive_index(
+                                &owner_id,
+                                &contact_id,
+                                address_index + 1,
+                            ) {
+                                tracing::warn!(
+                                    txid = %txid_str,
+                                    owner = %owner_str,
+                                    contact = %contact_str,
+                                    address = %address,
+                                    address_index,
+                                    error = %e,
+                                    "Failed to update DashPay receive index for received transaction"
+                                );
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                txid = %txid_str,
+                                owner = %owner_str,
+                                contact = %contact_str,
+                                address = %address,
+                                address_index,
+                                error = %e,
+                                "Failed to load DashPay receive indices for received transaction"
+                            );
+                        }
                     }
 
                     // Save the payment record
-                    let _ = self.db.save_payment(
+                    match self.db.save_payment_with_output_index(
                         &tx.txid().to_string(),
+                        Some(vout as u32),
                         &contact_id, // from contact
                         &owner_id,   // to us
                         tx_out.value as i64,
                         None, // memo not available for incoming
                         "received",
-                    );
-
-                    tracing::info!(
-                        "DashPay payment received: {} duffs from contact {} to address {} (index {})",
-                        tx_out.value,
-                        contact_id.to_string(
-                            dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58
-                        ),
-                        address,
-                        address_index
-                    );
+                        None, // real-time: use current time
+                    ) {
+                        Ok(save_result) if save_result.inserted => {
+                            tracing::info!(
+                                txid = %txid_str,
+                                owner = %owner_str,
+                                contact = %contact_str,
+                                address = %address,
+                                address_index,
+                                amount = tx_out.value,
+                                "DashPay payment received and saved"
+                            );
+                        }
+                        Ok(save_result) if save_result.updated_existing => {
+                            tracing::info!(
+                                txid = %txid_str,
+                                owner = %owner_str,
+                                contact = %contact_str,
+                                address = %address,
+                                address_index,
+                                amount = tx_out.value,
+                                "DashPay payment received and upgraded from legacy row"
+                            );
+                        }
+                        Ok(_) => {
+                            tracing::info!(
+                                txid = %txid_str,
+                                owner = %owner_str,
+                                contact = %contact_str,
+                                address = %address,
+                                address_index,
+                                amount = tx_out.value,
+                                "DashPay payment received but already recorded"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                txid = %txid_str,
+                                owner = %owner_str,
+                                contact = %contact_str,
+                                address = %address,
+                                address_index,
+                                amount = tx_out.value,
+                                error = %e,
+                                "Failed to save DashPay payment for received transaction"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -761,9 +761,6 @@ impl AppContext {
             wm_arc.read().await;
         let mapping = self.spv_manager.det_wallets_snapshot();
 
-        // Take a snapshot of known addresses per wallet so we can scope DB updates
-        let wallets_guard = self.wallets.read()?;
-
         for (seed_hash, wallet_id) in mapping.iter() {
             // Log total balance for visibility
             let balance = wm
@@ -775,7 +772,7 @@ impl AppContext {
                 continue;
             };
 
-            let Some(wallet_arc) = wallets_guard.get(seed_hash).cloned() else {
+            let Some(wallet_arc) = self.wallets.read()?.get(seed_hash).cloned() else {
                 continue;
             };
 
@@ -911,9 +908,7 @@ impl AppContext {
             }
 
             // Write per-address balances and UTXOs into wallet model
-            if let Some(wref) = wallets_guard.get(seed_hash)
-                && let Ok(mut w) = wref.write()
-            {
+            if let Ok(mut w) = wallet_arc.write() {
                 // Update in-memory UTXOs map
                 w.utxos = new_utxos;
 
@@ -979,9 +974,147 @@ impl AppContext {
                 )?;
             }
 
-            if let Some(wref) = wallets_guard.get(seed_hash)
-                && let Ok(mut wallet) = wref.write()
-                && !wallet_transactions.is_empty()
+            // Collect identity IDs and the pre-update txid set under a read
+            // lock, then drop it before scanning to avoid holding the wallet
+            // lock during DB work.
+            let (identity_ids, existing_txids, seed_hash, active_seed_bytes): (
+                Vec<dash_sdk::platform::Identifier>,
+                std::collections::HashSet<_>,
+                Option<WalletSeedHash>,
+                Option<[u8; 64]>,
+            ) = if !wallet_transactions.is_empty() {
+                use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                match wallet_arc.read() {
+                    Ok(wallet) => {
+                        let active_seed_bytes = if wallet.is_open() {
+                            wallet.seed_bytes().ok().copied()
+                        } else {
+                            None
+                        };
+                        (
+                            wallet.identities.values().map(|id| id.id()).collect(),
+                            wallet.transactions.iter().map(|tx| tx.txid).collect(),
+                            Some(wallet.seed_hash()),
+                            active_seed_bytes,
+                        )
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            seed_hash = %hex::encode(seed_hash),
+                            error = %err,
+                            "Skipping SPV reconcile identity scan because wallet read lock is poisoned"
+                        );
+                        (vec![], std::collections::HashSet::new(), None, None)
+                    }
+                }
+            } else {
+                (vec![], std::collections::HashSet::new(), None, None)
+            };
+
+            let network_str = self.network.to_string();
+
+            // Scan wallet transactions for DashPay payments and save any
+            // matches to the dashpay_payments table.  This bridges the gap
+            // between the SPV wallet (which knows about on-chain txs) and
+            // the DashPay payment history (which only knew about payments
+            // initiated through the app UI).
+            if !wallet_transactions.is_empty() && !identity_ids.is_empty() {
+                let mut delta_wallet_transactions: Option<Vec<WalletTransaction>> = None;
+                for identity_id in &identity_ids {
+                    let Some(seed_hash) = seed_hash else {
+                        break;
+                    };
+
+                    let has_scan_marker = self.db.has_dashpay_wallet_tx_scan_marker(
+                        &seed_hash,
+                        identity_id,
+                        &network_str,
+                    )?;
+
+                    let scan_transactions = if has_scan_marker {
+                        std::borrow::Cow::Borrowed(
+                            delta_wallet_transactions
+                                .get_or_insert_with(|| {
+                                    wallet_transactions
+                                        .iter()
+                                        .filter(|tx| !existing_txids.contains(&tx.txid))
+                                        .cloned()
+                                        .collect()
+                                })
+                                .as_slice(),
+                        )
+                    } else {
+                        std::borrow::Cow::Borrowed(wallet_transactions.as_slice())
+                    };
+
+                    if scan_transactions.is_empty() {
+                        continue;
+                    }
+
+                    let scan_mode = if has_scan_marker {
+                        crate::backend_task::dashpay::incoming_payments::DashPayWalletScanMode::Delta {
+                            active_seed_bytes: active_seed_bytes.as_ref(),
+                            active_wallet: Some(&wallet_arc),
+                        }
+                    } else {
+                        let Some(active_seed_bytes) = active_seed_bytes.as_ref() else {
+                            tracing::debug!(
+                                identity = %identity_id,
+                                full_wallet_scan = true,
+                                "SPV reconcile: skipping DashPay full scan because active wallet seed is unavailable"
+                            );
+                            continue;
+                        };
+                        crate::backend_task::dashpay::incoming_payments::DashPayWalletScanMode::Full {
+                            active_seed_bytes,
+                            active_wallet: &wallet_arc,
+                        }
+                    };
+
+                    match crate::backend_task::dashpay::incoming_payments::scan_wallet_transactions_for_dashpay_payments(
+                        self,
+                        identity_id,
+                        scan_transactions.as_ref(),
+                        scan_mode,
+                    ) {
+                        Ok(scan_result) if scan_result.saved_payments > 0 => {
+                            if !has_scan_marker && scan_result.mappings_available {
+                                self.db.mark_dashpay_wallet_tx_scan_complete(
+                                    &seed_hash,
+                                    identity_id,
+                                    &network_str,
+                                )?;
+                            }
+                            tracing::info!(
+                                identity = %identity_id,
+                                new_payments = scan_result.saved_payments,
+                                full_wallet_scan = !has_scan_marker,
+                                "SPV reconcile: discovered DashPay payments from wallet transactions"
+                            );
+                        }
+                        Ok(scan_result) => {
+                            if !has_scan_marker && scan_result.mappings_available {
+                                self.db.mark_dashpay_wallet_tx_scan_complete(
+                                    &seed_hash,
+                                    identity_id,
+                                    &network_str,
+                                )?;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                identity = %identity_id,
+                                full_wallet_scan = !has_scan_marker,
+                                error = %e,
+                                "SPV reconcile: DashPay payment scan failed"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if !wallet_transactions.is_empty()
+                && let Ok(mut wallet) = wallet_arc.write()
             {
                 wallet.set_transactions(wallet_transactions);
             }

--- a/src/database/dashpay.rs
+++ b/src/database/dashpay.rs
@@ -1,5 +1,6 @@
+use crate::model::wallet::WalletSeedHash;
 use dash_sdk::platform::Identifier;
-use rusqlite::params;
+use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 
 /// DashPay profile data stored locally
@@ -52,6 +53,7 @@ pub struct StoredContactRequest {
 pub struct StoredPayment {
     pub id: i64,
     pub tx_id: String,
+    pub output_index: i64,
     pub from_identity_id: Vec<u8>,
     pub to_identity_id: Vec<u8>,
     pub amount: i64, // in credits
@@ -74,6 +76,19 @@ pub struct ContactAddressIndex {
     pub highest_receive_index: u32,
     /// Number of addresses registered in bloom filter for this contact
     pub bloom_registered_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaymentSaveResult {
+    pub row_id: Option<i64>,
+    pub inserted: bool,
+    pub updated_existing: bool,
+}
+
+impl PaymentSaveResult {
+    pub fn changed(&self) -> bool {
+        self.inserted || self.updated_existing
+    }
 }
 
 impl crate::database::Database {
@@ -152,7 +167,8 @@ impl crate::database::Database {
         tx.execute(
             "CREATE TABLE IF NOT EXISTS dashpay_payments (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
-                tx_id TEXT UNIQUE NOT NULL,
+                tx_id TEXT NOT NULL,
+                output_index INTEGER NOT NULL DEFAULT -1,
                 from_identity_id BLOB NOT NULL,
                 to_identity_id BLOB NOT NULL,
                 amount INTEGER NOT NULL,
@@ -160,7 +176,8 @@ impl crate::database::Database {
                 payment_type TEXT NOT NULL CHECK (payment_type IN ('sent', 'received')),
                 status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'failed')),
                 created_at INTEGER DEFAULT (unixepoch()),
-                confirmed_at INTEGER
+                confirmed_at INTEGER,
+                UNIQUE (tx_id, from_identity_id, to_identity_id, output_index)
             )",
             [],
         )?;
@@ -197,6 +214,7 @@ impl crate::database::Database {
         tx.execute(
             "CREATE TABLE IF NOT EXISTS dashpay_address_mappings (
                 address TEXT PRIMARY KEY,
+                seed_hash BLOB,
                 owner_identity_id BLOB NOT NULL,
                 contact_identity_id BLOB NOT NULL,
                 address_index INTEGER NOT NULL,
@@ -212,6 +230,27 @@ impl crate::database::Database {
         tx.execute(
             "CREATE INDEX IF NOT EXISTS idx_dashpay_address_mappings_contact
              ON dashpay_address_mappings(owner_identity_id, contact_identity_id)",
+            [],
+        )?;
+        tx.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dashpay_address_mappings_owner_seed_contact
+             ON dashpay_address_mappings(owner_identity_id, seed_hash, contact_identity_id, address_index)",
+            [],
+        )?;
+
+        tx.execute(
+            "CREATE TABLE IF NOT EXISTS dashpay_wallet_tx_scan_markers (
+                seed_hash BLOB NOT NULL,
+                identity_id BLOB NOT NULL,
+                network TEXT NOT NULL,
+                completed_at INTEGER NOT NULL DEFAULT (unixepoch()),
+                PRIMARY KEY (seed_hash, identity_id, network)
+            )",
+            [],
+        )?;
+        tx.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dashpay_wallet_tx_scan_markers_identity
+             ON dashpay_wallet_tx_scan_markers(identity_id, network)",
             [],
         )?;
 
@@ -328,15 +367,27 @@ impl crate::database::Database {
         public_message: Option<&str>,
         contact_status: &str,
     ) -> rusqlite::Result<()> {
-        let sql = "
-            INSERT OR REPLACE INTO dashpay_contacts
-            (owner_identity_id, contact_identity_id, network, username, display_name,
-             avatar_url, public_message, contact_status, updated_at)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, unixepoch())
-        ";
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let previous_status: Option<String> = tx
+            .query_row(
+                "SELECT contact_status
+             FROM dashpay_contacts
+             WHERE owner_identity_id = ?1 AND contact_identity_id = ?2 AND network = ?3",
+                params![
+                    owner_identity_id.to_buffer().to_vec(),
+                    contact_identity_id.to_buffer().to_vec(),
+                    network,
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
 
-        self.execute(
-            sql,
+        tx.execute(
+            "INSERT OR REPLACE INTO dashpay_contacts
+             (owner_identity_id, contact_identity_id, network, username, display_name,
+              avatar_url, public_message, contact_status, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, unixepoch())",
             params![
                 owner_identity_id.to_buffer().to_vec(),
                 contact_identity_id.to_buffer().to_vec(),
@@ -348,6 +399,18 @@ impl crate::database::Database {
                 contact_status,
             ],
         )?;
+
+        let should_clear_scan_markers =
+            contact_status == "accepted" && previous_status.as_deref() != Some("accepted");
+        if should_clear_scan_markers {
+            tx.execute(
+                "DELETE FROM dashpay_wallet_tx_scan_markers
+                 WHERE identity_id = ?1 AND network = ?2",
+                params![owner_identity_id.to_buffer().to_vec(), network],
+            )?;
+        }
+
+        tx.commit()?;
         Ok(())
     }
 
@@ -518,6 +581,13 @@ impl crate::database::Database {
 
     // Payment operations
 
+    /// Save a payment record.
+    ///
+    /// `created_at` is an optional Unix timestamp. Pass `None` for real-time
+    /// events (the current time is used via `unixepoch()`). Pass `Some(ts)`
+    /// when backfilling from an existing wallet transaction, so the payment
+    /// row reflects the block time rather than the moment it was scanned.
+    #[allow(clippy::too_many_arguments)]
     pub fn save_payment(
         &self,
         tx_id: &str,
@@ -526,27 +596,92 @@ impl crate::database::Database {
         amount: i64,
         memo: Option<&str>,
         payment_type: &str,
+        created_at: Option<i64>,
     ) -> rusqlite::Result<i64> {
-        let sql = "
-            INSERT INTO dashpay_payments
-            (tx_id, from_identity_id, to_identity_id, amount, memo, payment_type)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-        ";
+        let result = self.save_payment_with_output_index(
+            tx_id,
+            None,
+            from_identity_id,
+            to_identity_id,
+            amount,
+            memo,
+            payment_type,
+            created_at,
+        )?;
 
+        Ok(if result.inserted {
+            result.row_id.unwrap_or(0)
+        } else {
+            0
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn save_payment_with_output_index(
+        &self,
+        tx_id: &str,
+        output_index: Option<u32>,
+        from_identity_id: &Identifier,
+        to_identity_id: &Identifier,
+        amount: i64,
+        memo: Option<&str>,
+        payment_type: &str,
+        created_at: Option<i64>,
+    ) -> rusqlite::Result<PaymentSaveResult> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            sql,
+        let from_identity_bytes = from_identity_id.to_buffer().to_vec();
+        let to_identity_bytes = to_identity_id.to_buffer().to_vec();
+
+        let updated_existing = if let Some(output_index) = output_index {
+            conn.execute(
+                "UPDATE OR IGNORE dashpay_payments
+                 SET output_index = ?1
+                 WHERE tx_id = ?2
+                   AND from_identity_id = ?3
+                   AND to_identity_id = ?4
+                   AND output_index = -1",
+                params![
+                    i64::from(output_index),
+                    tx_id,
+                    &from_identity_bytes,
+                    &to_identity_bytes,
+                ],
+            )? > 0
+        } else {
+            false
+        };
+
+        if updated_existing {
+            return Ok(PaymentSaveResult {
+                row_id: None,
+                inserted: false,
+                updated_existing: true,
+            });
+        }
+
+        let inserted = conn.execute(
+            "
+            INSERT OR IGNORE INTO dashpay_payments
+            (tx_id, output_index, from_identity_id, to_identity_id, amount, memo, payment_type, created_at)
+            VALUES (?1, COALESCE(?2, -1), ?3, ?4, ?5, ?6, ?7, COALESCE(?8, unixepoch()))
+            ",
             params![
                 tx_id,
-                from_identity_id.to_buffer().to_vec(),
-                to_identity_id.to_buffer().to_vec(),
+                output_index.map(i64::from),
+                &from_identity_bytes,
+                &to_identity_bytes,
                 amount,
                 memo,
                 payment_type,
+                created_at,
             ],
-        )?;
+        )? > 0;
 
-        Ok(conn.last_insert_rowid())
+        Ok(PaymentSaveResult {
+            row_id: inserted.then(|| conn.last_insert_rowid()),
+            inserted,
+            updated_existing: false,
+        })
     }
 
     pub fn update_payment_status(&self, payment_id: i64, status: &str) -> rusqlite::Result<()> {
@@ -571,7 +706,7 @@ impl crate::database::Database {
     ) -> rusqlite::Result<Vec<StoredPayment>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, tx_id, from_identity_id, to_identity_id, amount, memo,
+            "SELECT id, tx_id, output_index, from_identity_id, to_identity_id, amount, memo,
                     payment_type, status, created_at, confirmed_at
              FROM dashpay_payments
              WHERE from_identity_id = ?1 OR to_identity_id = ?1
@@ -585,14 +720,58 @@ impl crate::database::Database {
                 Ok(StoredPayment {
                     id: row.get(0)?,
                     tx_id: row.get(1)?,
-                    from_identity_id: row.get(2)?,
-                    to_identity_id: row.get(3)?,
-                    amount: row.get(4)?,
-                    memo: row.get(5)?,
-                    payment_type: row.get(6)?,
-                    status: row.get(7)?,
-                    created_at: row.get(8)?,
-                    confirmed_at: row.get(9)?,
+                    output_index: row.get(2)?,
+                    from_identity_id: row.get(3)?,
+                    to_identity_id: row.get(4)?,
+                    amount: row.get(5)?,
+                    memo: row.get(6)?,
+                    payment_type: row.get(7)?,
+                    status: row.get(8)?,
+                    created_at: row.get(9)?,
+                    confirmed_at: row.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(payments)
+    }
+
+    /// Load payment history filtered to a specific contact relationship.
+    /// Returns payments where both identity_id and contact_id are involved
+    /// (either as sender or receiver), ordered by most recent first.
+    pub fn load_payment_history_for_contact(
+        &self,
+        identity_id: &Identifier,
+        contact_id: &Identifier,
+        limit: u32,
+    ) -> rusqlite::Result<Vec<StoredPayment>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, tx_id, output_index, from_identity_id, to_identity_id, amount, memo,
+                    payment_type, status, created_at, confirmed_at
+             FROM dashpay_payments
+             WHERE (from_identity_id = ?1 OR to_identity_id = ?1)
+               AND (from_identity_id = ?2 OR to_identity_id = ?2)
+             ORDER BY created_at DESC
+             LIMIT ?3",
+        )?;
+
+        let identity_bytes = identity_id.to_buffer().to_vec();
+        let contact_bytes = contact_id.to_buffer().to_vec();
+        let payments = stmt
+            .query_map(params![identity_bytes, contact_bytes, limit], |row| {
+                Ok(StoredPayment {
+                    id: row.get(0)?,
+                    tx_id: row.get(1)?,
+                    output_index: row.get(2)?,
+                    from_identity_id: row.get(3)?,
+                    to_identity_id: row.get(4)?,
+                    amount: row.get(5)?,
+                    memo: row.get(6)?,
+                    payment_type: row.get(7)?,
+                    status: row.get(8)?,
+                    created_at: row.get(9)?,
+                    confirmed_at: row.get(10)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -828,19 +1007,21 @@ impl crate::database::Database {
         &self,
         owner_identity_id: &Identifier,
         contact_identity_id: &Identifier,
+        seed_hash: &WalletSeedHash,
         address: &dash_sdk::dpp::dashcore::Address,
         address_index: u32,
     ) -> rusqlite::Result<()> {
         let sql = "
             INSERT OR REPLACE INTO dashpay_address_mappings
-            (address, owner_identity_id, contact_identity_id, address_index, created_at)
-            VALUES (?1, ?2, ?3, ?4, unixepoch())
+            (address, seed_hash, owner_identity_id, contact_identity_id, address_index, created_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, unixepoch())
         ";
 
         self.execute(
             sql,
             params![
                 address.to_string(),
+                seed_hash.as_slice(),
                 owner_identity_id.to_buffer().to_vec(),
                 contact_identity_id.to_buffer().to_vec(),
                 address_index,
@@ -888,6 +1069,8 @@ impl crate::database::Database {
         &self,
         owner_identity_id: &Identifier,
     ) -> rusqlite::Result<Vec<(String, Identifier, u32)>> {
+        use rusqlite::types::Type;
+
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT address, contact_identity_id, address_index
@@ -903,14 +1086,54 @@ impl crate::database::Database {
                 let address_index: u32 = row.get(2)?;
                 Ok((address, contact_bytes, address_index))
             })?
-            .filter_map(|r| {
-                r.ok().and_then(|(address, contact_bytes, address_index)| {
-                    Identifier::from_bytes(&contact_bytes)
-                        .ok()
-                        .map(|contact_id| (address, contact_id, address_index))
+            .map(|row_result| {
+                row_result.and_then(|(address, contact_bytes, address_index)| {
+                    let contact_id = Identifier::from_bytes(&contact_bytes).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(1, Type::Blob, Box::new(e))
+                    })?;
+                    Ok((address, contact_id, address_index))
                 })
             })
-            .collect();
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+
+        Ok(mappings)
+    }
+
+    /// Get all DashPay address mappings for an identity scoped to a wallet seed.
+    pub fn get_dashpay_address_mappings_for_wallet(
+        &self,
+        owner_identity_id: &Identifier,
+        seed_hash: &WalletSeedHash,
+    ) -> rusqlite::Result<Vec<(String, Identifier, u32)>> {
+        use rusqlite::types::Type;
+
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT address, contact_identity_id, address_index
+             FROM dashpay_address_mappings
+             WHERE owner_identity_id = ?1 AND seed_hash = ?2
+             ORDER BY contact_identity_id, address_index",
+        )?;
+
+        let mappings = stmt
+            .query_map(
+                params![owner_identity_id.to_buffer().to_vec(), seed_hash.as_slice()],
+                |row| {
+                    let address: String = row.get(0)?;
+                    let contact_bytes: Vec<u8> = row.get(1)?;
+                    let address_index: u32 = row.get(2)?;
+                    Ok((address, contact_bytes, address_index))
+                },
+            )?
+            .map(|row_result| {
+                row_result.and_then(|(address, contact_bytes, address_index)| {
+                    let contact_id = Identifier::from_bytes(&contact_bytes).map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(1, Type::Blob, Box::new(e))
+                    })?;
+                    Ok((address, contact_id, address_index))
+                })
+            })
+            .collect::<rusqlite::Result<Vec<_>>>()?;
 
         Ok(mappings)
     }
@@ -930,5 +1153,259 @@ impl crate::database::Database {
             ],
         )?;
         Ok(())
+    }
+
+    pub fn has_dashpay_wallet_tx_scan_marker(
+        &self,
+        seed_hash: &[u8; 32],
+        identity_id: &Identifier,
+        network: &str,
+    ) -> rusqlite::Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1
+                FROM dashpay_wallet_tx_scan_markers
+                WHERE seed_hash = ?1 AND identity_id = ?2 AND network = ?3
+            )",
+            params![
+                seed_hash.as_slice(),
+                identity_id.to_buffer().to_vec(),
+                network
+            ],
+            |row| row.get(0),
+        )
+    }
+
+    pub fn mark_dashpay_wallet_tx_scan_complete(
+        &self,
+        seed_hash: &[u8; 32],
+        identity_id: &Identifier,
+        network: &str,
+    ) -> rusqlite::Result<()> {
+        self.execute(
+            "INSERT INTO dashpay_wallet_tx_scan_markers (seed_hash, identity_id, network, completed_at)
+             VALUES (?1, ?2, ?3, unixepoch())
+             ON CONFLICT(seed_hash, identity_id, network) DO UPDATE SET completed_at = unixepoch()",
+            params![seed_hash.as_slice(), identity_id.to_buffer().to_vec(), network],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::test_helpers::create_test_database;
+
+    #[test]
+    fn save_payment_with_output_index_upgrades_legacy_row_in_place() {
+        let db = create_test_database().expect("test db");
+        let from_identity_id = Identifier::random();
+        let to_identity_id = Identifier::random();
+
+        let seeded = db
+            .save_payment_with_output_index(
+                "txid_upgrade",
+                None,
+                &from_identity_id,
+                &to_identity_id,
+                42,
+                Some("memo"),
+                "received",
+                Some(1_700_000_000),
+            )
+            .expect("seed legacy row");
+        assert!(seeded.inserted);
+        assert!(!seeded.updated_existing);
+
+        let upgraded = db
+            .save_payment_with_output_index(
+                "txid_upgrade",
+                Some(3),
+                &from_identity_id,
+                &to_identity_id,
+                999,
+                None,
+                "received",
+                Some(1_700_000_100),
+            )
+            .expect("upgrade row");
+        assert!(!upgraded.inserted);
+        assert!(upgraded.updated_existing);
+
+        let duplicate = db
+            .save_payment_with_output_index(
+                "txid_upgrade",
+                Some(3),
+                &from_identity_id,
+                &to_identity_id,
+                999,
+                None,
+                "received",
+                Some(1_700_000_200),
+            )
+            .expect("duplicate row");
+        assert!(!duplicate.changed());
+
+        let payments = db
+            .load_payment_history(&to_identity_id, 10)
+            .expect("load payments");
+        assert_eq!(payments.len(), 1);
+        assert_eq!(payments[0].output_index, 3);
+        assert_eq!(payments[0].amount, 42);
+        assert_eq!(payments[0].memo.as_deref(), Some("memo"));
+        assert_eq!(payments[0].created_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn dashpay_wallet_tx_scan_marker_round_trip_is_network_scoped() {
+        let db = create_test_database().expect("test db");
+        let seed_hash = [0xAB; 32];
+        let identity_id = Identifier::random();
+
+        assert!(
+            !db.has_dashpay_wallet_tx_scan_marker(&seed_hash, &identity_id, "testnet")
+                .expect("marker absent initially")
+        );
+
+        db.mark_dashpay_wallet_tx_scan_complete(&seed_hash, &identity_id, "testnet")
+            .expect("mark complete");
+
+        assert!(
+            db.has_dashpay_wallet_tx_scan_marker(&seed_hash, &identity_id, "testnet")
+                .expect("marker present")
+        );
+        assert!(
+            !db.has_dashpay_wallet_tx_scan_marker(&seed_hash, &identity_id, "mainnet")
+                .expect("marker isolated by network")
+        );
+    }
+
+    #[test]
+    fn get_all_dashpay_address_mappings_returns_error_for_malformed_contact_id() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+
+        db.execute(
+            "INSERT INTO dashpay_address_mappings
+             (address, seed_hash, owner_identity_id, contact_identity_id, address_index, created_at)
+             VALUES (?1, NULL, ?2, ?3, ?4, unixepoch())",
+            rusqlite::params![
+                "yXbQ1xJVDKEXAMPLE9SvM6Vx4dTuk49k19",
+                owner_id.to_buffer().to_vec(),
+                vec![1_u8, 2, 3],
+                0_u32,
+            ],
+        )
+        .expect("insert malformed row");
+
+        let err = db
+            .get_all_dashpay_address_mappings(&owner_id)
+            .expect_err("malformed identifier should fail");
+
+        assert!(matches!(
+            err,
+            rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Blob, _)
+        ));
+    }
+
+    #[test]
+    fn save_new_accepted_contact_clears_scan_markers_for_identity_and_network() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let other_identity = Identifier::random();
+        let testnet_seed = [0x11; 32];
+        let mainnet_seed = [0x22; 32];
+        let other_seed = [0x33; 32];
+
+        db.mark_dashpay_wallet_tx_scan_complete(&testnet_seed, &owner_id, "testnet")
+            .expect("mark testnet complete");
+        db.mark_dashpay_wallet_tx_scan_complete(&mainnet_seed, &owner_id, "mainnet")
+            .expect("mark mainnet complete");
+        db.mark_dashpay_wallet_tx_scan_complete(&other_seed, &other_identity, "testnet")
+            .expect("mark other identity complete");
+
+        db.save_dashpay_contact(
+            &owner_id,
+            &contact_id,
+            "testnet",
+            Some("contact"),
+            None,
+            None,
+            None,
+            "accepted",
+        )
+        .expect("save accepted contact");
+
+        assert!(
+            !db.has_dashpay_wallet_tx_scan_marker(&testnet_seed, &owner_id, "testnet")
+                .expect("testnet marker cleared")
+        );
+        assert!(
+            db.has_dashpay_wallet_tx_scan_marker(&mainnet_seed, &owner_id, "mainnet")
+                .expect("mainnet marker preserved")
+        );
+        assert!(
+            db.has_dashpay_wallet_tx_scan_marker(&other_seed, &other_identity, "testnet")
+                .expect("other identity marker preserved")
+        );
+    }
+
+    #[test]
+    fn save_contact_acceptance_transition_clears_markers_once() {
+        let db = create_test_database().expect("test db");
+        let owner_id = Identifier::random();
+        let contact_id = Identifier::random();
+        let seed_hash = [0x44; 32];
+
+        db.save_dashpay_contact(
+            &owner_id,
+            &contact_id,
+            "testnet",
+            Some("contact"),
+            None,
+            None,
+            None,
+            "pending",
+        )
+        .expect("save pending contact");
+        db.mark_dashpay_wallet_tx_scan_complete(&seed_hash, &owner_id, "testnet")
+            .expect("mark pending scan");
+
+        db.save_dashpay_contact(
+            &owner_id,
+            &contact_id,
+            "testnet",
+            Some("contact"),
+            None,
+            None,
+            None,
+            "accepted",
+        )
+        .expect("promote to accepted");
+        assert!(
+            !db.has_dashpay_wallet_tx_scan_marker(&seed_hash, &owner_id, "testnet")
+                .expect("marker cleared on acceptance")
+        );
+
+        db.mark_dashpay_wallet_tx_scan_complete(&seed_hash, &owner_id, "testnet")
+            .expect("mark complete again");
+        db.save_dashpay_contact(
+            &owner_id,
+            &contact_id,
+            "testnet",
+            Some("contact-renamed"),
+            Some("Updated"),
+            None,
+            None,
+            "accepted",
+        )
+        .expect("refresh accepted contact");
+        assert!(
+            db.has_dashpay_wallet_tx_scan_marker(&seed_hash, &owner_id, "testnet")
+                .expect("accepted refresh keeps marker")
+        );
     }
 }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -35,7 +35,7 @@ impl<T> MigrationResultExt<T> for rusqlite::Result<T> {
     }
 }
 
-pub const DEFAULT_DB_VERSION: u16 = 34;
+pub const DEFAULT_DB_VERSION: u16 = 37;
 
 /// Minimal view of `.env` values the v34 migration needs.
 struct V34EnvSnapshot {
@@ -156,6 +156,18 @@ impl Database {
                          (local Dash Core node configured)"
                     );
                 }
+            }
+            35 => {
+                self.migrate_dashpay_payments_to_output_identity(tx)
+                    .migration_err("dashpay_payments", "migrate to per-output uniqueness")?;
+            }
+            36 => {
+                self.create_dashpay_wallet_tx_scan_markers_table(tx)
+                    .migration_err("dashpay_wallet_tx_scan_markers", "create table")?;
+            }
+            37 => {
+                self.add_seed_hash_to_dashpay_address_mappings(tx)
+                    .migration_err("dashpay_address_mappings", "add seed_hash column")?;
             }
             // Versions 28-32 were consolidated into v33 to resolve migration
             // numbering conflicts between the zk and v1.0-dev branches.
@@ -1138,6 +1150,100 @@ impl Database {
         Ok(())
     }
 
+    /// Migration 35: allow multiple DashPay payment rows per transaction by
+    /// keying stored rows by transaction + contact relationship + output index.
+    fn migrate_dashpay_payments_to_output_identity(
+        &self,
+        conn: &Connection,
+    ) -> rusqlite::Result<()> {
+        let has_output_index: bool = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('dashpay_payments') WHERE name='output_index'",
+            [],
+            |row| row.get::<_, i32>(0).map(|count| count > 0),
+        )?;
+        if has_output_index {
+            return Ok(());
+        }
+
+        conn.execute_batch(
+            "ALTER TABLE dashpay_payments RENAME TO dashpay_payments_old;
+             CREATE TABLE dashpay_payments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                tx_id TEXT NOT NULL,
+                output_index INTEGER NOT NULL DEFAULT -1,
+                from_identity_id BLOB NOT NULL,
+                to_identity_id BLOB NOT NULL,
+                amount INTEGER NOT NULL,
+                memo TEXT,
+                payment_type TEXT NOT NULL CHECK (payment_type IN ('sent', 'received')),
+                status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'failed')),
+                created_at INTEGER DEFAULT (unixepoch()),
+                confirmed_at INTEGER,
+                UNIQUE (tx_id, from_identity_id, to_identity_id, output_index)
+             );
+             INSERT INTO dashpay_payments (
+                id, tx_id, output_index, from_identity_id, to_identity_id, amount, memo,
+                payment_type, status, created_at, confirmed_at
+             )
+             SELECT
+                id, tx_id, -1, from_identity_id, to_identity_id, amount, memo,
+                payment_type, status, created_at, confirmed_at
+             FROM dashpay_payments_old;
+             DROP TABLE dashpay_payments_old;
+             CREATE INDEX IF NOT EXISTS idx_payments_from
+                ON dashpay_payments(from_identity_id);
+             CREATE INDEX IF NOT EXISTS idx_payments_to
+                ON dashpay_payments(to_identity_id);",
+        )?;
+
+        Ok(())
+    }
+
+    /// Migration 36: add a one-time DashPay wallet transaction scan marker.
+    fn create_dashpay_wallet_tx_scan_markers_table(
+        &self,
+        conn: &Connection,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS dashpay_wallet_tx_scan_markers (
+                seed_hash BLOB NOT NULL,
+                identity_id BLOB NOT NULL,
+                network TEXT NOT NULL,
+                completed_at INTEGER NOT NULL DEFAULT (unixepoch()),
+                PRIMARY KEY (seed_hash, identity_id, network)
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dashpay_wallet_tx_scan_markers_identity
+             ON dashpay_wallet_tx_scan_markers(identity_id, network)",
+            [],
+        )?;
+        Ok(())
+    }
+
+    /// Migration 37: scope DashPay address mappings to the wallet seed that derived them.
+    fn add_seed_hash_to_dashpay_address_mappings(&self, conn: &Connection) -> rusqlite::Result<()> {
+        let has_seed_hash: bool = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('dashpay_address_mappings') WHERE name='seed_hash'",
+            [],
+            |row| row.get::<_, i32>(0).map(|count| count > 0),
+        )?;
+        if !has_seed_hash {
+            conn.execute(
+                "ALTER TABLE dashpay_address_mappings ADD COLUMN seed_hash BLOB DEFAULT NULL",
+                [],
+            )?;
+        }
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_dashpay_address_mappings_owner_seed_contact
+             ON dashpay_address_mappings(owner_identity_id, seed_hash, contact_identity_id, address_index)",
+            [],
+        )?;
+        Ok(())
+    }
+
     // Shielded table helpers (create_shielded_tables, create_shielded_wallet_meta_table,
     // add_nullifier_sync_timestamp_column) are implemented in database/shielded.rs.
 
@@ -1552,8 +1658,8 @@ mod test {
         assert!(exists, "column `{column}` should exist in table `{table}`");
     }
 
-    /// Verify the full v33 schema: all tables and columns introduced in v28-v33.
-    fn assert_v33_schema(conn: &Connection) {
+    /// Verify the full current schema, including the DashPay payment output identity.
+    fn assert_current_schema(conn: &Connection) {
         // wallet.core_wallet_name (v28)
         assert_column_exists(conn, "wallet", "core_wallet_name");
 
@@ -1589,6 +1695,8 @@ mod test {
 
         // dashpay_contact_requests table (pre-existing, but checked for completeness)
         assert_table_exists(conn, "dashpay_contact_requests");
+        assert_column_exists(conn, "dashpay_payments", "output_index");
+        assert_column_exists(conn, "dashpay_address_mappings", "seed_hash");
     }
 
     #[test]
@@ -1675,7 +1783,7 @@ mod test {
     }
 
     #[test]
-    fn test_v33_migration_fresh_install() {
+    fn test_v35_migration_fresh_install() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_file_path = temp_dir.path().join("fresh.db");
         let db = super::Database::new(&db_file_path).unwrap();
@@ -1707,11 +1815,11 @@ mod test {
             "fresh install must default to SPV (core_backend_mode = 1)"
         );
 
-        assert_v33_schema(&conn);
+        assert_current_schema(&conn);
     }
 
     #[test]
-    fn test_v33_migration_from_v27() {
+    fn test_v35_migration_from_v27() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_file_path = temp_dir.path().join("v27.db");
         let db = super::Database::new(&db_file_path).unwrap();
@@ -1824,13 +1932,187 @@ mod test {
         // Verify final version
         assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
 
-        // Verify full v33 schema
+        // Verify full current schema
         let conn = db.conn.lock().unwrap();
-        assert_v33_schema(&conn);
+        assert_current_schema(&conn);
     }
 
     #[test]
-    fn test_v33_migration_with_orphaned_fk_rows() {
+    fn test_v36_migration_creates_dashpay_wallet_tx_scan_markers_table() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_file_path = temp_dir.path().join("v35_dashpay_scan_markers.db");
+        let db = super::Database::new(&db_file_path).unwrap();
+        db.create_tables().unwrap();
+        db.set_default_version().unwrap();
+
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute("DROP TABLE dashpay_wallet_tx_scan_markers", [])
+                .unwrap();
+            conn.execute("UPDATE settings SET database_version = 35 WHERE id = 1", [])
+                .unwrap();
+        }
+
+        let result = db.try_perform_migration(35, DEFAULT_DB_VERSION, None);
+        assert!(
+            result.is_ok(),
+            "migration from v35 to v{DEFAULT_DB_VERSION} failed: {:?}",
+            result.err()
+        );
+
+        assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
+
+        let conn = db.conn.lock().unwrap();
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'table' AND name = 'dashpay_wallet_tx_scan_markers'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            table_exists,
+            "scan marker table should exist after migration"
+        );
+    }
+
+    #[test]
+    fn test_v37_migration_adds_seed_hash_to_dashpay_address_mappings() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_file_path = temp_dir.path().join("v36_dashpay_address_mappings.db");
+        let db = super::Database::new(&db_file_path).unwrap();
+        db.create_tables().unwrap();
+        db.set_default_version().unwrap();
+
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute_batch(
+                "ALTER TABLE dashpay_address_mappings RENAME TO dashpay_address_mappings_new;
+                 CREATE TABLE dashpay_address_mappings (
+                    address TEXT PRIMARY KEY,
+                    owner_identity_id BLOB NOT NULL,
+                    contact_identity_id BLOB NOT NULL,
+                    address_index INTEGER NOT NULL,
+                    created_at INTEGER DEFAULT (unixepoch())
+                 );
+                 INSERT INTO dashpay_address_mappings
+                    (address, owner_identity_id, contact_identity_id, address_index, created_at)
+                 SELECT
+                    address, owner_identity_id, contact_identity_id, address_index, created_at
+                 FROM dashpay_address_mappings_new;
+                 DROP TABLE dashpay_address_mappings_new;",
+            )
+            .unwrap();
+            conn.execute("UPDATE settings SET database_version = 36 WHERE id = 1", [])
+                .unwrap();
+        }
+
+        let result = db.try_perform_migration(36, DEFAULT_DB_VERSION, None);
+        assert!(
+            result.is_ok(),
+            "migration from v36 to v{DEFAULT_DB_VERSION} failed: {:?}",
+            result.err()
+        );
+
+        assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
+
+        let conn = db.conn.lock().unwrap();
+        assert_column_exists(&conn, "dashpay_address_mappings", "seed_hash");
+    }
+
+    #[test]
+    fn test_v35_migration_preserves_legacy_dashpay_payments() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_file_path = temp_dir.path().join("v34_dashpay_payments.db");
+        let db = super::Database::new(&db_file_path).unwrap();
+        db.create_tables().unwrap();
+        db.set_default_version().unwrap();
+
+        let owner_identity_id = vec![0x11u8; 32];
+        let contact_identity_id = vec![0x22u8; 32];
+
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute_batch(
+                "ALTER TABLE dashpay_payments RENAME TO dashpay_payments_new;
+                 CREATE TABLE dashpay_payments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tx_id TEXT NOT NULL,
+                    from_identity_id BLOB NOT NULL,
+                    to_identity_id BLOB NOT NULL,
+                    amount INTEGER NOT NULL,
+                    memo TEXT,
+                    payment_type TEXT NOT NULL CHECK (payment_type IN ('sent', 'received')),
+                    status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'failed')),
+                    created_at INTEGER DEFAULT (unixepoch()),
+                    confirmed_at INTEGER,
+                    UNIQUE (tx_id, from_identity_id, to_identity_id)
+                 );
+                 DROP TABLE dashpay_payments_new;",
+            )
+            .unwrap();
+
+            conn.execute(
+                "INSERT INTO dashpay_payments
+                 (tx_id, from_identity_id, to_identity_id, amount, memo, payment_type, status, created_at, confirmed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    "legacy_txid",
+                    &owner_identity_id,
+                    &contact_identity_id,
+                    123_456_i64,
+                    "legacy memo",
+                    "sent",
+                    "confirmed",
+                    1_700_000_000_i64,
+                    1_700_000_010_i64,
+                ],
+            )
+            .unwrap();
+
+            conn.execute("UPDATE settings SET database_version = 34 WHERE id = 1", [])
+                .unwrap();
+        }
+
+        let result = db.try_perform_migration(34, DEFAULT_DB_VERSION, None);
+        assert!(
+            result.is_ok(),
+            "migration from v34 to v{DEFAULT_DB_VERSION} failed: {:?}",
+            result.err()
+        );
+
+        assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
+
+        let owner_identifier =
+            dash_sdk::platform::Identifier::from_bytes(&owner_identity_id).unwrap();
+        let contact_identifier =
+            dash_sdk::platform::Identifier::from_bytes(&contact_identity_id).unwrap();
+
+        let payments = db.load_payment_history(&owner_identifier, 10).unwrap();
+        assert_eq!(payments.len(), 1);
+        let payment = &payments[0];
+        assert_eq!(payment.tx_id, "legacy_txid");
+        assert_eq!(payment.output_index, -1);
+        assert_eq!(payment.from_identity_id, owner_identity_id);
+        assert_eq!(payment.to_identity_id, contact_identity_id);
+        assert_eq!(payment.amount, 123_456);
+        assert_eq!(payment.memo.as_deref(), Some("legacy memo"));
+        assert_eq!(payment.status, "confirmed");
+        assert_eq!(payment.created_at, 1_700_000_000);
+        assert_eq!(payment.confirmed_at, Some(1_700_000_010));
+
+        let contact_payments = db
+            .load_payment_history_for_contact(&owner_identifier, &contact_identifier, 10)
+            .unwrap();
+        assert_eq!(contact_payments.len(), 1);
+        assert_eq!(contact_payments[0].tx_id, "legacy_txid");
+    }
+
+    #[test]
+    fn test_v35_migration_with_orphaned_fk_rows() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_file_path = temp_dir.path().join("orphans.db");
         let db = super::Database::new(&db_file_path).unwrap();
@@ -2087,7 +2369,7 @@ mod test {
         assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
 
         let conn = db.conn.lock().unwrap();
-        assert_v33_schema(&conn);
+        assert_current_schema(&conn);
 
         // Orphaned wallet_transactions should be gone
         let orphan_txs: i64 = conn
@@ -2435,7 +2717,7 @@ mod test {
         assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
 
         let conn = db.conn.lock().unwrap();
-        assert_v33_schema(&conn);
+        assert_current_schema(&conn);
 
         // Verify data survived migration
         let wallet_network: String = conn

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -124,6 +124,11 @@ impl Database {
             )?;
 
             tx.execute(
+                "DELETE FROM dashpay_wallet_tx_scan_markers WHERE network = ?1",
+                rusqlite::params![&network_str],
+            )?;
+
+            tx.execute(
                 "DELETE FROM identity_token_balances WHERE network = ?1",
                 rusqlite::params![&network_str],
             )?;

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -12,7 +12,6 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::dashpay::DashPaySubscreen;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike, ScreenType};
-use dash_sdk::dpp::balances::credits::Credits;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::platform::Identifier;
 use egui::{Color32, RichText, ScrollArea, TextEdit, Ui};
@@ -27,7 +26,8 @@ const PRIVATE_CONTACT_INFO_TEXT: &str = "About Private Contact Information:\n\n\
 #[derive(Debug, Clone)]
 pub struct Payment {
     pub tx_id: String,
-    pub amount: Credits,
+    /// Amount in duffs (1 Dash = 100_000_000 duffs)
+    pub amount: u64,
     pub timestamp: u64,
     pub is_incoming: bool,
     pub memo: Option<String>,
@@ -58,7 +58,9 @@ pub struct ContactDetailsScreen {
     edit_hidden: bool,
     loading: bool,
     show_info_popup: bool,
-    needs_backend_fetch: bool,
+    payment_history_error: Option<String>,
+    needs_profile_fetch: bool,
+    needs_payment_history_load: bool,
 }
 
 impl ContactDetailsScreen {
@@ -79,7 +81,9 @@ impl ContactDetailsScreen {
             edit_hidden: false,
             loading: false,
             show_info_popup: false,
-            needs_backend_fetch: true,
+            payment_history_error: None,
+            needs_profile_fetch: true,
+            needs_payment_history_load: true,
         };
         screen.load_from_database();
         screen
@@ -89,6 +93,48 @@ impl ContactDetailsScreen {
     fn load_from_database(&mut self) {
         let identity_id = self.identity.identity.id();
         let network_str = self.app_context.network.to_string();
+
+        // Load payment history from database for this contact
+        self.payment_history.clear();
+        self.payment_history_error = None;
+        match self.app_context.db.load_payment_history_for_contact(
+            &identity_id,
+            &self.contact_id,
+            1000,
+        ) {
+            Ok(stored_payments) => {
+                for sp in stored_payments {
+                    let is_incoming = sp.to_identity_id == identity_id.to_buffer().to_vec();
+                    let amount = if sp.amount < 0 {
+                        0u64
+                    } else {
+                        sp.amount as u64
+                    };
+
+                    self.payment_history.push(Payment {
+                        tx_id: sp.tx_id,
+                        amount,
+                        timestamp: if sp.created_at < 0 {
+                            0u64
+                        } else {
+                            sp.created_at as u64
+                        },
+                        is_incoming,
+                        memo: sp.memo,
+                    });
+                }
+            }
+            Err(error) => {
+                let message = "Could not load payment history for this contact. Try opening the contact again.";
+                let handle = MessageBanner::set_global(
+                    self.app_context.egui_ctx(),
+                    message,
+                    MessageType::Error,
+                );
+                handle.with_details(&error);
+                self.payment_history_error = Some(message.to_string());
+            }
+        }
 
         // Try to load the contact's public info from the dashpay_contacts table
         let mut username = None;
@@ -169,6 +215,15 @@ impl ContactDetailsScreen {
         )))
     }
 
+    fn trigger_payment_history_load(&mut self) -> AppAction {
+        self.loading = true;
+        AppAction::BackendTask(BackendTask::DashPayTask(Box::new(
+            DashPayTask::LoadPaymentHistory {
+                identity: self.identity.clone(),
+            },
+        )))
+    }
+
     fn start_editing(&mut self) {
         if let Some(info) = &self.contact_info {
             self.edit_nickname = info.nickname.clone().unwrap_or_default();
@@ -240,9 +295,11 @@ impl ContactDetailsScreen {
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
 
-        // Dispatch deferred backend fetch if flagged
-        if self.needs_backend_fetch {
-            self.needs_backend_fetch = false;
+        if self.needs_payment_history_load {
+            self.needs_payment_history_load = false;
+            action = self.trigger_payment_history_load();
+        } else if self.needs_profile_fetch {
+            self.needs_profile_fetch = false;
             action = self.trigger_backend_fetch();
         }
 
@@ -420,7 +477,9 @@ impl ContactDetailsScreen {
                     ui.label(RichText::new("Payment History").strong());
                     ui.separator();
 
-                    if self.payment_history.is_empty() {
+                    if let Some(error) = &self.payment_history_error {
+                        ui.label(RichText::new(error).color(DashColors::ERROR));
+                    } else if self.payment_history.is_empty() {
                         ui.label("No payment history with this contact");
                     } else {
                         for payment in &self.payment_history {
@@ -435,8 +494,9 @@ impl ContactDetailsScreen {
 
                                 ui.vertical(|ui| {
                                     ui.horizontal(|ui| {
-                                        // Amount
-                                        let amount_str = format!("{} Dash", payment.amount);
+                                        // Amount (stored in duffs, display as Dash)
+                                        let dash_amount = payment.amount as f64 / 100_000_000.0;
+                                        let amount_str = format!("{:.8} Dash", dash_amount);
                                         if payment.is_incoming {
                                             ui.label(
                                                 RichText::new(format!("+{}", amount_str))
@@ -516,8 +576,8 @@ impl ScreenLike for ContactDetailsScreen {
 
     fn refresh_on_arrival(&mut self) {
         self.load_from_database();
-        // Flag that we need a backend fetch; it will be dispatched from render()
-        self.needs_backend_fetch = true;
+        self.needs_payment_history_load = true;
+        self.needs_profile_fetch = true;
     }
 
     fn ui(&mut self, ctx: &egui::Context) -> AppAction {
@@ -635,6 +695,16 @@ impl ScreenLike for ContactDetailsScreen {
                         account_reference: 0,
                     });
                 }
+            }
+            BackendTaskSuccessResult::DashPayPaymentHistory(history_result) => {
+                if let Some(warning) = history_result.warning {
+                    MessageBanner::set_global(
+                        self.app_context.egui_ctx(),
+                        warning,
+                        MessageType::Warning,
+                    );
+                }
+                self.load_from_database();
             }
             BackendTaskSuccessResult::DashPayContactInfoUpdated(contact_id) => {
                 if contact_id == self.contact_id {

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -793,73 +793,31 @@ impl PaymentHistory {
         self.loading = false;
 
         match result {
-            BackendTaskSuccessResult::DashPayPaymentHistory(payment_data) => {
+            BackendTaskSuccessResult::DashPayPaymentHistory(payment_history) => {
                 self.payments.clear();
                 self.has_searched = true;
 
-                // Get current identity for saving to database
-                if let Some(identity) = &self.selected_identity {
-                    let identity_id = identity.identity.id();
+                if let Some(warning) = payment_history.warning {
+                    MessageBanner::set_global(
+                        self.app_context.egui_ctx(),
+                        warning,
+                        MessageType::Warning,
+                    );
+                }
 
-                    // Convert backend data to PaymentRecord structs and save to database
-                    for (tx_id, contact_name, amount, is_incoming, memo) in payment_data {
-                        // Parse contact identity from contact_name if it contains ID
-                        let contact_id = if contact_name.contains("(") && contact_name.contains(")")
-                        {
-                            // Extract ID from format "Unknown (abcd1234)"
-                            let start = contact_name.find('(').unwrap() + 1;
-                            let end = contact_name.find(')').unwrap();
-                            let _id_str = &contact_name[start..end];
-                            // This is likely a partial base58 ID, we'd need the full ID
-                            // For now, we'll use a placeholder
-                            Identifier::new([0; 32])
+                for payment_data in payment_history.payments {
+                    self.payments.push(PaymentRecord {
+                        tx_id: payment_data.tx_id,
+                        contact_name: payment_data.contact_name,
+                        amount: Credits::from(payment_data.amount),
+                        is_incoming: payment_data.is_incoming,
+                        timestamp: payment_data.timestamp,
+                        memo: if payment_data.memo.is_empty() {
+                            None
                         } else {
-                            Identifier::new([0; 32])
-                        };
-
-                        let payment = PaymentRecord {
-                            tx_id: tx_id.clone(),
-                            contact_name,
-                            amount: Credits::from(amount),
-                            is_incoming,
-                            timestamp: 0, // TODO: Include timestamp in backend data
-                            memo: if memo.is_empty() {
-                                None
-                            } else {
-                                Some(memo.clone())
-                            },
-                        };
-                        self.payments.push(payment);
-
-                        // Save to database
-                        let (from_id, to_id, payment_type) = if is_incoming {
-                            (contact_id, identity_id, "received")
-                        } else {
-                            (identity_id, contact_id, "sent")
-                        };
-
-                        let _ = self.app_context.db.save_payment(
-                            &tx_id,
-                            &from_id,
-                            &to_id,
-                            amount as i64,
-                            if memo.is_empty() { None } else { Some(&memo) },
-                            payment_type,
-                        );
-                    }
-                } else {
-                    // No selected identity, just populate in-memory
-                    for (tx_id, contact_name, amount, is_incoming, memo) in payment_data {
-                        let payment = PaymentRecord {
-                            tx_id,
-                            contact_name,
-                            amount: Credits::from(amount),
-                            is_incoming,
-                            timestamp: 0, // TODO: Include timestamp in backend data
-                            memo: if memo.is_empty() { None } else { Some(memo) },
-                        };
-                        self.payments.push(payment);
-                    }
+                            Some(payment_data.memo)
+                        },
+                    });
                 }
             }
             _ => {

--- a/tests/backend-e2e/dashpay_tasks.rs
+++ b/tests/backend-e2e/dashpay_tasks.rs
@@ -612,7 +612,7 @@ async fn tc_041_load_payment_history_empty() {
         BackendTaskSuccessResult::DashPayPaymentHistory(history) => {
             tracing::info!(
                 "TC-041: LoadPaymentHistory returned {} entries",
-                history.len()
+                history.payments.len()
             );
         }
         other => panic!("TC-041: expected DashPayPaymentHistory, got: {:?}", other),


### PR DESCRIPTION
## Issue

Fixes https://github.com/dashpay/dash-evo-tool/issues/688

## Description

The Payment History screen shows nothing because payments were only recorded when sent through the app UI. Wallet transactions from SPV sync were never cross-referenced with DashPay contact addresses, and `ContactDetailsScreen` never loaded payment history from the database.

### Root Cause

1. `dashpay_payments` table was only populated by payments initiated in-app
2. `process_incoming_payment()` existed but was never called for SPV-synced transactions
3. `ContactDetailsScreen` had an empty `payment_history` vector that was never populated

### Fix

**New function** `scan_wallet_transactions_for_dashpay_payments()` in `incoming_payments.rs`:
- Iterates all wallet transactions and checks each output address against the DashPay address-mapping table
- Saves matched payments (idempotent via `tx_id UNIQUE` constraint + client-side dedup)
- Determines payment direction (sent/received) from `WalletTransaction::is_incoming()`
- Updates highest receive address index for incoming payments

**Integration points:**
- Called from `LoadPaymentHistory` backend task for immediate retroactive detection when opening Payment History
- Called during SPV reconcile (`wallet_lifecycle.rs`) for ongoing automatic detection after wallet sync

**UI fix:** `ContactDetailsScreen::load_contact_info()` now loads and filters payment history from the database for the specific contact.

## Testing

- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅ (clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retroactive DashPay wallet scanning now supports full/delta modes, backfills missed incoming payments, and records per-wallet scan completion markers.
  * Contact payment history now loads on demand and can show an optional warning banner, including memo, timestamp, and properly formatted duffs amounts.

* **Backend / Bug Fixes**
  * Improved DashPay payment scan/history resilience with clearer retryable scan errors.
  * Sending payments no longer fails due to local history save issues; received payments are persisted with the correct output index.

* **Database**
  * Expanded DashPay storage with output indexing, wallet scan tracking, and wallet-scoped address mappings.

* **Tests**
  * Updated DashPay payment-history e2e expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->