### PR TITLE
ci: optimize Claude review workflow — enforce skills, reduce token waste

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,25 +68,22 @@ jobs:
             MemCan is NOT available in CI — skip memcan:recall, memcan:lessons-learned, and all mcp__plugin_memcan_brain__* tools.
             When spawning agents, instruct them to not use memcan tools.
 
-            FIRST, before anything else, probe GitHub MCP availability by calling
-            mcp__plugin_claudius_github__get_me (no arguments). If it succeeds, use MCP tools
-            for GitHub API operations. If it fails or is denied, set GITHUB_MCP_AVAILABLE=false
-            mentally and use gh CLI for all GitHub operations instead. When spawning sub-agents,
-            always include "GitHub MCP is available" or "GitHub MCP is NOT available — use gh CLI
-            for all GitHub operations" in their prompts so they don't waste turns rediscovering this.
+            Use MCP tools (mcp__plugin_claudius_github__*) for GitHub operations. If an MCP call fails, fall back to gh CLI.
 
-            Load /claudash:dash-platform for Dash Platform domain context, and instruct agents to also do this.
             Sub-agents have no conversation history —
             pass all relevant PR context explicitly when spawning them.
             Write all PR comments in Claudius persona — witty, confident, subtly snarky,
             but always respectful and genuinely helpful, as if advising a trusted colleague.
 
-            Follow this review flow in order:
+            Follow this review flow in order. Steps 1 and 2 MUST use the Skill tool —
+            do NOT skip them or perform their work manually.
 
-            1. Run /claudius:check-pr-comments to check if previous review comments are addressed.
+            1. Invoke Skill(skill="claudius:check-pr-comments") to check previous review comments.
                For each thread that IS fixed but NOT yet resolved, reply describing the fix
                and resolve the thread.
-            2. Run /claudius:grumpy-review to perform a fresh code review.
+            2. Invoke Skill(skill="claudius:grumpy-review") to perform a fresh code review.
+               This spawns parallel specialist agents and produces a consolidated report.
+               Do NOT review the code yourself — the skill handles the full pipeline.
             3. Post only MEDIUM severity and higher findings as new inline PR comments.
             4. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |


### PR DESCRIPTION
## Summary

Fixes three issues observed in the CI review run for PR #719 (log analysis):

- **Remove MCP probe step** — the 6-line `get_me` probe was never actually called (Claude used ToolSearch instead, giving a false positive). Replaced with a single line: "Use MCP tools, fall back to gh CLI on failure."
- **Remove unconditional dash-platform skill load** — was injecting ~1,500 tokens/turn of Platform SDK docs regardless of PR content. UI/wallet PRs don't need it.
- **Enforce Skill tool invocation** for `check-pr-comments` and `grumpy-review` — Claude was ignoring the skill instructions and doing freestyle reviews inline. Now uses explicit `Skill(skill="...")` syntax with "do NOT skip" enforcement.

## Context

Analysis of PR #719 review run showed:
- 24 turns, $1.30 cost, 3m 37s wall clock
- ~13s wasted on false-positive MCP probe → denial → gh CLI fallback
- ~36K tokens wasted on irrelevant Platform SDK context
- Neither `check-pr-comments` nor `grumpy-review` skills were invoked despite prompt instructions

## Test plan

- [ ] Trigger a review on a simple PR — verify `check-pr-comments` and `grumpy-review` skills are actually invoked (visible in log output as Skill tool calls)
- [ ] Verify MCP tools work without the probe step (should succeed directly with `mcp__plugin_claudius_github` in allowedTools from #722)
- [ ] Verify dash-platform skill is NOT loaded for non-Platform PRs

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>