### PR TITLE
fix(ui): prevent stacking banners during wallet identity search

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -825,6 +825,10 @@ impl App for AppState {
                             self.visible_screen_mut()
                                 .display_task_result(unboxed_message);
                         }
+                        BackendTaskSuccessResult::Progress(_) => {
+                            self.visible_screen_mut()
+                                .display_task_result(unboxed_message);
+                        }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
                             self.visible_screen_mut().display_message(

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -285,7 +285,7 @@ impl AppContext {
             // Send progress update before starting search for this index
             sender
                 .send(TaskResult::Success(Box::new(
-                    BackendTaskSuccessResult::Message(format!(
+                    BackendTaskSuccessResult::Progress(format!(
                         "Searching index {} of {}...",
                         identity_index, max_identity_index
                     )),

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -101,8 +101,9 @@ pub enum BackendTaskSuccessResult {
     // General results
     None,
     Refresh,
-    Message(String), // Used for: progress messages during long operations, placeholder messages for
+    Message(String), // Used for: placeholder messages for
     // not-yet-implemented functionality, and DashPay operations that would need their own typed variants.
+    Progress(String), // Progress updates during long operations — NOT displayed as global banners.
     WalletPayment {
         txid: String,
         /// List of (address, amount) pairs for each recipient

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -989,6 +989,9 @@ impl ScreenLike for AddExistingIdentityScreen {
                     self.backend_message = Some(msg);
                 }
             }
+            BackendTaskSuccessResult::Progress(msg) => {
+                self.backend_message = Some(msg);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

Fixes #713 — "Load identity: load from wallet displays messy messages."

When searching a wallet for identities up to a given index, each progress update ("Searching index X of Y...") was sent as a `BackendTaskSuccessResult::Message`, which triggered `MessageBanner::set_global()` in `app.rs` — creating a **new** green success banner for every iteration. These banners stacked up, cluttering the UI.

## Changes

- **Add `BackendTaskSuccessResult::Progress(String)`** — a new variant for progress messages that should NOT create global banners
- **`app.rs`** — handle `Progress` by forwarding to the screen's `display_task_result` only (no `MessageBanner::set_global`)
- **`load_identity_from_wallet.rs`** — change the loop's progress sends from `Message` to `Progress`
- **`add_existing_identity_screen.rs`** — handle `Progress` by updating `backend_message` (rendered inline as a label, not a stacking banner)

## Validation

- `cargo check` passes
- `cargo fmt` passes
- Verified that the `Progress` variant skips `MessageBanner::set_global` in `app.rs` (line 1115)
- Verified that `backend_message` is rendered inline at line 1143 as `"{progress_msg} ({elapsed})"` — single updating label, no stacking


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added progress tracking for long-running backend operations, enabling real-time feedback to be displayed during extended tasks such as identity loading.
  * Progress information is now displayed separately from general messages, providing users with clearer, more granular updates throughout multi-step operations and improving overall application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->