### PR TITLE
fix(ui): improve auth key error message and suppress on startup auto-select

### DIFF
--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -15,7 +15,7 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::components::{MessageBanner, ResultBannerExt};
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
-use crate::ui::identities::{get_selected_wallet, is_missing_document_signing_key_error};
+use crate::ui::identities::{auto_selected_wallet_or_banner, get_selected_wallet};
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, Screen, ScreenLike, ScreenType};
 use dash_sdk::dpp::document::DocumentV0Getters;
@@ -115,19 +115,10 @@ impl ContactRequests {
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
-            // Get wallet for the selected identity. Suppress the expected
-            // "missing document-signing key" error on auto-select (some
-            // identities, e.g. evonodes, legitimately lack one); surface
-            // anything else so we don't silently hide real failures.
-            new_self.selected_wallet =
-                match get_selected_wallet(&preferred, Some(&app_context), None) {
-                    Ok(wallet) => wallet,
-                    Err(e) if is_missing_document_signing_key_error(&e) => None,
-                    Err(e) => {
-                        MessageBanner::set_global(app_context.egui_ctx(), &e, MessageType::Error);
-                        None
-                    }
-                };
+            new_self.selected_wallet = auto_selected_wallet_or_banner(
+                app_context.egui_ctx(),
+                get_selected_wallet(&preferred, Some(&app_context), None),
+            );
         }
 
         new_self

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -14,8 +14,8 @@ use crate::ui::components::wallet_unlock_popup::{
     WalletUnlockPopup, WalletUnlockResult, try_open_wallet_no_password, wallet_needs_unlock,
 };
 use crate::ui::components::{MessageBanner, ResultBannerExt};
-use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
+use crate::ui::identities::{get_selected_wallet, is_missing_document_signing_key_error};
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, Screen, ScreenLike, ScreenType};
 use dash_sdk::dpp::document::DocumentV0Getters;
@@ -115,10 +115,19 @@ impl ContactRequests {
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
-            // Get wallet for the selected identity (don't show error on auto-select;
-            // some identities like evonodes may lack document signing keys)
+            // Get wallet for the selected identity. Suppress the expected
+            // "missing document-signing key" error on auto-select (some
+            // identities, e.g. evonodes, legitimately lack one); surface
+            // anything else so we don't silently hide real failures.
             new_self.selected_wallet =
-                get_selected_wallet(&preferred, Some(&app_context), None).unwrap_or(None);
+                match get_selected_wallet(&preferred, Some(&app_context), None) {
+                    Ok(wallet) => wallet,
+                    Err(e) if is_missing_document_signing_key_error(&e) => None,
+                    Err(e) => {
+                        MessageBanner::set_global(app_context.egui_ctx(), &e, MessageType::Error);
+                        None
+                    }
+                };
         }
 
         new_self

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -115,10 +115,10 @@ impl ContactRequests {
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
-            // Get wallet for the selected identity
-            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
-                .or_show_error(app_context.egui_ctx())
-                .unwrap_or(None);
+            // Get wallet for the selected identity (don't show error on auto-select;
+            // some identities like evonodes may lack document signing keys)
+            new_self.selected_wallet =
+                get_selected_wallet(&preferred, Some(&app_context), None).unwrap_or(None);
         }
 
         new_self

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -17,7 +17,7 @@ use crate::ui::components::wallet_unlock_popup::{
 };
 use crate::ui::components::{MessageBanner, ResultBannerExt};
 use crate::ui::helpers::{ModalOpeningGuard, clicked_outside_window_after_open};
-use crate::ui::identities::get_selected_wallet;
+use crate::ui::identities::{auto_selected_wallet_or_banner, get_selected_wallet};
 use crate::ui::state::AvatarCache;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
@@ -134,9 +134,10 @@ impl ProfileScreen {
                 new_self.selected_identity_string
             );
 
