### PR TITLE
feat: add ResponseExt trait to enforce tooltip cursor policy

### DIFF
--- a/docs/ux-design-patterns.md
+++ b/docs/ux-design-patterns.md
@@ -182,7 +182,7 @@ Use `ResponseExt` methods (defined in `src/ui/theme.rs`) instead of raw `.on_hov
 | `.disabled_tooltip("text")` | `NotAllowed` | Disabled elements explaining why the action is unavailable |
 
 - Import: `use crate::ui::theme::ResponseExt;`
-- `ComponentStyles` button constructors (`add_primary_button`, etc.) set `PointingHand` automatically -- no tooltip helper needed
+- `ComponentStyles` button constructors (`add_primary_button`, etc.) set `PointingHand` automatically -- no `clickable_tooltip` needed for the cursor. You still need `disabled_tooltip` when the button can be disabled
 - Never use bare `.on_hover_text()` or `.on_disabled_hover_text()` -- always use the `ResponseExt` methods above
 - `ResponseExt` is the general extension point for `egui::Response` behavior policies; future methods may enforce hover effects, accessibility, or other conventions
 

--- a/docs/ux-design-patterns.md
+++ b/docs/ux-design-patterns.md
@@ -171,6 +171,21 @@ Reference: `MessageBanner` in `src/ui/components/message_banner.rs`.
 - All interactive elements: WCAG AA compliant click targets
 - Note: egui has limited a11y support -- no screen reader annotations available
 
+### Cursor Icons and Tooltips
+
+Use `ResponseExt` methods (defined in `src/ui/theme.rs`) instead of raw `.on_hover_text()`. These enforce the correct cursor automatically.
+
+| Method | Cursor | When to use |
+|---|---|---|
+| `.clickable_tooltip("text")` | `PointingHand` | Interactive elements with click handlers (buttons, links, clickable labels) |
+| `.info_tooltip("text")` | `Help` (?) | Non-interactive elements showing explanatory text (status labels, settings, column headers) |
+| `.disabled_tooltip("text")` | `NotAllowed` | Disabled elements explaining why the action is unavailable |
+
+- Import: `use crate::ui::theme::ResponseExt;`
+- `StyledButton` helpers (`add_primary_button`, etc.) set `PointingHand` automatically -- no tooltip helper needed
+- Never use bare `.on_hover_text()` -- always use the `ResponseExt` methods above
+- `ResponseExt` is the general extension point for `egui::Response` behavior policies; future methods may enforce hover effects, accessibility, or other conventions
+
 ## 11. Progressive Disclosure
 
 Reference personas in `docs/personas/`.

--- a/docs/ux-design-patterns.md
+++ b/docs/ux-design-patterns.md
@@ -182,8 +182,8 @@ Use `ResponseExt` methods (defined in `src/ui/theme.rs`) instead of raw `.on_hov
 | `.disabled_tooltip("text")` | `NotAllowed` | Disabled elements explaining why the action is unavailable |
 
 - Import: `use crate::ui::theme::ResponseExt;`
-- `StyledButton` helpers (`add_primary_button`, etc.) set `PointingHand` automatically -- no tooltip helper needed
-- Never use bare `.on_hover_text()` -- always use the `ResponseExt` methods above
+- `ComponentStyles` button constructors (`add_primary_button`, etc.) set `PointingHand` automatically -- no tooltip helper needed
+- Never use bare `.on_hover_text()` or `.on_disabled_hover_text()` -- always use the `ResponseExt` methods above
 - `ResponseExt` is the general extension point for `egui::Response` behavior policies; future methods may enforce hover effects, accessibility, or other conventions
 
 ## 11. Progressive Disclosure

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -2,7 +2,7 @@ use crate::app::AppAction;
 use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::components::styled::GradientButton;
-use crate::ui::theme::{DashColors, Shadow, Shape, Spacing};
+use crate::ui::theme::{DashColors, ResponseExt, Shadow, Shape, Spacing};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use eframe::epaint::Margin;
 use egui::{Context, Frame, Image, RichText, SidePanel, TextureHandle};
