### PR TITLE
fix(database): add migration for missing contact_private_info table

### DIFF
--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 28;
+pub const DEFAULT_DB_VERSION: u16 = 29;
 
 pub const DEFAULT_NETWORK: &str = "dash";
 
@@ -51,9 +51,11 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
+            29 => {
+                self.init_contacts_tables(tx)?;
+            }
             28 => {
                 self.add_core_wallet_name_column(tx)?;
-                self.init_contacts_tables(tx)?;
             }
             27 => {
                 self.add_network_indexes(tx)?;


### PR DESCRIPTION
## Issue

Fixes https://github.com/dashpay/dash-evo-tool/issues/686

## Description

Users with existing databases get "no such table: contact_private_info" errors because `contact_private_info` was only created in `create_tables()` (fresh installs) but had no migration step in `apply_version_changes()`.

### Fix

Added migration version 29 that calls `init_contacts_tables()`. Uses `CREATE TABLE IF NOT EXISTS` so it's idempotent and safe for all database states (fresh installs already have the table; upgraders will get it via migration).

## Testing

- `cargo check` ✅
- All 41 database tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database to version 29 with refined migration handling for data initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->