-            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
-                .or_show_error(app_context.egui_ctx())
-                .unwrap_or(None);
+            new_self.selected_wallet = auto_selected_wallet_or_banner(
+                app_context.egui_ctx(),
+                get_selected_wallet(&preferred, Some(&app_context), None),
+            );
         }
 
         new_self

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -16,7 +16,7 @@ use crate::ui::components::wallet_unlock_popup::{
 use crate::ui::components::{MessageBanner, ResultBannerExt};
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::identities::funding_common::generate_qr_code_image;
-use crate::ui::identities::get_selected_wallet;
+use crate::ui::identities::{get_selected_wallet, is_missing_document_signing_key_error};
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use eframe::epaint::TextureHandle;
@@ -82,10 +82,19 @@ impl QRCodeGeneratorScreen {
             new_self.selected_identity = Some(preferred.clone());
             new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
 
-            // Get wallet for the selected identity (don't show error on auto-select;
-            // some identities like evonodes may lack document signing keys)
+            // Get wallet for the selected identity. Suppress the expected
+            // "missing document-signing key" error on auto-select (some
+            // identities, e.g. evonodes, legitimately lack one); surface
+            // anything else so we don't silently hide real failures.
             new_self.selected_wallet =
-                get_selected_wallet(&preferred, Some(&app_context), None).unwrap_or(None);
+                match get_selected_wallet(&preferred, Some(&app_context), None) {
+                    Ok(wallet) => wallet,
+                    Err(e) if is_missing_document_signing_key_error(&e) => None,
+                    Err(e) => {
+                        MessageBanner::set_global(app_context.egui_ctx(), &e, MessageType::Error);
+                        None
+                    }
+                };
         }
 
         new_self

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -82,10 +82,10 @@ impl QRCodeGeneratorScreen {
             new_self.selected_identity = Some(preferred.clone());
             new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
 
-            // Get wallet for the selected identity
-            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
-                .or_show_error(app_context.egui_ctx())
-                .unwrap_or(None);
+            // Get wallet for the selected identity (don't show error on auto-select;
+            // some identities like evonodes may lack document signing keys)
+            new_self.selected_wallet =
+                get_selected_wallet(&preferred, Some(&app_context), None).unwrap_or(None);
         }
 
         new_self

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -16,7 +16,7 @@ use crate::ui::components::wallet_unlock_popup::{
 use crate::ui::components::{MessageBanner, ResultBannerExt};
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::identities::funding_common::generate_qr_code_image;
-use crate::ui::identities::{get_selected_wallet, is_missing_document_signing_key_error};
+use crate::ui::identities::{auto_selected_wallet_or_banner, get_selected_wallet};
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use eframe::epaint::TextureHandle;
@@ -82,19 +82,10 @@ impl QRCodeGeneratorScreen {
             new_self.selected_identity = Some(preferred.clone());
             new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
 
-            // Get wallet for the selected identity. Suppress the expected
-            // "missing document-signing key" error on auto-select (some
-            // identities, e.g. evonodes, legitimately lack one); surface
-            // anything else so we don't silently hide real failures.
-            new_self.selected_wallet =
-                match get_selected_wallet(&preferred, Some(&app_context), None) {
-                    Ok(wallet) => wallet,
-                    Err(e) if is_missing_document_signing_key_error(&e) => None,
-                    Err(e) => {
-                        MessageBanner::set_global(app_context.egui_ctx(), &e, MessageType::Error);
-                        None
-                    }
-                };
+            new_self.selected_wallet = auto_selected_wallet_or_banner(
+                app_context.egui_ctx(),
+                get_selected_wallet(&preferred, Some(&app_context), None),
+            );
         }
 
         new_self

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -51,16 +51,16 @@ impl fmt::Display for SelectedWalletError {
                 if let Some(identity_label) = identity_label {
                     write!(
                         f,
-                        "Identity {identity_label} ({identity_id}) cannot sign DashPay actions \
-                         because it has no signing key. Add a signing key with high or critical \
-                         security level to this identity, or choose a different identity."
+                        "Identity {identity_label} ({identity_id}) cannot sign this action \
+                         because it has no high-security signing key. Add a high-security \
+                         signing key to this identity, or choose a different identity."
                     )
                 } else {
                     write!(
                         f,
-                        "Identity {identity_id} cannot sign DashPay actions because it has no \
-                         signing key. Add a signing key with high or critical security level to \
-                         this identity, or choose a different identity."
+                        "Identity {identity_id} cannot sign this action because it has no \
+                         high-security signing key. Add a high-security signing key to this \
+                         identity, or choose a different identity."
                     )
                 }
             }
@@ -292,9 +292,9 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Identity Test Identity (TestIdentityId) cannot sign DashPay actions because it has \
-             no signing key. Add a signing key with high or critical security level to this \
-             identity, or choose a different identity."
+            "Identity Test Identity (TestIdentityId) cannot sign this action because it has no \
+             high-security signing key. Add a high-security signing key to this identity, or \
+             choose a different identity."
         );
     }
 
