### PR TITLE
feat(spv): enable mempool transaction detection via bloom filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,9 +167,9 @@ Screens hold `Arc<AppContext>` and manage their own UI state.
 
 ### ConnectionStatus (single source of truth for connection health)
 
-`ConnectionStatus` (`src/context/connection_status.rs`) is the **single source of truth** for all connection health state — RPC, ZMQ, SPV, and DAPI. Always read connection state from `ConnectionStatus`, never directly from `SpvManager` or other subsystems.
+`ConnectionStatus` (`src/context/connection_status.rs`) is the **single source of truth** for all high-level connection health state — RPC, ZMQ, SPV, and DAPI. For connection health (status, peer counts, errors, overall state), always read from `ConnectionStatus`, not directly from `SpvManager` or other subsystems.
 
-SPV status is **push-based**: `SpvManager` event handlers write directly to `ConnectionStatus` atomics (status, peer count, errors) as events arrive. The UI frame loop calls `refresh_state()` to recompute `overall_state` from these atomics, but does not poll SPV. This means `ConnectionStatus` is up-to-date in both GUI and headless/test contexts.
+SPV status is **push-based**: `SpvManager` event handlers write directly to `ConnectionStatus` atomics (status, peer count, errors) as events arrive. The UI frame loop calls `refresh_state()` to recompute `overall_state` from these atomics, but does not poll SPV for health. This means `ConnectionStatus` is up-to-date in both GUI and headless/test contexts. Detailed SPV sync progress (heights, phase summaries used by tooltips) may still be read directly from `SpvManager.status()` until that progress reporting is migrated into `ConnectionStatus`.
 
 ## UI Component Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,12 @@ Screens hold `Arc<AppContext>` and manage their own UI state.
 - `connection_status`, `developer_mode`, `fee_multiplier_permille`
 - Per-network instances (mainnet always present, others created on demand)
 
+### ConnectionStatus (single source of truth for connection health)
+
+`ConnectionStatus` (`src/context/connection_status.rs`) is the **single source of truth** for all connection health state — RPC, ZMQ, SPV, and DAPI. Always read connection state from `ConnectionStatus`, never directly from `SpvManager` or other subsystems.
+
+SPV status is **push-based**: `SpvManager` event handlers write directly to `ConnectionStatus` atomics (status, peer count, errors) as events arrive. The UI frame loop calls `refresh_state()` to recompute `overall_state` from these atomics, but does not poll SPV. This means `ConnectionStatus` is up-to-date in both GUI and headless/test contexts.
+
 ## UI Component Pattern
 
 Components follow a lazy initialization pattern (see `docs/COMPONENT_DESIGN_PATTERN.md`):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1919,8 +1919,8 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
  "futures",
  "hex",
  "hickory-resolver",
