### PR TITLE
ci: upload HTML review report as artifact

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,7 @@ jobs:
       id-token: write
     env:
       CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'opus' }}
+      REPORT_DIR: ${{ github.workspace }}/review-report
     steps:
       - name: Check for OAuth token
         env:
@@ -84,13 +85,24 @@ jobs:
             2. Invoke Skill(skill="claudius:grumpy-review") to perform a fresh code review.
                This spawns parallel specialist agents and produces a consolidated report.
                Do NOT review the code yourself — the skill handles the full pipeline.
+               Generate HTML format instead of markdown (use --format html in the render step).
+               Save the final report.json and report.html to $REPORT_DIR.
             3. Post only MEDIUM severity and higher findings as new inline PR comments.
             4. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 150
-            --allowedTools "mcp__plugin_claudius_github,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(git status),Bash(git status *),Bash(git remote *),Bash(git merge-base *),Bash(cat *),Bash(python3 *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
+            --allowedTools "mcp__plugin_claudius_github,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(git status),Bash(git status *),Bash(git remote *),Bash(git merge-base *),Bash(cat *),Bash(python3 *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *),Bash(cp *)"
+
+      - name: Upload review report
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-report-pr-${{ github.event.pull_request.number }}
+          path: ${{ env.REPORT_DIR }}/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Remove claudius-review label
         if: success()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Configure git to use HTTPS instead of SSH
         run: git config --global url."https://github.com/".insteadOf "git@github.com:"
 
+      - name: Create review report directory
+        run: mkdir -p "$REPORT_DIR"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -86,21 +89,23 @@ jobs:
                This spawns parallel specialist agents and produces a consolidated report.
                Do NOT review the code yourself — the skill handles the full pipeline.
                Generate HTML format instead of markdown (use --format html in the render step).
-               Save the final report.json and report.html to $REPORT_DIR.
+               Write the final report.json and report.html directly to $REPORT_DIR (directory already exists).
             3. Post only MEDIUM severity and higher findings as new inline PR comments.
             4. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |
             --agent claudius:claudius
             --model ${{ env.CLAUDE_MODEL }}
             --max-turns 150
-            --allowedTools "mcp__plugin_claudius_github,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(git status),Bash(git status *),Bash(git remote *),Bash(git merge-base *),Bash(cat *),Bash(python3 *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *),Bash(cp *)"
+            --allowedTools "mcp__plugin_claudius_github,Read,Write,Edit,Glob,Grep,Agent,Skill,Task,TaskCreate,TaskUpdate,TaskList,TaskGet,TaskOutput,SendMessage,Bash(gh pr *),Bash(gh api *),Bash(git diff *),Bash(git log *),Bash(git fetch *),Bash(git branch *),Bash(git rev-parse *),Bash(git show *),Bash(git pull *),Bash(git checkout *),Bash(git status),Bash(git status *),Bash(git remote *),Bash(git merge-base *),Bash(cat *),Bash(python3 *),Bash(echo *),Bash(ls *),Bash(grep *),Bash(mkdir *),Bash(mktemp *),Bash(pwd *)"
 
       - name: Upload review report
         if: '!cancelled()'
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-report-pr-${{ github.event.pull_request.number }}
-          path: ${{ env.REPORT_DIR }}/
+          path: |
+            ${{ env.REPORT_DIR }}/report.json
+            ${{ env.REPORT_DIR }}/report.html
           retention-days: 14
           if-no-files-found: ignore
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,7 +89,7 @@ jobs:
                This spawns parallel specialist agents and produces a consolidated report.
                Do NOT review the code yourself — the skill handles the full pipeline.
                Generate HTML format instead of markdown (use --format html in the render step).
-               Write the final report.json and report.html directly to $REPORT_DIR (directory already exists).
+               Write the final report.json and report.html to $REPORT_DIR.
             3. Post only MEDIUM severity and higher findings as new inline PR comments.
             4. If no unresolved comments remain after the full flow, approve the PR.
           claude_args: |


### PR DESCRIPTION
## Summary

- Instruct grumpy-review to render **HTML** instead of markdown (interactive report with Chart.js charts, severity filtering, sorting)
- Save `report.json` + `report.html` to a known directory (`$REPORT_DIR`)
- Add `upload-artifact` step so the report is downloadable from the Actions run (14-day retention)
- Add `Bash(cp *)` to allowed tools for file operations

## Test plan

- [ ] Trigger a review on a test PR with the `claudius-review` label
- [ ] Verify grumpy-review produces `report.html` (not just `report.md`)
- [ ] Verify the artifact `claude-review-report-pr-<N>` appears in the Actions run
- [ ] Download the artifact ZIP, extract, and open `report.html` — confirm charts and filtering work
- [ ] Verify artifact is skipped gracefully if no report was produced (e.g. timeout)

No manual test scenario file needed — this is a CI-only change.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code review reports are now automatically generated and uploaded as HTML and JSON artifacts for easy access and sharing.
  * Reports are retained for 14 days.
  * Uploads occur when the review run completes (skips cancelled runs) and artifacts are organized per pull request for straightforward retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->