@@ -304,9 +304,9 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "Identity TestIdentityId cannot sign DashPay actions because it has no signing key. \
-             Add a signing key with high or critical security level to this identity, or choose \
-             a different identity."
+            "Identity TestIdentityId cannot sign this action because it has no high-security \
+             signing key. Add a high-security signing key to this identity, or choose a \
+             different identity."
         );
     }
 

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -1,12 +1,19 @@
+use std::error::Error as StdError;
+use std::fmt;
 use std::sync::{Arc, RwLock};
 
 use dash_sdk::{
-    dpp::data_contract::accessors::v0::DataContractV0Getters, platform::IdentityPublicKey,
+    dpp::{
+        data_contract::accessors::v0::DataContractV0Getters,
+        data_contract::errors::DataContractError,
+    },
+    platform::IdentityPublicKey,
 };
 
 use crate::{
     context::AppContext,
     model::{qualified_identity::QualifiedIdentity, wallet::Wallet},
+    ui::{MessageType, components::MessageBanner},
 };
 
 pub mod add_existing_identity_screen;
@@ -19,18 +26,79 @@ pub mod top_up_identity_screen;
 pub mod transfer_screen;
 pub mod withdraw_screen;
 
-/// Substring used to identify the "missing document-signing key" error returned
-/// by [`get_selected_wallet`] when an identity has no key suitable for signing
-/// document state transitions. Callsites that auto-select an identity (e.g.
-/// DashPay startup) use this to suppress the expected case while still
-/// surfacing unrelated errors.
-const MISSING_DOCUMENT_SIGNING_KEY_MARKER: &str =
-    "doesn't have an authentication key for signing document transitions";
+#[derive(Debug)]
+pub enum SelectedWalletError {
+    DpnsPreorderDocumentTypeNotFound {
+        source: DataContractError,
+    },
+    MissingDocumentSigningKey {
+        identity_label: Option<String>,
+        identity_id: String,
+    },
+    NoKeyProvided,
+}
 
-/// Returns `true` if the given error string is the expected
-/// "identity has no document-signing key" error from [`get_selected_wallet`].
-pub fn is_missing_document_signing_key_error(error: &str) -> bool {
-    error.contains(MISSING_DOCUMENT_SIGNING_KEY_MARKER)
+impl fmt::Display for SelectedWalletError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DpnsPreorderDocumentTypeNotFound { .. } => {
+                write!(f, "DPNS preorder document type not found")
+            }
+            Self::MissingDocumentSigningKey {
+                identity_label,
+                identity_id,
+            } => {
+                if let Some(identity_label) = identity_label {
+                    write!(
+                        f,
+                        "Identity {identity_label} ({identity_id}) cannot sign DashPay actions \
+                         because it has no signing key. Add a signing key with high or critical \
+                         security level to this identity, or choose a different identity."
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Identity {identity_id} cannot sign DashPay actions because it has no \
+                         signing key. Add a signing key with high or critical security level to \
+                         this identity, or choose a different identity."
+                    )
+                }
+            }
+            Self::NoKeyProvided => write!(f, "No key provided when getting selected wallet"),
+        }
+    }
+}
+
+impl StdError for SelectedWalletError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::DpnsPreorderDocumentTypeNotFound { source } => Some(source),
+            Self::MissingDocumentSigningKey { .. } | Self::NoKeyProvided => None,
+        }
+    }
+}
+
+/// Returns `true` if the given error is the expected "identity has no
+/// document-signing key" error from [`get_selected_wallet`].
+pub fn is_missing_document_signing_key_error(error: &SelectedWalletError) -> bool {
+    matches!(error, SelectedWalletError::MissingDocumentSigningKey { .. })
+}
+
+/// Applies the auto-selection policy for screen construction:
+/// suppress the expected missing-document-signing-key error for
+/// auto-selected identities, but surface every other failure.
+pub fn auto_selected_wallet_or_banner(
+    ctx: &egui::Context,
+    result: Result<Option<Arc<RwLock<Wallet>>>, SelectedWalletError>,
+) -> Option<Arc<RwLock<Wallet>>> {
+    match result {
+        Ok(wallet) => wallet,
+        Err(error) if is_missing_document_signing_key_error(&error) => None,
+        Err(error) => {
+            MessageBanner::set_global(ctx, &error, MessageType::Error);
+            None
+        }
+    }
 }
 
 /// Retrieves the appropriate wallet (if any) associated with the given identity.
