### PR TITLE
fix(ui): include identity name in auth key error message

### DIFF
--- a/src/backend_task/identity/register_dpns_name.rs
+++ b/src/backend_task/identity/register_dpns_name.rs
@@ -125,10 +125,12 @@ impl AppContext {
 
         let public_key = qualified_identity
             .document_signing_key(&preorder_document_type)
-            .ok_or(
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string(),
-            )?;
+            .ok_or_else(|| {
+                format!(
+                    "Identity '{}' doesn't have an authentication key for signing document transitions",
+                    qualified_identity.display_string()
+                )
+            })?;
 
         // Estimate fees for DPNS registration (2 document batch transitions)
         let fee_estimator = PlatformFeeEstimator::new();

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -78,8 +78,10 @@ pub fn get_selected_wallet(
         qualified_identity
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string()
+                format!(
+                    "Identity '{}' doesn't have an authentication key for signing document transitions",
+                    qualified_identity.display_string()
+                )
             })?
     } else {
         // Fallback: directly use the provided selected key.


### PR DESCRIPTION
## Summary

When an identity lacks an authentication key for signing document transitions, the error banner now includes the identity alias (or base58 ID if no alias) so users can tell **which** identity has the issue.

Before: `Identity doesn't have an authentication key for signing document transitions`
After: `Identity 'MyEvonode' doesn't have an authentication key for signing document transitions`

This is especially helpful for users with many identities (the reporter has 16).

Closes #743

## Changes

- `src/ui/identities/mod.rs`: Use `format!()` with `display_string()` instead of static string
- `src/backend_task/identity/register_dpns_name.rs`: Same — also switched from `.ok_or()` to `.ok_or_else()` to avoid eager allocation