@@ -1939,31 +1939,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "dashcore"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
-dependencies = [
- "anyhow",
- "base64-compat",
- "bech32 0.9.1",
- "bincode 2.0.1",
- "bincode_derive",
- "bitvec",
- "blake3",
- "blsful",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "ed25519-dalek",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1988,9 +1963,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore-private"
+name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+dependencies = [
+ "anyhow",
+ "base64-compat",
+ "bech32 0.9.1",
+ "bincode 2.0.1",
+ "bincode_derive",
+ "bitvec",
+ "blake3",
+ "blsful",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "ed25519-dalek",
+ "hex",
+ "hex_lit",
+ "log",
+ "rustversion",
+ "secp256k1",
+ "serde",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "dashcore-private"
@@ -1998,9 +1993,14 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 
 [[package]]
+name = "dashcore-private"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+
+[[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2013,10 +2013,10 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
 dependencies = [
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
  "hex",
  "key-wallet",
  "serde",
@@ -2028,23 +2028,23 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
-dependencies = [
- "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "rs-x11-hash",
- "secp256k1",
- "serde",
-]
-
-[[package]]
-name = "dashcore_hashes"
-version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
  "secp256k1",
+]
+
+[[package]]
+name = "dashcore_hashes"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+dependencies = [
+ "bincode 2.0.1",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "rs-x11-hash",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2327,7 +2327,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2351,7 +2351,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4583,9 +4583,9 @@ dependencies = [
  "bincode_derive",
  "bip39",
  "bitflags 2.11.0",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
  "getrandom 0.2.17",
  "hex",
  "rand 0.8.5",
@@ -4600,12 +4600,12 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
  "key-wallet",
  "rayon",
  "secp256k1",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5876,7 +5876,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "aes",
  "cbc",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5897,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5908,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "backon",
  "chrono",
@@ -7801,7 +7801,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
+source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1919,8 +1919,8 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore",
- "dashcore_hashes",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "futures",
  "hex",
  "hickory-resolver",
@@ -1954,8 +1954,8 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
- "dashcore-private",
- "dashcore_hashes",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "ed25519-dalek",
  "hex",
  "hex_lit",
@@ -1967,9 +1967,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashcore"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+dependencies = [
+ "anyhow",
+ "bech32 0.9.1",
+ "bincode 2.0.1",
+ "bincode_derive",
+ "bitvec",
+ "blake3",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "hex",
+ "hex_lit",
+ "log",
+ "rustversion",
+ "secp256k1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dashcore-private"
 version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+
+[[package]]
+name = "dashcore-private"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 
 [[package]]
 name = "dashcore-rpc"
@@ -1990,7 +2016,7 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
- "dashcore",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "hex",
  "key-wallet",
  "serde",
@@ -2005,10 +2031,20 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
- "dashcore-private",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "rs-x11-hash",
  "secp256k1",
  "serde",
+]
+
+[[package]]
+name = "dashcore_hashes"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+dependencies = [
+ "bincode 2.0.1",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "secp256k1",
 ]
 
 [[package]]
@@ -2027,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2038,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2291,7 +2327,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2302,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2315,7 +2351,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -2351,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2361,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2386,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -2970,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4167,7 +4203,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4547,9 +4583,9 @@ dependencies = [
  "bincode_derive",
  "bip39",
  "bitflags 2.11.0",
- "dashcore",
- "dashcore-private",
- "dashcore_hashes",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "getrandom 0.2.17",
  "hex",
  "rand 0.8.5",
@@ -4568,8 +4604,8 @@ source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
- "dashcore",
- "dashcore_hashes",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "key-wallet",
  "rayon",
  "secp256k1",
@@ -4580,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4782,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5840,18 +5876,19 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "aes",
  "cbc",
- "dashcore",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "sha2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5860,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5871,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5891,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5902,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6073,7 +6110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6094,7 +6131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -6624,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "backon",
  "chrono",
@@ -7764,7 +7801,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8540,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9934,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
+source = "git+https://github.com/dashpay/platform?rev=2414799b73befd1e6c73e154ba4299c7b71d4f7c#2414799b73befd1e6c73e154ba4299c7b71d4f7c"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1919,14 +1919,13 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
  "futures",
  "hex",
  "hickory-resolver",
  "indexmap 2.13.0",
  "key-wallet",
- "key-wallet-manager",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -1939,31 +1938,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "dashcore"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
-dependencies = [
- "anyhow",
- "base64-compat",
- "bech32 0.9.1",
- "bincode 2.0.1",
- "bincode_derive",
- "bitvec",
- "blake3",
- "blsful",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "ed25519-dalek",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1988,9 +1962,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore-private"
+name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+dependencies = [
+ "anyhow",
+ "base64-compat",
+ "bech32 0.9.1",
+ "bincode 2.0.1",
+ "bincode_derive",
+ "bitvec",
+ "blake3",
+ "blsful",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "ed25519-dalek",
+ "hex",
+ "hex_lit",
+ "log",
+ "rustversion",
+ "secp256k1",
+ "serde",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "dashcore-private"
@@ -1998,9 +1992,14 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 
 [[package]]
+name = "dashcore-private"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+
+[[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2013,10 +2012,10 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
 dependencies = [
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
  "hex",
  "key-wallet",
  "serde",
@@ -2028,23 +2027,23 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
-dependencies = [
- "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "rs-x11-hash",
- "secp256k1",
- "serde",
-]
-
-[[package]]
-name = "dashcore_hashes"
-version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
  "secp256k1",
+]
+
+[[package]]
+name = "dashcore_hashes"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+dependencies = [
+ "bincode 2.0.1",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "rs-x11-hash",
+ "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -2063,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2074,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2327,7 +2326,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2338,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2351,7 +2350,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -2363,7 +2362,6 @@ dependencies = [
  "integer-encoding",
  "itertools 0.13.0",
  "key-wallet",
- "key-wallet-manager",
  "lazy_static",
  "nohash-hasher",
  "num_enum 0.7.5",
@@ -2387,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2422,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3006,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4575,48 +4573,32 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
 dependencies = [
  "async-trait",
  "base58ck",
- "bincode 2.0.1",
- "bincode_derive",
  "bip39",
  "bitflags 2.11.0",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
  "getrandom 0.2.17",
  "hex",
  "rand 0.8.5",
+ "rayon",
  "secp256k1",
  "serde",
  "serde_json",
  "sha2",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "key-wallet-manager"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
-dependencies = [
- "async-trait",
- "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
- "key-wallet",
- "rayon",
- "secp256k1",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4818,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5876,7 +5858,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "aes",
  "cbc",
@@ -5888,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5897,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5908,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5928,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5939,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6661,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "backon",
  "chrono",
@@ -7801,7 +7783,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8577,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9971,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
+source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1969,12 +1969,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2291,7 +2291,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2351,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2361,7 +2361,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5840,19 +5840,18 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "aes",
  "cbc",
  "dashcore",
- "sha2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5861,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5872,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5892,7 +5891,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5903,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6625,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "backon",
  "chrono",
@@ -7765,7 +7764,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8541,7 +8540,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9935,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=6d9efa97b46261a521280ed4bdbc3799f31371b5#6d9efa97b46261a521280ed4bdbc3799f31371b5"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1919,8 +1919,8 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
  "futures",
  "hex",
  "hickory-resolver",
@@ -1938,6 +1938,31 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "dashcore"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
+dependencies = [
+ "anyhow",
+ "base64-compat",
+ "bech32 0.9.1",
+ "bincode 2.0.1",
+ "bincode_derive",
+ "bitvec",
+ "blake3",
+ "blsful",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "ed25519-dalek",
+ "hex",
+ "hex_lit",
+ "log",
+ "rustversion",
+ "secp256k1",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1962,29 +1987,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore"
+name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
-dependencies = [
- "anyhow",
- "base64-compat",
- "bech32 0.9.1",
- "bincode 2.0.1",
- "bincode_derive",
- "bitvec",
- "blake3",
- "blsful",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "ed25519-dalek",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "serde",
- "thiserror 2.0.18",
-]
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 
 [[package]]
 name = "dashcore-private"
@@ -1992,14 +1997,9 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 
 [[package]]
-name = "dashcore-private"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
-
-[[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2012,10 +2012,10 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 dependencies = [
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
  "hex",
  "key-wallet",
  "serde",
@@ -2027,23 +2027,23 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 dependencies = [
  "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "rs-x11-hash",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 dependencies = [
  "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "rs-x11-hash",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
  "secp256k1",
- "serde",
 ]
 
 [[package]]
@@ -2062,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2073,7 +2073,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2326,7 +2326,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2350,7 +2350,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -2385,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2420,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4573,15 +4573,15 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c#b03252affc1ecbe9218b2f0dc8f557ba333f166c"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=450f72f#450f72f5148b9fea2cd79bd1e37fa9d68a9fd18a"
 dependencies = [
  "async-trait",
  "base58ck",
  "bip39",
  "bitflags 2.11.0",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=b03252affc1ecbe9218b2f0dc8f557ba333f166c)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=450f72f)",
  "getrandom 0.2.17",
  "hex",
  "rand 0.8.5",
@@ -4598,7 +4598,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4800,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5858,7 +5858,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "aes",
  "cbc",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5890,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5910,7 +5910,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "backon",
  "chrono",
@@ -7783,7 +7783,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=be2082b3c43653dabdcdbd09e77fb7298ca64871#be2082b3c43653dabdcdbd09e77fb7298ca64871"
+source = "git+https://github.com/dashpay/platform?rev=93556aa4b#93556aa4b97fa024890926e315c1061181c8b663"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1919,8 +1919,8 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "futures",
  "hex",
  "hickory-resolver",
@@ -1939,6 +1939,31 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "dashcore"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
+dependencies = [
+ "anyhow",
+ "base64-compat",
+ "bech32 0.9.1",
+ "bincode 2.0.1",
+ "bincode_derive",
+ "bitvec",
+ "blake3",
+ "blsful",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "ed25519-dalek",
+ "hex",
+ "hex_lit",
+ "log",
+ "rustversion",
+ "secp256k1",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1963,29 +1988,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore"
+name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
-dependencies = [
- "anyhow",
- "base64-compat",
- "bech32 0.9.1",
- "bincode 2.0.1",
- "bincode_derive",
- "bitvec",
- "blake3",
- "blsful",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "ed25519-dalek",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "serde",
- "thiserror 2.0.18",
-]
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 
 [[package]]
 name = "dashcore-private"
@@ -1993,14 +1998,9 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 
 [[package]]
-name = "dashcore-private"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
-
-[[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2013,10 +2013,10 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "hex",
  "key-wallet",
  "serde",
@@ -2028,23 +2028,23 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "rs-x11-hash",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
 dependencies = [
  "bincode 2.0.1",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "rs-x11-hash",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca)",
  "secp256k1",
- "serde",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2074,7 +2074,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2327,7 +2327,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2351,7 +2351,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4583,9 +4583,9 @@ dependencies = [
  "bincode_derive",
  "bip39",
  "bitflags 2.11.0",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "getrandom 0.2.17",
  "hex",
  "rand 0.8.5",
@@ -4600,12 +4600,12 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062#c451a1c640f24ae1d4f1879c29f7ae4b91d8c062"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13#1af96dd02f12576ba0727476e39ff78aca0a1e13"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=c451a1c640f24ae1d4f1879c29f7ae4b91d8c062)",
+ "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
+ "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=1af96dd02f12576ba0727476e39ff78aca0a1e13)",
  "key-wallet",
  "rayon",
  "secp256k1",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5876,7 +5876,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "aes",
  "cbc",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5897,7 +5897,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5908,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6661,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "backon",
  "chrono",
@@ -7801,7 +7801,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9971,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=d9de0fd255c42a23d188721b9fda04572ab6d831#d9de0fd255c42a23d188721b9fda04572ab6d831"
+source = "git+https://github.com/dashpay/platform?rev=2af8cac6a7867b7d1c591380a03dd0b79bfed651#2af8cac6a7867b7d1c591380a03dd0b79bfed651"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "aa86b74f7e28dd0444fec9ceb13373bd22f768d9", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "6d9efa97b46261a521280ed4bdbc3799f31371b5", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "be2082b3c43653dabdcdbd09e77fb7298ca64871", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "93556aa4b", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "d9de0fd255c42a23d188721b9fda04572ab6d831", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "2af8cac6a7867b7d1c591380a03dd0b79bfed651", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "6d9efa97b46261a521280ed4bdbc3799f31371b5", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "2414799b73befd1e6c73e154ba4299c7b71d4f7c", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "2414799b73befd1e6c73e154ba4299c7b71d4f7c", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "d9de0fd255c42a23d188721b9fda04572ab6d831", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "2af8cac6a7867b7d1c591380a03dd0b79bfed651", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "be2082b3c43653dabdcdbd09e77fb7298ca64871", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -109,3 +109,4 @@ check-cfg = ["cfg(tokio_unstable)", "cfg(feature, values(\"testing\"))"]
 
 [lints.clippy]
 uninlined_format_args = "allow"
+

--- a/src/app.rs
+++ b/src/app.rs
@@ -836,9 +836,7 @@ impl AppState {
         let sender = self.task_result_sender.clone();
         let app_context = self.current_app_context().clone();
         tokio::spawn(async move {
-            let result = app_context
-                .run_backend_task_send(task, sender.clone())
-                .await;
+            let result = app_context.run_backend_task(task, sender.clone()).await;
             if let Err(e) = sender.send(result.into()).await {
                 tracing::error!("Failed to send task result: {}", e);
             }
@@ -854,12 +852,12 @@ impl AppState {
             let results = match mode {
                 BackendTasksExecutionMode::Sequential => {
                     app_context
-                        .run_backend_tasks_sequential_send(tasks, sender.clone())
+                        .run_backend_tasks_sequential(tasks, sender.clone())
                         .await
                 }
                 BackendTasksExecutionMode::Concurrent => {
                     app_context
-                        .run_backend_tasks_concurrent_send(tasks, sender.clone())
+                        .run_backend_tasks_concurrent(tasks, sender.clone())
                         .await
                 }
             };

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,7 +228,7 @@ impl AppState {
         let connection_status = Arc::new(ConnectionStatus::new());
         let mainnet_app_context = AppContext::new(
             data_dir.clone(),
-            Network::Dash,
+            Network::Mainnet,
             db.clone(),
             password_info.clone(),
             subtasks.clone(),
@@ -311,7 +311,7 @@ impl AppState {
             testnet_app_context.as_ref(),
             devnet_app_context.as_ref(),
             local_app_context.as_ref(),
-            Network::Dash,
+            Network::Mainnet,
             overwrite_dash_conf,
         );
 
@@ -323,7 +323,7 @@ impl AppState {
         // Validate that the saved network has an available context.
         // We fail fast instead of silently routing user actions to a different network.
         let chosen_network = match settings.network {
-            Network::Dash => Network::Dash,
+            Network::Mainnet => Network::Mainnet,
             Network::Testnet => {
                 assert!(
                     testnet_app_context.is_some(),
@@ -484,7 +484,7 @@ impl AppState {
             .unwrap_or(false);
         let mainnet_core_zmq_listener = if !mainnet_disable_zmq {
             match CoreZMQListener::spawn_listener(
-                Network::Dash,
+                Network::Mainnet,
                 &mainnet_core_zmq_endpoint,
                 core_message_sender.clone(),
                 Some(mainnet_app_context.sx_zmq_status.clone()),
@@ -787,7 +787,7 @@ impl AppState {
         // Invariant: chosen_network must always have a corresponding context.
         // Fail fast on violations to avoid silently routing operations to mainnet.
         match self.chosen_network {
-            Network::Dash => &self.mainnet_app_context,
+            Network::Mainnet => &self.mainnet_app_context,
             Network::Testnet => self.testnet_app_context.as_ref().unwrap_or_else(|| {
                 panic!(
                     "BUG: chosen network is Testnet but testnet_app_context is missing; refusing silent mainnet fallback"
@@ -812,7 +812,7 @@ impl AppState {
 
     fn context_available_for_network(&self, network: Network) -> bool {
         match network {
-            Network::Dash => true, // Mainnet is always available
+            Network::Mainnet => true, // Mainnet is always available
             Network::Testnet => self.testnet_app_context.is_some(),
             Network::Devnet => self.devnet_app_context.is_some(),
             Network::Regtest => self.local_app_context.is_some(),
@@ -836,9 +836,9 @@ impl AppState {
         let sender = self.task_result_sender.clone();
         let app_context = self.current_app_context().clone();
         tokio::spawn(async move {
-            let result = app_context.run_backend_task(task, sender.clone()).await;
-
-            // Send the result back to the main thread
+            let result = app_context
+                .run_backend_task_send(task, sender.clone())
+                .await;
             if let Err(e) = sender.send(result.into()).await {
                 tracing::error!("Failed to send task result: {}", e);
             }
@@ -854,17 +854,16 @@ impl AppState {
             let results = match mode {
                 BackendTasksExecutionMode::Sequential => {
                     app_context
-                        .run_backend_tasks_sequential(tasks, sender.clone())
+                        .run_backend_tasks_sequential_send(tasks, sender.clone())
                         .await
                 }
                 BackendTasksExecutionMode::Concurrent => {
                     app_context
-                        .run_backend_tasks_concurrent(tasks, sender.clone())
+                        .run_backend_tasks_concurrent_send(tasks, sender.clone())
                         .await
                 }
             };
 
-            // Send the results back to the main thread
             for result in results {
                 if let Err(e) = sender.send(result.into()).await {
                     tracing::error!("Failed to send task result: {}", e);
@@ -1003,7 +1002,7 @@ impl AppState {
     //     task::spawn_blocking(move || {
     //         while let Ok((tx, islock, network)) = instant_send_receiver.recv() {
     //             let app_context = match network {
-    //                 Network::Dash => &mainnet_app_context,
+    //                 Network::Mainnet => &mainnet_app_context,
     //                 Network::Testnet => {
     //                     if let Some(context) = testnet_app_context.as_ref() {
     //                         context
@@ -1198,7 +1197,7 @@ impl App for AppState {
         // **Poll the instant_send_receiver for any new InstantSend messages**
         while let Ok((message, network)) = self.core_message_receiver.try_recv() {
             let app_context = match network {
-                Network::Dash => &self.mainnet_app_context,
+                Network::Mainnet => &self.mainnet_app_context,
                 Network::Testnet => {
                     if let Some(context) = self.testnet_app_context.as_ref() {
                         context

--- a/src/app.rs
+++ b/src/app.rs
@@ -967,11 +967,15 @@ impl AppState {
                     Some(MessageBanner::set_global(ctx, msg, MessageType::Warning));
             }
             OverallConnectionState::Error => {
-                self.connection_banner_handle = Some(MessageBanner::set_global(
+                let handle = MessageBanner::set_global(
                     ctx,
-                    "SPV sync error — check connection status for details",
+                    "SPV sync failed. Go to Settings for connection details.",
                     MessageType::Error,
-                ));
+                );
+                if let Some(detail) = connection_status.spv_last_error() {
+                    handle.with_details(detail);
+                }
+                self.connection_banner_handle = Some(handle);
             }
             OverallConnectionState::Synced => {
                 // No banner needed for fully synced state

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,8 +87,6 @@ pub struct AppState {
     pub task_result_sender: egui_mpsc::SenderAsync<TaskResult>, // Channel sender for sending task results
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
-    resolved_theme: ThemeMode, // Cached resolved theme (Light/Dark, never System)
-    theme_last_checked: Instant, // Last time we polled the OS for system theme
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
     last_repaint_request: Instant,      // Throttle periodic repaint scheduling to once per second
     pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
@@ -722,8 +720,6 @@ impl AppState {
             core_message_receiver,
             task_result_sender,
             task_result_receiver,
-            resolved_theme: crate::ui::theme::resolve_theme_mode(theme_preference),
-            theme_last_checked: Instant::now(),
             theme_preference,
             last_scheduled_vote_check: Instant::now(),
             last_repaint_request: Instant::now(),
@@ -1094,19 +1090,8 @@ impl App for AppState {
             return;
         }
 
-        // Throttle OS theme detection to every 2 s to prevent white flash from
-        // transient dark_light::detect() glitches during high-frequency repaints.
-        if self.theme_preference == ThemeMode::System {
-            let now = Instant::now();
-            if now.duration_since(self.theme_last_checked) > Duration::from_secs(2) {
-                self.theme_last_checked = now;
-                let new_resolved = crate::ui::theme::resolve_theme_mode(self.theme_preference);
-                if new_resolved != self.resolved_theme {
-                    self.resolved_theme = new_resolved;
-                }
-            }
-        }
-        crate::ui::theme::apply_theme(ctx, self.resolved_theme);
+        // Apply Dash theme with user preference
+        crate::ui::theme::apply_theme(ctx, self.theme_preference);
 
         self.enforce_network_context_invariant();
         let active_context = self.current_app_context().clone();
@@ -1148,9 +1133,6 @@ impl App for AppState {
                         }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
-                            self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
-                            self.theme_last_checked = Instant::now();
-                            crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             MessageBanner::set_global(
                                 ctx,
                                 "Theme preference updated successfully",

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,8 @@ pub struct AppState {
     pub task_result_sender: egui_mpsc::SenderAsync<TaskResult>, // Channel sender for sending task results
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
+    resolved_theme: ThemeMode, // Cached resolved theme (Light/Dark, never System)
+    theme_last_checked: Instant, // Last time we polled the OS for system theme
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
     last_repaint_request: Instant,      // Throttle periodic repaint scheduling to once per second
     pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
@@ -720,6 +722,8 @@ impl AppState {
             core_message_receiver,
             task_result_sender,
             task_result_receiver,
+            resolved_theme: crate::ui::theme::resolve_theme_mode(theme_preference),
+            theme_last_checked: Instant::now(),
             theme_preference,
             last_scheduled_vote_check: Instant::now(),
             last_repaint_request: Instant::now(),
@@ -1090,8 +1094,19 @@ impl App for AppState {
             return;
         }
 
-        // Apply Dash theme with user preference
-        crate::ui::theme::apply_theme(ctx, self.theme_preference);
+        // Throttle OS theme detection to every 2 s to prevent white flash from
+        // transient dark_light::detect() glitches during high-frequency repaints.
+        if self.theme_preference == ThemeMode::System {
+            let now = Instant::now();
+            if now.duration_since(self.theme_last_checked) > Duration::from_secs(2) {
+                self.theme_last_checked = now;
+                let new_resolved = crate::ui::theme::resolve_theme_mode(self.theme_preference);
+                if new_resolved != self.resolved_theme {
+                    self.resolved_theme = new_resolved;
+                }
+            }
+        }
+        crate::ui::theme::apply_theme(ctx, self.resolved_theme);
 
         self.enforce_network_context_invariant();
         let active_context = self.current_app_context().clone();
@@ -1133,6 +1148,9 @@ impl App for AppState {
                         }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
+                            self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
+                            self.theme_last_checked = Instant::now();
+                            crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             MessageBanner::set_global(
                                 ctx,
                                 "Theme preference updated successfully",

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -62,7 +62,7 @@ pub fn core_cookie_path(
 ) -> Result<PathBuf, std::io::Error> {
     core_user_data_dir_path().and_then(|path| {
         let network_dir = match network {
-            Network::Dash => "",
+            Network::Mainnet => "",
             Network::Testnet => "testnet3",
             Network::Devnet => devnet_name.as_deref().unwrap_or(""),
             Network::Regtest => "regtest",
@@ -135,7 +135,7 @@ pub fn create_dash_core_config_if_not_exists(
     network: Network,
 ) -> Result<PathBuf, io::Error> {
     let (resource, filename) = match network {
-        Network::Dash => (BundledResource::CoreConfigMainnet, "mainnet.conf"),
+        Network::Mainnet => (BundledResource::CoreConfigMainnet, "mainnet.conf"),
         Network::Testnet => (BundledResource::CoreConfigTestnet, "testnet.conf"),
         Network::Devnet => (BundledResource::CoreConfigDevnet, "devnet.conf"),
         Network::Regtest => {

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -43,7 +43,7 @@ const DEFAULT_BIP44_ACCOUNT_INDEX: u32 = 0;
 fn networks_address_compatible(a: &Network, b: &Network) -> bool {
     matches!(
         (a, b),
-        (Network::Dash, Network::Dash)
+        (Network::Mainnet, Network::Mainnet)
             | (
                 Network::Testnet | Network::Devnet | Network::Regtest,
                 Network::Testnet | Network::Devnet | Network::Regtest,
@@ -182,12 +182,13 @@ impl AppContext {
                 // Load configs
                 let config = Config::load_from(&self.data_dir)?;
 
-                let maybe_mainnet_config = config.config_for_network(Network::Dash);
+                let maybe_mainnet_config = config.config_for_network(Network::Mainnet);
                 let maybe_testnet_config = config.config_for_network(Network::Testnet);
                 let maybe_devnet_config = config.config_for_network(Network::Devnet);
                 let maybe_local_config = config.config_for_network(Network::Regtest);
 
-                let mainnet_result = Self::get_best_chain_lock(maybe_mainnet_config, Network::Dash);
+                let mainnet_result =
+                    Self::get_best_chain_lock(maybe_mainnet_config, Network::Mainnet);
                 let testnet_result =
                     Self::get_best_chain_lock(maybe_testnet_config, Network::Testnet);
                 let devnet_result = Self::get_best_chain_lock(maybe_devnet_config, Network::Devnet);

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -31,7 +31,7 @@ use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::transaction_builder:
 };
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::transaction_building::AccountTypePreference;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-use dash_sdk::dpp::key_wallet_manager::wallet_manager::{WalletError, WalletId, WalletManager};
+use dash_sdk::dpp::key_wallet_manager::manager::{WalletError, WalletId, WalletManager};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};

--- a/src/backend_task/core/refresh_wallet_info.rs
+++ b/src/backend_task/core/refresh_wallet_info.rs
@@ -1,7 +1,7 @@
 use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::error::TaskError;
 use crate::context::AppContext;
-use crate::model::wallet::{DerivationPathHelpers, Wallet, WalletTransaction};
+use crate::model::wallet::{DerivationPathHelpers, TransactionStatus, Wallet, WalletTransaction};
 use dash_sdk::dashcore_rpc::RpcApi;
 use dash_sdk::dashcore_rpc::json::GetTransactionResultDetailCategory;
 use dash_sdk::dpp::dashcore::hashes::Hash;
@@ -218,6 +218,8 @@ impl AppContext {
                             fee: agg.fee,
                             label: agg.label,
                             is_ours: agg.is_ours,
+                            // RPC only returns confirmed transactions
+                            status: TransactionStatus::from_height(agg.height),
                         });
                     }
 

--- a/src/backend_task/dashpay.rs
+++ b/src/backend_task/dashpay.rs
@@ -264,6 +264,10 @@ impl AppContext {
                             }
                         })?;
 
+                if result.addresses_registered > 0 {
+                    self.spv_manager.notify_wallet_addresses_changed().await;
+                }
+
                 Ok(BackendTaskSuccessResult::Message(format!(
                     "Registered {} DashPay addresses for {} contacts{}",
                     result.addresses_registered,

--- a/src/backend_task/dashpay.rs
+++ b/src/backend_task/dashpay.rs
@@ -264,10 +264,6 @@ impl AppContext {
                             }
                         })?;
 
-                if result.addresses_registered > 0 {
-                    self.spv_manager.notify_wallet_addresses_changed().await;
-                }
-
                 Ok(BackendTaskSuccessResult::Message(format!(
                     "Registered {} DashPay addresses for {} contacts{}",
                     result.addresses_registered,

--- a/src/backend_task/dashpay/hd_derivation.rs
+++ b/src/backend_task/dashpay/hd_derivation.rs
@@ -383,12 +383,17 @@ mod tests {
             &recipient_id,
         )
         .expect("Should derive xpub for testnet");
-        let xpub_mainnet =
-            derive_dashpay_incoming_xpub(&master_seed, Network::Dash, 0, &sender_id, &recipient_id)
-                .expect("Should derive xpub for mainnet");
+        let xpub_mainnet = derive_dashpay_incoming_xpub(
+            &master_seed,
+            Network::Mainnet,
+            0,
+            &sender_id,
+            &recipient_id,
+        )
+        .expect("Should derive xpub for mainnet");
 
         // Keys should be the same but network should differ
         assert_eq!(xpub_testnet.network, Network::Testnet);
-        assert_eq!(xpub_mainnet.network, Network::Dash);
+        assert_eq!(xpub_mainnet.network, Network::Mainnet);
     }
 }

--- a/src/backend_task/mnlist.rs
+++ b/src/backend_task/mnlist.rs
@@ -80,7 +80,7 @@ pub async fn run_mnlist_task(
         } => {
             let client = app.core_client.read()?;
             let loaded_list_height = match app.network {
-                Network::Dash => 2_227_096,
+                Network::Mainnet => 2_227_096,
                 Network::Testnet => 1_296_600,
                 _ => 0,
             };

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -36,8 +36,6 @@ use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::
 use dash_sdk::platform::{Document, Identifier};
 use dash_sdk::query_types::{Documents, IndexMap};
 use futures::future::join_all;
-use std::future::Future;
-use std::pin::Pin;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokens::TokenTask;
@@ -284,94 +282,7 @@ pub enum BackendTaskSuccessResult {
 
 impl BackendTaskSuccessResult {}
 
-type SendBoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
-
-/// Assert that a pinned, boxed future is `Send`.
-///
-/// # Safety
-///
-/// The caller must guarantee the future never holds non-Send data across an
-/// `.await` point.  This is used to work around RPITIT-generated opaque types
-/// in the Dash Platform SDK whose Send bound the compiler cannot verify.
-unsafe fn assert_send<T>(
-    fut: Pin<Box<dyn Future<Output = T>>>,
-) -> Pin<Box<dyn Future<Output = T> + Send>> {
-    // SAFETY: caller guarantees the future is Send in practice.
-    unsafe { std::mem::transmute(fut) }
-}
-
 impl AppContext {
-    /// Run backend tasks sequentially, returning a `Send` future suitable for
-    /// `tokio::spawn`.
-    pub fn run_backend_tasks_sequential_send(
-        self: &Arc<Self>,
-        tasks: Vec<BackendTask>,
-        sender: SenderAsync<TaskResult>,
-    ) -> SendBoxFuture<Vec<Result<BackendTaskSuccessResult, TaskError>>> {
-        let this = Arc::clone(self);
-        // SAFETY: see `run_backend_task_send` doc comment.
-        unsafe {
-            assert_send(Box::pin(async move {
-                let mut results = Vec::new();
-                for task in tasks {
-                    match this.run_backend_task(task, sender.clone()).await {
-                        Ok(result) => results.push(Ok(result)),
-                        Err(e) => results.push(Err(e)),
-                    };
-                }
-                results
-            }))
-        }
-    }
-
-    /// Run backend tasks concurrently, returning a `Send` future suitable for
-    /// `tokio::spawn`.
-    pub fn run_backend_tasks_concurrent_send(
-        self: &Arc<Self>,
-        tasks: Vec<BackendTask>,
-        sender: SenderAsync<TaskResult>,
-    ) -> SendBoxFuture<Vec<Result<BackendTaskSuccessResult, TaskError>>> {
-        let this = Arc::clone(self);
-        // SAFETY: see `run_backend_task_send` doc comment.
-        unsafe {
-            assert_send(Box::pin(async move {
-                let futures = tasks
-                    .into_iter()
-                    .map(|task| {
-                        let cloned_self = Arc::clone(&this);
-                        let cloned_sender = sender.clone();
-                        cloned_self.run_backend_task_send(task, cloned_sender)
-                    })
-                    .collect::<Vec<_>>();
-
-                join_all(futures).await
-            }))
-        }
-    }
-
-    /// Run a single backend task, returning a `Send` future suitable for
-    /// `tokio::spawn`.
-    ///
-    /// The future from [`run_backend_task`] is safe to send across threads —
-    /// all non-Send references (`&Sdk`, `&DataContract`) are temporaries
-    /// confined to individual `.await` points.  The compiler cannot prove
-    /// this automatically because upstream SDK traits use RPITIT, which
-    /// produces opaque types that defeat HRTB Send inference.  We pin-box
-    /// the future and transmute the Send bound via [`assert_send`].
-    pub fn run_backend_task_send(
-        self: &Arc<Self>,
-        task: BackendTask,
-        sender: SenderAsync<TaskResult>,
-    ) -> SendBoxFuture<Result<BackendTaskSuccessResult, TaskError>> {
-        let this = Arc::clone(self);
-        // SAFETY: see doc comment above.
-        unsafe {
-            assert_send(Box::pin(async move {
-                this.run_backend_task(task, sender).await
-            }))
-        }
-    }
-
     /// Run backend tasks sequentially
     pub async fn run_backend_tasks_sequential(
         self: &Arc<Self>,

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -36,6 +36,8 @@ use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::
 use dash_sdk::platform::{Document, Identifier};
 use dash_sdk::query_types::{Documents, IndexMap};
 use futures::future::join_all;
+use std::future::Future;
+use std::pin::Pin;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokens::TokenTask;
@@ -282,7 +284,94 @@ pub enum BackendTaskSuccessResult {
 
 impl BackendTaskSuccessResult {}
 
+type SendBoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+/// Assert that a pinned, boxed future is `Send`.
+///
+/// # Safety
+///
+/// The caller must guarantee the future never holds non-Send data across an
+/// `.await` point.  This is used to work around RPITIT-generated opaque types
+/// in the Dash Platform SDK whose Send bound the compiler cannot verify.
+unsafe fn assert_send<T>(
+    fut: Pin<Box<dyn Future<Output = T>>>,
+) -> Pin<Box<dyn Future<Output = T> + Send>> {
+    // SAFETY: caller guarantees the future is Send in practice.
+    unsafe { std::mem::transmute(fut) }
+}
+
 impl AppContext {
+    /// Run backend tasks sequentially, returning a `Send` future suitable for
+    /// `tokio::spawn`.
+    pub fn run_backend_tasks_sequential_send(
+        self: &Arc<Self>,
+        tasks: Vec<BackendTask>,
+        sender: SenderAsync<TaskResult>,
+    ) -> SendBoxFuture<Vec<Result<BackendTaskSuccessResult, TaskError>>> {
+        let this = Arc::clone(self);
+        // SAFETY: see `run_backend_task_send` doc comment.
+        unsafe {
+            assert_send(Box::pin(async move {
+                let mut results = Vec::new();
+                for task in tasks {
+                    match this.run_backend_task(task, sender.clone()).await {
+                        Ok(result) => results.push(Ok(result)),
+                        Err(e) => results.push(Err(e)),
+                    };
+                }
+                results
+            }))
+        }
+    }
+
+    /// Run backend tasks concurrently, returning a `Send` future suitable for
+    /// `tokio::spawn`.
+    pub fn run_backend_tasks_concurrent_send(
+        self: &Arc<Self>,
+        tasks: Vec<BackendTask>,
+        sender: SenderAsync<TaskResult>,
+    ) -> SendBoxFuture<Vec<Result<BackendTaskSuccessResult, TaskError>>> {
+        let this = Arc::clone(self);
+        // SAFETY: see `run_backend_task_send` doc comment.
+        unsafe {
+            assert_send(Box::pin(async move {
+                let futures = tasks
+                    .into_iter()
+                    .map(|task| {
+                        let cloned_self = Arc::clone(&this);
+                        let cloned_sender = sender.clone();
+                        cloned_self.run_backend_task_send(task, cloned_sender)
+                    })
+                    .collect::<Vec<_>>();
+
+                join_all(futures).await
+            }))
+        }
+    }
+
+    /// Run a single backend task, returning a `Send` future suitable for
+    /// `tokio::spawn`.
+    ///
+    /// The future from [`run_backend_task`] is safe to send across threads —
+    /// all non-Send references (`&Sdk`, `&DataContract`) are temporaries
+    /// confined to individual `.await` points.  The compiler cannot prove
+    /// this automatically because upstream SDK traits use RPITIT, which
+    /// produces opaque types that defeat HRTB Send inference.  We pin-box
+    /// the future and transmute the Send bound via [`assert_send`].
+    pub fn run_backend_task_send(
+        self: &Arc<Self>,
+        task: BackendTask,
+        sender: SenderAsync<TaskResult>,
+    ) -> SendBoxFuture<Result<BackendTaskSuccessResult, TaskError>> {
+        let this = Arc::clone(self);
+        // SAFETY: see doc comment above.
+        unsafe {
+            assert_send(Box::pin(async move {
+                this.run_backend_task(task, sender).await
+            }))
+        }
+    }
+
     /// Run backend tasks sequentially
     pub async fn run_backend_tasks_sequential(
         self: &Arc<Self>,

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -116,7 +116,7 @@ fn format_extended_epoch_info(
         };
 
     let epoch_estimated_time = match network {
-        Network::Dash => 788_400_000,
+        Network::Mainnet => 788_400_000,
         Network::Testnet => 3_600_000,
         Network::Devnet => 3_600_000,
         Network::Regtest => 1_200_000,

--- a/src/components/core_p2p_handler.rs
+++ b/src/components/core_p2p_handler.rs
@@ -88,7 +88,7 @@ enum ReadMessageError {
 impl CoreP2PHandler {
     pub fn new(network: Network, use_port: Option<u16>) -> Result<CoreP2PHandler, P2PError> {
         let port = use_port.unwrap_or(match network {
-            Network::Dash => 9999,
+            Network::Mainnet => 9999,
             Network::Testnet => 19999,
             Network::Devnet => 29999,
             Network::Regtest => 29999,
@@ -190,7 +190,7 @@ impl CoreP2PHandler {
         // QRInfo on mainnet can take noticeably longer to prepare.
         // Temporarily increase socket read timeout and our overall wait.
         let (socket_timeout, overall_timeout) = match self.network {
-            Network::Dash => (Duration::from_secs(60), Duration::from_secs(60)),
+            Network::Mainnet => (Duration::from_secs(60), Duration::from_secs(60)),
             _ => (Duration::from_secs(15), Duration::from_secs(15)),
         };
         let previous_socket_timeout = self.stream.read_timeout()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,7 @@ pub struct NetworkConfig {
 impl Config {
     pub fn config_for_network(&self, network: Network) -> &Option<NetworkConfig> {
         match network {
-            Network::Dash => &self.mainnet_config,
+            Network::Mainnet => &self.mainnet_config,
             Network::Testnet => &self.testnet_config,
             Network::Devnet => &self.devnet_config,
             Network::Regtest => &self.local_config,
@@ -306,7 +306,7 @@ impl Config {
     /// Update (overwrite) the configuration for a particular network.
     pub fn update_config_for_network(&mut self, network: Network, new_config: NetworkConfig) {
         match network {
-            Network::Dash => self.mainnet_config = Some(new_config),
+            Network::Mainnet => self.mainnet_config = Some(new_config),
             Network::Testnet => self.testnet_config = Some(new_config),
             Network::Devnet => self.devnet_config = Some(new_config),
             Network::Regtest => self.local_config = Some(new_config),
@@ -456,7 +456,7 @@ mod tests {
             local_config: None,
             developer_mode: None,
         };
-        assert!(config.config_for_network(Network::Dash).is_some());
+        assert!(config.config_for_network(Network::Mainnet).is_some());
         assert!(config.config_for_network(Network::Testnet).is_none());
         assert!(config.config_for_network(Network::Devnet).is_none());
         assert!(config.config_for_network(Network::Regtest).is_none());
@@ -471,7 +471,10 @@ mod tests {
             local_config: Some(make_network_config("http://127.0.0.1:2443", 20302)),
             developer_mode: Some(true),
         };
-        let main = config.config_for_network(Network::Dash).as_ref().unwrap();
+        let main = config
+            .config_for_network(Network::Mainnet)
+            .as_ref()
+            .unwrap();
         assert_eq!(main.core_rpc_port, 9998);
         let test = config
             .config_for_network(Network::Testnet)
@@ -500,7 +503,7 @@ mod tests {
         };
         assert!(config.mainnet_config.is_none());
         let new_cfg = make_network_config("https://1.1.1.1:443", 9998);
-        config.update_config_for_network(Network::Dash, new_cfg);
+        config.update_config_for_network(Network::Mainnet, new_cfg);
         assert!(config.mainnet_config.is_some());
         assert_eq!(config.mainnet_config.as_ref().unwrap().core_rpc_port, 9998);
     }
@@ -515,7 +518,7 @@ mod tests {
             developer_mode: None,
         };
         let new_cfg = make_network_config("https://new.example.com:443", 2222);
-        config.update_config_for_network(Network::Dash, new_cfg);
+        config.update_config_for_network(Network::Mainnet, new_cfg);
         let main = config.mainnet_config.as_ref().unwrap();
         assert_eq!(main.core_rpc_port, 2222);
         assert_eq!(main.dapi_addresses, "https://new.example.com:443");

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -360,7 +360,7 @@ impl ConnectionStatus {
         local_chainlock: &Option<ChainLock>,
     ) {
         let online = match network {
-            Network::Dash => mainnet_chainlock.is_some(),
+            Network::Mainnet => mainnet_chainlock.is_some(),
             Network::Testnet => testnet_chainlock.is_some(),
             Network::Devnet => devnet_chainlock.is_some(),
             Network::Regtest => local_chainlock.is_some(),

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -145,6 +145,13 @@ impl ConnectionStatus {
 
     pub fn set_spv_status(&self, status: SpvStatus) {
         self.spv_status.store(status as u8, Ordering::Relaxed);
+        // Clear the "no peers" timer when SPV leaves an active state to avoid
+        // stale peer-degraded warnings in tooltips.
+        if !status.is_active()
+            && let Ok(mut since) = self.spv_no_peers_since.lock()
+        {
+            *since = None;
+        }
     }
 
     /// Set the last SPV error message (push-based from SpvManager event handlers).

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -161,6 +161,11 @@ impl ConnectionStatus {
         }
     }
 
+    /// Get the last SPV error message, if any.
+    pub fn spv_last_error(&self) -> Option<String> {
+        self.spv_last_error.lock().ok().and_then(|g| g.clone())
+    }
+
     /// Update SPV connected peer count and maintain `spv_no_peers_since` tracking.
     ///
     /// Called from SpvManager's network event handler when peer count changes.
@@ -349,10 +354,7 @@ impl ConnectionStatus {
                     OverallConnectionState::Syncing => "Syncing".into(),
                     OverallConnectionState::Error => {
                         let detail = self
-                            .spv_last_error
-                            .lock()
-                            .ok()
-                            .and_then(|g| g.clone())
+                            .spv_last_error()
                             .unwrap_or_else(|| "unknown error".to_string());
                         format!("SPV sync error: {detail}").into()
                     }

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -147,18 +147,22 @@ impl ConnectionStatus {
         self.spv_status.store(status as u8, Ordering::Relaxed);
         // Clear the "no peers" timer when SPV leaves an active state to avoid
         // stale peer-degraded warnings in tooltips.
-        if !status.is_active()
-            && let Ok(mut since) = self.spv_no_peers_since.lock()
-        {
+        if !status.is_active() {
+            let mut since = self
+                .spv_no_peers_since
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             *since = None;
         }
     }
 
     /// Set the last SPV error message (push-based from SpvManager event handlers).
     pub fn set_spv_last_error(&self, error: Option<String>) {
-        if let Ok(mut err) = self.spv_last_error.lock() {
-            *err = error;
-        }
+        let mut err = self
+            .spv_last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *err = error;
     }
 
     /// Get the last SPV error message, if any.

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -147,6 +147,29 @@ impl ConnectionStatus {
         self.spv_status.store(status as u8, Ordering::Relaxed);
     }
 
+    /// Set the last SPV error message (push-based from SpvManager event handlers).
+    pub fn set_spv_last_error(&self, error: Option<String>) {
+        if let Ok(mut err) = self.spv_last_error.lock() {
+            *err = error;
+        }
+    }
+
+    /// Update SPV connected peer count and maintain `spv_no_peers_since` tracking.
+    ///
+    /// Called from SpvManager's network event handler when peer count changes.
+    pub fn set_spv_connected_peers(&self, count: u16) {
+        self.spv_connected_peers.store(count, Ordering::Relaxed);
+        let mut since = self
+            .spv_no_peers_since
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if count > 0 || !self.spv_status().is_active() {
+            *since = None;
+        } else if since.is_none() {
+            *since = Some(Instant::now());
+        }
+    }
+
     pub fn backend_mode(&self) -> CoreBackendMode {
         self.backend_mode.load(Ordering::Relaxed).into()
     }
@@ -435,28 +458,9 @@ impl ConnectionStatus {
 
         match backend_mode {
             CoreBackendMode::Spv => {
-                let snapshot = app_context.spv_manager().status();
-                tracing::trace!(
-                    "ConnectionStatus: polled SPV status = {:?}",
-                    snapshot.status
-                );
-                self.set_spv_status(snapshot.status);
-                if let Ok(mut err) = self.spv_last_error.lock() {
-                    *err = snapshot.last_error;
-                }
-                let peers = (snapshot.connected_peers).min(u16::MAX as usize) as u16;
-                self.spv_connected_peers.store(peers, Ordering::Relaxed);
-
-                // Track how long we've been active with zero peers.
-                let mut since = self
-                    .spv_no_peers_since
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
-                if peers > 0 || !snapshot.status.is_active() {
-                    *since = None;
-                } else if since.is_none() {
-                    *since = Some(Instant::now());
-                }
+                // SPV status is push-based: SpvManager event handlers call
+                // set_spv_status / set_spv_connected_peers / set_spv_last_error
+                // directly, so no polling is needed here.
             }
             CoreBackendMode::Rpc => {
                 // Update ZMQ status if there's a new event

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -729,7 +729,7 @@ impl AppContext {
 pub(crate) const fn default_platform_version(network: &Network) -> &'static PlatformVersion {
     // TODO: Ideally use sdk.load().version() but this is a free function with no sdk access
     match network {
-        Network::Dash => &PLATFORM_V11,
+        Network::Mainnet => &PLATFORM_V11,
         Network::Testnet => &PLATFORM_V11,
         Network::Devnet => &PLATFORM_V11,
         Network::Regtest => &PLATFORM_V11,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -271,6 +271,9 @@ impl AppContext {
         let use_local_spv_node = db.get_use_local_spv_node().unwrap_or(false);
         spv_manager.set_use_local_node(use_local_spv_node);
 
+        // Wire up push-based SPV status updates to ConnectionStatus
+        spv_manager.set_connection_status(Arc::clone(&connection_status));
+
         // Load the core backend mode from settings, defaulting to RPC if not set
         let saved_core_backend_mode = db
             .get_settings()

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -381,7 +381,13 @@ impl AppContext {
             Network::Testnet => WalletNetwork::Testnet,
             Network::Devnet => WalletNetwork::Devnet,
             Network::Regtest => WalletNetwork::Regtest,
-            _ => WalletNetwork::Mainnet,
+            other => {
+                tracing::debug!(
+                    ?other,
+                    "Unknown Network variant, defaulting to Mainnet wallet key"
+                );
+                WalletNetwork::Mainnet
+            }
         }
     }
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -377,11 +377,11 @@ impl AppContext {
 
     pub(crate) fn wallet_network_key(&self) -> WalletNetwork {
         match self.network {
-            Network::Dash => WalletNetwork::Dash,
+            Network::Mainnet => WalletNetwork::Mainnet,
             Network::Testnet => WalletNetwork::Testnet,
             Network::Devnet => WalletNetwork::Devnet,
             Network::Regtest => WalletNetwork::Regtest,
-            _ => WalletNetwork::Dash,
+            _ => WalletNetwork::Mainnet,
         }
     }
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -182,13 +182,8 @@ impl AppContext {
     fn queue_spv_wallet_load(self: &Arc<Self>, seed_hash: WalletSeedHash, seed_bytes: [u8; 64]) {
         let spv = Arc::clone(&self.spv_manager);
         self.subtasks.spawn_sync("spv_wallet_load", async move {
-            match spv.load_wallet_from_seed(seed_hash, seed_bytes).await {
-                Ok(_wallet_id) => {
-                    spv.notify_wallet_addresses_changed().await;
-                }
-                Err(error) => {
-                    tracing::error!(seed = %hex::encode(seed_hash), %error, "Failed to load SPV wallet from seed");
-                }
+            if let Err(error) = spv.load_wallet_from_seed(seed_hash, seed_bytes).await {
+                tracing::error!(seed = %hex::encode(seed_hash), %error, "Failed to load SPV wallet from seed");
             }
         });
     }

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -4,7 +4,7 @@ use crate::backend_task::error::TaskError;
 use crate::database::is_unique_constraint_violation;
 use crate::model::wallet::{
     AddressInfo as WalletAddressInfo, DerivationPathHelpers, DerivationPathReference,
-    DerivationPathType, Wallet, WalletSeedHash, WalletTransaction,
+    DerivationPathType, TransactionStatus, Wallet, WalletSeedHash, WalletTransaction,
 };
 use crate::spv::{AssetLockFinalityEvent, CoreBackendMode, SpvManager};
 use dash_sdk::dpp::dashcore::hashes::Hash;
@@ -824,16 +824,20 @@ impl AppContext {
                 .map_err(|e| crate::spv::SpvError::WalletError(e.to_string()))?;
             let wallet_transactions: Vec<WalletTransaction> = history
                 .into_iter()
-                .map(|record| WalletTransaction {
-                    txid: record.txid,
-                    transaction: record.transaction.clone(),
-                    timestamp: record.timestamp,
-                    height: record.height,
-                    block_hash: record.block_hash,
-                    net_amount: record.net_amount,
-                    fee: record.fee,
-                    label: record.label.clone(),
-                    is_ours: record.is_ours,
+                .map(|record| {
+                    let status = TransactionStatus::from_height(record.height);
+                    WalletTransaction {
+                        txid: record.txid,
+                        transaction: record.transaction.clone(),
+                        timestamp: record.timestamp,
+                        height: record.height,
+                        block_hash: record.block_hash,
+                        net_amount: record.net_amount,
+                        fee: record.fee,
+                        label: record.label.clone(),
+                        is_ours: record.is_ours,
+                        status,
+                    }
                 })
                 .collect();
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -182,8 +182,13 @@ impl AppContext {
     fn queue_spv_wallet_load(self: &Arc<Self>, seed_hash: WalletSeedHash, seed_bytes: [u8; 64]) {
         let spv = Arc::clone(&self.spv_manager);
         self.subtasks.spawn_sync("spv_wallet_load", async move {
-            if let Err(error) = spv.load_wallet_from_seed(seed_hash, seed_bytes).await {
-                tracing::error!(seed = %hex::encode(seed_hash), %error, "Failed to load SPV wallet from seed");
+            match spv.load_wallet_from_seed(seed_hash, seed_bytes).await {
+                Ok(_wallet_id) => {
+                    spv.notify_wallet_addresses_changed().await;
+                }
+                Err(error) => {
+                    tracing::error!(seed = %hex::encode(seed_hash), %error, "Failed to load SPV wallet from seed");
+                }
             }
         });
     }

--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -18,7 +18,7 @@ use tracing::{error, info};
 impl Database {
     pub fn get_all_contested_names(&self, app_context: &AppContext) -> Result<Vec<ContestedName>> {
         let network = app_context.network.to_string();
-        let contest_duration = if app_context.network == Network::Dash {
+        let contest_duration = if app_context.network == Network::Mainnet {
             Duration::from_secs(60 * 60 * 24 * 14)
         } else {
             Duration::from_secs(60 * 90)
@@ -183,7 +183,7 @@ impl Database {
         app_context: &AppContext,
     ) -> Result<Vec<ContestedName>> {
         let network = app_context.network.to_string();
-        let contest_duration = if app_context.network == Network::Dash {
+        let contest_duration = if app_context.network == Network::Mainnet {
             Duration::from_secs(60 * 60 * 24 * 14)
         } else {
             Duration::from_secs(60 * 90)

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -930,7 +930,12 @@ impl Database {
             conn.execute(
                 &format!("UPDATE {table} SET network = 'mainnet' WHERE network = 'dash'"),
                 [],
-            )?;
+            )
+            .map_err(|e| {
+                rusqlite::Error::InvalidParameterName(format!(
+                    "migration 29: failed to update network in table `{table}`: {e}"
+                ))
+            })?;
         }
         Ok(())
     }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,9 +4,9 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 28;
+pub const DEFAULT_DB_VERSION: u16 = 29;
 
-pub const DEFAULT_NETWORK: &str = "dash";
+pub const DEFAULT_NETWORK: &str = "mainnet";
 
 impl Database {
     pub fn initialize(&self, db_file_path: &Path) -> rusqlite::Result<()> {
@@ -51,6 +51,9 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
+            29 => {
+                self.rename_network_dash_to_mainnet(tx)?;
+            }
             28 => {
                 self.add_core_wallet_name_column(tx)?;
                 self.init_contacts_tables(tx)?;
@@ -894,6 +897,41 @@ impl Database {
             "CREATE INDEX IF NOT EXISTS idx_asset_lock_transaction_network ON asset_lock_transaction (network)",
             [],
         )?;
+        Ok(())
+    }
+
+    /// Migration 29: rename network value "dash" to "mainnet" in all tables.
+    ///
+    /// Upstream `dashcore` renamed `Network::Dash` to `Network::Mainnet`,
+    /// which changes `Display`/`FromStr` representations from `"dash"` to
+    /// `"mainnet"`.  This migration updates every table that stores the
+    /// network as a string.
+    fn rename_network_dash_to_mainnet(&self, conn: &Connection) -> rusqlite::Result<()> {
+        let tables = [
+            "settings",
+            "wallet",
+            "wallet_addresses",
+            "platform_address_balances",
+            "utxos",
+            "asset_lock_transaction",
+            "identity",
+            "contested_name",
+            "contestant",
+            "contract",
+            "scheduled_votes",
+            "dashpay_profiles",
+            "dashpay_contact_requests",
+            "dashpay_contacts",
+            "wallet_transactions",
+            "single_key_wallet",
+            "token",
+        ];
+        for table in tables {
+            conn.execute(
+                &format!("UPDATE {table} SET network = 'mainnet' WHERE network = 'dash'"),
+                [],
+            )?;
+        }
         Ok(())
     }
 }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -910,7 +910,7 @@ impl Database {
         let tables = [
             "settings",
             "wallet",
-            "wallet_addresses",
+            "identity_token_balances",
             "platform_address_balances",
             "utxos",
             "asset_lock_transaction",

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 29;
+pub const DEFAULT_DB_VERSION: u16 = 30;
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
 
@@ -51,6 +51,9 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
+            30 => {
+                self.add_wallet_transaction_status_column(tx)?;
+            }
             29 => {
                 self.rename_network_dash_to_mainnet(tx)?;
             }
@@ -906,6 +909,16 @@ impl Database {
     /// which changes `Display`/`FromStr` representations from `"dash"` to
     /// `"mainnet"`.  This migration updates every table that stores the
     /// network as a string.
+    /// Migration 30: add `status` column to `wallet_transactions`.
+    /// Default 2 (Confirmed) — all pre-existing rows were confirmed transactions.
+    fn add_wallet_transaction_status_column(&self, conn: &Connection) -> rusqlite::Result<()> {
+        conn.execute(
+            "ALTER TABLE wallet_transactions ADD COLUMN status INTEGER NOT NULL DEFAULT 2",
+            [],
+        )?;
+        Ok(())
+    }
+
     fn rename_network_dash_to_mainnet(&self, conn: &Connection) -> rusqlite::Result<()> {
         let tables = [
             "settings",

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 30;
+pub const DEFAULT_DB_VERSION: u16 = 29;
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
 
@@ -51,11 +51,9 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
-            30 => {
-                self.add_wallet_transaction_status_column(tx)?;
-            }
             29 => {
                 self.rename_network_dash_to_mainnet(tx)?;
+                self.add_wallet_transaction_status_column(tx)?;
             }
             28 => {
                 self.add_core_wallet_name_column(tx)?;

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -910,10 +910,17 @@ impl Database {
     /// Migration 30: add `status` column to `wallet_transactions`.
     /// Default 2 (Confirmed) — all pre-existing rows were confirmed transactions.
     fn add_wallet_transaction_status_column(&self, conn: &Connection) -> rusqlite::Result<()> {
-        conn.execute(
-            "ALTER TABLE wallet_transactions ADD COLUMN status INTEGER NOT NULL DEFAULT 2",
+        let has_status: bool = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('wallet_transactions') WHERE name='status'",
             [],
+            |row| row.get::<_, i32>(0).map(|count| count > 0),
         )?;
+        if !has_status {
+            conn.execute(
+                "ALTER TABLE wallet_transactions ADD COLUMN status INTEGER NOT NULL DEFAULT 2",
+                [],
+            )?;
+        }
         Ok(())
     }
 

--- a/src/database/settings.rs
+++ b/src/database/settings.rs
@@ -586,8 +586,7 @@ impl Database {
             // Network::Dash -> Network::Mainnet rename.
             let parsed_network = match network.to_lowercase().as_str() {
                 "dash" => Network::Mainnet,
-                other => Network::from_str(other)
-                    .map_err(|_| rusqlite::Error::InvalidQuery)?,
+                other => Network::from_str(other).map_err(|_| rusqlite::Error::InvalidQuery)?,
             };
 
             // Convert start_root_screen from int to enum

--- a/src/database/settings.rs
+++ b/src/database/settings.rs
@@ -581,9 +581,14 @@ impl Database {
                 _ => None,
             };
 
-            // Convert network from string to enum
-            let parsed_network =
-                Network::from_str(&network).map_err(|_| rusqlite::Error::InvalidQuery)?;
+            // Convert network from string to enum.
+            // Handle legacy "dash" value from databases created before the
+            // Network::Dash -> Network::Mainnet rename.
+            let parsed_network = match network.to_lowercase().as_str() {
+                "dash" => Network::Mainnet,
+                other => Network::from_str(other)
+                    .map_err(|_| rusqlite::Error::InvalidQuery)?,
+            };
 
             // Convert start_root_screen from int to enum
             let root_screen_type = RootScreenType::from_int(start_root_screen)
@@ -646,8 +651,8 @@ mod tests {
 
         let (network, root_screen, password_info, _, _, _, theme, core_mode, _, _, _, _) =
             settings.unwrap();
-        // Default network is "dash" (mainnet)
-        assert_eq!(network, Network::Dash);
+        // Default network is mainnet
+        assert_eq!(network, Network::Mainnet);
         // Default start screen is RootScreenDashPayProfile (20)
         assert_eq!(root_screen, RootScreenType::RootScreenDashPayProfile);
         // No password set initially

--- a/src/database/utxo.rs
+++ b/src/database/utxo.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_utxo_network_filtering() {
         let db = create_test_database().expect("Failed to create test database");
         let testnet_address = create_test_address(Network::Testnet);
-        let mainnet_address = create_test_address(Network::Dash);
+        let mainnet_address = create_test_address(Network::Mainnet);
         let txid = create_test_txid();
 
         // Insert UTXO for testnet
@@ -240,7 +240,7 @@ mod tests {
             &mainnet_address,
             200_000_000,
             mainnet_address.script_pubkey().as_bytes(),
-            Network::Dash,
+            Network::Mainnet,
         )
         .expect("Failed to insert mainnet UTXO");
 
@@ -253,7 +253,7 @@ mod tests {
 
         // Query mainnet UTXOs
         let mainnet_utxos = db
-            .get_utxos_by_address(&mainnet_address.to_string(), "dash")
+            .get_utxos_by_address(&mainnet_address.to_string(), "mainnet")
             .expect("Failed to get mainnet UTXOs");
         assert_eq!(mainnet_utxos.len(), 1);
         assert_eq!(mainnet_utxos[0].1.value, 200_000_000);

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -404,6 +404,10 @@ impl Database {
     }
 
     /// Replace all persisted transactions for a wallet+network with the provided set.
+    ///
+    /// Deduplicates by txid — if the same txid appears more than once (e.g. as
+    /// both a mempool entry and a confirmed entry), the confirmed version (with
+    /// a block height) takes priority.
     pub fn replace_wallet_transactions(
         &self,
         seed_hash: &[u8; 32],
@@ -424,6 +428,22 @@ impl Database {
             return Ok(());
         }
 
+        // Deduplicate by txid. With mempool support, upstream may return the
+        // same transaction both as unconfirmed (mempool) and confirmed (block).
+        // Prefer the confirmed version (has height) over unconfirmed.
+        let mut seen: std::collections::HashMap<dash_sdk::dpp::dashcore::Txid, &WalletTransaction> =
+            std::collections::HashMap::with_capacity(transactions.len());
+        for transaction in transactions {
+            seen.entry(transaction.txid)
+                .and_modify(|existing| {
+                    // Replace if the new entry is confirmed and the existing one isn't
+                    if transaction.height.is_some() && existing.height.is_none() {
+                        *existing = transaction;
+                    }
+                })
+                .or_insert(transaction);
+        }
+
         {
             let mut insert_stmt = tx.prepare(
                 "INSERT INTO wallet_transactions (
@@ -441,7 +461,7 @@ impl Database {
                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             )?;
 
-            for transaction in transactions {
+            for transaction in seen.values() {
                 let tx_bytes = serialize(&transaction.transaction);
                 let block_hash_bytes: Option<Vec<u8>> = transaction
                     .block_hash

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -2,7 +2,7 @@ use crate::database::{CorruptedBlobError, Database};
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::{
     AddressInfo, ClosedKeyItem, DerivationPathReference, DerivationPathType, OpenWalletSeed,
-    Wallet, WalletSeed, WalletTransaction,
+    TransactionStatus, Wallet, WalletSeed, WalletTransaction,
 };
 use dash_sdk::dashcore_rpc::dashcore::Address;
 use dash_sdk::dashcore_rpc::dashcore::transaction::special_transaction::TransactionPayload;
@@ -388,6 +388,7 @@ impl Database {
                 label TEXT,
                 is_ours INTEGER NOT NULL,
                 raw_transaction BLOB NOT NULL,
+                status INTEGER NOT NULL DEFAULT 2,
                 PRIMARY KEY (seed_hash, txid, network),
                 FOREIGN KEY (seed_hash) REFERENCES wallet(seed_hash) ON DELETE CASCADE
             )",
@@ -405,9 +406,10 @@ impl Database {
 
     /// Replace all persisted transactions for a wallet+network with the provided set.
     ///
-    /// Deduplicates by txid — if the same txid appears more than once (e.g. as
-    /// both a mempool entry and a confirmed entry), the confirmed version (with
-    /// a block height) takes priority.
+    /// Uses `INSERT OR REPLACE` so that when upstream returns the same txid
+    /// twice (e.g. as mempool + confirmed), the last-written version wins.
+    /// Callers should sort confirmed entries after unconfirmed to ensure the
+    /// confirmed version takes precedence.
     pub fn replace_wallet_transactions(
         &self,
         seed_hash: &[u8; 32],
@@ -428,25 +430,9 @@ impl Database {
             return Ok(());
         }
 
-        // Deduplicate by txid. With mempool support, upstream may return the
-        // same transaction both as unconfirmed (mempool) and confirmed (block).
-        // Prefer the confirmed version (has height) over unconfirmed.
-        let mut seen: std::collections::HashMap<dash_sdk::dpp::dashcore::Txid, &WalletTransaction> =
-            std::collections::HashMap::with_capacity(transactions.len());
-        for transaction in transactions {
-            seen.entry(transaction.txid)
-                .and_modify(|existing| {
-                    // Replace if the new entry is confirmed and the existing one isn't
-                    if transaction.height.is_some() && existing.height.is_none() {
-                        *existing = transaction;
-                    }
-                })
-                .or_insert(transaction);
-        }
-
         {
             let mut insert_stmt = tx.prepare(
-                "INSERT INTO wallet_transactions (
+                "INSERT OR REPLACE INTO wallet_transactions (
                     seed_hash,
                     txid,
                     network,
@@ -457,11 +443,12 @@ impl Database {
                     fee,
                     label,
                     is_ours,
-                    raw_transaction
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                    raw_transaction,
+                    status
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             )?;
 
-            for transaction in seen.values() {
+            for transaction in transactions {
                 let tx_bytes = serialize(&transaction.transaction);
                 let block_hash_bytes: Option<Vec<u8>> = transaction
                     .block_hash
@@ -480,6 +467,7 @@ impl Database {
                     transaction.label.as_deref(),
                     transaction.is_ours,
                     tx_bytes,
+                    transaction.status as u8,
                 ])?;
             }
         }
@@ -879,7 +867,7 @@ impl Database {
 
         tracing::trace!("step 7: load wallet transactions for each wallet");
         let mut tx_stmt = conn.prepare(
-            "SELECT seed_hash, txid, timestamp, height, block_hash, net_amount, fee, label, is_ours, raw_transaction
+            "SELECT seed_hash, txid, timestamp, height, block_hash, net_amount, fee, label, is_ours, raw_transaction, status
              FROM wallet_transactions WHERE network = ? ORDER BY timestamp DESC",
         )?;
 
@@ -894,6 +882,7 @@ impl Database {
             let label: Option<String> = row.get(7)?;
             let is_ours: bool = row.get(8)?;
             let raw_transaction: Vec<u8> = row.get(9)?;
+            let status_u8: u8 = row.get(10)?;
 
             let seed_hash_array: [u8; 32] = seed_hash.try_into().map_err(|_| {
                 rusqlite::Error::InvalidParameterName("Seed hash should be 32 bytes".to_string())
@@ -930,6 +919,7 @@ impl Database {
                     fee,
                     label,
                     is_ours,
+                    status: TransactionStatus::from_u8(status_u8),
                 },
             ))
         })?;

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -388,7 +388,7 @@ impl Database {
                 label TEXT,
                 is_ours INTEGER NOT NULL,
                 raw_transaction BLOB NOT NULL,
-                status INTEGER NOT NULL DEFAULT 2,
+                status INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (seed_hash, txid, network),
                 FOREIGN KEY (seed_hash) REFERENCES wallet(seed_hash) ON DELETE CASCADE
             )",

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -20,7 +20,7 @@ fn initialize_logger_internal() {
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::try_new(
-            "info,dash_evo_tool=trace,dash_sdk=debug,dash_sdk::platform::transition=trace,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn,dash_spv=debug",
+            "info,dash_evo_tool=trace,dash_sdk=debug,dash_sdk::platform::transition=trace,tenderdash_abci=debug,drive=debug,drive_proof_verifier=debug,rs_dapi_client=debug,h2=warn,dash_spv=debug,key_wallet=debug,mempool_filter=debug",
         )
         .unwrap_or_else(|_| EnvFilter::new("info"))
     });

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -287,7 +287,7 @@ impl<C> Decode<C> for QualifiedIdentity {
             wallet_index: None,
             top_ups: Default::default(),
             status: IdentityStatus::Unknown, // Loaded from the database, not encoded
-            network: Network::Dash,          // Loaded from the database, not encoded
+            network: Network::Mainnet,       // Loaded from the database, not encoded
         })
     }
 }

--- a/src/model/qualified_identity/qualified_identity_public_key.rs
+++ b/src/model/qualified_identity/qualified_identity_public_key.rs
@@ -56,7 +56,7 @@ impl QualifiedIdentityPublicKey {
 
                     let address = Address::new(network, Payload::PubkeyHash(pubkey_hash));
 
-                    let testnet_address = if network != Network::Dash {
+                    let testnet_address = if network != Network::Mainnet {
                         Some(Address::new(
                             Network::Testnet,
                             Payload::PubkeyHash(pubkey_hash),
@@ -100,7 +100,7 @@ impl QualifiedIdentityPublicKey {
 
                     let address = Address::p2pkh(&pubkey, network);
 
-                    let testnet_address = if network != Network::Dash {
+                    let testnet_address = if network != Network::Mainnet {
                         Some(Address::p2pkh(&pubkey, Network::Testnet))
                     } else {
                         None
@@ -147,7 +147,7 @@ impl QualifiedIdentityPublicKey {
 
                 let address = Address::new(network, Payload::PubkeyHash(pubkey_hash));
 
-                let testnet_address = if network != Network::Dash {
+                let testnet_address = if network != Network::Mainnet {
                     Some(Address::new(
                         Network::Testnet,
                         Payload::PubkeyHash(pubkey_hash),

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -101,7 +101,7 @@ impl Default for Settings {
     /// Default settings for the application
     fn default() -> Self {
         Self::new(
-            Network::Dash,
+            Network::Mainnet,
             RootScreenType::RootScreenDashpay,
             None,
             None, // autodetect

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -69,7 +69,7 @@ pub const DASH_BIP44_ACCOUNT_0_PATH_TESTNET: [ChildNumber; 3] = [
 fn networks_address_compatible(a: &Network, b: &Network) -> bool {
     matches!(
         (a, b),
-        (Network::Dash, Network::Dash)
+        (Network::Mainnet, Network::Mainnet)
             | (
                 Network::Testnet | Network::Devnet | Network::Regtest,
                 Network::Testnet | Network::Devnet | Network::Regtest,
@@ -151,7 +151,7 @@ pub trait DerivationPathHelpers {
 
 pub(crate) fn is_bip44_path(path: &DerivationPath, network: Network) -> bool {
     let coin_type = match network {
-        Network::Dash => 5,
+        Network::Mainnet => 5,
         _ => 1,
     };
     let components = path.as_ref();
@@ -188,7 +188,7 @@ impl DerivationPathHelpers for DerivationPath {
 
     fn is_asset_lock_funding(&self, network: Network) -> bool {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         let components = self.as_ref();
@@ -217,7 +217,7 @@ impl DerivationPathHelpers for DerivationPath {
     /// Check if this path is a DIP-17 Platform payment path: m/9'/coin_type'/17'/account'/key_class'/index
     fn is_platform_payment(&self, network: Network) -> bool {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         let components = self.as_ref();
@@ -236,7 +236,7 @@ impl DerivationPathHelpers for DerivationPath {
         index: u32,
     ) -> DerivationPath {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         DerivationPath::from(vec![
@@ -450,7 +450,7 @@ impl Wallet {
     /// Returns the BIP44 account 0 derivation path for the given network.
     fn bip44_account0_path(network: Network) -> DerivationPath {
         match network {
-            Network::Dash => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_MAINNET.as_slice()),
+            Network::Mainnet => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_MAINNET.as_slice()),
             _ => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_TESTNET.as_slice()),
         }
     }
@@ -485,7 +485,7 @@ impl Wallet {
             .map_err(|e| format!("Failed to derive first receive address: {e}"))?;
         let address = Address::p2pkh(&pk.to_pub(), network);
         let bip44 = match network {
-            Network::Dash => &DASH_BIP44_ACCOUNT_0_PATH_MAINNET,
+            Network::Mainnet => &DASH_BIP44_ACCOUNT_0_PATH_MAINNET,
             _ => &DASH_BIP44_ACCOUNT_0_PATH_TESTNET,
         };
         let full_path = DerivationPath::from(
@@ -1498,7 +1498,7 @@ impl Wallet {
 
     fn coin_type(network: Network) -> u32 {
         match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         }
     }
@@ -2245,7 +2245,7 @@ impl Signer<PlatformAddress> for Wallet {
         // 3. get_platform_address_private_key will only succeed for the correct network
         // 4. Only one network's derivation will match the wallet's seed
         let private_key = self
-            .get_platform_address_private_key(platform_address, Network::Dash)
+            .get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| {
@@ -2274,7 +2274,7 @@ impl Signer<PlatformAddress> for Wallet {
         // The Signer trait doesn't pass network info, so we try each network.
         // This is safe - see comment in sign() above for explanation.
         let private_key = self
-            .get_platform_address_private_key(platform_address, Network::Dash)
+            .get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| {
@@ -2298,7 +2298,7 @@ impl Signer<PlatformAddress> for Wallet {
         }
 
         // Check if we have the private key for this address
-        self.get_platform_address_private_key(platform_address, Network::Dash)
+        self.get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Regtest))
@@ -3222,7 +3222,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
             ChildNumber::Normal { index: 0 },
         ]);
-        assert!(path.is_bip44(Network::Dash));
+        assert!(path.is_bip44(Network::Mainnet));
         assert!(!path.is_bip44(Network::Testnet));
     }
 
@@ -3237,7 +3237,7 @@ mod tests {
         ]);
         assert!(path.is_bip44(Network::Testnet));
         assert!(path.is_bip44(Network::Devnet));
-        assert!(!path.is_bip44(Network::Dash));
+        assert!(!path.is_bip44(Network::Mainnet));
     }
 
     #[test]
@@ -3276,7 +3276,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
         ]);
         assert!(path.is_asset_lock_funding(Network::Testnet));
-        assert!(!path.is_asset_lock_funding(Network::Dash));
+        assert!(!path.is_asset_lock_funding(Network::Mainnet));
     }
 
     #[test]
@@ -3290,7 +3290,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
         ]);
         assert!(path.is_platform_payment(Network::Testnet));
-        assert!(!path.is_platform_payment(Network::Dash));
+        assert!(!path.is_platform_payment(Network::Mainnet));
     }
 
     #[test]
@@ -3369,7 +3369,10 @@ mod tests {
 
     #[test]
     fn test_networks_address_compatible() {
-        assert!(networks_address_compatible(&Network::Dash, &Network::Dash));
+        assert!(networks_address_compatible(
+            &Network::Mainnet,
+            &Network::Mainnet
+        ));
         assert!(networks_address_compatible(
             &Network::Testnet,
             &Network::Testnet
@@ -3383,12 +3386,12 @@ mod tests {
             &Network::Regtest
         ));
         assert!(!networks_address_compatible(
-            &Network::Dash,
+            &Network::Mainnet,
             &Network::Testnet
         ));
         assert!(!networks_address_compatible(
             &Network::Testnet,
-            &Network::Dash
+            &Network::Mainnet
         ));
     }
 

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -512,6 +512,62 @@ impl Wallet {
     }
 }
 
+/// Transaction lifecycle status.
+///
+/// Tracks the progression: Unconfirmed → InstantSendLocked → Confirmed → ChainLocked.
+/// Currently only Unconfirmed and Confirmed can be inferred from upstream data;
+/// InstantSendLocked and ChainLocked require upstream changes (rust-dashcore#569).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum TransactionStatus {
+    /// In mempool, no InstantSend lock
+    Unconfirmed = 0,
+    /// InstantSend-locked but not yet mined (requires rust-dashcore#569)
+    InstantSendLocked = 1,
+    /// Mined in a block
+    Confirmed = 2,
+    /// In a chain-locked block (highest finality, requires rust-dashcore#569)
+    ChainLocked = 3,
+}
+
+impl TransactionStatus {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            0 => Self::Unconfirmed,
+            1 => Self::InstantSendLocked,
+            2 => Self::Confirmed,
+            3 => Self::ChainLocked,
+            _ => Self::Unconfirmed,
+        }
+    }
+
+    /// Infer status from block height presence.
+    /// This is a best-effort heuristic until upstream provides richer context.
+    pub fn from_height(height: Option<u32>) -> Self {
+        if height.is_some() {
+            Self::Confirmed
+        } else {
+            Self::Unconfirmed
+        }
+    }
+
+    /// User-facing label for UI display.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Unconfirmed => "Unconfirmed",
+            Self::InstantSendLocked => "InstantSend",
+            Self::Confirmed => "Confirmed",
+            Self::ChainLocked => "ChainLocked",
+        }
+    }
+}
+
+impl std::fmt::Display for TransactionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct WalletTransaction {
     pub txid: Txid,
@@ -523,6 +579,7 @@ pub struct WalletTransaction {
     pub fee: Option<u64>,
     pub label: Option<String>,
     pub is_ours: bool,
+    pub status: TransactionStatus,
 }
 
 impl WalletTransaction {
@@ -3103,6 +3160,7 @@ mod tests {
             fee: Some(226),
             label: None,
             is_ours: true,
+            status: TransactionStatus::Confirmed,
         };
 
         assert!(tx.is_incoming());
@@ -3129,6 +3187,7 @@ mod tests {
             fee: Some(226),
             label: None,
             is_ours: true,
+            status: TransactionStatus::Unconfirmed,
         };
 
         assert!(!tx.is_incoming());
@@ -3155,6 +3214,7 @@ mod tests {
             fee: None,
             label: None,
             is_ours: false,
+            status: TransactionStatus::Unconfirmed,
         };
 
         assert!(!tx.is_incoming());

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -592,7 +592,10 @@ impl WalletTransaction {
     }
 
     pub fn is_confirmed(&self) -> bool {
-        self.height.is_some()
+        matches!(
+            self.status,
+            TransactionStatus::Confirmed | TransactionStatus::ChainLocked
+        )
     }
 
     pub fn amount_abs(&self) -> u64 {

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -453,6 +453,14 @@ impl SpvManager {
         Arc::clone(&self.wallet)
     }
 
+    /// Notify the SPV client that wallet addresses have changed, triggering
+    /// a mempool bloom filter rebuild.
+    pub async fn notify_wallet_addresses_changed(&self) {
+        if let Some(client) = self.spv_client.load_full() {
+            client.notify_wallet_addresses_changed().await;
+        }
+    }
+
     pub fn det_wallets_snapshot(&self) -> std::collections::BTreeMap<[u8; 32], WalletId> {
         self.det_wallets
             .read()

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1145,9 +1145,13 @@ impl SpvManager {
                             if let Some(s) = new_status {
                                 cs.set_spv_status(s);
                             }
-                            if is_error {
-                                cs.set_spv_last_error(error_msg);
-                            } else {
+                            // Only update last_error when we have a new message to set,
+                            // or when syncing successfully (clear stale errors).
+                            // Avoid clearing when is_error && error_msg is None — that
+                            // means last_error was already set by a prior error.
+                            if let Some(msg) = error_msg {
+                                cs.set_spv_last_error(Some(msg));
+                            } else if !is_error {
                                 cs.set_spv_last_error(None);
                             }
                             cs.refresh_state();

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -412,6 +412,15 @@ impl SpvManager {
         self.write_progress_updated_at(None)
             .map_err(|e| e.to_string())?;
 
+        // Push Starting status to ConnectionStatus immediately so the UI
+        // shows SPV Sync Status as soon as the user clicks "Sync", before
+        // the async progress watcher task starts.
+        if let Some(cs) = self.connection_status_snapshot() {
+            cs.set_spv_status(SpvStatus::Starting);
+            cs.set_spv_last_error(None);
+            cs.refresh_state();
+        }
+
         // Derive stop_token as a child of the global cancellation token so that
         // global shutdown automatically cancels SPV without requiring an explicit
         // SpvManager::stop() call.  SpvManager::stop() can still cancel it early.
@@ -463,10 +472,18 @@ impl SpvManager {
         if let Some(token) = maybe_token {
             tracing::info!("SpvManager::stop(): cancelling stop_token, setting Stopping");
             let _ = self.write_status(SpvStatus::Stopping);
+            if let Some(cs) = self.connection_status_snapshot() {
+                cs.set_spv_status(SpvStatus::Stopping);
+                cs.refresh_state();
+            }
             token.cancel();
         } else {
             tracing::debug!("SpvManager::stop(): no stop_token, setting Stopped immediately");
             let _ = self.write_status(SpvStatus::Stopped);
+            if let Some(cs) = self.connection_status_snapshot() {
+                cs.set_spv_status(SpvStatus::Stopped);
+                cs.refresh_state();
+            }
         }
     }
 

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -213,6 +213,12 @@ impl SpvManager {
             .write()
             .map_err(|_| SpvError::LockPoisoned("status".into()))?;
         *guard = value;
+        // Push every status transition to ConnectionStatus so the UI
+        // reflects changes immediately, without waiting for async watchers.
+        if let Some(cs) = self.connection_status_snapshot() {
+            cs.set_spv_status(value);
+            cs.refresh_state();
+        }
         Ok(())
     }
 
@@ -412,15 +418,6 @@ impl SpvManager {
         self.write_progress_updated_at(None)
             .map_err(|e| e.to_string())?;
 
-        // Push Starting status to ConnectionStatus immediately so the UI
-        // shows SPV Sync Status as soon as the user clicks "Sync", before
-        // the async progress watcher task starts.
-        if let Some(cs) = self.connection_status_snapshot() {
-            cs.set_spv_status(SpvStatus::Starting);
-            cs.set_spv_last_error(None);
-            cs.refresh_state();
-        }
-
         // Derive stop_token as a child of the global cancellation token so that
         // global shutdown automatically cancels SPV without requiring an explicit
         // SpvManager::stop() call.  SpvManager::stop() can still cancel it early.
@@ -449,10 +446,9 @@ impl SpvManager {
                 if let Err(e) = manager.write_status(SpvStatus::Error) {
                     tracing::error!("Failed to write SPV status: {}", e);
                 }
+                // Push last_error separately — write_status already pushed the status.
                 if let Some(cs) = manager.connection_status_snapshot() {
-                    cs.set_spv_status(SpvStatus::Error);
                     cs.set_spv_last_error(Some(err));
-                    cs.refresh_state();
                 }
             }
 
@@ -472,18 +468,10 @@ impl SpvManager {
         if let Some(token) = maybe_token {
             tracing::info!("SpvManager::stop(): cancelling stop_token, setting Stopping");
             let _ = self.write_status(SpvStatus::Stopping);
-            if let Some(cs) = self.connection_status_snapshot() {
-                cs.set_spv_status(SpvStatus::Stopping);
-                cs.refresh_state();
-            }
             token.cancel();
         } else {
             tracing::debug!("SpvManager::stop(): no stop_token, setting Stopped immediately");
             let _ = self.write_status(SpvStatus::Stopped);
-            if let Some(cs) = self.connection_status_snapshot() {
-                cs.set_spv_status(SpvStatus::Stopped);
-                cs.refresh_state();
-            }
         }
     }
 
@@ -904,10 +892,6 @@ impl SpvManager {
         self.spawn_request_handler(request_rx, stop_token.clone());
 
         let _ = self.write_status(SpvStatus::Syncing);
-        if let Some(cs) = self.connection_status_snapshot() {
-            cs.set_spv_status(SpvStatus::Syncing);
-            cs.refresh_state();
-        }
 
         // Run the client — handles start, monitoring, and stop internally
         let result = self.clone().run_client(client, stop_token).await;
@@ -957,18 +941,13 @@ impl SpvManager {
         match &result {
             Ok(()) => {
                 let _ = self.write_status(SpvStatus::Stopped);
-                if let Some(cs) = self.connection_status_snapshot() {
-                    cs.set_spv_status(SpvStatus::Stopped);
-                    cs.refresh_state();
-                }
             }
             Err(message) => {
                 let _ = self.write_last_error(Some(message.clone()));
                 let _ = self.write_status(SpvStatus::Error);
+                // Push last_error separately — write_status already pushed the status.
                 if let Some(cs) = self.connection_status_snapshot() {
-                    cs.set_spv_status(SpvStatus::Error);
                     cs.set_spv_last_error(Some(message.clone()));
-                    cs.refresh_state();
                 }
             }
         }

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -208,6 +208,10 @@ impl SpvManager {
     }
 
     fn write_status(&self, value: SpvStatus) -> SpvResult<()> {
+        // NOTE: spawn_progress_watcher() bypasses this method because it runs in an
+        // async move closure that captures Arc<RwLock<SpvStatus>> directly (no &self).
+        // If you add side-effects here, replicate them in spawn_progress_watcher()
+        // (around line ~1107).
         let mut guard = self
             .status
             .write()
@@ -230,6 +234,10 @@ impl SpvManager {
     }
 
     fn write_last_error(&self, value: Option<String>) -> SpvResult<()> {
+        // TODO: Push to ConnectionStatus here (like write_status does) to eliminate
+        // the scattered `cs.set_spv_last_error()` calls at each callsite.
+        // See: run_client exit (line ~451), sync manager error (line ~950),
+        // progress watcher (line ~1153), sync event handler (line ~1246).
         let mut guard = self
             .last_error
             .write()
@@ -1104,6 +1112,9 @@ impl SpvManager {
                         }
 
                         // Update status based on progress
+                        // NOTE: This bypasses write_status() because &self is unavailable in this
+                        // async move closure. If write_status() gains new side-effects, replicate
+                        // them here. See write_status() for the canonical status-push logic.
                         let new_status;
                         if let Ok(mut status_guard) = status.write() {
                             if is_synced {

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -3,6 +3,7 @@ use crate::config::NetworkConfig;
 use crate::model::wallet::WalletSeedHash;
 use crate::utils::tasks::TaskManager;
 use arc_swap::ArcSwapOption;
+use dash_sdk::dash_spv::client::config::MempoolStrategy;
 use dash_sdk::dash_spv::network::NetworkEvent;
 use dash_sdk::dash_spv::network::PeerNetworkManager;
 use dash_sdk::dash_spv::storage::DiskStorageManager;
@@ -1286,7 +1287,8 @@ impl SpvManager {
         let mut config = ClientConfig::new(self.network)
             .with_storage_path(self.data_dir.clone())
             .with_validation_mode(ValidationMode::Full)
-            .with_start_height(start_height);
+            .with_start_height(start_height)
+            .with_mempool_tracking(MempoolStrategy::BloomFilter);
 
         // Configure peer discovery based on network type and user preference.
         // Devnet/Regtest always need explicit peers since they're local networks.
@@ -1333,7 +1335,7 @@ impl SpvManager {
 
         let host = config.core_host.as_str();
         let port = match self.network {
-            Network::Dash => 9999,
+            Network::Mainnet => 9999,
             Network::Testnet => 19999,
             Network::Devnet => 20001,
             Network::Regtest => 19899,
@@ -1355,7 +1357,7 @@ fn build_spv_data_dir(
     fs::create_dir_all(&base).map_err(|e| format!("Failed to create SPV base dir: {e}"))?;
 
     let network_dir = match network {
-        Network::Dash => "mainnet".to_string(),
+        Network::Mainnet => "mainnet".to_string(),
         Network::Testnet => "testnet".to_string(),
         Network::Devnet => {
             let name = config
@@ -1400,7 +1402,7 @@ async fn notify_wallet_after_broadcast(
 ) {
     {
         let mut wm = wallet.write().await;
-        wm.process_mempool_transaction(tx).await;
+        let _ = wm.process_mempool_transaction(tx, false).await;
     }
     if let Some(ch) = reconcile_tx {
         let _ = ch.try_send(());

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -19,9 +19,9 @@ use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::{
     ManagedWalletInfo, transaction_building::AccountTypePreference,
     wallet_info_interface::WalletInfoInterface,
 };
-use dash_sdk::dpp::key_wallet_manager::WalletEvent;
-use dash_sdk::dpp::key_wallet_manager::wallet_interface::WalletInterface;
-use dash_sdk::dpp::key_wallet_manager::wallet_manager::{WalletError, WalletId, WalletManager};
+use dash_sdk::dpp::key_wallet_manager::manager::{
+    WalletError, WalletEvent, WalletId, WalletInterface, WalletManager,
+};
 use std::fmt;
 use std::fs;
 use std::net::ToSocketAddrs;

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1,5 +1,6 @@
 use super::error::{SpvError, SpvResult};
 use crate::config::NetworkConfig;
+use crate::context::connection_status::ConnectionStatus;
 use crate::model::wallet::WalletSeedHash;
 use crate::utils::tasks::TaskManager;
 use arc_swap::ArcSwapOption;
@@ -173,6 +174,8 @@ pub struct SpvManager {
     network_manager: Arc<AsyncRwLock<Option<PeerNetworkManager>>>,
     // Number of currently connected SPV peers
     connected_peers: Arc<RwLock<usize>>,
+    // Push SPV status updates to ConnectionStatus (set after construction)
+    connection_status: Mutex<Option<Arc<ConnectionStatus>>>,
 }
 
 /// Requests that can be sent to the SPV runtime thread
@@ -313,6 +316,7 @@ impl SpvManager {
             request_tx: Mutex::new(None),
             network_manager: Arc::new(AsyncRwLock::new(None)),
             connected_peers: Arc::new(RwLock::new(0)),
+            connection_status: Mutex::new(None),
         });
 
         Ok(manager)
@@ -327,6 +331,18 @@ impl SpvManager {
     /// Get whether to use local Dash Core node for SPV sync.
     pub fn use_local_node(&self) -> bool {
         self.use_local_node.load(Ordering::SeqCst)
+    }
+
+    /// Set the ConnectionStatus to receive push-based SPV status updates.
+    /// Must be called before `start()` so event handlers can push updates.
+    pub fn set_connection_status(&self, cs: Arc<ConnectionStatus>) {
+        if let Ok(mut guard) = self.connection_status.lock() {
+            *guard = Some(cs);
+        }
+    }
+
+    fn connection_status_snapshot(&self) -> Option<Arc<ConnectionStatus>> {
+        self.connection_status.lock().ok().and_then(|g| g.clone())
     }
 
     /// Async status method for getting full details including progress.
@@ -423,6 +439,11 @@ impl SpvManager {
                 }
                 if let Err(e) = manager.write_status(SpvStatus::Error) {
                     tracing::error!("Failed to write SPV status: {}", e);
+                }
+                if let Some(cs) = manager.connection_status_snapshot() {
+                    cs.set_spv_status(SpvStatus::Error);
+                    cs.set_spv_last_error(Some(err));
+                    cs.refresh_state();
                 }
             }
 
@@ -866,6 +887,10 @@ impl SpvManager {
         self.spawn_request_handler(request_rx, stop_token.clone());
 
         let _ = self.write_status(SpvStatus::Syncing);
+        if let Some(cs) = self.connection_status_snapshot() {
+            cs.set_spv_status(SpvStatus::Syncing);
+            cs.refresh_state();
+        }
 
         // Run the client — handles start, monitoring, and stop internally
         let result = self.clone().run_client(client, stop_token).await;
@@ -878,6 +903,9 @@ impl SpvManager {
         }
         if let Ok(mut guard) = self.connected_peers.write() {
             *guard = 0;
+        }
+        if let Some(cs) = self.connection_status_snapshot() {
+            cs.set_spv_connected_peers(0);
         }
         {
             // Drop shared storage/request handles so the disk lock is released before restart.
@@ -912,10 +940,19 @@ impl SpvManager {
         match &result {
             Ok(()) => {
                 let _ = self.write_status(SpvStatus::Stopped);
+                if let Some(cs) = self.connection_status_snapshot() {
+                    cs.set_spv_status(SpvStatus::Stopped);
+                    cs.refresh_state();
+                }
             }
             Err(message) => {
                 let _ = self.write_last_error(Some(message.clone()));
                 let _ = self.write_status(SpvStatus::Error);
+                if let Some(cs) = self.connection_status_snapshot() {
+                    cs.set_spv_status(SpvStatus::Error);
+                    cs.set_spv_last_error(Some(message.clone()));
+                    cs.refresh_state();
+                }
             }
         }
         result
@@ -1043,6 +1080,7 @@ impl SpvManager {
         let sync_progress_state = Arc::clone(&self.sync_progress_state);
         let progress_updated_at = Arc::clone(&self.progress_updated_at);
         let cancel = self.subtasks.cancellation_token.clone();
+        let connection_status = self.connection_status_snapshot();
 
         self.subtasks.spawn_sync("spv_progress_watcher", async move {
             loop {
@@ -1070,17 +1108,26 @@ impl SpvManager {
                         }
 
                         // Update status based on progress
+                        let new_status;
                         if let Ok(mut status_guard) = status.write() {
                             if is_synced {
                                 *status_guard = SpvStatus::Running;
+                                new_status = Some(SpvStatus::Running);
                             } else if is_error {
                                 *status_guard = SpvStatus::Error;
+                                new_status = Some(SpvStatus::Error);
                             } else if !matches!(*status_guard, SpvStatus::Stopping | SpvStatus::Stopped | SpvStatus::Error) {
                                 *status_guard = SpvStatus::Syncing;
+                                new_status = Some(SpvStatus::Syncing);
+                            } else {
+                                new_status = None;
                             }
+                        } else {
+                            new_status = None;
                         }
                         // Write last_error outside status lock to maintain
                         // consistent lock ordering (status → release → last_error).
+                        let mut error_msg = None;
                         if is_error
                             && let Ok(mut err_guard) = last_error.write()
                             && err_guard.is_none()
@@ -1089,10 +1136,25 @@ impl SpvManager {
                             // bug dashpay/rust-dashcore#469 (progress channel never
                             // receives SyncState::Error). Once fixed, this will fire.
                             let phase = failed_phase.unwrap_or("unknown phase");
-                            *err_guard = Some(format!(
+                            let msg = format!(
                                 "Sync failed: {} (reported by SPV progress channel)",
                                 phase
-                            ));
+                            );
+                            *err_guard = Some(msg.clone());
+                            error_msg = Some(msg);
+                        }
+
+                        // Push to ConnectionStatus
+                        if let Some(cs) = &connection_status {
+                            if let Some(s) = new_status {
+                                cs.set_spv_status(s);
+                            }
+                            if is_error {
+                                cs.set_spv_last_error(error_msg);
+                            } else {
+                                cs.set_spv_last_error(None);
+                            }
+                            cs.refresh_state();
                         }
                     }
                 }
@@ -1107,6 +1169,7 @@ impl SpvManager {
         let status = Arc::clone(&self.status);
         let last_error = Arc::clone(&self.last_error);
         let cancel = self.subtasks.cancellation_token.clone();
+        let connection_status = self.connection_status_snapshot();
 
         self.subtasks.spawn_sync("spv_sync_event_handler", async move {
             loop {
@@ -1149,6 +1212,11 @@ impl SpvManager {
                                     && let Ok(mut guard) = status.write()
                                 {
                                     *guard = SpvStatus::Running;
+                                    drop(guard);
+                                    if let Some(cs) = &connection_status {
+                                        cs.set_spv_status(SpvStatus::Running);
+                                        cs.refresh_state();
+                                    }
                                 }
 
                                 // Transition to Error when a sync manager reports a
@@ -1168,10 +1236,15 @@ impl SpvManager {
                                     let msg = format!("Sync manager {} failed: {}", manager, &error[..limit]);
                                     if let Ok(mut err_guard) = last_error.write() {
                                         if err_guard.is_none() {
-                                            *err_guard = Some(msg);
+                                            *err_guard = Some(msg.clone());
                                         } else {
                                             tracing::warn!(%manager, error, "SPV last_error already set, ignoring subsequent: {}", msg);
                                         }
+                                    }
+                                    if let Some(cs) = &connection_status {
+                                        cs.set_spv_status(SpvStatus::Error);
+                                        cs.set_spv_last_error(Some(msg));
+                                        cs.refresh_state();
                                     }
                                 }
 
@@ -1239,6 +1312,7 @@ impl SpvManager {
     ) {
         let connected_peers = Arc::clone(&self.connected_peers);
         let cancel = self.subtasks.cancellation_token.clone();
+        let connection_status = self.connection_status_snapshot();
 
         self.subtasks
             .spawn_sync("spv_network_event_handler", async move {
@@ -1250,6 +1324,11 @@ impl SpvManager {
                                 Ok(NetworkEvent::PeersUpdated { connected_count, .. }) => {
                                     if let Ok(mut guard) = connected_peers.write() {
                                         *guard = connected_count;
+                                    }
+                                    if let Some(cs) = &connection_status {
+                                        let peers = connected_count.min(u16::MAX as usize) as u16;
+                                        cs.set_spv_connected_peers(peers);
+                                        cs.refresh_state();
                                     }
                                 }
                                 Ok(_) => {

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -453,14 +453,6 @@ impl SpvManager {
         Arc::clone(&self.wallet)
     }
 
-    /// Notify the SPV client that wallet addresses have changed, triggering
-    /// a mempool bloom filter rebuild.
-    pub async fn notify_wallet_addresses_changed(&self) {
-        if let Some(client) = self.spv_client.load_full() {
-            client.notify_wallet_addresses_changed().await;
-        }
-    }
-
     pub fn det_wallets_snapshot(&self) -> std::collections::BTreeMap<[u8; 32], WalletId> {
         self.det_wallets
             .read()

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -177,7 +177,7 @@ pub fn add_left_panel(
                     // Reserve a fixed area at the bottom for the logo and labels,
                     // and make the button list above it vertically scrollable.
                     let mut bottom_reserved = Spacing::SM + 20.0; // spacing + logo height
-                    if app_context.network != Network::Dash {
+                    if app_context.network != Network::Mainnet {
                         bottom_reserved += 22.0; // network label + spacing
                     }
                     if app_context.is_developer_mode() {
@@ -311,7 +311,7 @@ pub fn add_left_panel(
                                         // Dash logo at the very bottom
                                         // Use 100x40 for rendering (2x for crisp display), then scale down
                                         if let Some(dash_texture) = load_svg_icon(ctx, "dashlogo.svg", 100, 40) {
-                                            if app_context.network == Network::Dash {
+                                            if app_context.network == Network::Mainnet {
                                                 ui.add_space(Spacing::SM);
                                             }
                                             let logo_size = egui::vec2(50.0, 20.0);
@@ -334,7 +334,7 @@ pub fn add_left_panel(
                                         }
 
                                         // Network label (if not on mainnet)
-                                        if app_context.network != Network::Dash {
+                                        if app_context.network != Network::Mainnet {
                                             let (network_name, network_color) = match app_context.network {
                                                 Network::Testnet => (
                                                     "Testnet",

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -621,7 +621,7 @@ impl ScreenLike for DocumentQueryScreen {
             DesiredAppAction::AddScreenType(Box::new(ScreenType::GroupActions)),
         );
         let mut action = AppAction::None;
-        if self.app_context.network == Network::Dash {
+        if self.app_context.network == Network::Mainnet {
             action |= add_top_panel(
                 ctx,
                 &self.app_context,

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -249,7 +249,7 @@ impl TransferScreen {
                 egui::TextEdit::singleline(&mut self.platform_address_input)
                     .hint_text(
                         if self.app_context.network
-                            == dash_sdk::dashcore_rpc::dashcore::Network::Dash
+                            == dash_sdk::dashcore_rpc::dashcore::Network::Mainnet
                         {
                             "Enter Platform address (dash1...)"
                         } else {

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -147,7 +147,7 @@ impl WithdrawalScreen {
             ui.horizontal(|ui| {
                 ui.label("Address:");
 
-                let hint = if self.app_context.network == Network::Dash {
+                let hint = if self.app_context.network == Network::Mainnet {
                     "Enter Core address (X.../7...)"
                 } else {
                     "Enter Core address (y.../8...)"

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -129,7 +129,7 @@ impl NetworkChooserScreen {
         }
 
         let current_context = match current_network {
-            Network::Dash => mainnet_app_context,
+            Network::Mainnet => mainnet_app_context,
             Network::Testnet => testnet_app_context.unwrap_or(mainnet_app_context),
             Network::Devnet => devnet_app_context.unwrap_or(mainnet_app_context),
             Network::Regtest => local_app_context.unwrap_or(mainnet_app_context),
@@ -157,7 +157,7 @@ impl NetworkChooserScreen {
             .unwrap_or(true);
 
         let mut backend_modes = HashMap::new();
-        backend_modes.insert(Network::Dash, mainnet_app_context.core_backend_mode());
+        backend_modes.insert(Network::Mainnet, mainnet_app_context.core_backend_mode());
         backend_modes.insert(
             Network::Testnet,
             testnet_app_context
@@ -210,7 +210,7 @@ impl NetworkChooserScreen {
 
     pub fn context_for_network(&self, network: Network) -> &Arc<AppContext> {
         match network {
-            Network::Dash => &self.mainnet_app_context,
+            Network::Mainnet => &self.mainnet_app_context,
             Network::Testnet if self.testnet_app_context.is_some() => {
                 self.testnet_app_context.as_ref().unwrap()
             }
@@ -354,7 +354,7 @@ impl NetworkChooserScreen {
                     };
 
                     let network_text = match self.current_network {
-                        Network::Dash => "Mainnet",
+                        Network::Mainnet => "Mainnet",
                         Network::Testnet => "Testnet",
                         Network::Devnet => "Devnet",
                         Network::Regtest => "Local",
@@ -371,12 +371,12 @@ impl NetworkChooserScreen {
                                 if ui
                                     .selectable_value(
                                         &mut self.current_network,
-                                        Network::Dash,
+                                        Network::Mainnet,
                                         "Mainnet",
                                     )
                                     .clicked()
                                 {
-                                    app_action = AppAction::SwitchNetwork(Network::Dash);
+                                    app_action = AppAction::SwitchNetwork(Network::Mainnet);
                                 }
                                 if self.testnet_app_context.is_some()
                                     && ui
@@ -1064,7 +1064,7 @@ impl NetworkChooserScreen {
                             if self.mainnet_app_context.core_backend_mode() == CoreBackendMode::Spv {
                                 self.mainnet_app_context.set_core_backend_mode(CoreBackendMode::Rpc);
                             }
-                            self.backend_modes.insert(Network::Dash, CoreBackendMode::Rpc);
+                            self.backend_modes.insert(Network::Mainnet, CoreBackendMode::Rpc);
 
                             if let Some(ref ctx) = self.testnet_app_context {
                                 ctx.stop_spv();
@@ -1753,7 +1753,7 @@ impl NetworkChooserScreen {
 
     fn current_network_label(&self) -> &'static str {
         match self.current_network {
-            Network::Dash => "Mainnet",
+            Network::Mainnet => "Mainnet",
             Network::Testnet => "Testnet",
             Network::Devnet => "Devnet",
             Network::Regtest => "Local",
@@ -1930,7 +1930,7 @@ impl NetworkChooserScreen {
 
     fn has_context_for(&self, network: Network) -> bool {
         match network {
-            Network::Dash => true,
+            Network::Mainnet => true,
             Network::Testnet => self.testnet_app_context.is_some(),
             Network::Devnet => self.devnet_app_context.is_some(),
             Network::Regtest => self.local_app_context.is_some(),
@@ -2031,8 +2031,10 @@ impl ScreenLike for NetworkChooserScreen {
             self.theme_preference = settings.theme_mode;
         }
 
-        self.backend_modes
-            .insert(Network::Dash, self.mainnet_app_context.core_backend_mode());
+        self.backend_modes.insert(
+            Network::Mainnet,
+            self.mainnet_app_context.core_backend_mode(),
+        );
         if let Some(ctx) = &self.testnet_app_context {
             self.backend_modes
                 .insert(Network::Testnet, ctx.core_backend_mode());

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -516,13 +516,14 @@ impl NetworkChooserScreen {
                 .entry(self.current_network)
                 .or_insert(CoreBackendMode::Rpc);
 
-            let ctx = self.current_app_context();
+            let ctx = self.current_app_context().clone();
             let status = ctx.connection_status();
             let disable_zmq = status.disable_zmq();
             let rpc_online = status.rpc_online();
             let zmq_connected = status.zmq_connected();
             let spv_status = status.spv_status();
             let spv_connected = ConnectionStatus::spv_connected(spv_status);
+            let spv_error_detail = status.spv_last_error();
             let snapshot = if current_backend_mode == CoreBackendMode::Spv {
                 Some(ctx.spv_manager().status().clone())
             } else {
@@ -734,7 +735,15 @@ impl NetworkChooserScreen {
                         } else {
                             DashColors::ERROR
                         };
-                        ui.colored_label(color, spv_status.to_string());
+                        let label = if spv_status == SpvStatus::Error {
+                            spv_error_detail
+                                .as_ref()
+                                .map(|e| format!("Error: {e}"))
+                                .unwrap_or_else(|| "Error".to_string())
+                        } else {
+                            spv_status.to_string()
+                        };
+                        ui.colored_label(color, label);
                     });
 
                     ui.horizontal(|ui| {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,6 +2,7 @@ use egui::{
     Button, Color32, CursorIcon, FontData, FontDefinitions, FontFamily, FontId, RichText, Stroke,
     Vec2, WidgetText,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1150,5 +1151,9 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
     ctx.set_style(style);
-    ctx.set_fonts(configure_fonts());
+
+    static FONTS_INITIALIZED: AtomicBool = AtomicBool::new(false);
+    if !FONTS_INITIALIZED.swap(true, Ordering::Relaxed) {
+        ctx.set_fonts(configure_fonts());
+    }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -477,7 +477,7 @@ impl DashColors {
         dark_mode: bool,
     ) -> Color32 {
         match network {
-            dash_sdk::dashcore_rpc::dashcore::Network::Dash => {
+            dash_sdk::dashcore_rpc::dashcore::Network::Mainnet => {
                 if dark_mode {
                     Self::DASH_BLUE_DARK
                 } else {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,7 +2,6 @@ use egui::{
     Button, Color32, CursorIcon, FontData, FontDefinitions, FontFamily, FontId, RichText, Stroke,
     Vec2, WidgetText,
 };
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1151,9 +1150,5 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
     ctx.set_style(style);
-
-    static FONTS_INITIALIZED: AtomicBool = AtomicBool::new(false);
-    if !FONTS_INITIALIZED.swap(true, Ordering::Relaxed) {
-        ctx.set_fonts(configure_fonts());
-    }
+    ctx.set_fonts(configure_fonts());
 }

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -3263,7 +3263,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3577,7 +3577,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3705,7 +3705,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -145,7 +145,7 @@ impl MnListData {
                     }
                 } else {
                     tracing::warn!("MNListDiff file not found: {}", file_path);
-                    MasternodeListEngine::default_for_network(Network::Mainnet)
+                    MasternodeListEngine::default_for_network(Network::Testnet)
                 }
             }
             _ => MasternodeListEngine::default_for_network(app_context.network),

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -91,7 +91,7 @@ impl MnListData {
     fn new(app_context: &Arc<AppContext>) -> Self {
         let mut mnlist_diffs = BTreeMap::new();
         let masternode_list_engine = match app_context.network {
-            Network::Dash => {
+            Network::Mainnet => {
                 use std::env;
                 tracing::debug!(
                     "Current working directory: {:?}",
@@ -108,18 +108,18 @@ impl MnListData {
                             MasternodeListEngine::initialize_with_diff_to_height(
                                 diff,
                                 2227096,
-                                Network::Dash,
+                                Network::Mainnet,
                             )
                             .expect("expected to start engine")
                         }
                         Err(e) => {
                             tracing::error!("Failed to read MNListDiff file: {}", e);
-                            MasternodeListEngine::default_for_network(Network::Dash)
+                            MasternodeListEngine::default_for_network(Network::Mainnet)
                         }
                     }
                 } else {
                     tracing::warn!("MNListDiff file not found: {}", file_path);
-                    MasternodeListEngine::default_for_network(Network::Dash)
+                    MasternodeListEngine::default_for_network(Network::Mainnet)
                 }
             }
             Network::Testnet => {
@@ -145,7 +145,7 @@ impl MnListData {
                     }
                 } else {
                     tracing::warn!("MNListDiff file not found: {}", file_path);
-                    MasternodeListEngine::default_for_network(Network::Dash)
+                    MasternodeListEngine::default_for_network(Network::Mainnet)
                 }
             }
             _ => MasternodeListEngine::default_for_network(app_context.network),
@@ -1285,7 +1285,7 @@ impl MasternodeListDiffScreen {
         let max_blocks = 2000;
 
         let loaded_list_height = match self.app_context.network {
-            Network::Dash => 2227096,
+            Network::Mainnet => 2227096,
             Network::Testnet => 1296600,
             _ => 0,
         };

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -153,7 +153,7 @@ impl WalletsBalancesScreen {
             .open(&mut open)
             .show(ctx, |ui| {
                 ui.label("Recipient Address");
-                let hint = if self.app_context.network == Network::Dash {
+                let hint = if self.app_context.network == Network::Mainnet {
                     "Enter Core address (X.../7...)"
                 } else {
                     "Enter Core address (y.../8...)"

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -10,7 +10,7 @@ use crate::backend_task::error::TaskError;
 use crate::context::AppContext;
 use crate::context::connection_status::spv_phase_summary;
 use crate::model::amount::Amount;
-use crate::model::wallet::{Wallet, WalletSeedHash, WalletTransaction};
+use crate::model::wallet::{TransactionStatus, Wallet, WalletSeedHash, WalletTransaction};
 use crate::spv::{CoreBackendMode, SpvStatus};
 use crate::ui::components::component_trait::Component;
 use crate::ui::components::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};
@@ -956,12 +956,17 @@ impl WalletsBalancesScreen {
     }
 
     fn format_transaction_status(tx: &WalletTransaction) -> String {
-        if tx.is_confirmed() {
-            tx.height
+        match tx.status {
+            TransactionStatus::Unconfirmed => "Pending".to_string(),
+            TransactionStatus::InstantSendLocked => "⚡ InstantSend".to_string(),
+            TransactionStatus::Confirmed => tx
+                .height
                 .map(|h| format!("Confirmed @{}", h))
-                .unwrap_or_else(|| "Confirmed".to_string())
-        } else {
-            "Pending".to_string()
+                .unwrap_or_else(|| "Confirmed".to_string()),
+            TransactionStatus::ChainLocked => tx
+                .height
+                .map(|h| format!("🔒 ChainLocked @{}", h))
+                .unwrap_or_else(|| "🔒 ChainLocked".to_string()),
         }
     }
 

--- a/tests/backend-e2e/framework/harness.rs
+++ b/tests/backend-e2e/framework/harness.rs
@@ -238,11 +238,17 @@ impl BackendTestContext {
         let (seed_hash, wallet_arc) = app_context
             .register_wallet(wallet)
             .expect("Failed to register test wallet");
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            amount_duffs,
+            "create_funded_test_wallet: registered new wallet"
+        );
 
         // Wait for SPV to pick up the wallet
         wait::wait_for_wallet_in_spv(app_context, seed_hash, Duration::from_secs(30))
             .await
             .expect("Test wallet not picked up by SPV");
+        tracing::trace!(seed_hash = ?&seed_hash[..4], "create_funded_test_wallet: wallet visible in SPV");
 
         // Get test wallet's receive address
         let test_address = {
@@ -251,6 +257,7 @@ impl BackendTestContext {
                 .expect("Failed to get test wallet receive address")
                 .to_string()
         };
+        tracing::trace!(address = %test_address, "create_funded_test_wallet: receive address derived");
 
         let framework_wallet_arc = {
             let wallets = app_context.wallets().read().expect("wallets lock");
@@ -275,11 +282,19 @@ impl BackendTestContext {
             request,
         });
 
+        tracing::trace!(seed_hash = ?&seed_hash[..4], "create_funded_test_wallet: broadcasting funding tx...");
+        let funding_start = std::time::Instant::now();
         run_task(app_context, task)
             .await
             .expect("Failed to send funds to test wallet");
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            elapsed_ms = funding_start.elapsed().as_millis(),
+            "create_funded_test_wallet: funding tx broadcast"
+        );
 
         // Wait for test wallet to see the funds
+        tracing::trace!(seed_hash = ?&seed_hash[..4], min = amount_duffs, "create_funded_test_wallet: waiting for total balance...");
         wait::wait_for_balance(
             app_context,
             seed_hash,
@@ -288,9 +303,15 @@ impl BackendTestContext {
         )
         .await
         .expect("Test wallet did not receive expected funds");
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            elapsed_ms = funding_start.elapsed().as_millis(),
+            "create_funded_test_wallet: total balance reached"
+        );
 
         // Wait for the full funded amount to become spendable so callers can
         // immediately build transactions without racing confirmations/IS locks.
+        tracing::trace!(seed_hash = ?&seed_hash[..4], min = amount_duffs, "create_funded_test_wallet: waiting for spendable balance (IS lock)...");
         wait::wait_for_spendable_balance(
             app_context,
             seed_hash,
@@ -299,8 +320,14 @@ impl BackendTestContext {
         )
         .await
         .expect("Test wallet funds did not become spendable");
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            elapsed_ms = funding_start.elapsed().as_millis(),
+            "create_funded_test_wallet: funds spendable (IS-locked)"
+        );
 
         // Wait for framework wallet change output to become spendable.
+        tracing::trace!(seed_hash = ?&seed_hash[..4], "create_funded_test_wallet: waiting for framework change to settle...");
         let _ = wait::wait_for_spendable_balance(
             app_context,
             self.framework_wallet_hash,
@@ -308,6 +335,11 @@ impl BackendTestContext {
             Duration::from_secs(30),
         )
         .await;
+        tracing::info!(
+            seed_hash = ?&seed_hash[..4],
+            total_elapsed_ms = funding_start.elapsed().as_millis(),
+            "create_funded_test_wallet: complete"
+        );
 
         (seed_hash, wallet_arc)
     }

--- a/tests/backend-e2e/framework/harness.rs
+++ b/tests/backend-e2e/framework/harness.rs
@@ -54,8 +54,10 @@ impl BackendTestContext {
         // Initialize tracing for test output
         let _ = tracing_subscriber::fmt()
             .with_env_filter(
-                tracing_subscriber::EnvFilter::from_default_env()
-                    .add_directive("backend_e2e=info".parse().unwrap()),
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| {
+                        tracing_subscriber::EnvFilter::new("backend_e2e=info")
+                    }),
             )
             .with_target(false)
             .try_init();

--- a/tests/backend-e2e/framework/harness.rs
+++ b/tests/backend-e2e/framework/harness.rs
@@ -55,9 +55,7 @@ impl BackendTestContext {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| {
-                        tracing_subscriber::EnvFilter::new("backend_e2e=info")
-                    }),
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("backend_e2e=info")),
             )
             .with_target(false)
             .try_init();
@@ -195,6 +193,14 @@ impl BackendTestContext {
             }
         }
 
+        // Wait for SPV to fully sync (including masternodes) so MempoolManager
+        // is active and bloom filter is built before any test broadcasts.
+        tracing::info!("Waiting for SPV to complete full sync (masternodes + mempool)...");
+        wait::wait_for_spv_running(&app_context, Duration::from_secs(120))
+            .await
+            .expect("SPV did not reach Running state within 120s");
+        tracing::info!("SPV fully synced — mempool bloom filter active");
+
         // Verify balance is above minimum threshold
         funding::verify_framework_funded(&app_context, framework_wallet_hash).await;
 
@@ -251,6 +257,11 @@ impl BackendTestContext {
             .await
             .expect("Test wallet not picked up by SPV");
         tracing::trace!(seed_hash = ?&seed_hash[..4], "create_funded_test_wallet: wallet visible in SPV");
+
+        // Allow mempool manager tick (100ms) to detect wallet address change
+        // and rebuild bloom filter before we broadcast.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        tracing::trace!(seed_hash = ?&seed_hash[..4], "create_funded_test_wallet: waited for bloom filter rebuild tick");
 
         // Get test wallet's receive address
         let test_address = {

--- a/tests/backend-e2e/framework/wait.rs
+++ b/tests/backend-e2e/framework/wait.rs
@@ -168,7 +168,7 @@ pub async fn wait_for_spv_running(
     use dash_evo_tool::spv::SpvStatus;
     timeout(wait_timeout, async {
         loop {
-            if app_context.spv_manager().status().status == SpvStatus::Running {
+            if app_context.connection_status().spv_status() == SpvStatus::Running {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;

--- a/tests/backend-e2e/framework/wait.rs
+++ b/tests/backend-e2e/framework/wait.rs
@@ -157,6 +157,32 @@ pub async fn wait_for_wallet_in_spv(
     .map_err(|_| "Timed out waiting for wallet in SPV".to_string())
 }
 
+/// Wait for SPV to complete initial sync (all managers including masternodes).
+///
+/// `SpvStatus::Running` is set after `SyncComplete` fires, which means
+/// MempoolManager is activated and bloom filter is built.
+pub async fn wait_for_spv_running(
+    app_context: &Arc<AppContext>,
+    wait_timeout: Duration,
+) -> Result<(), String> {
+    use dash_evo_tool::spv::SpvStatus;
+    timeout(wait_timeout, async {
+        loop {
+            if app_context.connection_status().spv_status() == SpvStatus::Running {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        format!(
+            "Timed out after {:?} waiting for SPV to reach Running state",
+            wait_timeout
+        )
+    })
+}
+
 /// Wait for SPV to connect to at least one peer.
 pub async fn wait_for_spv_peers(
     app_context: &Arc<AppContext>,

--- a/tests/backend-e2e/framework/wait.rs
+++ b/tests/backend-e2e/framework/wait.rs
@@ -14,7 +14,9 @@ pub async fn wait_for_balance(
     min_balance: u64,
     wait_timeout: Duration,
 ) -> Result<u64, String> {
+    let start = std::time::Instant::now();
     timeout(wait_timeout, async {
+        let mut poll_count = 0u32;
         loop {
             // Trigger reconcile so DET wallet model reflects latest SPV state
             if let Err(e) = app_context.reconcile_spv_wallets().await {
@@ -28,10 +30,26 @@ pub async fn wait_for_balance(
                     wallet.total_balance_duffs()
                 })
             };
+            poll_count += 1;
             if let Some(b) = balance
                 && b >= min_balance
             {
+                tracing::trace!(
+                    elapsed_ms = start.elapsed().as_millis(),
+                    polls = poll_count,
+                    balance = b,
+                    "wait_for_balance: satisfied"
+                );
                 return b;
+            }
+            if poll_count.is_multiple_of(5) {
+                tracing::trace!(
+                    elapsed_ms = start.elapsed().as_millis(),
+                    polls = poll_count,
+                    current = ?balance,
+                    target = min_balance,
+                    "wait_for_balance: polling..."
+                );
             }
             tokio::time::sleep(Duration::from_secs(2)).await;
         }
@@ -56,7 +74,9 @@ pub async fn wait_for_spendable_balance(
     min_balance: u64,
     wait_timeout: Duration,
 ) -> Result<u64, String> {
+    let start = std::time::Instant::now();
     timeout(wait_timeout, async {
+        let mut poll_count = 0u32;
         loop {
             // Trigger reconcile so DET wallet model reflects latest SPV state
             if let Err(e) = app_context.reconcile_spv_wallets().await {
@@ -70,10 +90,26 @@ pub async fn wait_for_spendable_balance(
                     wallet.spv_confirmed_balance()
                 })
             };
+            poll_count += 1;
             if let Some(b) = balance
                 && b >= min_balance
             {
+                tracing::trace!(
+                    elapsed_ms = start.elapsed().as_millis(),
+                    polls = poll_count,
+                    balance = b,
+                    "wait_for_spendable_balance: satisfied"
+                );
                 return b;
+            }
+            if poll_count.is_multiple_of(5) {
+                tracing::trace!(
+                    elapsed_ms = start.elapsed().as_millis(),
+                    polls = poll_count,
+                    current = ?balance,
+                    target = min_balance,
+                    "wait_for_spendable_balance: polling..."
+                );
             }
             tokio::time::sleep(Duration::from_secs(2)).await;
         }

--- a/tests/backend-e2e/framework/wait.rs
+++ b/tests/backend-e2e/framework/wait.rs
@@ -168,7 +168,7 @@ pub async fn wait_for_spv_running(
     use dash_evo_tool::spv::SpvStatus;
     timeout(wait_timeout, async {
         loop {
-            if app_context.connection_status().spv_status() == SpvStatus::Running {
+            if app_context.spv_manager().status().status == SpvStatus::Running {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
## Summary

Enable rust-dashcore's `MempoolManager` (8th SPV sync manager) with BIP37 bloom filter strategy. This is the **infrastructure layer** — the SPV client now detects incoming mempool transactions and processes them internally via `WalletManager`. UI-side improvements (instant balance refresh, unconfirmed tx indicators) are tracked separately in #780.

### What this PR does

- **Enable mempool tracking**: Configure `MempoolStrategy::BloomFilter` in `create_spv_client()` — MempoolManager starts automatically after sync completes
- **Push-based ConnectionStatus**: SPV status, peer count, and errors are now pushed from SpvManager event handlers (no UI frame loop needed). Both GUI and headless/test code use `ConnectionStatus` as single source of truth
- **Fix `process_mempool_transaction()` signature**: Updated for new `is_instant_send: bool` param + `MempoolTransactionResult` return type
- **Fix migration 29**: Was querying `wallet_addresses` (no network column) — now uses `identity_token_balances`
- **Fix testnet fallback**: Masternode list diff screen fell back to `Mainnet` instead of `Testnet`
- **E2E test harness**: Wait for `SpvStatus::Running` before broadcasting (ensures bloom filter is active), 200ms sleep for filter rebuild after new wallet registration
- **Import renames**: `key_wallet_manager` → `key_wallet` (upstream crate merge #503/#568)

### What this PR does NOT do (see #780)

- Handle `WalletEvent::TransactionReceived` / `TransactionStatusChanged` (consumed by wildcard match)
- Trigger immediate UI balance refresh on mempool detection
- Show visual indicators for unconfirmed vs confirmed transactions
- Display separate confirmed/pending balances

### Platform dependency

Updated through `dashpay/platform` `feat/mempool-support` branch → rust-dashcore `450f72f`.

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean
- [x] Backend E2E tests: 7/7 passed (63s) with bloom filter timing fix
- [ ] Manual: Start app on testnet, verify SPV reaches Running state, confirm mempool detection in logs

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push-based SPV status updates with mempool tracking for faster, more accurate network/sync reporting.
  * Explicit transaction status (Pending / InstantSend / Confirmed / ChainLocked) shown in wallet views.
  * Test helpers to wait for SPV running and richer timing/tracing in end-to-end flows.

* **Bug Fixes**
  * More informative connection error messages with surfaced SPV error details.

* **Chores**
  * Standardized mainnet identifier across app, UI, defaults and migrations; DB migration added and SDK revision updated.

* **Documentation**
  * Added a single-source-of-truth section for connection health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->