### PR TITLE
ci: add binary dependency verification for Linux, macOS, and Flatpak

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -98,8 +98,10 @@ jobs:
             echo "::error::Binary not found at $BINARY"
             exit 1
           fi
-          echo "Checking shared library dependencies..."
-          DEPS=$(ldd "$BINARY" 2>&1 || true)
+          echo "Checking shared library dependencies inside Flatpak sandbox..."
+          # Run ldd inside the Flatpak build environment so libraries resolve
+          # against the Flatpak runtime (/usr) and app (/app), not the host.
+          DEPS=$(flatpak build build-dir ldd /app/bin/dash-evo-tool 2>&1 || true)
           echo "$DEPS"
           # Fail on missing libraries (not found = will crash at runtime)
           if echo "$DEPS" | grep -q "not found"; then

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -90,6 +90,25 @@ jobs:
         run: |
           flatpak-builder --force-clean --repo=flatpak-repo build-dir flatpak/org.dash.DashEvoTool.yml
 
+
+      - name: Verify Flatpak binary dependencies
+        run: |
+          BINARY="build-dir/files/bin/dash-evo-tool"
+          if [ ! -f "$BINARY" ]; then
+            echo "::error::Binary not found at $BINARY"
+            exit 1
+          fi
+          echo "Checking shared library dependencies..."
+          DEPS=$(ldd "$BINARY" 2>&1 || true)
+          echo "$DEPS"
+          # Fail on missing libraries (not found = will crash at runtime)
+          if echo "$DEPS" | grep -q "not found"; then
+            echo "::error::Binary has missing shared library dependencies"
+            echo "$DEPS" | grep "not found"
+            exit 1
+          fi
+          echo "✅ Flatpak binary dependencies look clean"
+
       - name: Create Flatpak bundle
         run: |
           flatpak build-bundle flatpak-repo dash-evo-tool-linux-${{ matrix.arch }}.flatpak org.dash.DashEvoTool

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           DEPS=$(ldd dash-evo-tool/dash-evo-tool)
           echo "$DEPS"
           # Allowlist: only standard system libraries should appear
-          UNEXPECTED=$(echo "$DEPS" | grep "=>" | grep -v "not found" | awk '{print $1}' | grep -Ev "^(linux-vdso|libm|libc|libdl|librt|libpthread|libgcc_s|libstdc\+\+|ld-linux|libz|libssl|libcrypto)\.so")
+          UNEXPECTED=$(echo "$DEPS" | grep "=>" | grep -v "not found" | awk '{print $1}' | grep -Ev "^(linux-vdso|libm|libc|libdl|librt|libpthread|libgcc_s|libstdc\+\+|ld-linux|libz|libssl|libcrypto)\.so" || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "::warning::Unexpected shared dependencies found:"
             echo "$UNEXPECTED"
@@ -279,14 +279,14 @@ jobs:
           DEPS=$(otool -L build/dash-evo-tool)
           echo "$DEPS"
           # Only system libraries (/usr/lib/) and frameworks (/System/Library/) are allowed
-          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)")
+          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)" || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "::error::Binary links non-system libraries:"
             echo "$UNEXPECTED"
             exit 1
           fi
           # Warn on @rpath dependencies (acceptable for frameworks but worth noting)
-          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/")
+          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/" || true)
           if [ -n "$RPATH" ]; then
             echo "::warning::Binary has @rpath dependencies (verify these are bundled):"
             echo "$RPATH"
@@ -568,14 +568,14 @@ jobs:
           DEPS=$(otool -L build/dash-evo-tool)
           echo "$DEPS"
           # Only system libraries (/usr/lib/) and frameworks (/System/Library/) are allowed
-          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)")
+          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)" || true)
           if [ -n "$UNEXPECTED" ]; then
             echo "::error::Binary links non-system libraries:"
             echo "$UNEXPECTED"
             exit 1
           fi
           # Warn on @rpath dependencies (acceptable for frameworks but worth noting)
-          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/")
+          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/" || true)
           if [ -n "$RPATH" ]; then
             echo "::warning::Binary has @rpath dependencies (verify these are bundled):"
             echo "$RPATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,26 @@ jobs:
           done
           echo "✅ Binary is self-contained — no MinGW runtime or null DLL dependencies"
 