@@ -57,8 +125,8 @@ pub fn is_missing_document_signing_key_error(error: &str) -> bool {
 /// # Returns
 ///
 /// Returns `Ok(Some(Arc<RwLock<Wallet>>))` if a matching wallet is found,
-/// `Ok(None)` if no wallet is associated with the key, or `Err(String)` if
-/// an error is encountered.
+/// `Ok(None)` if no wallet is associated with the key, or
+/// `Err(SelectedWalletError)` if an error is encountered.
 ///
 /// # Errors
 ///
@@ -69,7 +137,7 @@ pub fn get_selected_wallet(
     qualified_identity: &QualifiedIdentity,
     app_context: Option<&AppContext>,
     selected_key: Option<&IdentityPublicKey>,
-) -> Result<Option<Arc<RwLock<Wallet>>>, String> {
+) -> Result<Option<Arc<RwLock<Wallet>>>, SelectedWalletError> {
     // If `app_context` is provided, use the DPNS-based approach.
     let public_key = if let Some(context) = app_context {
         let dpns_contract = &context.dpns_contract;
@@ -77,7 +145,7 @@ pub fn get_selected_wallet(
         // Attempt to fetch the `preorder` document type from the DPNS contract.
         let preorder_document_type = dpns_contract
             .document_type_for_name("preorder")
-            .map_err(|e| format!("DPNS preorder document type not found: {}", e))?;
+            .map_err(|source| SelectedWalletError::DpnsPreorderDocumentTypeNotFound { source })?;
 
         // Attempt to retrieve the public key from the identity.
         qualified_identity
@@ -85,26 +153,20 @@ pub fn get_selected_wallet(
             .ok_or_else(|| {
                 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
                 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-                let identity_label = qualified_identity
-                    .alias
-                    .as_deref()
-                    .or_else(|| {
-                        qualified_identity
-                            .dpns_names
-                            .first()
-                            .map(|n| n.name.as_str())
-                    })
-                    .unwrap_or("");
-                format!(
-                    "Identity {} ({}) {}",
-                    identity_label,
-                    qualified_identity.identity.id().to_string(Encoding::Base58),
-                    MISSING_DOCUMENT_SIGNING_KEY_MARKER,
-                )
+                let identity_label = qualified_identity.alias.as_deref().or_else(|| {
+                    qualified_identity
+                        .dpns_names
+                        .first()
+                        .map(|n| n.name.as_str())
+                });
+                SelectedWalletError::MissingDocumentSigningKey {
+                    identity_label: identity_label.map(str::to_owned),
+                    identity_id: qualified_identity.identity.id().to_string(Encoding::Base58),
+                }
             })?
     } else {
         // Fallback: directly use the provided selected key.
-        selected_key.ok_or_else(|| "No key provided when getting selected wallet".to_string())?
+        selected_key.ok_or(SelectedWalletError::NoKeyProvided)?
     };
 
     // Once we have the public key (either from DPNS or directly), ask which
@@ -214,6 +276,64 @@ mod tests {
         assert!(
             selected.is_some(),
             "the wallet deriving this key must be found whichever placement names it"
+        );
+    }
+
+    fn missing_document_signing_key_error(identity_label: Option<&str>) -> SelectedWalletError {
+        SelectedWalletError::MissingDocumentSigningKey {
+            identity_label: identity_label.map(str::to_owned),
+            identity_id: "TestIdentityId".to_string(),
+        }
+    }
+
+    #[test]
+    fn missing_document_signing_key_display_includes_label_when_present() {
+        let error = missing_document_signing_key_error(Some("Test Identity"));
+
+        assert_eq!(
+            error.to_string(),
+            "Identity Test Identity (TestIdentityId) cannot sign DashPay actions because it has \
+             no signing key. Add a signing key with high or critical security level to this \
+             identity, or choose a different identity."
+        );
+    }
+
+    #[test]
+    fn missing_document_signing_key_display_uses_identity_id_without_label() {
+        let error = missing_document_signing_key_error(None);
+
+        assert_eq!(
+            error.to_string(),
+            "Identity TestIdentityId cannot sign DashPay actions because it has no signing key. \
+             Add a signing key with high or critical security level to this identity, or choose \
+             a different identity."
+        );
+    }
+
+    #[test]
+    fn auto_selection_policy_suppresses_missing_document_signing_key() {
+        let ctx = egui::Context::default();
+
+        let wallet =
+            auto_selected_wallet_or_banner(&ctx, Err(missing_document_signing_key_error(None)));
+
+        assert!(wallet.is_none());
+        assert!(
+            !MessageBanner::has_global(&ctx),
+            "automatic selection must suppress the typed missing-document-signing-key banner"
+        );
+    }
+
+    #[test]
+    fn auto_selection_policy_surfaces_unrelated_selected_wallet_error() {
+        let ctx = egui::Context::default();
+
+        let wallet = auto_selected_wallet_or_banner(&ctx, Err(SelectedWalletError::NoKeyProvided));
+
+        assert!(wallet.is_none());
+        assert!(
+            MessageBanner::has_global(&ctx),
+            "automatic selection must only suppress MissingDocumentSigningKey"
         );
     }
 }

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -69,8 +69,17 @@ pub fn get_selected_wallet(
         qualified_identity
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
-                "Identity doesn't have an authentication key for signing document transitions"
-                    .to_string()
+                use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                let identity_label = qualified_identity
+                    .alias
+                    .as_deref()
+                    .or_else(|| qualified_identity.dpns_names.first().map(|n| n.name.as_str()))
+                    .unwrap_or("unknown");
+                format!(
+                    "Identity '{}' ({}) doesn't have an authentication key for signing document transitions",
+                    identity_label,
+                    qualified_identity.identity.id()
+                )
             })?
     } else {
         // Fallback: directly use the provided selected key.

--- a/src/ui/identities/mod.rs
+++ b/src/ui/identities/mod.rs
@@ -19,6 +19,20 @@ pub mod top_up_identity_screen;
 pub mod transfer_screen;
 pub mod withdraw_screen;
 
+/// Substring used to identify the "missing document-signing key" error returned
+/// by [`get_selected_wallet`] when an identity has no key suitable for signing
+/// document state transitions. Callsites that auto-select an identity (e.g.
+/// DashPay startup) use this to suppress the expected case while still
+/// surfacing unrelated errors.
+const MISSING_DOCUMENT_SIGNING_KEY_MARKER: &str =
+    "doesn't have an authentication key for signing document transitions";
+
+/// Returns `true` if the given error string is the expected
+/// "identity has no document-signing key" error from [`get_selected_wallet`].
+pub fn is_missing_document_signing_key_error(error: &str) -> bool {
+    error.contains(MISSING_DOCUMENT_SIGNING_KEY_MARKER)
+}
+
 /// Retrieves the appropriate wallet (if any) associated with the given identity.
 ///
 /// # Description
@@ -70,15 +84,22 @@ pub fn get_selected_wallet(
             .document_signing_key(&preorder_document_type)
             .ok_or_else(|| {
                 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                use dash_sdk::dpp::platform_value::string_encoding::Encoding;
                 let identity_label = qualified_identity
                     .alias
                     .as_deref()
-                    .or_else(|| qualified_identity.dpns_names.first().map(|n| n.name.as_str()))
-                    .unwrap_or("unknown");
+                    .or_else(|| {
+                        qualified_identity
+                            .dpns_names
+                            .first()
+                            .map(|n| n.name.as_str())
+                    })
+                    .unwrap_or("");
                 format!(
-                    "Identity '{}' ({}) doesn't have an authentication key for signing document transitions",
+                    "Identity {} ({}) {}",
                     identity_label,
-                    qualified_identity.identity.id()
+                    qualified_identity.identity.id().to_string(Encoding::Base58),
+                    MISSING_DOCUMENT_SIGNING_KEY_MARKER,
                 )
             })?
     } else {

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -264,7 +264,7 @@ impl SetTokenPriceScreen {
         let selected_wallet =
             get_selected_wallet(&identity_token_info.identity, None, possible_key).unwrap_or_else(
                 |e| {
-                    set_error_banner(&e);
+                    set_error_banner(&e.to_string());
                     None
                 },
             );

--- a/src/ui/tokens/token_action_screen.rs
+++ b/src/ui/tokens/token_action_screen.rs
@@ -192,7 +192,7 @@ impl<A: TokenAction> TokenActionScreen<A> {
         let selected_wallet =
             get_selected_wallet(&identity_token_info.identity, None, possible_key.as_ref())
                 .unwrap_or_else(|e| {
-                    super::set_error_banner(app_context, &e);
+                    super::set_error_banner(app_context, &e.to_string());
                     None
                 });
 

--- a/tests/kittest/dashpay_screen.rs
+++ b/tests/kittest/dashpay_screen.rs
@@ -13,6 +13,7 @@ use dash_evo_tool::context::AppContext;
 use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
 use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
 use dash_evo_tool::ui::ScreenLike;
+use dash_evo_tool::ui::components::MessageBanner;
 use dash_evo_tool::ui::dashpay::add_contact_screen::AddContactScreen;
 use dash_evo_tool::ui::dashpay::contact_requests::ContactRequests;
 use dash_evo_tool::ui::dashpay::contacts_list::ContactsList;
@@ -27,7 +28,10 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::platform::Identifier;
 use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// On the Contacts subscreen, a `MissingEncryptionKey` error must route to
@@ -166,6 +170,34 @@ fn contact_requests_defaults_to_app_scoped_identity() {
     });
 }
 
+/// `ContactRequests::new()` must suppress only the typed startup
+/// `MissingDocumentSigningKey` selection banner for wallet-less identities.
+#[test]
+fn contact_requests_startup_suppresses_missing_document_signing_key_banner() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let selected = seed_dp_identity(&ctx, 0xD5, "CR Startup Missing Key");
+        ctx.set_selected_identity(Some(selected));
+        MessageBanner::clear_all_global(ctx.egui_ctx());
+
+        let screen = ContactRequests::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(selected),
+            "ContactRequests must still select the app-scoped identity at startup"
+        );
+        assert!(
+            !MessageBanner::has_global(ctx.egui_ctx()),
+            "ContactRequests startup must suppress the typed missing-document-signing-key banner"
+        );
+    });
+}
+
 /// `PaymentHistory::new()` must default to the app-scoped identity.
 #[test]
 fn payment_history_defaults_to_app_scoped_identity() {
@@ -214,6 +246,85 @@ fn profile_screen_defaults_to_app_scoped_identity() {
     });
 }
 
