### PR TITLE
ci: fix model config and add MemCan to review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,5 +31,5 @@ jobs:
         uses: lklimek/claudius-review-action@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
-          memcan_url: ${{ secrets.MEMCAN_URL }}
+          memcan_url: ${{ vars.MEMCAN_URL }}
           memcan_api_key: ${{ secrets.MEMCAN_API_KEY }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,9 +24,12 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+    env:
+      ANTHROPIC_MODEL: ${{ vars.CLAUDE_MODEL || 'opus' }}
     steps:
       - name: Claudius Review
         uses: lklimek/claudius-review-action@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
-          claude_model: ${{ vars.CLAUDE_MODEL || 'opus' }}
+          memcan_url: ${{ secrets.MEMCAN_URL }}
+          memcan_api_key: ${{ secrets.MEMCAN_API_KEY }}


### PR DESCRIPTION
## Summary

- **Fix model configuration**: Replace invalid `claude_model` input (doesn't exist in claudius-review-action) with `ANTHROPIC_MODEL` env var — the correct way to control the model
- **Add MemCan support**: Wire `memcan_url` (repo variable) and `memcan_api_key` (secret) so the review agent has persistent memory across reviews

## Setup required

| Type | Name | Value |
|------|------|-------|
| Variable | `MEMCAN_URL` | MemCan server URL (e.g., `http://host:8190`) |
| Secret | `MEMCAN_API_KEY` | MemCan API key |

## Test plan

- [ ] Verify `MEMCAN_URL` variable and `MEMCAN_API_KEY` secret are configured in repo settings
- [ ] Label a test PR with `claudius-review` and confirm the review workflow runs successfully
- [ ] Check workflow logs for MemCan pre-flight message (should show available, not warning)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for code review automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->