### PR TITLE
fix: include identity name in auth key missing error messages

### DIFF
--- a/src/backend_task/identity/register_dpns_name.rs
+++ b/src/backend_task/identity/register_dpns_name.rs
@@ -125,10 +125,12 @@ impl AppContext {
 
         let public_key = qualified_identity
             .document_signing_key(&preorder_document_type)
-            .ok_or(format!(
-                "Identity {} doesn't have an authentication key for signing document transitions",
-                qualified_identity.display_string()
-            ))?;
+            .ok_or_else(|| {
+                format!(
+                    "Identity {} doesn't have an authentication key for signing document transitions",
+                    qualified_identity.display_string()
+                )
+            })?;
 
         // Estimate fees for DPNS registration (2 document batch transitions)
         let fee_estimator = PlatformFeeEstimator::new();

--- a/src/backend_task/identity/register_dpns_name.rs
+++ b/src/backend_task/identity/register_dpns_name.rs
@@ -125,10 +125,10 @@ impl AppContext {
 
         let public_key = qualified_identity
             .document_signing_key(&preorder_document_type)
-            .ok_or(
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string(),
-            )?;
+            .ok_or(format!(
+                "Identity {} doesn't have an authentication key for signing document transitions",
+                qualified_identity.display_string()
+            ))?;
 
         // Estimate fees for DPNS registration (2 document batch transitions)
         let fee_estimator = PlatformFeeEstimator::new();

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -78,8 +78,10 @@ pub fn get_selected_wallet(
         qualified_identity
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string()
+                format!(
+                    "Identity {} doesn't have an authentication key for signing document transitions",
+                    qualified_identity.display_string()
+                )
             })?
     } else {
         // Fallback: directly use the provided selected key.


### PR DESCRIPTION
## Summary

When an identity lacks an authentication key for signing document transitions,
the error message now includes the identity name (or base58 ID if no alias is
set). This helps users with multiple identities identify which one has the
problem.

Closes #743

## Changes

- `src/ui/identities/mod.rs` — include `qualified_identity.display_string()`
  in the error from `get_selected_wallet`
- `src/backend_task/identity/register_dpns_name.rs` — same fix in the DPNS
  name registration path

## Validation

- `cargo clippy` — no warnings
- `cargo fmt --all -- --check` — clean
- `cargo check` — compiles successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when authentication keys are missing during identity registration and document processing operations. Error messages now include specific identity identifiers, providing users with clearer context to identify affected identities and resolve authentication-related issues more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->