+      - name: Verify Linux binary dependencies
+        if: ${{ contains(matrix.target, 'linux') }}
+        run: |
+          echo "Checking shared library dependencies..."
+          DEPS=$(ldd dash-evo-tool/dash-evo-tool)
+          echo "$DEPS"
+          # Allowlist: only standard system libraries should appear
+          UNEXPECTED=$(echo "$DEPS" | grep "=>" | grep -v "not found" | awk '{print $1}' | grep -Ev "^(linux-vdso|libm|libc|libdl|librt|libpthread|libgcc_s|libstdc\+\+|ld-linux|libz|libssl|libcrypto)\.so")
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::warning::Unexpected shared dependencies found:"
+            echo "$UNEXPECTED"
+          fi
+          # Fail on missing libraries
+          if echo "$DEPS" | grep -q "not found"; then
+            echo "::error::Binary has missing shared library dependencies"
+            echo "$DEPS" | grep "not found"
+            exit 1
+          fi
+          echo "✅ Linux binary dependencies look clean"
+
       - name: Package release
         run: |
           zip -r dash-evo-tool-${{ matrix.platform }}.zip dash-evo-tool/
@@ -251,6 +271,27 @@ jobs:
           </dict>
           </plist>
           EOF
+
+
+      - name: Verify macOS binary dependencies
+        run: |
+          echo "Checking dynamic library dependencies..."
+          DEPS=$(otool -L build/dash-evo-tool)
+          echo "$DEPS"
+          # Only system libraries (/usr/lib/) and frameworks (/System/Library/) are allowed
+          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)")
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Binary links non-system libraries:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          # Warn on @rpath dependencies (acceptable for frameworks but worth noting)
+          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/")
+          if [ -n "$RPATH" ]; then
+            echo "::warning::Binary has @rpath dependencies (verify these are bundled):"
+            echo "$RPATH"
+          fi
+          echo "✅ macOS binary dependencies look clean"
 
       - name: Import signing certificates
         uses: Apple-Actions/import-codesign-certs@v3
@@ -519,6 +560,27 @@ jobs:
           </dict>
           </plist>
           EOF
+
+
+      - name: Verify macOS binary dependencies
+        run: |
+          echo "Checking dynamic library dependencies..."
+          DEPS=$(otool -L build/dash-evo-tool)
+          echo "$DEPS"
+          # Only system libraries (/usr/lib/) and frameworks (/System/Library/) are allowed
+          UNEXPECTED=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep -Ev "^(/usr/lib/|/System/Library/|@rpath/)")
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Binary links non-system libraries:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+          # Warn on @rpath dependencies (acceptable for frameworks but worth noting)
+          RPATH=$(echo "$DEPS" | tail -n +2 | awk '{print $1}' | grep "^@rpath/")
+          if [ -n "$RPATH" ]; then
+            echo "::warning::Binary has @rpath dependencies (verify these are bundled):"
+            echo "$RPATH"
+          fi
+          echo "✅ macOS binary dependencies look clean"
 
       - name: Import signing certificates
         uses: Apple-Actions/import-codesign-certs@v3


### PR DESCRIPTION
## Summary

- Adds post-build binary dependency verification to all non-Windows platform builds
- **Linux**: `ldd` check with system library allowlist, fails on "not found" deps
- **macOS** (both ARM64 and x86_64): `otool -L` check, fails on non-system libraries, warns on `@rpath` deps
- **Flatpak**: `ldd` check inside `build-dir`, fails on "not found" deps

Complements the Windows PE verification added in #769. Together, these checks ensure release binaries across all platforms are self-contained and won't crash at runtime due to missing shared libraries.

## Test plan

- [ ] Linux matrix builds pass the new `ldd` verification step
- [ ] macOS ARM64 build passes the new `otool -L` verification step
- [ ] macOS x86_64 build passes the new `otool -L` verification step
- [ ] Flatpak build passes the new `ldd` verification step
- [ ] No false positives from the allowlist/system library filters

Depends on #769 (builds on `fix/windows-static-linking` branch).

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated binary dependency verification checks for Linux and macOS platform builds to enhance release validation and build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->