### PR TITLE
fix: fall back to ENCRYPTION key when recipient lacks DECRYPTION key for ECDH

### DIFF
--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -254,8 +254,11 @@ pub async fn send_contact_request_with_proof(
             "Sender does not have a compatible ECDSA_SECP256K1 ENCRYPTION key for ECDH. Please add a DashPay-compatible encryption key to your identity.".to_string()
         })?;
 
-    // Find a recipient DECRYPTION key that supports ECDH (must be ECDSA_SECP256K1)
-    // Platform enforces MEDIUM security level for ENCRYPTION/DECRYPTION keys
+    // Find a recipient key that supports ECDH (must be ECDSA_SECP256K1).
+    // Try DECRYPTION first (preferred per DIP-15 convention), then fall back to
+    // ENCRYPTION — both are valid ECDSA_SECP256K1 keys and work identically for
+    // ECDH.  Many identities created by the mobile wallet or other tools only
+    // carry an ENCRYPTION key, so the fallback is essential for interoperability.
     let recipient_key = to_identity
         .get_first_public_key_matching(
             Purpose::DECRYPTION,
@@ -263,8 +266,16 @@ pub async fn send_contact_request_with_proof(
             HashSet::from([KeyType::ECDSA_SECP256K1]),
             false,
         )
+        .or_else(|| {
+            to_identity.get_first_public_key_matching(
+                Purpose::ENCRYPTION,
+                HashSet::from([SecurityLevel::MEDIUM]),
+                HashSet::from([KeyType::ECDSA_SECP256K1]),
+                false,
+            )
+        })
         .ok_or_else(|| {
-            "Recipient does not have a compatible ECDSA_SECP256K1 DECRYPTION key for ECDH. They need to add a DashPay-compatible decryption key to their identity.".to_string()
+            "Recipient does not have a compatible ECDSA_SECP256K1 key (ENCRYPTION or DECRYPTION) for ECDH. They need to add a DashPay-compatible key to their identity.".to_string()
         })?;
 
     // Step 4: Generate ECDH shared key and encrypt data

--- a/src/backend_task/dashpay/errors.rs
+++ b/src/backend_task/dashpay/errors.rs
@@ -36,6 +36,9 @@ pub enum DashPayError {
     #[error("Missing DECRYPTION key required for DashPay")]
     MissingDecryptionKey,
 
+    #[error("Recipient identity is missing a DashPay-compatible key")]
+    RecipientMissingKey,
+
     #[error("ECDH key generation failed: {reason}")]
     EcdhFailed { reason: String },
 
@@ -174,6 +177,9 @@ impl DashPayError {
             DashPayError::MissingDecryptionKey => {
                 "Your identity is missing a DECRYPTION key required for DashPay. Please add a DashPay-compatible decryption key.".to_string()
             }
+            DashPayError::RecipientMissingKey => {
+                "The recipient's identity does not have a DashPay-compatible key. They need to add an ENCRYPTION or DECRYPTION key to their identity before you can send them a contact request.".to_string()
+            }
             _ => "An error occurred. Please try again.".to_string(),
         }
     }
@@ -203,6 +209,7 @@ impl DashPayError {
                 | DashPayError::MissingField { .. }
                 | DashPayError::MissingEncryptionKey
                 | DashPayError::MissingDecryptionKey
+                | DashPayError::RecipientMissingKey
         )
     }
 }

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -390,6 +390,9 @@ impl ScreenLike for AddContactScreen {
                                             ));
                                         }
                                 }
+                                DashPayError::RecipientMissingKey => {
+                                    ui.label(RichText::new("The recipient needs to add a DashPay-compatible key (ENCRYPTION or DECRYPTION) to their identity before you can contact them.").small().color(DashColors::text_secondary(dark_mode)));
+                                }
                                 _ => {}
                             }
                         }
@@ -637,7 +640,9 @@ impl ScreenLike for AddContactScreen {
                     || message.contains("does not have")
                 {
                     // Try to parse structured error, fallback to generic
-                    let error = if message.contains("ENCRYPTION key") {
+                    let error = if message.contains("Recipient does not have") {
+                        DashPayError::RecipientMissingKey
+                    } else if message.contains("ENCRYPTION key") {
                         DashPayError::MissingEncryptionKey
                     } else if message.contains("DECRYPTION key") {
                         DashPayError::MissingDecryptionKey

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -1044,7 +1044,10 @@ impl ScreenLike for ContactRequests {
 
         // TODO(RUST-002): String-based error classification — see #660
         if matches!(message_type, MessageType::Error | MessageType::Warning) {
-            if message.contains("ENCRYPTION key") {
+            if message.contains("Recipient does not have") {
+                self.error = Some(DashPayError::RecipientMissingKey);
+                return;
+            } else if message.contains("ENCRYPTION key") {
                 self.error = Some(DashPayError::MissingEncryptionKey);
             } else if message.contains("DECRYPTION key") {
                 self.error = Some(DashPayError::MissingDecryptionKey);
@@ -1211,7 +1214,9 @@ impl ScreenLike for ContactRequests {
             }
             BackendTaskSuccessResult::Message(msg) => {
                 // Check if this is an error message about missing keys
-                if msg.contains("ENCRYPTION key") {
+                if msg.contains("Recipient does not have") {
+                    self.error = Some(DashPayError::RecipientMissingKey);
+                } else if msg.contains("ENCRYPTION key") {
                     self.error = Some(DashPayError::MissingEncryptionKey);
                 } else if msg.contains("DECRYPTION key") {
                     self.error = Some(DashPayError::MissingDecryptionKey);

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -1046,7 +1046,6 @@ impl ScreenLike for ContactRequests {
         if matches!(message_type, MessageType::Error | MessageType::Warning) {
             if message.contains("Recipient does not have") {
                 self.error = Some(DashPayError::RecipientMissingKey);
-                return;
             } else if message.contains("ENCRYPTION key") {
                 self.error = Some(DashPayError::MissingEncryptionKey);
             } else if message.contains("DECRYPTION key") {


### PR DESCRIPTION
## Issue

Fixes https://github.com/dashpay/dash-evo-tool/issues/687 (partial — contact request interoperability)

## Description

Contact requests fail when the recipient identity only has an `ENCRYPTION` key (no `DECRYPTION` key). Many identities created by the mobile wallet or other tools only carry an `ENCRYPTION` key, which is equally valid for ECDH.

### Root Cause

`send_contact_request_with_proof` only looked for a recipient key with `Purpose::DECRYPTION`. When the recipient had only `Purpose::ENCRYPTION`, the lookup returned `None` and the request failed — but the error message incorrectly implied the *sender* should add keys.

### Fix

1. **Key fallback**: Try `Purpose::DECRYPTION` first (preferred per DIP-15 convention), then fall back to `Purpose::ENCRYPTION` — both are valid ECDSA_SECP256K1 keys that work identically for ECDH
2. **New `RecipientMissingKey` error variant**: Distinguishes "recipient needs to add a key" from "sender needs to add a key", so the UI shows the correct guidance
3. **UI updates**: Both `AddContactScreen` and `ContactRequests` recognize the new error and display appropriate messaging

## Testing

- `cargo check` ✅
- `cargo clippy` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Contact request key lookup now accepts an encryption key when a decryption key isn't available.
  * Error handling now prioritizes detecting a recipient who lacks a compatible key to avoid misleading key-type errors.

* **UI**
  * Added a clear, actionable message prompting recipients to add a compatible key when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->