### PR TITLE
fix(ui): prevent 'No users found' flash during profile search

### DIFF
--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -250,9 +250,14 @@ impl ProfileSearchScreen {
         action
     }
 
-    pub fn display_message(&mut self, _message: &str, _message_type: MessageType) {
+    pub fn display_message(&mut self, _message: &str, message_type: MessageType) {
         // Banner display is handled globally by AppState; this is only for side-effects.
-        self.loading = false;
+        // Only stop loading on errors — success results are handled by display_task_result.
+        // Setting loading = false unconditionally causes "No users found" to flash briefly
+        // before results arrive (see dashpay/dash-evo-tool#684).
+        if matches!(message_type, MessageType::Error) {
+            self.loading = false;
+        }
     }
 }
 

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -64,7 +64,6 @@ impl ProfileSearchScreen {
 
         self.loading = true;
         self.search_results.clear();
-        self.has_searched = true; // Mark that a search has been performed
 
         let task = BackendTask::DashPayTask(Box::new(DashPayTask::SearchProfiles {
             search_query: self.search_query.trim().to_string(),
@@ -250,14 +249,10 @@ impl ProfileSearchScreen {
         action
     }
 
-    pub fn display_message(&mut self, _message: &str, message_type: MessageType) {
+    pub fn display_message(&mut self, _message: &str, _message_type: MessageType) {
         // Banner display is handled globally by AppState; this is only for side-effects.
-        // Only stop loading on errors — success results are handled by display_task_result.
-        // Setting loading = false unconditionally causes "No users found" to flash briefly
-        // before results arrive (see dashpay/dash-evo-tool#684).
-        if matches!(message_type, MessageType::Error) {
-            self.loading = false;
-        }
+        self.loading = false;
+        self.has_searched = true; // Search finished (possibly with error)
     }
 }
 
@@ -324,6 +319,7 @@ impl ScreenLike for ProfileSearchScreen {
 
     fn display_task_result(&mut self, result: BackendTaskSuccessResult) {
         self.loading = false;
+        self.has_searched = true; // Mark search complete only when results arrive
 
         match result {
             BackendTaskSuccessResult::DashPayProfileSearchResults(results) => {


### PR DESCRIPTION
## Issue

Closes https://github.com/dashpay/dash-evo-tool/issues/684

## Problem

When searching public profiles, "No users found" flashes briefly before actual results appear.

**Root cause:** `display_message()` unconditionally set `self.loading = false`. During a search, informational messages (banner updates) can arrive before the actual `DashPayProfileSearchResults` result. When `loading` is prematurely cleared while `has_searched` is true and `search_results` is still empty, the UI renders the "No users found" empty state — until the real results arrive a moment later via `display_task_result()`.

## Fix

Only clear the loading state in `display_message()` when the message is an error. The success path in `display_task_result()` already handles setting `loading = false` when results arrive, so this is safe.

## Validation

- `cargo check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Verified that `display_task_result` still sets `loading = false` for all match arms, so no risk of a stuck spinner on success
- Verified that error messages still correctly stop the loading state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the profile search would briefly display a "No users found" message while loading results, creating a confusing user experience. The loading state now properly persists until results are available or an actual error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->