### PR TITLE
fix(ui): block click pass-through on modal overlays

### DIFF
--- a/src/ui/components/confirmation_dialog.rs
+++ b/src/ui/components/confirmation_dialog.rs
@@ -111,7 +111,7 @@ impl ConfirmationDialog {
             required_confirmation_text: None,
             confirmation_prompt: None,
             confirmation_input: String::new(),
-            blocks_input: false,
+            blocks_input: true,
             is_open: true,
             opening_guard: ModalOpeningGuard::armed(),
         }

--- a/src/ui/components/info_popup.rs
+++ b/src/ui/components/info_popup.rs
@@ -68,10 +68,10 @@ impl InfoPopup {
                 title: self.title.clone(),
                 overlay_id: self.id.with("overlay"),
                 overlay_order: egui::Order::Background,
-                window_order: egui::Order::Middle,
+                window_order: egui::Order::Foreground,
                 resizable: is_markdown, // Allow resizing for markdown content
                 show_close_button: true,
-                blocks_input: false,
+                blocks_input: true,
                 inner_margin: 16,
             },
             |ui| {

--- a/src/ui/components/selection_dialog.rs
+++ b/src/ui/components/selection_dialog.rs
@@ -189,7 +189,7 @@ impl SelectionDialog {
                 window_order: egui::Order::Foreground,
                 resizable: false,
                 show_close_button: true,
-                blocks_input: false,
+                blocks_input: true,
                 inner_margin: 16,
             },
             |ui| {

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -13,7 +13,9 @@ use crate::ui::components::contract_chooser_panel::{
 use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::message_banner::{BannerHandle, MessageBanner, OptionBannerExt};
 use crate::ui::components::top_panel::{add_top_panel_with_global_nav, subdued_everyday_spec};
-use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
+use crate::ui::helpers::{
+    ModalOpeningGuard, clicked_outside_window_after_open, draw_modal_overlay,
+};
 use crate::ui::theme::{ComponentStyles, DashColors, Shadow, Shape};
 use crate::ui::{BackendTaskSuccessResult, MessageType, RootScreenType, ScreenLike, ScreenType};
 use crate::utils::parsers::{DocumentQueryTextInputParser, TextInputParser};
@@ -323,9 +325,12 @@ impl DocumentQueryScreen {
                     }
                 }
 
+                draw_modal_overlay(ui.ctx(), "select_properties_dialog_overlay");
+
                 let window_response = egui::Window::new("Select Properties")
                     .collapsible(false)
                     .resizable(true)
+                    .order(egui::Order::Foreground)
                     .min_width(400.0)
                     .title_bar(false)
                     .show(ui.ctx(), |ui| {

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -16,7 +16,9 @@ use crate::ui::components::wallet_unlock_popup::{
     WalletUnlockPopup, WalletUnlockResult, try_open_wallet_no_password, wallet_needs_unlock,
 };
 use crate::ui::components::{MessageBanner, ResultBannerExt};
-use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
+use crate::ui::helpers::{
+    ModalOpeningGuard, clicked_outside_window_after_open, draw_modal_overlay,
+};
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::state::AvatarCache;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
@@ -943,17 +945,12 @@ impl ProfileScreen {
             if let Some(profile) = &self.profile {
                 let avatar_url = profile.avatar_url.clone();
 
-                // Draw modal overlay
-                let screen_rect = ui.ctx().content_rect();
-                let painter = ui.ctx().layer_painter(egui::LayerId::new(
-                    egui::Order::Background,
-                    egui::Id::new("avatar_popup_overlay"),
-                ));
-                painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+                draw_modal_overlay(ui.ctx(), "avatar_popup_overlay");
 
                 let window_response = egui::Window::new("Avatar")
                     .collapsible(false)
                     .resizable(false)
+                    .order(egui::Order::Foreground)
                     .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
                     .show(ui.ctx(), |ui| {
                         ui.vertical_centered(|ui| {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -4,6 +4,27 @@ use std::sync::Arc;
 // Re-export from the model layer so existing callers don't break.
 pub use crate::model::address::is_platform_address_string;
 
+/// Paint a semi-transparent modal backdrop for legacy `egui::Window` modals
+/// and consume click/drag input so pointer events cannot pass through.
+///
+/// New shared modal components should prefer `modal_chrome` with
+/// `blocks_input: true`. This helper exists for call sites that still own their
+/// window layout directly. Pair it with a foreground-order window so the sink
+/// stays below the modal itself.
+pub fn draw_modal_overlay(ctx: &egui::Context, id: &str) {
+    let screen_rect = ctx.content_rect();
+    let overlay_id = egui::Id::new(id);
+    ctx.layer_painter(egui::LayerId::new(egui::Order::Background, overlay_id))
+        .rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+
+    egui::Area::new(overlay_id.with("input_sink"))
+        .fixed_pos(screen_rect.min)
+        .order(egui::Order::Middle)
+        .show(ctx, |ui| {
+            ui.allocate_response(screen_rect.size(), egui::Sense::click_and_drag());
+        });
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct ModalOpeningGuard {
     skip_outside_click_once: bool,

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -12,7 +12,9 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::{ConfirmationDialog, ConfirmationStatus, island_central_panel};
 use crate::ui::components::top_panel::{add_top_panel_with_global_nav, subdued_everyday_spec};
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt};
-use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
+use crate::ui::helpers::{
+    ModalOpeningGuard, clicked_outside_window_after_open, draw_modal_overlay,
+};
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
 use crate::ui::identities::register_dpns_name_screen::{
@@ -937,17 +939,12 @@ impl IdentitiesScreen {
             return AppAction::None;
         };
 
-        // Draw dark overlay behind the popup
-        let screen_rect = ctx.content_rect();
-        let painter = ctx.layer_painter(egui::LayerId::new(
-            egui::Order::Background,
-            egui::Id::new("edit_alias_overlay"),
-        ));
-        painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+        draw_modal_overlay(ctx, "edit_alias_overlay");
 
         let window_response = egui::Window::new("Update Alias")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .frame(egui::Frame {
                 inner_margin: egui::Margin::same(20),

--- a/src/ui/tokens/tokens_screen/data_contract_json_pop_up.rs
+++ b/src/ui/tokens/tokens_screen/data_contract_json_pop_up.rs
@@ -1,4 +1,4 @@
-use crate::ui::helpers::clicked_outside_window_after_open;
+use crate::ui::helpers::{clicked_outside_window_after_open, draw_modal_overlay};
 use crate::ui::theme::{ComponentStyles, DashColors};
 use crate::ui::tokens::tokens_screen::TokensScreen;
 use egui::Ui;
@@ -15,17 +15,12 @@ impl TokensScreen {
         if self.show_json_popup {
             let mut is_open = true;
 
-            // Draw dark overlay behind the dialog for better visibility
-            let screen_rect = ui.ctx().content_rect();
-            let painter = ui.ctx().layer_painter(egui::LayerId::new(
-                egui::Order::Background,
-                egui::Id::new("json_popup_overlay"),
-            ));
-            painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+            draw_modal_overlay(ui.ctx(), "json_popup_overlay");
 
             let window_response = egui::Window::new("Data Contract JSON")
                 .collapsible(false)
                 .resizable(true)
+                .order(egui::Order::Foreground)
                 .max_height(600.0)
                 .max_width(800.0)
                 .scroll(true)

--- a/src/ui/tokens/tokens_screen/my_tokens.rs
+++ b/src/ui/tokens/tokens_screen/my_tokens.rs
@@ -4,7 +4,7 @@ use crate::backend_task::tokens::TokenTask;
 use crate::model::amount::Amount;
 use crate::model::user_role::UserRole;
 use crate::ui::components::MessageBanner;
-use crate::ui::helpers::clicked_outside_window_after_open;
+use crate::ui::helpers::{clicked_outside_window_after_open, draw_modal_overlay};
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::burn_tokens_screen::BurnTokensScreen;
 use crate::ui::tokens::claim_tokens_screen::ClaimTokensScreen;
@@ -180,9 +180,12 @@ impl TokensScreen {
                 let mut close_popup = false;
                 let dark_mode = ui.style().visuals.dark_mode;
 
+                draw_modal_overlay(ui.ctx(), "token_info_popup_overlay");
+
                 let window_response = egui::Window::new("Token Configuration Details")
                     .resizable(true)
                     .collapsible(false)
+                    .order(egui::Order::Foreground)
                     .default_width(600.0)
                     .default_height(500.0)
                     .open(&mut is_open)
@@ -565,17 +568,12 @@ impl TokensScreen {
             if let Some(explanation) = self.reward_explanations.get(&identity_token_id) {
                 let mut is_open = true;
 
-                // Draw dark overlay behind the popup
-                let screen_rect = ui.ctx().content_rect();
-                let painter = ui.ctx().layer_painter(egui::LayerId::new(
-                    egui::Order::Background,
-                    egui::Id::new("reward_explanation_overlay"),
-                ));
-                painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+                draw_modal_overlay(ui.ctx(), "reward_explanation_overlay");
 
                 let window_response = egui::Window::new("Reward Calculation Explanation")
                     .resizable(true)
                     .collapsible(false)
+                    .order(egui::Order::Foreground)
                     .default_width(600.0)
                     .default_height(400.0)
                     .open(&mut is_open)

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -6,7 +6,9 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::password_input::PasswordInput;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
+use crate::ui::helpers::{
+    ModalOpeningGuard, clicked_outside_window_after_open, draw_modal_overlay,
+};
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::identities::funding_common::generate_qr_code_image;
 use crate::ui::theme::{ComponentStyles, DashColors};
@@ -295,13 +297,7 @@ impl AddNewWalletScreen {
             return AppAction::None;
         }
 
-        // Draw dark overlay behind the dialog
-        let screen_rect = ctx.content_rect();
-        let painter = ctx.layer_painter(egui::LayerId::new(
-            egui::Order::Background,
-            egui::Id::new("receive_funds_overlay"),
-        ));
-        painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+        draw_modal_overlay(ctx, "receive_funds_overlay");
 
         // Generate QR code if needed
         let mut qr_error: Option<String> = None;
@@ -327,6 +323,7 @@ impl AddNewWalletScreen {
         let window_response = egui::Window::new("Fund Wallet")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .open(&mut open)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .show(ctx, |ui| {
@@ -716,9 +713,11 @@ impl ScreenLike for AddNewWalletScreen {
         // Display error popup if there's an error
         if let Some(error_message) = self.error.as_ref() {
             let error_message = error_message.clone();
+            draw_modal_overlay(ctx, "add_wallet_error_dialog_overlay");
             egui::Window::new("Error")
                 .resizable(false)
                 .collapsible(false)
+                .order(egui::Order::Foreground)
                 .anchor(egui::Align2::CENTER_CENTER, Vec2::new(0.0, 0.0))
                 .show(ctx, |ui| {
                     ui.label(error_message);

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -128,12 +128,7 @@ pub(super) struct PrivateKeyDialogState {
 
 impl WalletsBalancesScreen {
     pub(super) fn draw_modal_overlay(ctx: &Context, id: &str) {
-        let screen_rect = ctx.content_rect();
-        let painter = ctx.layer_painter(egui::LayerId::new(
-            egui::Order::Background,
-            egui::Id::new(id),
-        ));
-        painter.rect_filled(screen_rect, 0.0, DashColors::modal_overlay());
+        crate::ui::helpers::draw_modal_overlay(ctx, id);
     }
 
     pub(super) fn modal_frame(ctx: &Context) -> Frame {
@@ -223,6 +218,7 @@ impl WalletsBalancesScreen {
         let window_response = egui::Window::new("Receive")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .open(&mut open)
             .frame(Self::modal_frame(ctx))
@@ -589,6 +585,7 @@ impl WalletsBalancesScreen {
         let window_response = egui::Window::new("Fund Platform Address from Asset Lock")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .open(&mut open)
             .frame(Self::modal_frame(ctx))
@@ -769,6 +766,7 @@ impl WalletsBalancesScreen {
         egui::Window::new("Private Key")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .open(&mut open)
             .frame(Self::modal_frame(ctx))
@@ -1167,6 +1165,7 @@ impl WalletsBalancesScreen {
         let window_response = egui::Window::new("Mine Blocks")
             .collapsible(false)
             .resizable(false)
+            .order(egui::Order::Foreground)
             .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
             .open(&mut open)
             .frame(Self::modal_frame(ctx))

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -26,7 +26,9 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::{add_top_panel_with_global_nav_capturing, wallet_only_spec};
 use crate::ui::components::wallet_unlock_popup::{WalletUnlockPopup, WalletUnlockResult};
 use crate::ui::helpers::copy_text_to_clipboard;
-use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
+use crate::ui::helpers::{
+    ModalOpeningGuard, clicked_outside_window_after_open, draw_modal_overlay,
+};
 use crate::ui::state::TrackedAssetLockCache;
 use crate::ui::state::account_summary::{
     AccountCategory, AccountSummary, collect_account_summaries,
@@ -2635,9 +2637,12 @@ impl ScreenLike for WalletsBalancesScreen {
 
         // Rename dialog
         if self.show_rename_dialog {
+            draw_modal_overlay(ctx, "rename_wallet_dialog_overlay");
+
             let window_response = egui::Window::new("Rename Wallet")
                 .collapsible(false)
                 .resizable(false)
+                .order(egui::Order::Foreground)
                 .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
                 .show(ctx, |ui| {
                     let dark_mode = ui.style().visuals.dark_mode;
@@ -2820,10 +2825,13 @@ impl ScreenLike for WalletsBalancesScreen {
 
         // SK wallet unlock dialog
         if self.show_sk_unlock_dialog {
+            draw_modal_overlay(ctx, "single_key_unlock_dialog_overlay");
+
             let mut close_dialog = false;
             egui::Window::new("Unlock Wallet")
                 .collapsible(false)
                 .resizable(false)
+                .order(egui::Order::Foreground)
                 .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
                 .show(ctx, |ui| {
                     ui.vertical(|ui| {

--- a/tests/kittest/confirmation_dialog.rs
+++ b/tests/kittest/confirmation_dialog.rs
@@ -3,6 +3,7 @@ use dash_evo_tool::ui::components::component_trait::ComponentResponse;
 use dash_evo_tool::ui::components::confirmation_dialog::{
     ConfirmationDialog, ConfirmationStatus, NOTHING,
 };
+use dash_evo_tool::ui::helpers::draw_modal_overlay;
 use egui_kittest::Harness;
 use egui_kittest::kittest::Queryable;
 
@@ -220,4 +221,158 @@ fn test_open_false_component_response() {
             assert!(response.inner.changed_value().is_none());
         });
     harness.run();
+}
+
+/// Regression guard for PR #732: a blocking confirmation modal must consume
+/// pointer events so they cannot reach background widgets.
+#[test]
+fn test_modal_overlay_blocks_click_through_to_background_widget() {
+    // Place a clickable background widget at a known rect that sits entirely
+    // outside the centered dialog window but well within the screen-sized
+    // modal. If modal chrome correctly consumes pointer events, the background
+    // button must never be activated.
+    let background_rect =
+        egui::Rect::from_min_size(egui::pos2(20.0, 20.0), egui::vec2(120.0, 30.0));
+
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 400.0))
+        .build_ui_state(
+            |ui, clicks: &mut u32| {
+                let response = ui.put(background_rect, egui::Button::new("Background"));
+                if response.clicked() {
+                    *clicks += 1;
+                }
+                let mut dialog = ConfirmationDialog::new("Modal Title", "Modal Message");
+                dialog.show(ui);
+            },
+            0u32,
+        );
+
+    // Compute layout / paint so modal input blocking is registered.
+    harness.run();
+
+    // Sanity check: the dialog window does not cover the background button rect
+    // (otherwise the click would be blocked by the dialog itself, not the overlay).
+    let dialog_node = harness
+        .query_by_label("Modal Title")
+        .expect("dialog should be rendered");
+    assert!(
+        !dialog_node.rect().intersects(background_rect),
+        "test setup invalid: background widget rect overlaps the dialog window rect"
+    );
+
+    // Click on the background button. The position is over the background
+    // widget and inside the modal overlay, but outside the dialog window.
+    let click_pos = background_rect.center();
+    harness.event(egui::Event::PointerMoved(click_pos));
+    harness.event(egui::Event::PointerButton {
+        pos: click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: true,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.event(egui::Event::PointerButton {
+        pos: click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.run();
+
+    assert_eq!(
+        *harness.state(),
+        0,
+        "modal chrome must consume pointer events; background widget was activated through the modal"
+    );
+}
+
+/// Regression guard for legacy manual `egui::Window` modals that use
+/// `draw_modal_overlay` directly instead of `modal_chrome`.
+#[test]
+fn test_legacy_modal_overlay_blocks_background_and_preserves_window_input() {
+    let background_rect =
+        egui::Rect::from_min_size(egui::pos2(20.0, 20.0), egui::vec2(120.0, 30.0));
+
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 400.0))
+        .build_ui_state(
+            |ui, clicks: &mut (u32, u32)| {
+                let background_response = ui.put(background_rect, egui::Button::new("Background"));
+                if background_response.clicked() {
+                    clicks.0 += 1;
+                }
+
+                draw_modal_overlay(ui.ctx(), "legacy_helper_test_overlay");
+
+                egui::Window::new("Legacy Modal")
+                    .collapsible(false)
+                    .resizable(false)
+                    .order(egui::Order::Foreground)
+                    .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+                    .show(ui.ctx(), |ui| {
+                        if ui.button("Modal Button").clicked() {
+                            clicks.1 += 1;
+                        }
+                    });
+            },
+            (0u32, 0u32),
+        );
+
+    harness.run();
+
+    let modal_node = harness
+        .query_by_label("Legacy Modal")
+        .expect("legacy modal should be rendered");
+    assert!(
+        !modal_node.rect().intersects(background_rect),
+        "test setup invalid: background widget rect overlaps the legacy modal rect"
+    );
+
+    let background_click_pos = background_rect.center();
+    harness.event(egui::Event::PointerMoved(background_click_pos));
+    harness.event(egui::Event::PointerButton {
+        pos: background_click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: true,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.event(egui::Event::PointerButton {
+        pos: background_click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.run();
+
+    assert_eq!(
+        harness.state().0,
+        0,
+        "legacy modal overlay must consume pointer events before background widgets"
+    );
+
+    let modal_button_rect = harness
+        .query_by_label("Modal Button")
+        .expect("modal button should be rendered")
+        .rect();
+    let modal_click_pos = modal_button_rect.center();
+    harness.event(egui::Event::PointerMoved(modal_click_pos));
+    harness.event(egui::Event::PointerButton {
+        pos: modal_click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: true,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.event(egui::Event::PointerButton {
+        pos: modal_click_pos,
+        button: egui::PointerButton::Primary,
+        pressed: false,
+        modifiers: egui::Modifiers::NONE,
+    });
+    harness.run();
+
+    assert_eq!(
+        harness.state().1,
+        1,
+        "foreground legacy modal window must remain interactive above the overlay sink"
+    );
 }


### PR DESCRIPTION
## Issue

Closes #704

## Summary

All modal overlays used `painter.rect_filled()` via `layer_painter(Order::Background)` which is purely visual — clicks pass through the overlay to background widgets in the same frame.

## Changes

- **New `src/ui/components/modal_overlay.rs`** — centralized `draw_modal_overlay(ctx, id)` helper that uses `egui::Area` with `allocate_response(Sense::click_and_drag())` to both paint the semi-transparent overlay and consume all pointer events
- **Updated 11 call sites** across confirmation dialogs, info popups, wallet unlock, profile screen, identities screen, wallet screens, token screens, and asset lock detail to use the shared helper
- **Removed** the duplicate `WalletsBalancesScreen::draw_modal_overlay` method from `dialogs.rs`

Net: -29 lines (59 added, 88 removed across 13 files).

## Validation

- `cargo check` — compiles clean
- `cargo clippy -- -D warnings` — no warnings
- `cargo fmt --all -- --check` — formatted
- Verified all 17 `modal_overlay()` references now go through the centralized helper (grep confirms no remaining inline `rect_filled` + `modal_overlay` patterns)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized dimmed modal backdrop rendering across multiple dialogs and popups to use a shared overlay approach for consistent appearance.
* **Bug Fixes**
  * Modal overlays now more reliably prevent click/tap interactions from passing through to background content.
* **Tests**
  * Added a regression test that verifies background widgets are not activated while a modal overlay is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->