### PR TITLE
fix(ci): statically link MinGW runtime for Windows builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,7 @@ rustflags = ["-C", "target-feature=-crt-static", "-C", "target-cpu=x86-64"]
 [target.x86_64-pc-windows-gnu]
 linker = "x86_64-w64-mingw32-gcc-posix"
 ar = "x86_64-w64-mingw32-ar"
+rustflags = ["-C", "link-args=-static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic"]
 
 [env]
 CC_x86_64_pc_windows_gnu = "x86_64-w64-mingw32-gcc-posix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,17 +94,32 @@ jobs:
         env:
           PROTOC: /usr/local/bin/protoc
 
-      - name: Windows libsql
-        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
-        run: curl -OL https://www.sqlite.org/2024/sqlite-dll-win-x64-3460100.zip && sudo unzip -o sqlite-dll-win-x64-3460100.zip -d winlibs && sudo chown -R runner:docker winlibs/ && pwd && ls -lah && cd winlibs && x86_64-w64-mingw32-dlltool -d sqlite3.def -l libsqlite3.a && ls -lah && cd .. && sudo cp winlibs/libsqlite3.a /usr/x86_64-w64-mingw32/lib/libsqlite3.a
-
       - name: Build project
         run: |
           cargo build --release --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/dash-evo-tool${{ matrix.ext }} dash-evo-tool/dash-evo-tool${{ matrix.ext }}
-          if [ -f winlibs/sqlite3.dll ]; then cp winlibs/sqlite3.dll dash-evo-tool/sqlite3.dll; fi
         env:
           OPENSSL_STATIC: "1"
+
+      - name: Verify Windows binary is self-contained
+        if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
+        run: |
+          echo "Checking DLL imports..."
+          IMPORTS=$(x86_64-w64-mingw32-objdump -p dash-evo-tool/dash-evo-tool.exe | grep "DLL Name:" | sort -u)
+          echo "$IMPORTS"
+          # Fail if any null DLL imports (broken import table)
+          if echo "$IMPORTS" | grep -q "(null)"; then
+            echo "::error::Binary has null DLL imports — broken import table detected"
+            exit 1
+          fi
+          # Fail if MinGW runtime DLLs are dynamically linked
+          for dll in libgcc_s_seh-1.dll libwinpthread-1.dll libstdc++-6.dll; do
+            if echo "$IMPORTS" | grep -qi "$dll"; then
+              echo "::error::Binary dynamically links $dll — must be statically linked"
+              exit 1
+            fi
+          done
+          echo "✅ Binary is self-contained — no MinGW runtime or null DLL dependencies"
 
       - name: Package release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
           cargo build --release --target ${{ matrix.target }}
           mv target/${{ matrix.target }}/release/dash-evo-tool${{ matrix.ext }} dash-evo-tool/dash-evo-tool${{ matrix.ext }}
           if [ -f winlibs/sqlite3.dll ]; then cp winlibs/sqlite3.dll dash-evo-tool/sqlite3.dll; fi
+        env:
+          OPENSSL_STATIC: "1"
 
       - name: Package release
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4599,6 +4599,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ arboard = { version = "3.6.0", default-features = false, features = [
     "windows-sys",
 ] }
 directories = "6.0.0"
-rusqlite = { version = "0.38.0", features = ["functions", "fallible_uint"] }
+rusqlite = { version = "0.38.0", features = ["bundled", "functions", "fallible_uint"] }
 dark-light = "2.0.0"
 image = { version = "0.25.6", default-features = false, features = [
     "png",

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -2752,6 +2752,8 @@ mod tests {
     /// Helper: register a wallet address in the test database so that
     /// `update_address_balance` can find the row.
     fn register_test_address(db: &Database, wallet: &Wallet, address: &Address) {
+        db.store_wallet(wallet, &Network::Testnet)
+            .expect("store test wallet");
         let seed_hash = wallet.seed_hash();
         let path = DerivationPath::from(vec![
             ChildNumber::Hardened { index: 44 },


### PR DESCRIPTION
## Summary

Fixes #768 — Windows users get `"The code execution cannot proceed because (null).DLL was not found"` when running dash-evo-tool.

**Root cause:** Two issues in the Windows cross-compilation setup:
1. The binary dynamically linked MinGW runtime DLLs (`libgcc_s_seh-1.dll`, `libwinpthread-1.dll`, `libstdc++-6.dll`) that don't exist on normal Windows machines
2. The `sqlite3.dll` import library was generated by `dlltool` without the `-D` flag, producing a null DLL name in the PE import table — the direct cause of the `(null).DLL` error

**Fix:**
- Add `rustflags` to `.cargo/config.toml` for `x86_64-pc-windows-gnu` that statically links GCC runtime, C++ stdlib, and pthreads
- Add `bundled` feature to `rusqlite` so SQLite is compiled from C source and statically linked — eliminates `sqlite3.dll` dependency entirely
- Remove the `Windows libsql` CI step that downloaded and created the broken import library
- Set `OPENSSL_STATIC=1` in CI build step to statically link OpenSSL
- Add a post-build sanity check that inspects the PE import table and **fails the build** if null DLL imports or MinGW runtime DLLs are found

## Test plan

- [x] Trigger release workflow manually on this branch
- [x] Verify all 5 platform builds complete successfully
- [x] Verify Windows sanity check step passes (no null DLLs, no MinGW runtime DLLs)
- [ ] Download Windows artifact and verify it runs on a clean Windows machine

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Windows build to produce self-contained executables and bundle the SQLite runtime.
  * Added CI verification to ensure Windows binaries have no external DLL dependencies.

* **Tests**
  * Updated a test helper to persist wallet state before registering test addresses for more reliable test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->