+/// `ProfileScreen::new()` must suppress only the typed startup
+/// `MissingDocumentSigningKey` selection banner for wallet-less identities.
+#[test]
+fn profile_screen_startup_suppresses_missing_document_signing_key_banner() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let selected = seed_dp_identity(&ctx, 0x23, "PS Startup Missing Key");
+        ctx.set_selected_identity(Some(selected));
+        MessageBanner::clear_all_global(ctx.egui_ctx());
+
+        let screen = ProfileScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(selected),
+            "ProfileScreen must still select the app-scoped identity at startup"
+        );
+        assert!(
+            !MessageBanner::has_global(ctx.egui_ctx()),
+            "ProfileScreen startup must suppress the typed missing-document-signing-key banner"
+        );
+    });
+}
+
+/// Explicit/user-initiated profile identity selection must still surface the
+/// typed `MissingDocumentSigningKey` error through `ResultBannerExt`.
+#[test]
+fn profile_screen_user_selection_surfaces_missing_document_signing_key_banner() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let alpha = seed_dp_identity(&ctx, 0x24, "PS Explicit Alpha");
+        let beta = seed_dp_identity(&ctx, 0x25, "PS Explicit Beta");
+        ctx.set_selected_identity(Some(alpha));
+        MessageBanner::clear_all_global(ctx.egui_ctx());
+
+        let screen = Rc::new(RefCell::new(ProfileScreen::new(ctx.clone())));
+        assert!(
+            !MessageBanner::has_global(ctx.egui_ctx()),
+            "startup construction should not leave a banner before user selection"
+        );
+
+        let screen_for_ui = Rc::clone(&screen);
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(600.0, 140.0))
+            .build_ui(move |ui| {
+                let _ = screen_for_ui.borrow_mut().render(ui);
+            });
+
+        harness.step();
+        assert!(
+            !MessageBanner::has_global(ctx.egui_ctx()),
+            "initial render should not publish the startup-suppressed error"
+        );
+
+        harness.get_by_value("PS Explicit Alpha").click();
+        harness.run_steps(2);
+        harness.get_by_label("PS Explicit Beta").click();
+        harness.run_steps(2);
+
+        assert_eq!(
+            ctx.selected_identity_id(),
+            Some(beta),
+            "the picker interaction must be a real user-initiated selection"
+        );
+        assert!(
+            MessageBanner::has_global(ctx.egui_ctx()),
+            "explicit identity selection must publish MissingDocumentSigningKey"
+        );
+    });
+}
+
 /// `QRCodeGeneratorScreen::new()` must default to the app-scoped identity.
 #[test]
 fn qr_generator_defaults_to_app_scoped_identity() {
@@ -234,6 +345,34 @@ fn qr_generator_defaults_to_app_scoped_identity() {
             screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
             Some(second),
             "QRCodeGeneratorScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `QRCodeGeneratorScreen::new()` must suppress only the typed startup
+/// `MissingDocumentSigningKey` selection banner for wallet-less identities.
+#[test]
+fn qr_generator_startup_suppresses_missing_document_signing_key_banner() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let selected = seed_dp_identity(&ctx, 0x45, "QRG Startup Missing Key");
+        ctx.set_selected_identity(Some(selected));
+        MessageBanner::clear_all_global(ctx.egui_ctx());
+
+        let screen = QRCodeGeneratorScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(selected),
+            "QRCodeGeneratorScreen must still select the app-scoped identity at startup"
+        );
+        assert!(
+            !MessageBanner::has_global(ctx.egui_ctx()),
+            "QRCodeGeneratorScreen startup must suppress the typed missing-document-signing-key banner"
         );
     });
 }