@@ -366,7 +366,7 @@ pub fn add_left_panel(
                                             let dev_label = egui::RichText::new("🔧 Expert")
                                                 .color(DashColors::GRADIENT_PURPLE)
                                                 .size(12.0);
-                                            if ui.label(dev_label).on_hover_text("Expert mode is enabled — shows advanced options").on_hover_cursor(egui::CursorIcon::PointingHand).clicked() {
+                                            if ui.label(dev_label).clickable_tooltip("Expert mode is enabled — shows advanced options").clicked() {
                                                 action = AppAction::SetMainScreenThenGoToMainScreen(
                                                     RootScreenType::RootScreenNetworkChooser,
                                                 );

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -1,7 +1,7 @@
 use egui::{Rect, Response, Sense, Stroke, Ui, pos2, vec2};
 
 use crate::model::secret::Secret;
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 
 /// Response from [`PasswordInput::show`].
 ///
@@ -201,7 +201,7 @@ impl PasswordInput {
         if eye_response.hovered() {
             ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
         }
-        eye_response.on_hover_text("Hold to reveal");
+        eye_response.clickable_tooltip("Hold to reveal");
 
         if self.revealing || reveal_changed {
             ui.ctx().request_repaint();

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -5,7 +5,7 @@ use crate::context::AppContext;
 use crate::context::connection_status::OverallConnectionState;
 use crate::spv::CoreBackendMode;
 use crate::ui::ScreenType;
-use crate::ui::theme::{ComponentStyles, DashColors, Shadow, Shape};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt, Shadow, Shape};
 use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, TopBottomPanel, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
@@ -168,7 +168,7 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
                         app_context.repaint_animation(ui.ctx());
                     }
                     let tip = status.tooltip_text(app_context);
-                    let resp = resp.on_hover_text(tip);
+                    let resp = resp.info_tooltip(tip);
 
                     if resp.clicked()
                         && overall == OverallConnectionState::Disconnected

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -168,13 +168,16 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
                         app_context.repaint_animation(ui.ctx());
                     }
                     let tip = status.tooltip_text(app_context);
-                    let resp = resp.info_tooltip(tip);
-
-                    if resp.clicked()
-                        && overall == OverallConnectionState::Disconnected
+                    let can_start_dash_qt = overall == OverallConnectionState::Disconnected
                         && backend_mode == CoreBackendMode::Rpc
-                        && !status.rpc_online()
-                    {
+                        && !status.rpc_online();
+                    let resp = if can_start_dash_qt {
+                        resp.clickable_tooltip(tip)
+                    } else {
+                        resp.info_tooltip(tip)
+                    };
+
+                    if resp.clicked() && can_start_dash_qt {
                         let settings = app_context.get_settings().ok().flatten();
 
                         let (custom_path, overwrite) = settings

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -990,12 +990,14 @@ impl ProfileScreen {
                                             "Save profile changes".to_string()
                                         };
 
-                                        if ui
-                                            .add_enabled(can_save, save_button)
-                                            .clickable_tooltip(&hover_text)
-                                            .on_disabled_hover_text(&hover_text)
-                                            .clicked()
-                                        {
+                                        let response =
+                                            ui.add_enabled(can_save, save_button);
+                                        let response = if can_save {
+                                            response.clickable_tooltip(&hover_text)
+                                        } else {
+                                            response.disabled_tooltip(&hover_text)
+                                        };
+                                        if response.clicked() {
                                             action |= self.save_profile();
                                         }
                                     });

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -16,7 +16,7 @@ use crate::ui::components::wallet_unlock_popup::{
 use crate::ui::components::{MessageBanner, ResultBannerExt};
 use crate::ui::helpers::clicked_outside_window;
 use crate::ui::identities::get_selected_wallet;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use egui::{ColorImage, Frame, Margin, RichText, ScrollArea, TextEdit, TextureHandle, Ui};
 use std::collections::HashMap;
@@ -992,7 +992,7 @@ impl ProfileScreen {
 
                                         if ui
                                             .add_enabled(can_save, save_button)
-                                            .on_hover_text(&hover_text)
+                                            .clickable_tooltip(&hover_text)
                                             .on_disabled_hover_text(&hover_text)
                                             .clicked()
                                         {
@@ -1027,7 +1027,7 @@ impl ProfileScreen {
                                                         .fit_to_exact_size(egui::vec2(80.0, 80.0))
                                                         .corner_radius(8.0)
                                                         .sense(egui::Sense::click()),
-                                                ).on_hover_text("Click to view avatar URL");
+                                                ).clickable_tooltip("Click to view avatar URL");
                                                 if image_response.clicked() {
                                                     self.show_avatar_url_popup = true;
                                                 }
@@ -1062,7 +1062,7 @@ impl ProfileScreen {
                                                             .fit_to_exact_size(egui::vec2(80.0, 80.0))
                                                             .corner_radius(8.0)
                                                             .sense(egui::Sense::click()),
-                                                    ).on_hover_text("Click to view avatar URL");
+                                                    ).clickable_tooltip("Click to view avatar URL");
                                                     if image_response.clicked() {
                                                         self.show_avatar_url_popup = true;
                                                     }
@@ -1117,7 +1117,7 @@ impl ProfileScreen {
                                                                     .fit_to_exact_size(egui::vec2(80.0, 80.0))
                                                                     .corner_radius(8.0)
                                                                     .sense(egui::Sense::click()),
-                                                            ).on_hover_text("Click to view avatar URL");
+                                                            ).clickable_tooltip("Click to view avatar URL");
                                                             if image_response.clicked() {
                                                                 self.show_avatar_url_popup = true;
                                                             }

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -990,14 +990,11 @@ impl ProfileScreen {
                                             "Save profile changes".to_string()
                                         };
 
-                                        let response =
-                                            ui.add_enabled(can_save, save_button);
-                                        let response = if can_save {
-                                            response.clickable_tooltip(&hover_text)
-                                        } else {
-                                            response.disabled_tooltip(&hover_text)
-                                        };
-                                        if response.clicked() {
+                                        if ui.add_enabled(can_save, save_button)
+                                            .clickable_tooltip(&hover_text)
+                                            .disabled_tooltip(&hover_text)
+                                            .clicked()
+                                        {
                                             action |= self.save_profile();
                                         }
                                     });

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -25,7 +25,7 @@ use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_ch
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt};
 use crate::ui::identities::register_dpns_name_screen::RegisterDpnsNameSource;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::{BackendTaskSuccessResult, MessageType, RootScreenType, ScreenLike, ScreenType};
 
 /// Which DPNS sub-screen is currently showing.
@@ -471,7 +471,7 @@ impl DPNSScreen {
                                         .color(DashColors::text_primary(dark_mode)),
                                 );
                                 if let Some(tooltip) = highlighted {
-                                    label_response.on_hover_text(tooltip);
+                                    label_response.info_tooltip(tooltip);
                                 }
                             });
 

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,3 +1,4 @@
+use crate::ui::theme::ResponseExt;
 use dash_sdk::dpp::address_funds::{PLATFORM_HRP_MAINNET, PLATFORM_HRP_TESTNET};
 use std::sync::Arc;
 
@@ -262,9 +263,7 @@ pub fn info_icon_button(ui: &mut egui::Ui, hover_text: &str) -> Response {
         );
     }
 
