### PR TITLE
chore: rename "Developer mode" to "Expert mode" in UI

### DIFF
--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -363,7 +363,7 @@ pub fn add_left_panel(
                                         // Dev mode label (below network label if present)
                                         if app_context.is_developer_mode() {
                                             ui.add_space(2.0);
-                                            let dev_label = egui::RichText::new("🔧 Dev Mode")
+                                            let dev_label = egui::RichText::new("🔧 Expert Mode")
                                                 .color(DashColors::GRADIENT_PURPLE)
                                                 .size(12.0);
                                             if ui.label(dev_label).clicked() {

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -363,10 +363,10 @@ pub fn add_left_panel(
                                         // Dev mode label (below network label if present)
                                         if app_context.is_developer_mode() {
                                             ui.add_space(2.0);
-                                            let dev_label = egui::RichText::new("🔧 Expert Mode")
+                                            let dev_label = egui::RichText::new("🔧 Expert")
                                                 .color(DashColors::GRADIENT_PURPLE)
                                                 .size(12.0);
-                                            if ui.label(dev_label).clicked() {
+                                            if ui.label(dev_label).on_hover_text("Expert mode is enabled — shows advanced options").clicked() {
                                                 action = AppAction::SetMainScreenThenGoToMainScreen(
                                                     RootScreenType::RootScreenNetworkChooser,
                                                 );

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -362,11 +362,11 @@ pub fn add_left_panel(
 
                                         // Dev mode label (below network label if present)
                                         if app_context.is_developer_mode() {
-                                            ui.add_space(2.0);
+                                            ui.add_space(5.0);
                                             let dev_label = egui::RichText::new("🔧 Expert")
                                                 .color(DashColors::GRADIENT_PURPLE)
                                                 .size(12.0);
-                                            if ui.label(dev_label).on_hover_text("Expert mode is enabled — shows advanced options").clicked() {
+                                            if ui.label(dev_label).on_hover_text("Expert mode is enabled — shows advanced options").on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
                                                 action = AppAction::SetMainScreenThenGoToMainScreen(
                                                     RootScreenType::RootScreenNetworkChooser,
                                                 );

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -1029,6 +1029,7 @@ impl NetworkChooserScreen {
                 ui.horizontal(|ui| {
                     if StyledCheckbox::new(&mut self.developer_mode, "Expert mode")
                         .show(ui)
+                        .on_hover_text("Show advanced options for power users and developers")
                         .clicked()
                     {
                         // Always update all contexts first to keep UI in sync

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -1027,7 +1027,7 @@ impl NetworkChooserScreen {
                 ui.add_space(8.0);
 
                 ui.horizontal(|ui| {
-                    if StyledCheckbox::new(&mut self.developer_mode, "Developer mode")
+                    if StyledCheckbox::new(&mut self.developer_mode, "Expert mode")
                         .show(ui)
                         .clicked()
                     {


### PR DESCRIPTION
## Summary

- Renamed the "Developer mode" checkbox label to "Expert mode" in network settings
- Shortened the left panel badge from "🔧 Expert Mode" to "🔧 Expert" to fit column width
- Added hover tooltips to both the left panel badge and the network chooser checkbox

## Test plan

- [ ] Toggle the checkbox in network settings — verify it reads "Expert mode"
- [ ] Hover over the checkbox — verify tooltip "Show advanced options for power users and developers"
- [ ] Enable expert mode — verify the left panel badge shows "🔧 Expert"
- [ ] Hover over the left panel badge — verify tooltip "Expert mode is enabled — shows advanced options"

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Renamed "Dev Mode" label to "Expert" throughout the interface.
  * Added descriptive hover tooltips to expert mode options explaining functionality for advanced users.
  * Enhanced visual feedback with cursor changes on interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->