### PR DESCRIPTION
## Issue
Closes #743 — On startup, DET shows a confusing "Identity doesn't have an authentication key for signing document transitions" error banner with no indication of which identity is affected.

Supersedes #750 — recreated on top of v1.0-dev after the error handling refactor (#739) was merged, per lklimek's [request](https://github.com/dashpay/dash-evo-tool/pull/750#issuecomment-2726181571).

## Changes
1. **Better error message:** Include the identity alias/DPNS name and ID in the error, so users with multiple identities can identify which one lacks a signing key.
   - Before: `Identity doesn't have an authentication key for signing document transitions`
   - After: `Identity 'my-evonode' (4ZmR...) doesn't have an authentication key for signing document transitions`

2. **Suppress error banner on startup auto-select:** In `ContactRequests` and `QRCodeGenerator` constructors, the first identity is auto-selected. If it lacks a document signing key (e.g. evonodes), the error banner no longer fires. User-initiated selection still shows errors correctly.

## Testing
- `cargo check`, `cargo clippy`, `cargo fmt` — all clean
- Verified the three original issues from #743 are still present on v1.0-dev post-refactor, and all three are addressed by this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed an unnecessary "missing document-signing key" error during automatic wallet/identity auto-selection in dashboard and QR code screens.
  * Improved error text to include identity label and ID when document-signing key retrieval fails, and added a helper to reliably detect that specific error case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->