### PR TITLE
fix(dashpay): fix DPNS username resolution in contact requests

### DIFF
--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -29,6 +29,14 @@ use dash_sdk::query_types::{CurrentQuorumsInfo, NoParamQuery};
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
+/// Returns `true` when the error string matches a known transient platform-sync
+/// condition that should trigger retry logic.
+fn is_transient_platform_sync_error(err: &str) -> bool {
+    err.contains("temporarily out of sync")
+        || err.contains("height is outdated")
+        || err.contains("try another server")
+}
+
 pub async fn load_contact_requests(
     app_context: &Arc<AppContext>,
     sdk: &Sdk,
@@ -204,10 +212,7 @@ pub async fn send_contact_request_with_proof(
                         }
                         Err(e) => {
                             let err = e.to_string();
-                            if (err.contains("try another server")
-                                || err.contains("height is outdated"))
-                                && retries < MAX_RETRIES
-                            {
+                            if is_transient_platform_sync_error(&err) && retries < MAX_RETRIES {
                                 retries += 1;
                                 tracing::warn!(
                                     "Retrying identity fetch for '{}' (attempt {}/{}): {}",
@@ -218,9 +223,7 @@ pub async fn send_contact_request_with_proof(
                                 );
                                 continue;
                             }
-                            if err.contains("height is outdated")
-                                || err.contains("try another server")
-                            {
+                            if is_transient_platform_sync_error(&err) {
                                 return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
                             }
                             return Err(format!("Failed to fetch identity: {}", e));
@@ -539,11 +542,11 @@ async fn resolve_username_to_identity(
     sdk: &Sdk,
     username: &str,
 ) -> Result<Identity, String> {
-    // Parse username (e.g., "alice.dash" -> "alice")
-    let name = username
-        .split('.')
-        .next()
-        .ok_or_else(|| format!("Invalid username format: {}", username))?;
+    // Parse username: accept "alice" or "alice.dash", reject anything else with dots
+    let name = username.strip_suffix(".dash").unwrap_or(username);
+    if name.is_empty() || name.contains('.') {
+        return Err(format!("Invalid username format: {}", username));
+    }
 
     // Normalize the label using homograph-safe conversion, consistent with DPNS registration
     let normalized_name =
@@ -573,9 +576,7 @@ async fn resolve_username_to_identity(
             Ok(results) => break results,
             Err(e) => {
                 let err = e.to_string();
-                if (err.contains("try another server") || err.contains("height is outdated"))
-                    && retries < MAX_RETRIES
-                {
+                if is_transient_platform_sync_error(&err) && retries < MAX_RETRIES {
                     retries += 1;
                     tracing::warn!(
                         "Retrying DPNS query for '{}' (attempt {}/{}): {}",
@@ -586,7 +587,7 @@ async fn resolve_username_to_identity(
                     );
                     continue;
                 }
-                if err.contains("height is outdated") || err.contains("try another server") {
+                if is_transient_platform_sync_error(&err) {
                     return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
                 }
                 return Err(format!("Failed to query DPNS: {}", e));
@@ -635,9 +636,7 @@ async fn resolve_username_to_identity(
             Ok(None) => return Err(format!("Identity not found for username '{}'", username)),
             Err(e) => {
                 let err = e.to_string();
-                if (err.contains("try another server") || err.contains("height is outdated"))
-                    && retries < MAX_RETRIES
-                {
+                if is_transient_platform_sync_error(&err) && retries < MAX_RETRIES {
                     retries += 1;
                     tracing::warn!(
                         "Retrying identity fetch for '{}' (attempt {}/{}): {}",
@@ -648,7 +647,7 @@ async fn resolve_username_to_identity(
                     );
                     continue;
                 }
-                if err.contains("height is outdated") || err.contains("try another server") {
+                if is_transient_platform_sync_error(&err) {
                     return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
                 }
                 return Err(format!(

--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -192,11 +192,41 @@ pub async fn send_contact_request_with_proof(
             &[Encoding::Base58, Encoding::Hex],
         ) {
             Ok(to_id) => {
-                // Successfully parsed as ID, fetch the identity
-                Identity::fetch(sdk, to_id)
-                    .await
-                    .map_err(|e| format!("Failed to fetch identity: {}", e))?
-                    .ok_or_else(|| format!("Identity {} not found", to_username_or_id))?
+                // Successfully parsed as ID, fetch the identity with retry
+                // logic for transient platform errors.
+                const MAX_RETRIES: u32 = 3;
+                let mut retries = 0u32;
+                loop {
+                    match Identity::fetch(sdk, to_id).await {
+                        Ok(Some(identity)) => break identity,
+                        Ok(None) => {
+                            return Err(format!("Identity {} not found", to_username_or_id));
+                        }
+                        Err(e) => {
+                            let err = e.to_string();
+                            if (err.contains("try another server")
+                                || err.contains("height is outdated"))
+                                && retries < MAX_RETRIES
+                            {
+                                retries += 1;
+                                tracing::warn!(
+                                    "Retrying identity fetch for '{}' (attempt {}/{}): {}",
+                                    to_username_or_id,
+                                    retries,
+                                    MAX_RETRIES,
+                                    e
+                                );
+                                continue;
+                            }
+                            if err.contains("height is outdated")
+                                || err.contains("try another server")
+                            {
+                                return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
+                            }
+                            return Err(format!("Failed to fetch identity: {}", e));
+                        }
+                    }
+                }
             }
             Err(_) => {
                 // Not a valid ID format, assume it's a username without .dash suffix

--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -184,7 +184,7 @@ pub async fn send_contact_request_with_proof(
     // Step 1: Resolve the recipient identity
     let to_identity = if to_username_or_id.ends_with(".dash") {
         // It's a complete username, resolve via DPNS
-        resolve_username_to_identity(sdk, &to_username_or_id).await?
+        resolve_username_to_identity(app_context, sdk, &to_username_or_id).await?
     } else {
         // Try to parse as identity ID first
         match Identifier::from_string_try_encodings(
@@ -201,7 +201,7 @@ pub async fn send_contact_request_with_proof(
             Err(_) => {
                 // Not a valid ID format, assume it's a username without .dash suffix
                 let username_with_suffix = format!("{}.dash", to_username_or_id);
-                resolve_username_to_identity(sdk, &username_with_suffix).await?
+                resolve_username_to_identity(app_context, sdk, &username_with_suffix).await?
             }
         }
     };
@@ -504,33 +504,39 @@ pub async fn send_contact_request_with_proof(
     ))
 }
 
-async fn resolve_username_to_identity(sdk: &Sdk, username: &str) -> Result<Identity, String> {
+async fn resolve_username_to_identity(
+    app_context: &Arc<AppContext>,
+    sdk: &Sdk,
+    username: &str,
+) -> Result<Identity, String> {
     // Parse username (e.g., "alice.dash" -> "alice")
     let name = username
         .split('.')
         .next()
         .ok_or_else(|| format!("Invalid username format: {}", username))?;
 
-    // Query DPNS for the username
-    let dpns_contract_id = Identifier::from_string(
-        "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-        Encoding::Base58,
-    )
-    .map_err(|e| format!("Failed to parse DPNS contract ID: {}", e))?;
+    // Normalize the label using homograph-safe conversion, consistent with DPNS registration
+    let normalized_name =
+        dash_sdk::dpp::util::strings::convert_to_homograph_safe_chars(&name.to_lowercase());
 
-    let dpns_contract = dash_sdk::platform::DataContract::fetch(sdk, dpns_contract_id)
-        .await
-        .map_err(|e| format!("Failed to fetch DPNS contract: {}", e))?
-        .ok_or("DPNS contract not found")?;
+    // Query DPNS for the username using the app context's cached contract
+    let dpns_contract = app_context.dpns_contract.clone();
 
-    let mut query = DocumentQuery::new(Arc::new(dpns_contract), "domain")
+    let mut query = DocumentQuery::new(dpns_contract, "domain")
         .map_err(|e| format!("Failed to create DPNS query: {}", e))?;
 
-    query = query.with_where(WhereClause {
-        field: "normalizedLabel".to_string(),
-        operator: WhereOperator::Equal,
-        value: Value::Text(name.to_lowercase()),
-    });
+    // Both normalizedParentDomainName and normalizedLabel are required for DPNS queries
+    query = query
+        .with_where(WhereClause {
+            field: "normalizedParentDomainName".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text("dash".to_string()),
+        })
+        .with_where(WhereClause {
+            field: "normalizedLabel".to_string(),
+            operator: WhereOperator::Equal,
+            value: Value::Text(normalized_name),
+        });
     query.limit = 1;
 
     let results = Document::fetch_many(sdk, query)
@@ -544,8 +550,31 @@ async fn resolve_username_to_identity(sdk: &Sdk, username: &str) -> Result<Ident
 
     let document = document.ok_or_else(|| format!("Invalid DPNS document for '{}'", username))?;
 
-    // Get the identity ID from the DPNS document
-    let identity_id = document.owner_id();
+    // Extract the identity ID from records.identity (not owner_id, which may differ)
+    let identity_id = document
+        .get("records")
+        .and_then(|records| {
+            if let Value::Map(map) = records {
+                map.iter()
+                    .find(|(k, _)| matches!(k, Value::Text(key) if key == "identity"))
+                    .map(|(_, v)| v.clone())
+            } else {
+                None
+            }
+        })
+        .and_then(|id_value| {
+            if let Value::Identifier(id_bytes) = id_value {
+                Some(Identifier::from(id_bytes))
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| {
+            format!(
+                "DPNS document for '{}' does not contain a valid identity reference",
+                username
+            )
+        })?;
 
     // Fetch the identity
     Identity::fetch(sdk, identity_id)

--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -519,29 +519,50 @@ async fn resolve_username_to_identity(
     let normalized_name =
         dash_sdk::dpp::util::strings::convert_to_homograph_safe_chars(&name.to_lowercase());
 
-    // Query DPNS for the username using the app context's cached contract
+    // Query DPNS for the username using the app context's cached contract.
+    // Retry on transient "height is outdated" / "try another server" errors.
+    const MAX_RETRIES: u32 = 3;
     let dpns_contract = app_context.dpns_contract.clone();
 
-    let mut query = DocumentQuery::new(dpns_contract, "domain")
-        .map_err(|e| format!("Failed to create DPNS query: {}", e))?;
+    let mut retries = 0u32;
+    let results = loop {
+        let query = DocumentQuery::new(dpns_contract.clone(), "domain")
+            .map_err(|e| format!("Failed to create DPNS query: {}", e))?
+            .with_where(WhereClause {
+                field: "normalizedParentDomainName".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text("dash".to_string()),
+            })
+            .with_where(WhereClause {
+                field: "normalizedLabel".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Text(normalized_name.clone()),
+            });
 
-    // Both normalizedParentDomainName and normalizedLabel are required for DPNS queries
-    query = query
-        .with_where(WhereClause {
-            field: "normalizedParentDomainName".to_string(),
-            operator: WhereOperator::Equal,
-            value: Value::Text("dash".to_string()),
-        })
-        .with_where(WhereClause {
-            field: "normalizedLabel".to_string(),
-            operator: WhereOperator::Equal,
-            value: Value::Text(normalized_name),
-        });
-    query.limit = 1;
-
-    let results = Document::fetch_many(sdk, query)
-        .await
-        .map_err(|e| format!("Failed to query DPNS: {}", e))?;
+        match Document::fetch_many(sdk, query).await {
+            Ok(results) => break results,
+            Err(e) => {
+                let err = e.to_string();
+                if (err.contains("try another server") || err.contains("height is outdated"))
+                    && retries < MAX_RETRIES
+                {
+                    retries += 1;
+                    tracing::warn!(
+                        "Retrying DPNS query for '{}' (attempt {}/{}): {}",
+                        username,
+                        retries,
+                        MAX_RETRIES,
+                        e
+                    );
+                    continue;
+                }
+                if err.contains("height is outdated") || err.contains("try another server") {
+                    return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
+                }
+                return Err(format!("Failed to query DPNS: {}", e));
+            }
+        }
+    };
 
     let (_, document) = results
         .into_iter()
@@ -576,11 +597,37 @@ async fn resolve_username_to_identity(
             )
         })?;
 
-    // Fetch the identity
-    Identity::fetch(sdk, identity_id)
-        .await
-        .map_err(|e| format!("Failed to fetch identity for '{}': {}", username, e))?
-        .ok_or_else(|| format!("Identity not found for username '{}'", username))
+    // Fetch the identity with retry logic for transient errors
+    let mut retries = 0u32;
+    loop {
+        match Identity::fetch(sdk, identity_id).await {
+            Ok(Some(identity)) => return Ok(identity),
+            Ok(None) => return Err(format!("Identity not found for username '{}'", username)),
+            Err(e) => {
+                let err = e.to_string();
+                if (err.contains("try another server") || err.contains("height is outdated"))
+                    && retries < MAX_RETRIES
+                {
+                    retries += 1;
+                    tracing::warn!(
+                        "Retrying identity fetch for '{}' (attempt {}/{}): {}",
+                        username,
+                        retries,
+                        MAX_RETRIES,
+                        e
+                    );
+                    continue;
+                }
+                if err.contains("height is outdated") || err.contains("try another server") {
+                    return Err("Platform servers are temporarily out of sync. Please try again in a moment.".to_string());
+                }
+                return Err(format!(
+                    "Failed to fetch identity for '{}': {}",
+                    username, e
+                ));
+            }
+        }
+    }
 }
 
 pub async fn accept_contact_request(

--- a/src/backend_task/dashpay/errors.rs
+++ b/src/backend_task/dashpay/errors.rs
@@ -142,8 +142,17 @@ impl DashPayError {
             DashPayError::QrCodeExpired { .. } => {
                 "QR code has expired. Please ask for a new one.".to_string()
             }
-            DashPayError::NetworkError { .. } => {
-                "Network connection error. Please check your internet connection.".to_string()
+            DashPayError::NetworkError { reason } => {
+                // Surface curated reason when it's a known platform-sync message;
+                // fall back to generic network text for everything else.
+                if reason.contains("temporarily out of sync")
+                    || reason.contains("height is outdated")
+                    || reason.contains("try another server")
+                {
+                    reason.clone()
+                } else {
+                    "Network connection error. Please check your internet connection.".to_string()
+                }
             }
             DashPayError::ValidationFailed { errors } => {
                 if errors.len() == 1 {

--- a/src/backend_task/dashpay/errors.rs
+++ b/src/backend_task/dashpay/errors.rs
@@ -149,7 +149,8 @@ impl DashPayError {
                     || reason.contains("height is outdated")
                     || reason.contains("try another server")
                 {
-                    reason.clone()
+                    "Platform servers are temporarily out of sync. Please try again in a moment."
+                        .to_string()
                 } else {
                     "Network connection error. Please check your internet connection.".to_string()
                 }

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -653,6 +653,13 @@ impl ScreenLike for AddContactScreen {
                             )
                             .unwrap_or_else(|_| dash_sdk::platform::Identifier::random()),
                         }
+                    } else if message.contains("try another server")
+                        || message.contains("height is outdated")
+                        || message.contains("temporarily out of sync")
+                    {
+                        DashPayError::NetworkError {
+                            reason: "Platform servers are temporarily out of sync. Please try again in a moment.".to_string(),
+                        }
                     } else if message.contains("Network") || message.contains("connection") {
                         DashPayError::NetworkError {
                             reason: message.clone(),


### PR DESCRIPTION
## Issue

Fixes https://github.com/dashpay/dash-evo-tool/issues/687

## Description

Adding a contact by username silently fails — the DPNS lookup always returns empty results.

### Root Cause

`resolve_username_to_identity` was missing the required `normalizedParentDomainName` where clause in the DPNS document query. DPNS uses a compound index on `(normalizedParentDomainName, normalizedLabel)` — querying with only `normalizedLabel` returns empty results silently.

### Fix

1. **Added `normalizedParentDomainName = "dash"` where clause** — this is the primary fix that makes the DPNS query actually match the document type index
2. **Changed identity resolution from `document.owner_id()` to `records.identity`** — the DPNS document's `records.identity` field is the authoritative identity reference, which may differ from the document owner
3. **Added `convert_to_homograph_safe_chars` normalization** — consistent with how DPNS registration normalizes labels
4. **Uses cached `dpns_contract` from `app_context`** instead of fetching it from the network on every lookup

## Testing

- `cargo check` ✅
- `cargo clippy` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved username-to-identity resolution with safer normalization, broader resolution paths, and more robust identity extraction.

* **Bug Fixes / Reliability**
  * Added retry logic for transient lookup and identity fetch failures to reduce intermittent errors.
  * Standardized user-facing network error for temporary platform sync issues to a clear "temporarily out of sync" message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->