### PR TITLE
fix(ui): include identity name in auth key error banner

### DIFF
--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, RwLock};
 use dash_sdk::{
     dpp::{
         data_contract::accessors::v0::DataContractV0Getters,
-        identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0,
+        identity::{
+            accessors::IdentityGettersV0,
+            identity_public_key::accessors::v0::IdentityPublicKeyGettersV0,
+        },
     },
     platform::IdentityPublicKey,
 };
@@ -78,8 +81,17 @@ pub fn get_selected_wallet(
         qualified_identity
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string()
+                let id_string = qualified_identity.identity.id().to_string(
+                    dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58,
+                );
+                let identity_label = qualified_identity
+                    .alias
+                    .as_deref()
+                    .unwrap_or(&id_string);
+                format!(
+                    "Identity '{}' doesn't have an authentication key for signing document transitions",
+                    identity_label
+                )
             })?
     } else {
         // Fallback: directly use the provided selected key.


### PR DESCRIPTION
## Summary

The error banner "Identity doesn't have an authentication key for signing document transitions" now includes the identity alias (or base58 ID as fallback) so users with multiple identities can tell which one is affected.

Closes #743

## Problem

When DET starts and auto-selects an identity that lacks a DPNS document signing key (e.g., an evonode identity), a generic error banner is shown with no indication of which identity triggered it. For users with many identities this is confusing.

## Changes

- `get_selected_wallet()` in `src/ui/identities/mod.rs` now includes the identity's alias (or base58 ID) in the error message
- Added `IdentityGettersV0` import for `.id()` access

## Validation

- `cargo clippy -p dash-evo-tool --lib` — clean, no warnings
- Pre-commit hook passed (fmt + check)
- Reviewed the single changed file manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error messages when identities lack document-signing keys. Error messages now include the identity label or alias instead of generic text, providing clearer identification during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->