-    response
-        .on_hover_text(hover_text)
-        .on_hover_cursor(egui::CursorIcon::PointingHand)
+    response.clickable_tooltip(hover_text)
 }
 
 pub fn copy_text_to_clipboard(text: &str) -> Result<(), String> {

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -631,10 +631,13 @@ impl IdentitiesScreen {
                                                             if !can_withdraw {
                                                                 ui.disable();
                                                             }
-                                                            if ui.add_sized([width, 0.0], egui::Button::new("💸 Withdraw"))
-                                                                .clickable_tooltip(withdraw_hover)
-                                                                .clicked()
-                                                            {
+                                                            let resp = ui.add_sized([width, 0.0], egui::Button::new("💸 Withdraw"));
+                                                            let resp = if can_withdraw {
+                                                                resp.clickable_tooltip(withdraw_hover)
+                                                            } else {
+                                                                resp.disabled_tooltip(withdraw_hover)
+                                                            };
+                                                            if resp.clicked() {
                                                                 action = AppAction::AddScreen(
                                                                     Screen::WithdrawalScreen(WithdrawalScreen::new(
                                                                         qualified_identity.clone(),
@@ -667,10 +670,13 @@ impl IdentitiesScreen {
                                                             if !can_transfer {
                                                                 ui.disable();
                                                             }
-                                                            if ui.add_sized([width, 0.0], egui::Button::new("📤 Transfer"))
-                                                                .clickable_tooltip(transfer_hover)
-                                                                .clicked()
-                                                            {
+                                                            let resp = ui.add_sized([width, 0.0], egui::Button::new("📤 Transfer"));
+                                                            let resp = if can_transfer {
+                                                                resp.clickable_tooltip(transfer_hover)
+                                                            } else {
+                                                                resp.disabled_tooltip(transfer_hover)
+                                                            };
+                                                            if resp.clicked() {
                                                                 action = AppAction::AddScreen(
                                                                     Screen::TransferScreen(TransferScreen::new(
                                                                         qualified_identity.clone(),

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -608,7 +608,9 @@ impl IdentitiesScreen {
                                                         .corner_radius(3.0)
                                                         .min_size(egui::vec2(60.0, 20.0));
 
-                                                    let actions_response = ui.add(actions_button).clickable_tooltip("Manage identity credits");
+                                                    let actions_response = ui.add(actions_button)
+                                                        .clickable_tooltip("Manage identity credits")
+                                                        .disabled_tooltip("Identity actions are unavailable until this identity becomes active");
 
                                                     let actions_popup_id = ui.make_persistent_id(format!("actions_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                         egui::Popup::from_toggle_button_response(&actions_response).id(actions_popup_id)

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -20,7 +20,7 @@ use crate::ui::identities::register_dpns_name_screen::{
 };
 use crate::ui::identities::top_up_identity_screen::TopUpIdentityScreen;
 use crate::ui::identities::transfer_screen::TransferScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike, ScreenType};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
@@ -257,7 +257,7 @@ impl IdentitiesScreen {
                 .selectable(true)
                 .truncate(),
         )
-        .on_hover_text(helper);
+        .info_tooltip(helper);
     }
 
     // Up/down reorder methods
@@ -350,14 +350,14 @@ impl IdentitiesScreen {
         };
 
         ui.add(egui::Label::new(message).sense(egui::Sense::hover()))
-            .on_hover_text(format!("{}", qualified_identity.identity.balance()));
+            .info_tooltip(format!("{}", qualified_identity.identity.balance()));
     }
 
     fn show_balance(ui: &mut Ui, qualified_identity: &QualifiedIdentity) {
         let balance_in_dash = qualified_identity.identity.balance() as f64 * 1e-11;
         let formatted_balance = format!("{:.4} DASH", balance_in_dash);
         ui.add(egui::Label::new(formatted_balance).sense(egui::Sense::hover()))
-            .on_hover_text(format!("{}", qualified_identity.identity.balance()));
+            .info_tooltip(format!("{}", qualified_identity.identity.balance()));
     }
 
     fn format_key_name(&self, key: &IdentityPublicKey) -> String {
@@ -608,7 +608,7 @@ impl IdentitiesScreen {
                                                         .corner_radius(3.0)
                                                         .min_size(egui::vec2(60.0, 20.0));
 
-                                                    let actions_response = ui.add(actions_button).on_hover_text("Manage identity credits");
+                                                    let actions_response = ui.add(actions_button).clickable_tooltip("Manage identity credits");
 
                                                     let actions_popup_id = ui.make_persistent_id(format!("actions_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                         egui::Popup::from_toggle_button_response(&actions_response).id(actions_popup_id)
@@ -632,7 +632,7 @@ impl IdentitiesScreen {
                                                                 ui.disable();
                                                             }
                                                             if ui.add_sized([width, 0.0], egui::Button::new("💸 Withdraw"))
-                                                                .on_hover_text(withdraw_hover)
+                                                                .clickable_tooltip(withdraw_hover)
                                                                 .clicked()
                                                             {
                                                                 action = AppAction::AddScreen(
@@ -644,7 +644,7 @@ impl IdentitiesScreen {
                                                             }
                                                         });
 
-                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("💰 Top up")).on_hover_text("Increase this identity's balance by sending it Dash from the Core chain").clicked() {
+                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("💰 Top up")).clickable_tooltip("Increase this identity's balance by sending it Dash from the Core chain").clicked() {
                                                             action = AppAction::AddScreen(
                                                                 Screen::TopUpIdentityScreen(TopUpIdentityScreen::new(
                                                                     qualified_identity.clone(),
@@ -668,7 +668,7 @@ impl IdentitiesScreen {
                                                                 ui.disable();
                                                             }
                                                             if ui.add_sized([width, 0.0], egui::Button::new("📤 Transfer"))
-                                                                .on_hover_text(transfer_hover)
+                                                                .clickable_tooltip(transfer_hover)
                                                                 .clicked()
                                                             {
                                                                 action = AppAction::AddScreen(
@@ -680,7 +680,7 @@ impl IdentitiesScreen {
                                                             }
                                                         });
 
-                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("📛 Register DPNS Name")).on_hover_text("Register a DPNS username for this identity").clicked() {
+                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("📛 Register DPNS Name")).clickable_tooltip("Register a DPNS username for this identity").clicked() {
                                                             let mut screen = RegisterDpnsNameScreen::new(&self.app_context, RegisterDpnsNameSource::Identities);
                                                             screen.select_identity(qualified_identity.identity.id());
                                                             action = AppAction::AddScreen(
@@ -688,7 +688,7 @@ impl IdentitiesScreen {
                                                             );
                                                         }
 
-                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("✏ Update Alias")).on_hover_text("Change the display name for this identity").clicked() {
+                                                        if ui.add_sized([ui.available_width(), 0.0], egui::Button::new("✏ Update Alias")).clickable_tooltip("Change the display name for this identity").clicked() {
                                                             self.editing_alias_identity = Some(qualified_identity.identity.id());
                                                             self.editing_alias_value = qualified_identity.alias.clone().unwrap_or_default();
                                                             ui.close_kind(egui::UiKind::Menu);
@@ -716,7 +716,7 @@ impl IdentitiesScreen {
                                                         .corner_radius(3.0)
                                                         .min_size(egui::vec2(50.0, 20.0));
 
-                                                    let button_response = ui.add(button).on_hover_text("View and manage keys for this identity");
+                                                    let button_response = ui.add(button).clickable_tooltip("View and manage keys for this identity");
 
                                                     let popup_id = ui.make_persistent_id(format!("keys_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                     egui::Popup::from_toggle_button_response(&button_response).id(popup_id)
@@ -787,7 +787,7 @@ impl IdentitiesScreen {
 
                                                             // Add Key button
                                                             if qualified_identity.can_sign_with_master_key().is_some()
-                                                                && ui.add_sized([ui.available_width(), 0.0], egui::Button::new("+ Add Key")).on_hover_text("Add a new key to this identity").clicked() {
+                                                                && ui.add_sized([ui.available_width(), 0.0], egui::Button::new("+ Add Key")).clickable_tooltip("Add a new key to this identity").clicked() {
                                                                     action |= AppAction::AddScreen(Screen::AddKeyScreen(AddKeyScreen::new(
                                                                         qualified_identity.clone(),
                                                                         &self.app_context,
@@ -800,7 +800,7 @@ impl IdentitiesScreen {
                                                 }
 
                                                 // Remove
-                                                if ui.button("Remove").on_hover_text("Remove this identity from Dash Evo Tool (it'll still exist on Dash Platform)").clicked() {
+                                                if ui.button("Remove").clickable_tooltip("Remove this identity from Dash Evo Tool (it'll still exist on Dash Platform)").clicked() {
                                                     let message = format!(
                                                         "Are you sure you want to no longer track this {} identity?\n\nIdentity ID: {}",
                                                         qualified_identity.identity_type,
@@ -819,9 +819,9 @@ impl IdentitiesScreen {
                                                 }
 
                                                 // Up arrow
-                                                let up_btn = ui.button("⬆").on_hover_text("Move this identity up in the list");
+                                                let up_btn = ui.button("⬆").clickable_tooltip("Move this identity up in the list");
                                                 // Down arrow
-                                                let down_btn = ui.button("⬇").on_hover_text("Move this identity down in the list");
+                                                let down_btn = ui.button("⬇").clickable_tooltip("Move this identity down in the list");
 
                                                 if up_btn.clicked() {
                                                     // If we are currently sorted (not custom),

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -631,13 +631,11 @@ impl IdentitiesScreen {
                                                             if !can_withdraw {
                                                                 ui.disable();
                                                             }
-                                                            let resp = ui.add_sized([width, 0.0], egui::Button::new("💸 Withdraw"));
-                                                            let resp = if can_withdraw {
-                                                                resp.clickable_tooltip(withdraw_hover)
-                                                            } else {
-                                                                resp.disabled_tooltip(withdraw_hover)
-                                                            };
-                                                            if resp.clicked() {
+                                                            if ui.add_sized([width, 0.0], egui::Button::new("💸 Withdraw"))
+                                                                .clickable_tooltip(withdraw_hover)
+                                                                .disabled_tooltip(withdraw_hover)
+                                                                .clicked()
+                                                            {
                                                                 action = AppAction::AddScreen(
                                                                     Screen::WithdrawalScreen(WithdrawalScreen::new(
                                                                         qualified_identity.clone(),
@@ -670,13 +668,11 @@ impl IdentitiesScreen {
                                                             if !can_transfer {
                                                                 ui.disable();
                                                             }
-                                                            let resp = ui.add_sized([width, 0.0], egui::Button::new("📤 Transfer"));
-                                                            let resp = if can_transfer {
-                                                                resp.clickable_tooltip(transfer_hover)
-                                                            } else {
-                                                                resp.disabled_tooltip(transfer_hover)
-                                                            };
-                                                            if resp.clicked() {
+                                                            if ui.add_sized([width, 0.0], egui::Button::new("📤 Transfer"))
+                                                                .clickable_tooltip(transfer_hover)
+                                                                .disabled_tooltip(transfer_hover)
+                                                                .clicked()
+                                                            {
                                                                 action = AppAction::AddScreen(
                                                                     Screen::TransferScreen(TransferScreen::new(
                                                                         qualified_identity.clone(),

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -15,7 +15,7 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt, ResultBannerExt};
 use crate::ui::identities::get_selected_wallet;
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, ScreenLike};
 use bip39::rand::{SeedableRng, rngs::StdRng};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
@@ -563,7 +563,7 @@ impl ScreenLike for AddKeyScreen {
                             egui::Id::new("security_level_tooltip"),
                             egui::Sense::hover(),
                         );
-                        hover_response.on_hover_text(format!(
+                        hover_response.info_tooltip(format!(
                             "{:?} purpose requires {:?} security level",
                             self.purpose, self.security_level
                         ));

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -563,7 +563,7 @@ impl ScreenLike for AddKeyScreen {
                             egui::Id::new("security_level_tooltip"),
                             egui::Sense::hover(),
                         );
-                        hover_response.disabled_tooltip(format!(
+                        hover_response.info_tooltip(format!(
                             "{:?} purpose requires {:?} security level",
                             self.purpose, self.security_level
                         ));

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -563,7 +563,7 @@ impl ScreenLike for AddKeyScreen {
                             egui::Id::new("security_level_tooltip"),
                             egui::Sense::hover(),
                         );
-                        hover_response.info_tooltip(format!(
+                        hover_response.disabled_tooltip(format!(
                             "{:?} purpose requires {:?} security level",
                             self.purpose, self.security_level
                         ));

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -546,13 +546,11 @@ impl ScreenLike for RegisterDpnsNameScreen {
                 })
                 .frame(true)
                 .corner_radius(3.0);
-            let response = ui.add_enabled(button_enabled, button);
-            let response = if button_enabled {
-                response.clickable_tooltip(&hover_text)
-            } else {
-                response.disabled_tooltip(&hover_text)
-            };
-            if response.clicked() {
+            if ui.add_enabled(button_enabled, button)
+                .clickable_tooltip(&hover_text)
+                .disabled_tooltip(&hover_text)
+                .clicked()
+            {
                 self.register_dpns_name_status = RegisterDpnsNameStatus::WaitingForResult;
                 let handle = MessageBanner::set_global(ui.ctx(), "Registering DPNS name...", MessageType::Info);
                 handle.with_elapsed();

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -14,7 +14,7 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt, ResultBannerExt};
 use crate::ui::helpers::{TransactionType, add_key_chooser_with_doc_type};
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, ScreenLike};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::identity::Purpose;
@@ -548,7 +548,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
                 .corner_radius(3.0);
             if ui
                 .add_enabled(button_enabled, button)
-                .on_hover_text(&hover_text)
+                .clickable_tooltip(&hover_text)
                 .on_disabled_hover_text(&hover_text)
                 .clicked()
             {

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -546,12 +546,13 @@ impl ScreenLike for RegisterDpnsNameScreen {
                 })
                 .frame(true)
                 .corner_radius(3.0);
-            if ui
-                .add_enabled(button_enabled, button)
-                .clickable_tooltip(&hover_text)
-                .on_disabled_hover_text(&hover_text)
-                .clicked()
-            {
+            let response = ui.add_enabled(button_enabled, button);
+            let response = if button_enabled {
+                response.clickable_tooltip(&hover_text)
+            } else {
+                response.disabled_tooltip(&hover_text)
+            };
+            if response.clicked() {
                 self.register_dpns_name_status = RegisterDpnsNameStatus::WaitingForResult;
                 let handle = MessageBanner::set_global(ui.ctx(), "Registering DPNS name...", MessageType::Info);
                 handle.with_elapsed();

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -798,11 +798,13 @@ impl ScreenLike for TransferScreen {
                     "Please ensure all fields are filled correctly".to_string()
                 };
 
-                if ui
-                    .add_enabled(ready, button)
-                    .clickable_tooltip(hover_text)
-                    .clicked()
-                {
+                let response = ui.add_enabled(ready, button);
+                let response = if ready {
+                    response.clickable_tooltip(hover_text)
+                } else {
+                    response.disabled_tooltip(hover_text)
+                };
+                if response.clicked() {
                     self.confirmation_popup = true;
                 }
 

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -36,7 +36,7 @@ use crate::ui::components::wallet_unlock_popup::{
     WalletUnlockPopup, WalletUnlockResult, try_open_wallet_no_password, wallet_needs_unlock,
 };
 use crate::ui::helpers::{TransactionType, add_key_chooser};
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 
 /// Transfer destination type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -800,7 +800,7 @@ impl ScreenLike for TransferScreen {
 
                 if ui
                     .add_enabled(ready, button)
-                    .on_hover_text(hover_text)
+                    .clickable_tooltip(hover_text)
                     .clicked()
                 {
                     self.confirmation_popup = true;

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -798,13 +798,12 @@ impl ScreenLike for TransferScreen {
                     "Please ensure all fields are filled correctly".to_string()
                 };
 
-                let response = ui.add_enabled(ready, button);
-                let response = if ready {
-                    response.clickable_tooltip(hover_text)
-                } else {
-                    response.disabled_tooltip(hover_text)
-                };
-                if response.clicked() {
+                if ui
+                    .add_enabled(ready, button)
+                    .clickable_tooltip(&hover_text)
+                    .disabled_tooltip(&hover_text)
+                    .clicked()
+                {
                     self.confirmation_popup = true;
                 }
 

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -18,7 +18,7 @@ use crate::ui::components::wallet_unlock_popup::{
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt, ResultBannerExt};
 use crate::ui::components::{Component, ComponentResponse};
 use crate::ui::helpers::{TransactionType, add_key_chooser};
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::{Address, Network};
 use dash_sdk::dpp::fee::Credits;
@@ -624,7 +624,7 @@ impl ScreenLike for WithdrawalScreen {
 
                 if ui
                     .add_enabled(ready, button)
-                    .on_disabled_hover_text(&hover_text)
+                    .disabled_tooltip(&hover_text)
                     .clicked()
                     && self.confirmation_dialog.is_none()
                 {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -1637,7 +1637,7 @@ impl NetworkChooserScreen {
         let mut button_response = ui.add_enabled(!is_active, clear_button);
         if is_active {
             button_response =
-                button_response.on_disabled_hover_text("Stop the SPV client before clearing data");
+                button_response.disabled_tooltip("Stop the SPV client before clearing data");
         }
 
         if button_response.clicked() {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -15,7 +15,7 @@ use crate::ui::components::styled::{
     ConfirmationDialog, ConfirmationStatus, StyledCard, StyledCheckbox, island_central_panel,
 };
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::theme::{DashColors, Shape, ThemeMode};
+use crate::ui::theme::{DashColors, ResponseExt, Shape, ThemeMode};
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use crate::utils::path::format_path_for_display;
 use dash_sdk::dash_spv::sync::{ProgressPercentage, SyncProgress as SpvSyncProgress, SyncState};
@@ -415,7 +415,9 @@ impl NetworkChooserScreen {
                         });
 
                         if is_spv_connected {
-                            response.response.on_hover_text("Disconnect from SPV first");
+                            response
+                                .response
+                                .disabled_tooltip("Disconnect from SPV first");
                         }
                     });
 
@@ -1029,7 +1031,7 @@ impl NetworkChooserScreen {
                 ui.horizontal(|ui| {
                     if StyledCheckbox::new(&mut self.developer_mode, "Expert mode")
                         .show(ui)
-                        .on_hover_text("Show advanced options for power users and developers")
+                        .clickable_tooltip("Show advanced options for power users and developers")
                         .clicked()
                     {
                         // Always update all contexts first to keep UI in sync

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -926,24 +926,58 @@ impl ComponentStyles {
     }
 }
 
-/// Extension methods for [`egui::Response`] that enforce project-wide UI behavior policies.
+/// Extension methods for [`egui::Response`] that enforce the project-wide tooltip cursor
+/// policy. Never use bare `.on_hover_text()` or `.on_disabled_hover_text()` -- use these
+/// methods instead.
 ///
-/// This is the general-purpose extension point for `egui::Response`. Current scope:
-/// cursor icons (tooltip methods below). Future methods may enforce hover effects,
-/// accessibility attributes, interaction patterns, or other UX conventions.
+/// Methods are **state-aware**: `clickable_tooltip` only applies when the widget is
+/// enabled, `disabled_tooltip` only when disabled. This lets you chain both on the same
+/// response and have exactly the right one take effect:
 ///
-/// Use these instead of raw `.on_hover_text()` to ensure consistent behavior.
+/// ```ignore
+/// ui.add_enabled(ready, button)
+///     .clickable_tooltip("Transfer credits")
+///     .disabled_tooltip("Fill all fields first")
+///     .clicked()
+/// ```
+///
+/// All methods return `Self` for chaining -- this is a design contract. New methods
+/// added to this trait must also be state-aware and return `Self`.
 pub trait ResponseExt {
-    /// Informational tooltip with `Help` (?) cursor. For non-interactive elements
-    /// that show explanatory text on hover (status labels, setting descriptions).
+    /// Informational tooltip with `Help` (?) cursor.
+    ///
+    /// Applies regardless of enabled/disabled state -- informational text is always
+    /// relevant. Use for non-interactive elements that show explanatory text on hover
+    /// (status labels, setting descriptions).
+    ///
+    /// ```ignore
+    /// ui.label("Sync status: connected")
+    ///     .info_tooltip("Last synced 3 seconds ago");
+    /// ```
     fn info_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
 
-    /// Clickable tooltip with `PointingHand` cursor. For interactive elements
-    /// that show a tooltip and respond to clicks (custom clickable labels, links).
+    /// Clickable tooltip with `PointingHand` cursor.
+    ///
+    /// Only applies when the widget is **enabled** -- skips silently when disabled so
+    /// it can be chained with [`disabled_tooltip`](ResponseExt::disabled_tooltip). Use
+    /// for interactive elements (buttons, clickable labels, links).
+    ///
+    /// ```ignore
+    /// ui.add_enabled(ready, button)
+    ///     .clickable_tooltip("Submit the form");
+    /// ```
     fn clickable_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
 
-    /// Disabled tooltip with `NotAllowed` cursor. For disabled elements
-    /// that explain why the action is unavailable.
+    /// Disabled tooltip with `NotAllowed` cursor.
+    ///
+    /// Only applies when the widget is **disabled** -- skips silently when enabled so
+    /// it can be chained with [`clickable_tooltip`](ResponseExt::clickable_tooltip). Use
+    /// to explain why an action is unavailable.
+    ///
+    /// ```ignore
+    /// ui.add_enabled(ready, button)
+    ///     .disabled_tooltip("Fill all required fields first");
+    /// ```
     fn disabled_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
 }
 
@@ -953,13 +987,21 @@ impl ResponseExt for egui::Response {
     }
 
     fn clickable_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
-        self.on_hover_text(text)
-            .on_hover_cursor(CursorIcon::PointingHand)
+        if self.enabled() {
+            self.on_hover_text(text)
+                .on_hover_cursor(CursorIcon::PointingHand)
+        } else {
+            self
+        }
     }
 
     fn disabled_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
-        self.on_disabled_hover_text(text)
-            .on_hover_cursor(CursorIcon::NotAllowed)
+        if self.enabled() {
+            self
+        } else {
+            self.on_disabled_hover_text(text)
+                .on_hover_cursor(CursorIcon::NotAllowed)
+        }
     }
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -958,7 +958,7 @@ impl ResponseExt for egui::Response {
     }
 
     fn disabled_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
-        self.on_hover_text(text)
+        self.on_disabled_hover_text(text)
             .on_hover_cursor(CursorIcon::NotAllowed)
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -926,6 +926,43 @@ impl ComponentStyles {
     }
 }
 
+/// Extension methods for [`egui::Response`] that enforce project-wide UI behavior policies.
+///
+/// This is the general-purpose extension point for `egui::Response`. Current scope:
+/// cursor icons (tooltip methods below). Future methods may enforce hover effects,
+/// accessibility attributes, interaction patterns, or other UX conventions.
+///
+/// Use these instead of raw `.on_hover_text()` to ensure consistent behavior.
+pub trait ResponseExt {
+    /// Informational tooltip with `Help` (?) cursor. For non-interactive elements
+    /// that show explanatory text on hover (status labels, setting descriptions).
+    fn info_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
+
+    /// Clickable tooltip with `PointingHand` cursor. For interactive elements
+    /// that show a tooltip and respond to clicks (custom clickable labels, links).
+    fn clickable_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
+
+    /// Disabled tooltip with `NotAllowed` cursor. For disabled elements
+    /// that explain why the action is unavailable.
+    fn disabled_tooltip(self, text: impl Into<egui::WidgetText>) -> Self;
+}
+
+impl ResponseExt for egui::Response {
+    fn info_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
+        self.on_hover_text(text).on_hover_cursor(CursorIcon::Help)
+    }
+
+    fn clickable_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
+        self.on_hover_text(text)
+            .on_hover_cursor(CursorIcon::PointingHand)
+    }
+
+    fn disabled_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
+        self.on_hover_text(text)
+            .on_hover_cursor(CursorIcon::NotAllowed)
+    }
+}
+
 /// Configure fonts for the application
 pub fn configure_fonts() -> FontDefinitions {
     let mut fonts = FontDefinitions::default();

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -983,7 +983,10 @@ pub trait ResponseExt {
 
 impl ResponseExt for egui::Response {
     fn info_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {
-        self.on_hover_text(text).on_hover_cursor(CursorIcon::Help)
+        let text = text.into();
+        self.on_hover_text(text.clone())
+            .on_disabled_hover_text(text)
+            .on_hover_cursor(CursorIcon::Help)
     }
 
     fn clickable_tooltip(self, text: impl Into<egui::WidgetText>) -> Self {

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -568,16 +568,12 @@ impl ScreenLike for BurnTokensScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -8,7 +8,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tokens_subscreen_chooser_panel::add_tokens_subscreen_chooser_panel;
 use crate::ui::components::{BannerHandle, Component, ComponentResponse, OptionBannerExt};
 use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_text};
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::tokens_screen::IdentityTokenIdentifier;
 use crate::ui::tokens::validate_signing_key;
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -573,7 +573,7 @@ impl ScreenLike for BurnTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -456,16 +456,12 @@ impl ScreenLike for ClaimTokensScreen {
                 ui.heading("2. Public note (optional)");
                 ui.add_space(5.0);
                 ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
+                    ui.label("Public note (optional):").info_tooltip(
+                        "A note about the transaction that can be seen by the public.",
+                    );
                     ui.add_space(10.0);
                     let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .info_tooltip(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
+                    if ui.text_edit_singleline(&mut txt).changed() {
                         self.public_note = Some(txt);
                     }
                 });

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -30,7 +30,7 @@ use crate::context::AppContext;
 use crate::model::qualified_contract::QualifiedContract;
 use crate::model::qualified_identity::{IdentityType, QualifiedIdentity};
 use crate::model::wallet::Wallet;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::{MessageType, Screen, ScreenLike};
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt};
 use crate::ui::components::top_panel::add_top_panel;
@@ -461,7 +461,7 @@ impl ScreenLike for ClaimTokensScreen {
                     let mut txt = self.public_note.clone().unwrap_or_default();
                     if ui
                         .text_edit_singleline(&mut txt)
-                        .on_hover_text(
+                        .info_tooltip(
                             "A note about the transaction that can be seen by the public.",
                         )
                         .changed()

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -21,7 +21,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -553,7 +553,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -548,16 +548,12 @@ impl ScreenLike for DestroyFrozenFundsScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -32,7 +32,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser};
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
@@ -636,7 +636,7 @@ impl ScreenLike for PurchaseTokenScreen {
                     .fill(Color32::from_rgb(50, 50, 50))
                     .corner_radius(3.0);
 
-                    ui.add_enabled(false, button).on_hover_text(
+                    ui.add_enabled(false, button).disabled_tooltip(
                         if self.pricing_fetch_attempted && self.fetched_pricing_schedule.is_none() {
                             "This token is not available for purchase"
                         } else {

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -21,7 +21,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -537,7 +537,7 @@ impl ScreenLike for FreezeTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -532,16 +532,12 @@ impl ScreenLike for FreezeTokensScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -613,16 +613,12 @@ impl ScreenLike for MintTokensScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -23,7 +23,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -618,7 +618,7 @@ impl ScreenLike for MintTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -20,7 +20,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -466,7 +466,7 @@ impl ScreenLike for PauseTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -20,7 +20,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -467,7 +467,7 @@ impl ScreenLike for ResumeTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -22,7 +22,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser};
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::balances::credits::Credits;
@@ -1046,7 +1046,7 @@ impl ScreenLike for SetTokenPriceScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -1129,7 +1129,7 @@ impl ScreenLike for SetTokenPriceScreen {
                     ComponentStyles::add_primary_button_enabled(ui, button_active, set_price_text);
 
                 if let Err(hover_message) = validation_result {
-                    button_response.on_disabled_hover_text(hover_message);
+                    button_response.disabled_tooltip(hover_message);
                 } else if button_response.clicked() {
                     self.show_confirmation_popup = true;
                 }

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -1041,16 +1041,12 @@ impl ScreenLike for SetTokenPriceScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -46,7 +46,7 @@ use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use dash_sdk::query_types::IndexMap;
 use eframe::egui::{self, Color32, Context, Ui};
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use egui::{Checkbox, ColorImage, ComboBox, Response, RichText, TextEdit, TextureHandle};
 use enum_iterator::Sequence;
 use image::ImageReader;
@@ -474,7 +474,7 @@ impl ChangeControlRulesUI {
                                         .monospace()
                                         .color(Color32::LIGHT_BLUE),
                                 )
-                                    .on_hover_text("Enabling this setting allows transfers to frozen identities, reducing gas usage by approximately 20% per transfer. Disable this if you want to make sure frozen identities can not receive transfers.");
+                                    .info_tooltip("Enabling this setting allows transfers to frozen identities, reducing gas usage by approximately 20% per transfer. Disable this if you want to make sure frozen identities can not receive transfers.");
                             });
                             ui.end_row();
                         }
@@ -1915,7 +1915,7 @@ impl TokensScreen {
             };
             if ui
                 .small_button(format!("Advanced {arrow}"))
-                .on_hover_text("Configure individual history ledgers")
+                .clickable_tooltip("Configure individual history ledgers")
                 .clicked()
             {
                 self.show_advanced_keeps_history = !self.show_advanced_keeps_history;

--- a/src/ui/tokens/tokens_screen/my_tokens.rs
+++ b/src/ui/tokens/tokens_screen/my_tokens.rs
@@ -4,7 +4,7 @@ use crate::backend_task::tokens::TokenTask;
 use crate::model::amount::Amount;
 use crate::ui::components::MessageBanner;
 use crate::ui::helpers::clicked_outside_window;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::burn_tokens_screen::BurnTokensScreen;
 use crate::ui::tokens::claim_tokens_screen::ClaimTokensScreen;
 use crate::ui::tokens::destroy_frozen_funds_screen::DestroyFrozenFundsScreen;
@@ -445,7 +445,7 @@ impl TokensScreen {
                                                 ui.label(
                                                     RichText::new(itb.identity_id.to_string(Encoding::Base58))
                                                         .color(Color32::from_rgb(0, 100, 0)) // Dark green
-                                                ).on_hover_text("Owner of the contract");
+                                                ).info_tooltip("Owner of the contract");
                                             } else {
                                                 ui.label(itb.identity_id.to_string(Encoding::Base58));
                                             }
@@ -533,7 +533,7 @@ impl TokensScreen {
                                             // Remove
                                             if ui
                                                 .button("X")
-                                                .on_hover_text(
+                                                .clickable_tooltip(
                                                     "Remove identity token balance from DET",
                                                 )
                                                 .clicked()
@@ -681,7 +681,7 @@ impl TokensScreen {
                     false,
                     egui::Button::new(RichText::new("Transfer").color(Color32::GRAY)),
                 )
-                .on_hover_text("Transfer not available");
+                .disabled_tooltip("Transfer not available");
             }
         }
 
@@ -944,7 +944,7 @@ impl TokensScreen {
                                 false,
                                 egui::Button::new(RichText::new("Purchase").color(egui::Color32::GRAY)),
                             )
-                            .on_hover_text({
+                            .disabled_tooltip({
                                 if let Some(Some(pricing)) = self.token_pricing_data.get(&itb.token_id) {
                                     let min_price = get_min_token_price(pricing);
                                     format!("Insufficient credits. Need at least {} credits to purchase one token", min_price)
@@ -1060,7 +1060,7 @@ impl TokensScreen {
                                 // Remove button
                                 if ui
                                     .button("X")
-                                    .on_hover_text("Remove token from DET")
+                                    .clickable_tooltip("Remove token from DET")
                                     .clicked()
                                 {
                                     self.confirm_remove_token_popup = true;

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -21,7 +21,7 @@ use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt, Result
 use crate::ui::helpers::{TransactionType, add_key_chooser};
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
@@ -558,7 +558,7 @@ impl ScreenLike for TransferTokensScreen {
                     let mut txt = self.public_note.clone().unwrap_or_default();
                     if ui
                         .text_edit_singleline(&mut txt)
-                        .on_hover_text(
+                        .info_tooltip(
                             "A note about the transaction that can be seen by the public.",
                         )
                         .changed()

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -553,16 +553,12 @@ impl ScreenLike for TransferTokensScreen {
                 ui.heading(format!("{}. Public note (optional)", step_num));
                 ui.add_space(5.0);
                 ui.horizontal(|ui| {
-                    ui.label("Public note (optional):");
+                    ui.label("Public note (optional):").info_tooltip(
+                        "A note about the transaction that can be seen by the public.",
+                    );
                     ui.add_space(10.0);
                     let mut txt = self.public_note.clone().unwrap_or_default();
-                    if ui
-                        .text_edit_singleline(&mut txt)
-                        .info_tooltip(
-                            "A note about the transaction that can be seen by the public.",
-                        )
-                        .changed()
-                    {
+                    if ui.text_edit_singleline(&mut txt).changed() {
                         self.public_note = Some(txt);
                     }
                 });

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -610,7 +610,7 @@ impl ScreenLike for TransferTokensScreen {
                 };
 
                 if ComponentStyles::add_primary_button_enabled(ui, ready, "Transfer")
-                    .on_disabled_hover_text(&hover_text)
+                    .disabled_tooltip(&hover_text)
                     .clicked()
                 {
                     // Use the amount value directly since it's already parsed

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -535,16 +535,12 @@ impl ScreenLike for UnfreezeTokensScreen {
                     ));
                 } else {
                     ui.horizontal(|ui| {
-                        ui.label("Public note (optional):");
+                        ui.label("Public note (optional):").info_tooltip(
+                            "A note about the transaction that can be seen by the public.",
+                        );
                         ui.add_space(10.0);
                         let mut txt = self.public_note.clone().unwrap_or_default();
-                        if ui
-                            .text_edit_singleline(&mut txt)
-                            .info_tooltip(
-                                "A note about the transaction that can be seen by the public.",
-                            )
-                            .changed()
-                        {
+                        if ui.text_edit_singleline(&mut txt).changed() {
                             self.public_note = if !txt.is_empty() { Some(txt) } else { None };
                         }
                     });

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -21,7 +21,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -540,7 +540,7 @@ impl ScreenLike for UnfreezeTokensScreen {
                         let mut txt = self.public_note.clone().unwrap_or_default();
                         if ui
                             .text_edit_singleline(&mut txt)
-                            .on_hover_text(
+                            .info_tooltip(
                                 "A note about the transaction that can be seen by the public.",
                             )
                             .changed()

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -18,7 +18,7 @@ use crate::ui::helpers::{TransactionType, add_key_chooser, render_group_action_t
 use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::identities::keys::key_info_screen::KeyInfoScreen;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::tokens::validate_signing_key;
 use crate::ui::{MessageType, Screen, ScreenLike};
 use dash_sdk::dpp::data_contract::GroupContractPosition;
@@ -708,7 +708,7 @@ impl UpdateTokenConfigScreen {
                 let mut txt = self.public_note.clone().unwrap_or_default();
                 if ui
                     .text_edit_singleline(&mut txt)
-                    .on_hover_text("A note about the transaction that can be seen by the public.")
+                    .info_tooltip("A note about the transaction that can be seen by the public.")
                     .changed()
                 {
                     self.public_note = if !txt.is_empty() { Some(txt) } else { None };

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::{ConfirmationDialog, ConfirmationStatus, island_central_panel};
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dashcore_rpc::RpcApi;
 use dash_sdk::dashcore_rpc::json::QuorumType;
@@ -1529,7 +1529,7 @@ impl MasternodeListDiffScreen {
                     }
                     if ui
                         .button("Clear")
-                        .on_hover_text("Clear all data and reset to initial state.")
+                        .clickable_tooltip("Clear all data and reset to initial state.")
                         .clicked()
                     {
                         self.clear();
@@ -1537,7 +1537,7 @@ impl MasternodeListDiffScreen {
                     }
                     if ui
                         .button("Clear keep base")
-                        .on_hover_text(
+                        .clickable_tooltip(
                             "Clear all data except the oldest MNList diff starting from height 0.",
                         )
                         .clicked()

--- a/src/ui/tools/proof_log_screen.rs
+++ b/src/ui/tools/proof_log_screen.rs
@@ -5,7 +5,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::drive::grovedb::operations::proof::GroveDBProof;
 use dash_sdk::drive::query::PathQuery;
@@ -118,7 +118,7 @@ impl ProofLogScreen {
                         // Table headers with sorting
                         if ui
                             .button("Request Type")
-                            .on_hover_text("Click to sort by Request Type")
+                            .clickable_tooltip("Click to sort by Request Type")
                             .clicked()
                         {
                             self.sort_column = ProofLogColumn::RequestType;
@@ -127,7 +127,7 @@ impl ProofLogScreen {
                         }
                         if ui
                             .button("Height")
-                            .on_hover_text("Click to sort by Height")
+                            .clickable_tooltip("Click to sort by Height")
                             .clicked()
                         {
                             self.sort_column = ProofLogColumn::Height;
@@ -136,7 +136,7 @@ impl ProofLogScreen {
                         }
                         if ui
                             .button("Time")
-                            .on_hover_text("Click to sort by Time")
+                            .clickable_tooltip("Click to sort by Time")
                             .clicked()
                         {
                             self.sort_column = ProofLogColumn::Time;
@@ -145,7 +145,7 @@ impl ProofLogScreen {
                         }
                         if ui
                             .button("Error")
-                            .on_hover_text("Click to sort by Error")
+                            .clickable_tooltip("Click to sort by Error")
                             .clicked()
                         {
                             self.sort_column = ProofLogColumn::Error;
@@ -183,7 +183,7 @@ impl ProofLogScreen {
                                     }
                                 });
                             ui.label(error_text)
-                                .on_hover_text(item.error.as_deref().unwrap_or("No Error"));
+                                .info_tooltip(item.error.as_deref().unwrap_or("No Error"));
 
                             ui.end_row();
                         }

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -7,7 +7,7 @@ use crate::ui::components::message_banner::{BannerHandle, MessageBanner, OptionB
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
@@ -191,7 +191,7 @@ impl TransitionVisualizerScreen {
                         }
                         if ui
                             .link(contract_id)
-                            .on_hover_text("Click to view contract")
+                            .clickable_tooltip("Click to view contract")
                             .clicked()
                         {
                             self.selected_contract_id = Some(contract_id.clone());

--- a/src/ui/wallets/wallets_screen/asset_locks.rs
+++ b/src/ui/wallets/wallets_screen/asset_locks.rs
@@ -1,7 +1,7 @@
 use crate::app::AppAction;
 use crate::model::wallet::DerivationPathHelpers;
 use crate::ui::ScreenType;
-use crate::ui::theme::DashColors;
+use crate::ui::theme::{DashColors, ResponseExt};
 use eframe::egui::{self, Ui};
 use egui::{Color32, Frame, Margin, RichText};
 use egui_extras::{Column, TableBuilder};
@@ -33,7 +33,7 @@ impl WalletsBalancesScreen {
                                     ScreenType::CreateAssetLock(arc_wallet.clone()).create_screen(&self.app_context)
                                 );
                             }
-                            if ui.button("Search for Unused").on_hover_text("Scan Core wallet for untracked asset locks").clicked() {
+                            if ui.button("Search for Unused").clickable_tooltip("Scan Core wallet for untracked asset locks").clicked() {
                                 recover_asset_locks_clicked = true;
                             }
                         });
@@ -123,7 +123,7 @@ impl WalletsBalancesScreen {
                                         ui.label(status);
                                     });
                                     row.col(|ui| {
-                                        if ui.small_button("View").on_hover_text("View full asset lock details").clicked() {
+                                        if ui.small_button("View").clickable_tooltip("View full asset lock details").clicked() {
                                             app_action = AppAction::AddScreen(
                                                 ScreenType::AssetLockDetail(
                                                     wallet.seed_hash(),
@@ -132,7 +132,7 @@ impl WalletsBalancesScreen {
                                             );
                                         }
                                         if proof.is_some()
-                                            && ui.small_button("Fund").on_hover_text("Fund a Platform address with this asset lock").clicked() {
+                                            && ui.small_button("Fund").clickable_tooltip("Fund a Platform address with this asset lock").clicked() {
                                                 open_fund_dialog_for_idx = Some((index, platform_addresses.clone()));
                                             }
                                     });

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -23,7 +23,7 @@ use crate::ui::components::wallet_unlock_popup::{WalletUnlockPopup, WalletUnlock
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt};
 use crate::ui::helpers::clicked_outside_window;
 use crate::ui::helpers::copy_text_to_clipboard;
-use crate::ui::theme::{ComponentStyles, DashColors};
+use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use crate::ui::wallets::account_summary::{
     AccountCategory, AccountSummary, collect_account_summaries,
 };
@@ -1225,10 +1225,10 @@ impl WalletsBalancesScreen {
                             let full_txid = tx.txid.to_string();
                             ui.horizontal(|ui| {
                                 let response = ui.label(RichText::new(&full_txid).monospace());
-                                response.on_hover_text(&full_txid);
+                                response.info_tooltip(&full_txid);
                                 if ui
                                     .small_button("Copy")
-                                    .on_hover_text("Copy transaction ID")
+                                    .clickable_tooltip("Copy transaction ID")
                                     .clicked()
                                 {
                                     let _ = copy_text_to_clipboard(&full_txid);


### PR DESCRIPTION
## Summary

Introduces a `ResponseExt` trait for `egui::Response` that enforces a consistent tooltip cursor policy across the UI. Three semantic methods replace raw `.on_hover_text()` calls:

| Method | Cursor | Use case |
|---|---|---|
| `.info_tooltip()` | Help (❓) | Informational labels, non-interactive elements |
| `.clickable_tooltip()` | PointingHand (👆) | Clickable/actionable elements |
| `.disabled_tooltip()` | NotAllowed (🚫) | Disabled elements explaining why unavailable |

- Migrates ~56 callsites across 30 files to use the new trait methods
- Adds documentation section to `docs/ux-design-patterns.md`
- `disabled_tooltip()` uses `on_disabled_hover_text()` so tooltips appear correctly on disabled widgets
- Buttons using `add_enabled()` split tooltip path: `clickable_tooltip` when enabled, `disabled_tooltip` when disabled
- `info_tooltip()` on editable `TextEdit` fields moved to their labels to preserve the I-beam cursor
- Connection indicator uses contextual tooltip (clickable only when Dash-Qt can be launched)

## Test plan

- [ ] Hover over clickable buttons → PointingHand cursor + tooltip
- [ ] Hover over disabled buttons → NotAllowed cursor + tooltip visible
- [ ] Hover over info labels → Help cursor + tooltip
- [ ] Hover over "Public note" text inputs → normal I-beam cursor (tooltip on label only)
- [ ] Hover over connection indicator when disconnected in RPC mode → PointingHand cursor
- [ ] Hover over connection indicator when connected → Help cursor
- [ ] Verify no regressions in existing tooltip text content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three standardized tooltip types: info, clickable, and disabled — with matching cursor feedback and click-aware behavior.

* **Refactor**
  * Replaced many hover-only helper texts across the UI with the new tooltip helpers for consistent, accessible interactions and proper enabled/disabled affordances.

* **Documentation**
  * UX guidance added recommending the new tooltip helpers; the new subsection was unintentionally duplicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->