### PR TITLE
fix(ui): prevent 'No users found' flash during profile search

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1112,6 +1112,10 @@ impl App for AppState {
                             self.visible_screen_mut()
                                 .display_task_result(unboxed_message);
                         }
+                        BackendTaskSuccessResult::Progress(_) => {
+                            self.visible_screen_mut()
+                                .display_task_result(unboxed_message);
+                        }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
                             MessageBanner::set_global(

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -281,7 +281,7 @@ impl AppContext {
             // Send progress update before starting search for this index
             sender
                 .send(TaskResult::Success(Box::new(
-                    BackendTaskSuccessResult::Message(format!(
+                    BackendTaskSuccessResult::Progress(format!(
                         "Searching index {} of {}...",
                         identity_index, max_identity_index
                     )),

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -103,8 +103,9 @@ pub enum BackendTaskSuccessResult {
     // General results
     None,
     Refresh,
-    Message(String), // Used for: progress messages during long operations, placeholder messages for
+    Message(String), // Used for: placeholder messages for
     // not-yet-implemented functionality, and DashPay operations that would need their own typed variants.
+    Progress(String), // Progress updates during long operations — NOT displayed as global banners.
     WalletPayment {
         txid: String,
         /// List of (address, amount) pairs for each recipient

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -322,11 +322,10 @@ impl ScreenLike for ProfileSearchScreen {
     }
 
     fn display_task_result(&mut self, result: BackendTaskSuccessResult) {
-        self.loading = false;
-        self.search_completed = true;
-
         match result {
             BackendTaskSuccessResult::DashPayProfileSearchResults(results) => {
+                self.loading = false;
+                self.search_completed = true;
                 self.search_results.clear();
 
                 // Convert backend results to UI results

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -1,5 +1,6 @@
 use crate::app::{AppAction, DesiredAppAction};
 use crate::backend_task::dashpay::DashPayTask;
+use crate::backend_task::error::TaskError;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::context::AppContext;
 use crate::ui::components::dashpay_subscreen_chooser_panel::add_dashpay_subscreen_chooser_panel;
@@ -254,8 +255,12 @@ impl ProfileSearchScreen {
     }
 
     pub fn display_message(&mut self, _message: &str, _message_type: MessageType) {
-        // Banner display is handled globally by AppState; this is only for side-effects.
-        self.loading = false;
+        // Keep loading state tied to the profile-search task lifecycle:
+        // - display_task_result() clears loading on successful results
+        // - display_task_error() clears loading on task failure
+        // Don't clear loading here — AppState calls display_message on the
+        // visible screen for ANY completed task, which would hide the spinner
+        // before our search results arrive.
     }
 }
 
@@ -319,6 +324,12 @@ impl ScreenLike for ProfileSearchScreen {
 
     fn display_message(&mut self, message: &str, message_type: MessageType) {
         self.display_message(message, message_type);
+    }
+
+    fn display_task_error(&mut self, _error: &TaskError) -> bool {
+        // Clear loading on task errors so the spinner doesn't hang forever.
+        self.loading = false;
+        false // Don't suppress the global error banner
     }
 
     fn display_task_result(&mut self, result: BackendTaskSuccessResult) {

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -35,7 +35,8 @@ pub struct ProfileSearchScreen {
     search_query: String,
     search_results: Vec<ProfileSearchResult>,
     loading: bool,
-    has_searched: bool, // Track if a search has been performed
+    has_searched: bool,     // Track if a search has been performed
+    search_completed: bool, // True only after backend results received (prevents flash)
     show_info_popup: bool,
 }
 
@@ -47,6 +48,7 @@ impl ProfileSearchScreen {
             search_results: Vec::new(),
             loading: false,
             has_searched: false,
+            search_completed: false,
             show_info_popup: false,
         }
     }
@@ -65,6 +67,7 @@ impl ProfileSearchScreen {
         self.loading = true;
         self.search_results.clear();
         self.has_searched = true; // Mark that a search has been performed
+        self.search_completed = false; // Reset until backend responds
 
         let task = BackendTask::DashPayTask(Box::new(DashPayTask::SearchProfiles {
             search_query: self.search_query.trim().to_string(),
@@ -237,8 +240,8 @@ impl ProfileSearchScreen {
                         ui.add_space(4.0);
                     }
                 });
-            } else if self.has_searched && !self.loading {
-                // Only show "No users found" if we've actually performed a search
+            } else if self.search_completed && !self.loading {
+                // Only show "No users found" after backend has returned results
                 ui.group(|ui| {
                     ui.label("No users found");
                     ui.separator();
@@ -294,6 +297,7 @@ impl ScreenLike for ProfileSearchScreen {
             self.search_query.clear();
             self.search_results.clear();
             self.has_searched = false;
+            self.search_completed = false;
             action = AppAction::None; // Consume the action
         }
 
@@ -319,6 +323,7 @@ impl ScreenLike for ProfileSearchScreen {
 
     fn display_task_result(&mut self, result: BackendTaskSuccessResult) {
         self.loading = false;
+        self.search_completed = true;
 
         match result {
             BackendTaskSuccessResult::DashPayProfileSearchResults(results) => {

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -1048,6 +1048,11 @@ impl ScreenLike for AddExistingIdentityScreen {
                     }
                 }
             }
+            BackendTaskSuccessResult::Progress(msg) => {
+                if let Some(ref handle) = self.refresh_banner {
+                    handle.set_message(&msg);
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Issue
Fixes #684 — Search Public Profiles always shows "No users found" briefly before results load.

## Root Cause
When a search starts, `has_searched` is set to `true` and results are cleared. The `display_message()` method (called for banner side-effects) sets `loading = false` before `display_task_result()` delivers actual results. This creates a frame where `has_searched && !loading && results.is_empty()` is true, causing the "No users found" message to flash.

## Fix
Added a `search_completed` flag that's only set in `display_task_result()`, and changed the empty-results condition to check `search_completed` instead of `has_searched`. This ensures the "No users found" message only appears after the backend has actually returned (empty) results.

## Testing
- Start a profile search → spinner shows, no flash of "No users found"
- Complete search with results → results display normally
- Complete search with no matches → "No users found" displays (after results arrive)
- Clear Results button → resets all state correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time progress updates from long-running backend tasks are now shown in the UI and global refresh banner.
  * Search UI now tracks backend completion separately to drive loading and result visibility.

* **Bug Fixes**
  * Prevented premature "No users found" message by showing no-results only after backend search completes.
  * Improved loading/reset behavior on search and clear to avoid misleading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->