### PR TITLE
fix(ui): improve auth key error message and suppress on startup auto-select

### DIFF
--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -103,11 +103,10 @@ impl ContactRequests {
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
-            // Get wallet for the selected identity
+            // Get wallet for the selected identity (don't show error on auto-select;
+            // some identities like evonodes may lack document signing keys)
             new_self.selected_wallet =
-                get_selected_wallet(&identities[0], Some(&app_context), None)
-                    .or_show_error(app_context.egui_ctx())
-                    .unwrap_or(None);
+                get_selected_wallet(&identities[0], Some(&app_context), None).unwrap_or(None);
 
             // Load requests from database for this identity
             new_self.load_requests_from_database();

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -77,11 +77,10 @@ impl QRCodeGeneratorScreen {
             new_self.selected_identity_string =
                 identities[0].identity.id().to_string(Encoding::Base58);
 
-            // Get wallet for the selected identity
+            // Get wallet for the selected identity (don't show error on auto-select;
+            // some identities like evonodes may lack document signing keys)
             new_self.selected_wallet =
-                get_selected_wallet(&identities[0], Some(&app_context), None)
-                    .or_show_error(app_context.egui_ctx())
-                    .unwrap_or(None);
+                get_selected_wallet(&identities[0], Some(&app_context), None).unwrap_or(None);
         }
 
         new_self

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -78,8 +78,17 @@ pub fn get_selected_wallet(
         qualified_identity
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string()
+                use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                let identity_label = qualified_identity
+                    .alias
+                    .as_deref()
+                    .or_else(|| qualified_identity.dpns_names.first().map(|n| n.name.as_str()))
+                    .unwrap_or("unknown");
+                format!(
+                    "Identity '{}' ({}) doesn't have an authentication key for signing document transitions",
+                    identity_label,
+                    qualified_identity.identity.id()
+                )
             })?
     } else {
         // Fallback: directly use the provided selected key.


### PR DESCRIPTION
## Issue
Closes #743 — On startup, DET shows a confusing "Identity doesn't have an authentication key for signing document transitions" error banner with no indication of which identity is affected.

## Changes
1. **Better error message:** Include the identity alias/DPNS name and ID in the error, so users with multiple identities can identify which one lacks a signing key.

   Before: `Identity doesn't have an authentication key for signing document transitions`
   After: `Identity 'my-evonode' (7xK3...) doesn't have an authentication key for signing document transitions`

2. **Suppress banner on auto-select:** The ContactRequests and QRCodeGenerator screens auto-select the first identity during construction. If that identity lacks a document signing key (e.g., evonode identities), the error was shown immediately before the user did anything. Now these screens silently set wallet to `None` on auto-select — the error only appears when the user explicitly selects an identity that lacks the key.

## Testing
- `cargo check` — clean
- `cargo clippy` — clean
- `cargo fmt` — clean