### PR TITLE
test: prove platform PR #3376 breaks Send inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "dpp",
  "drive",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "heck",
  "quote",
@@ -1876,7 +1876,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1911,7 +1911,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1969,12 +1969,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2002,7 +2002,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2291,7 +2291,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2351,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2361,17 +2361,17 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
  "derive_more 1.0.0",
  "dpp",
- "grovedb 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-epoch-based-storage-flags",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3523,20 +3523,20 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-dense-fixed-sized-merkle-tree",
- "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-merk 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-merk 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-merkle-mountain-range",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-query",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "hex",
  "hex-literal",
  "indexmap 2.13.0",
@@ -3549,11 +3549,11 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-merkle-mountain-range",
  "grovedb-query",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3584,11 +3584,11 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-query",
  "thiserror 2.0.18",
 ]
@@ -3610,12 +3610,12 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "hex",
  "integer-encoding",
  "thiserror 2.0.18",
@@ -3624,9 +3624,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "hex",
  "integer-encoding",
  "intmap",
@@ -3657,19 +3657,19 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
  "blake3",
  "byteorder",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "grovedb-query",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-visualize 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-visualize 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -3679,11 +3679,11 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
 ]
 
 [[package]]
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "hex",
 ]
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=9959201593826def0ad1f6db51b2ceb95b68a1ca#9959201593826def0ad1f6db51b2ceb95b68a1ca"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e#42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5840,19 +5840,18 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "aes",
  "cbc",
  "dashcore",
- "sha2",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -5861,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5872,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -5892,10 +5891,10 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "bincode 2.0.1",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]
@@ -5903,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6625,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "backon",
  "chrono",
@@ -7765,7 +7764,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8541,7 +8540,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9935,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=aa86b74f7e28dd0444fec9ceb13373bd22f768d9#aa86b74f7e28dd0444fec9ceb13373bd22f768d9"
+source = "git+https://github.com/dashpay/platform?rev=3286fcfc34dd75683054067d589730c2f088acf2#3286fcfc34dd75683054067d589730c2f088acf2"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "aa86b74f7e28dd0444fec9ceb13373bd22f768d9", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "3286fcfc34dd75683054067d589730c2f088acf2", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",

--- a/src/app.rs
+++ b/src/app.rs
@@ -228,7 +228,7 @@ impl AppState {
         let connection_status = Arc::new(ConnectionStatus::new());
         let mainnet_app_context = AppContext::new(
             data_dir.clone(),
-            Network::Dash,
+            Network::Mainnet,
             db.clone(),
             password_info.clone(),
             subtasks.clone(),
@@ -311,7 +311,7 @@ impl AppState {
             testnet_app_context.as_ref(),
             devnet_app_context.as_ref(),
             local_app_context.as_ref(),
-            Network::Dash,
+            Network::Mainnet,
             overwrite_dash_conf,
         );
 
@@ -323,7 +323,7 @@ impl AppState {
         // Validate that the saved network has an available context.
         // We fail fast instead of silently routing user actions to a different network.
         let chosen_network = match settings.network {
-            Network::Dash => Network::Dash,
+            Network::Mainnet => Network::Mainnet,
             Network::Testnet => {
                 assert!(
                     testnet_app_context.is_some(),
@@ -484,7 +484,7 @@ impl AppState {
             .unwrap_or(false);
         let mainnet_core_zmq_listener = if !mainnet_disable_zmq {
             match CoreZMQListener::spawn_listener(
-                Network::Dash,
+                Network::Mainnet,
                 &mainnet_core_zmq_endpoint,
                 core_message_sender.clone(),
                 Some(mainnet_app_context.sx_zmq_status.clone()),
@@ -787,7 +787,7 @@ impl AppState {
         // Invariant: chosen_network must always have a corresponding context.
         // Fail fast on violations to avoid silently routing operations to mainnet.
         match self.chosen_network {
-            Network::Dash => &self.mainnet_app_context,
+            Network::Mainnet => &self.mainnet_app_context,
             Network::Testnet => self.testnet_app_context.as_ref().unwrap_or_else(|| {
                 panic!(
                     "BUG: chosen network is Testnet but testnet_app_context is missing; refusing silent mainnet fallback"
@@ -812,7 +812,7 @@ impl AppState {
 
     fn context_available_for_network(&self, network: Network) -> bool {
         match network {
-            Network::Dash => true, // Mainnet is always available
+            Network::Mainnet => true, // Mainnet is always available
             Network::Testnet => self.testnet_app_context.is_some(),
             Network::Devnet => self.devnet_app_context.is_some(),
             Network::Regtest => self.local_app_context.is_some(),
@@ -1003,7 +1003,7 @@ impl AppState {
     //     task::spawn_blocking(move || {
     //         while let Ok((tx, islock, network)) = instant_send_receiver.recv() {
     //             let app_context = match network {
-    //                 Network::Dash => &mainnet_app_context,
+    //                 Network::Mainnet => &mainnet_app_context,
     //                 Network::Testnet => {
     //                     if let Some(context) = testnet_app_context.as_ref() {
     //                         context
@@ -1198,7 +1198,7 @@ impl App for AppState {
         // **Poll the instant_send_receiver for any new InstantSend messages**
         while let Ok((message, network)) = self.core_message_receiver.try_recv() {
             let app_context = match network {
-                Network::Dash => &self.mainnet_app_context,
+                Network::Mainnet => &self.mainnet_app_context,
                 Network::Testnet => {
                     if let Some(context) = self.testnet_app_context.as_ref() {
                         context

--- a/src/app_dir.rs
+++ b/src/app_dir.rs
@@ -62,7 +62,7 @@ pub fn core_cookie_path(
 ) -> Result<PathBuf, std::io::Error> {
     core_user_data_dir_path().and_then(|path| {
         let network_dir = match network {
-            Network::Dash => "",
+            Network::Mainnet => "",
             Network::Testnet => "testnet3",
             Network::Devnet => devnet_name.as_deref().unwrap_or(""),
             Network::Regtest => "regtest",
@@ -135,7 +135,7 @@ pub fn create_dash_core_config_if_not_exists(
     network: Network,
 ) -> Result<PathBuf, io::Error> {
     let (resource, filename) = match network {
-        Network::Dash => (BundledResource::CoreConfigMainnet, "mainnet.conf"),
+        Network::Mainnet => (BundledResource::CoreConfigMainnet, "mainnet.conf"),
         Network::Testnet => (BundledResource::CoreConfigTestnet, "testnet.conf"),
         Network::Devnet => (BundledResource::CoreConfigDevnet, "devnet.conf"),
         Network::Regtest => {

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -43,7 +43,7 @@ const DEFAULT_BIP44_ACCOUNT_INDEX: u32 = 0;
 fn networks_address_compatible(a: &Network, b: &Network) -> bool {
     matches!(
         (a, b),
-        (Network::Dash, Network::Dash)
+        (Network::Mainnet, Network::Mainnet)
             | (
                 Network::Testnet | Network::Devnet | Network::Regtest,
                 Network::Testnet | Network::Devnet | Network::Regtest,
@@ -182,12 +182,12 @@ impl AppContext {
                 // Load configs
                 let config = Config::load_from(&self.data_dir)?;
 
-                let maybe_mainnet_config = config.config_for_network(Network::Dash);
+                let maybe_mainnet_config = config.config_for_network(Network::Mainnet);
                 let maybe_testnet_config = config.config_for_network(Network::Testnet);
                 let maybe_devnet_config = config.config_for_network(Network::Devnet);
                 let maybe_local_config = config.config_for_network(Network::Regtest);
 
-                let mainnet_result = Self::get_best_chain_lock(maybe_mainnet_config, Network::Dash);
+                let mainnet_result = Self::get_best_chain_lock(maybe_mainnet_config, Network::Mainnet);
                 let testnet_result =
                     Self::get_best_chain_lock(maybe_testnet_config, Network::Testnet);
                 let devnet_result = Self::get_best_chain_lock(maybe_devnet_config, Network::Devnet);

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -187,7 +187,8 @@ impl AppContext {
                 let maybe_devnet_config = config.config_for_network(Network::Devnet);
                 let maybe_local_config = config.config_for_network(Network::Regtest);
 
-                let mainnet_result = Self::get_best_chain_lock(maybe_mainnet_config, Network::Mainnet);
+                let mainnet_result =
+                    Self::get_best_chain_lock(maybe_mainnet_config, Network::Mainnet);
                 let testnet_result =
                     Self::get_best_chain_lock(maybe_testnet_config, Network::Testnet);
                 let devnet_result = Self::get_best_chain_lock(maybe_devnet_config, Network::Devnet);

--- a/src/backend_task/dashpay/hd_derivation.rs
+++ b/src/backend_task/dashpay/hd_derivation.rs
@@ -384,11 +384,11 @@ mod tests {
         )
         .expect("Should derive xpub for testnet");
         let xpub_mainnet =
-            derive_dashpay_incoming_xpub(&master_seed, Network::Dash, 0, &sender_id, &recipient_id)
+            derive_dashpay_incoming_xpub(&master_seed, Network::Mainnet, 0, &sender_id, &recipient_id)
                 .expect("Should derive xpub for mainnet");
 
         // Keys should be the same but network should differ
         assert_eq!(xpub_testnet.network, Network::Testnet);
-        assert_eq!(xpub_mainnet.network, Network::Dash);
+        assert_eq!(xpub_mainnet.network, Network::Mainnet);
     }
 }

--- a/src/backend_task/dashpay/hd_derivation.rs
+++ b/src/backend_task/dashpay/hd_derivation.rs
@@ -383,9 +383,14 @@ mod tests {
             &recipient_id,
         )
         .expect("Should derive xpub for testnet");
-        let xpub_mainnet =
-            derive_dashpay_incoming_xpub(&master_seed, Network::Mainnet, 0, &sender_id, &recipient_id)
-                .expect("Should derive xpub for mainnet");
+        let xpub_mainnet = derive_dashpay_incoming_xpub(
+            &master_seed,
+            Network::Mainnet,
+            0,
+            &sender_id,
+            &recipient_id,
+        )
+        .expect("Should derive xpub for mainnet");
 
         // Keys should be the same but network should differ
         assert_eq!(xpub_testnet.network, Network::Testnet);

--- a/src/backend_task/mnlist.rs
+++ b/src/backend_task/mnlist.rs
@@ -80,7 +80,7 @@ pub async fn run_mnlist_task(
         } => {
             let client = app.core_client.read()?;
             let loaded_list_height = match app.network {
-                Network::Dash => 2_227_096,
+                Network::Mainnet => 2_227_096,
                 Network::Testnet => 1_296_600,
                 _ => 0,
             };

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -116,7 +116,7 @@ fn format_extended_epoch_info(
         };
 
     let epoch_estimated_time = match network {
-        Network::Dash => 788_400_000,
+        Network::Mainnet => 788_400_000,
         Network::Testnet => 3_600_000,
         Network::Devnet => 3_600_000,
         Network::Regtest => 1_200_000,

--- a/src/components/core_p2p_handler.rs
+++ b/src/components/core_p2p_handler.rs
@@ -88,7 +88,7 @@ enum ReadMessageError {
 impl CoreP2PHandler {
     pub fn new(network: Network, use_port: Option<u16>) -> Result<CoreP2PHandler, P2PError> {
         let port = use_port.unwrap_or(match network {
-            Network::Dash => 9999,
+            Network::Mainnet => 9999,
             Network::Testnet => 19999,
             Network::Devnet => 29999,
             Network::Regtest => 29999,
@@ -190,7 +190,7 @@ impl CoreP2PHandler {
         // QRInfo on mainnet can take noticeably longer to prepare.
         // Temporarily increase socket read timeout and our overall wait.
         let (socket_timeout, overall_timeout) = match self.network {
-            Network::Dash => (Duration::from_secs(60), Duration::from_secs(60)),
+            Network::Mainnet => (Duration::from_secs(60), Duration::from_secs(60)),
             _ => (Duration::from_secs(15), Duration::from_secs(15)),
         };
         let previous_socket_timeout = self.stream.read_timeout()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,7 +471,10 @@ mod tests {
             local_config: Some(make_network_config("http://127.0.0.1:2443", 20302)),
             developer_mode: Some(true),
         };
-        let main = config.config_for_network(Network::Mainnet).as_ref().unwrap();
+        let main = config
+            .config_for_network(Network::Mainnet)
+            .as_ref()
+            .unwrap();
         assert_eq!(main.core_rpc_port, 9998);
         let test = config
             .config_for_network(Network::Testnet)

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,7 +61,7 @@ pub struct NetworkConfig {
 impl Config {
     pub fn config_for_network(&self, network: Network) -> &Option<NetworkConfig> {
         match network {
-            Network::Dash => &self.mainnet_config,
+            Network::Mainnet => &self.mainnet_config,
             Network::Testnet => &self.testnet_config,
             Network::Devnet => &self.devnet_config,
             Network::Regtest => &self.local_config,
@@ -306,7 +306,7 @@ impl Config {
     /// Update (overwrite) the configuration for a particular network.
     pub fn update_config_for_network(&mut self, network: Network, new_config: NetworkConfig) {
         match network {
-            Network::Dash => self.mainnet_config = Some(new_config),
+            Network::Mainnet => self.mainnet_config = Some(new_config),
             Network::Testnet => self.testnet_config = Some(new_config),
             Network::Devnet => self.devnet_config = Some(new_config),
             Network::Regtest => self.local_config = Some(new_config),
@@ -456,7 +456,7 @@ mod tests {
             local_config: None,
             developer_mode: None,
         };
-        assert!(config.config_for_network(Network::Dash).is_some());
+        assert!(config.config_for_network(Network::Mainnet).is_some());
         assert!(config.config_for_network(Network::Testnet).is_none());
         assert!(config.config_for_network(Network::Devnet).is_none());
         assert!(config.config_for_network(Network::Regtest).is_none());
@@ -471,7 +471,7 @@ mod tests {
             local_config: Some(make_network_config("http://127.0.0.1:2443", 20302)),
             developer_mode: Some(true),
         };
-        let main = config.config_for_network(Network::Dash).as_ref().unwrap();
+        let main = config.config_for_network(Network::Mainnet).as_ref().unwrap();
         assert_eq!(main.core_rpc_port, 9998);
         let test = config
             .config_for_network(Network::Testnet)
@@ -500,7 +500,7 @@ mod tests {
         };
         assert!(config.mainnet_config.is_none());
         let new_cfg = make_network_config("https://1.1.1.1:443", 9998);
-        config.update_config_for_network(Network::Dash, new_cfg);
+        config.update_config_for_network(Network::Mainnet, new_cfg);
         assert!(config.mainnet_config.is_some());
         assert_eq!(config.mainnet_config.as_ref().unwrap().core_rpc_port, 9998);
     }
@@ -515,7 +515,7 @@ mod tests {
             developer_mode: None,
         };
         let new_cfg = make_network_config("https://new.example.com:443", 2222);
-        config.update_config_for_network(Network::Dash, new_cfg);
+        config.update_config_for_network(Network::Mainnet, new_cfg);
         let main = config.mainnet_config.as_ref().unwrap();
         assert_eq!(main.core_rpc_port, 2222);
         assert_eq!(main.dapi_addresses, "https://new.example.com:443");

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -360,7 +360,7 @@ impl ConnectionStatus {
         local_chainlock: &Option<ChainLock>,
     ) {
         let online = match network {
-            Network::Dash => mainnet_chainlock.is_some(),
+            Network::Mainnet => mainnet_chainlock.is_some(),
             Network::Testnet => testnet_chainlock.is_some(),
             Network::Devnet => devnet_chainlock.is_some(),
             Network::Regtest => local_chainlock.is_some(),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -729,7 +729,7 @@ impl AppContext {
 pub(crate) const fn default_platform_version(network: &Network) -> &'static PlatformVersion {
     // TODO: Ideally use sdk.load().version() but this is a free function with no sdk access
     match network {
-        Network::Dash => &PLATFORM_V11,
+        Network::Mainnet => &PLATFORM_V11,
         Network::Testnet => &PLATFORM_V11,
         Network::Devnet => &PLATFORM_V11,
         Network::Regtest => &PLATFORM_V11,

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -377,11 +377,11 @@ impl AppContext {
 
     pub(crate) fn wallet_network_key(&self) -> WalletNetwork {
         match self.network {
-            Network::Dash => WalletNetwork::Dash,
+            Network::Mainnet => WalletNetwork::Mainnet,
             Network::Testnet => WalletNetwork::Testnet,
             Network::Devnet => WalletNetwork::Devnet,
             Network::Regtest => WalletNetwork::Regtest,
-            _ => WalletNetwork::Dash,
+            _ => WalletNetwork::Mainnet,
         }
     }
 

--- a/src/database/contested_names.rs
+++ b/src/database/contested_names.rs
@@ -18,7 +18,7 @@ use tracing::{error, info};
 impl Database {
     pub fn get_all_contested_names(&self, app_context: &AppContext) -> Result<Vec<ContestedName>> {
         let network = app_context.network.to_string();
-        let contest_duration = if app_context.network == Network::Dash {
+        let contest_duration = if app_context.network == Network::Mainnet {
             Duration::from_secs(60 * 60 * 24 * 14)
         } else {
             Duration::from_secs(60 * 90)
@@ -183,7 +183,7 @@ impl Database {
         app_context: &AppContext,
     ) -> Result<Vec<ContestedName>> {
         let network = app_context.network.to_string();
-        let contest_duration = if app_context.network == Network::Dash {
+        let contest_duration = if app_context.network == Network::Mainnet {
             Duration::from_secs(60 * 60 * 24 * 14)
         } else {
             Duration::from_secs(60 * 90)

--- a/src/database/settings.rs
+++ b/src/database/settings.rs
@@ -647,7 +647,7 @@ mod tests {
         let (network, root_screen, password_info, _, _, _, theme, core_mode, _, _, _, _) =
             settings.unwrap();
         // Default network is "dash" (mainnet)
-        assert_eq!(network, Network::Dash);
+        assert_eq!(network, Network::Mainnet);
         // Default start screen is RootScreenDashPayProfile (20)
         assert_eq!(root_screen, RootScreenType::RootScreenDashPayProfile);
         // No password set initially

--- a/src/database/utxo.rs
+++ b/src/database/utxo.rs
@@ -219,7 +219,7 @@ mod tests {
     fn test_utxo_network_filtering() {
         let db = create_test_database().expect("Failed to create test database");
         let testnet_address = create_test_address(Network::Testnet);
-        let mainnet_address = create_test_address(Network::Dash);
+        let mainnet_address = create_test_address(Network::Mainnet);
         let txid = create_test_txid();
 
         // Insert UTXO for testnet
@@ -240,7 +240,7 @@ mod tests {
             &mainnet_address,
             200_000_000,
             mainnet_address.script_pubkey().as_bytes(),
-            Network::Dash,
+            Network::Mainnet,
         )
         .expect("Failed to insert mainnet UTXO");
 

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -287,7 +287,7 @@ impl<C> Decode<C> for QualifiedIdentity {
             wallet_index: None,
             top_ups: Default::default(),
             status: IdentityStatus::Unknown, // Loaded from the database, not encoded
-            network: Network::Mainnet,          // Loaded from the database, not encoded
+            network: Network::Mainnet,       // Loaded from the database, not encoded
         })
     }
 }

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -287,7 +287,7 @@ impl<C> Decode<C> for QualifiedIdentity {
             wallet_index: None,
             top_ups: Default::default(),
             status: IdentityStatus::Unknown, // Loaded from the database, not encoded
-            network: Network::Dash,          // Loaded from the database, not encoded
+            network: Network::Mainnet,          // Loaded from the database, not encoded
         })
     }
 }

--- a/src/model/qualified_identity/qualified_identity_public_key.rs
+++ b/src/model/qualified_identity/qualified_identity_public_key.rs
@@ -56,7 +56,7 @@ impl QualifiedIdentityPublicKey {
 
                     let address = Address::new(network, Payload::PubkeyHash(pubkey_hash));
 
-                    let testnet_address = if network != Network::Dash {
+                    let testnet_address = if network != Network::Mainnet {
                         Some(Address::new(
                             Network::Testnet,
                             Payload::PubkeyHash(pubkey_hash),
@@ -100,7 +100,7 @@ impl QualifiedIdentityPublicKey {
 
                     let address = Address::p2pkh(&pubkey, network);
 
-                    let testnet_address = if network != Network::Dash {
+                    let testnet_address = if network != Network::Mainnet {
                         Some(Address::p2pkh(&pubkey, Network::Testnet))
                     } else {
                         None
@@ -147,7 +147,7 @@ impl QualifiedIdentityPublicKey {
 
                 let address = Address::new(network, Payload::PubkeyHash(pubkey_hash));
 
-                let testnet_address = if network != Network::Dash {
+                let testnet_address = if network != Network::Mainnet {
                     Some(Address::new(
                         Network::Testnet,
                         Payload::PubkeyHash(pubkey_hash),

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -101,7 +101,7 @@ impl Default for Settings {
     /// Default settings for the application
     fn default() -> Self {
         Self::new(
-            Network::Dash,
+            Network::Mainnet,
             RootScreenType::RootScreenDashpay,
             None,
             None, // autodetect

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -69,7 +69,7 @@ pub const DASH_BIP44_ACCOUNT_0_PATH_TESTNET: [ChildNumber; 3] = [
 fn networks_address_compatible(a: &Network, b: &Network) -> bool {
     matches!(
         (a, b),
-        (Network::Dash, Network::Dash)
+        (Network::Mainnet, Network::Mainnet)
             | (
                 Network::Testnet | Network::Devnet | Network::Regtest,
                 Network::Testnet | Network::Devnet | Network::Regtest,
@@ -151,7 +151,7 @@ pub trait DerivationPathHelpers {
 
 pub(crate) fn is_bip44_path(path: &DerivationPath, network: Network) -> bool {
     let coin_type = match network {
-        Network::Dash => 5,
+        Network::Mainnet => 5,
         _ => 1,
     };
     let components = path.as_ref();
@@ -188,7 +188,7 @@ impl DerivationPathHelpers for DerivationPath {
 
     fn is_asset_lock_funding(&self, network: Network) -> bool {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         let components = self.as_ref();
@@ -217,7 +217,7 @@ impl DerivationPathHelpers for DerivationPath {
     /// Check if this path is a DIP-17 Platform payment path: m/9'/coin_type'/17'/account'/key_class'/index
     fn is_platform_payment(&self, network: Network) -> bool {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         let components = self.as_ref();
@@ -236,7 +236,7 @@ impl DerivationPathHelpers for DerivationPath {
         index: u32,
     ) -> DerivationPath {
         let coin_type = match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         };
         DerivationPath::from(vec![
@@ -450,7 +450,7 @@ impl Wallet {
     /// Returns the BIP44 account 0 derivation path for the given network.
     fn bip44_account0_path(network: Network) -> DerivationPath {
         match network {
-            Network::Dash => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_MAINNET.as_slice()),
+            Network::Mainnet => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_MAINNET.as_slice()),
             _ => DerivationPath::from(DASH_BIP44_ACCOUNT_0_PATH_TESTNET.as_slice()),
         }
     }
@@ -485,7 +485,7 @@ impl Wallet {
             .map_err(|e| format!("Failed to derive first receive address: {e}"))?;
         let address = Address::p2pkh(&pk.to_pub(), network);
         let bip44 = match network {
-            Network::Dash => &DASH_BIP44_ACCOUNT_0_PATH_MAINNET,
+            Network::Mainnet => &DASH_BIP44_ACCOUNT_0_PATH_MAINNET,
             _ => &DASH_BIP44_ACCOUNT_0_PATH_TESTNET,
         };
         let full_path = DerivationPath::from(
@@ -1498,7 +1498,7 @@ impl Wallet {
 
     fn coin_type(network: Network) -> u32 {
         match network {
-            Network::Dash => 5,
+            Network::Mainnet => 5,
             _ => 1,
         }
     }
@@ -2245,7 +2245,7 @@ impl Signer<PlatformAddress> for Wallet {
         // 3. get_platform_address_private_key will only succeed for the correct network
         // 4. Only one network's derivation will match the wallet's seed
         let private_key = self
-            .get_platform_address_private_key(platform_address, Network::Dash)
+            .get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| {
@@ -2274,7 +2274,7 @@ impl Signer<PlatformAddress> for Wallet {
         // The Signer trait doesn't pass network info, so we try each network.
         // This is safe - see comment in sign() above for explanation.
         let private_key = self
-            .get_platform_address_private_key(platform_address, Network::Dash)
+            .get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| {
@@ -2298,7 +2298,7 @@ impl Signer<PlatformAddress> for Wallet {
         }
 
         // Check if we have the private key for this address
-        self.get_platform_address_private_key(platform_address, Network::Dash)
+        self.get_platform_address_private_key(platform_address, Network::Mainnet)
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Testnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Devnet))
             .or_else(|_| self.get_platform_address_private_key(platform_address, Network::Regtest))
@@ -3222,7 +3222,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
             ChildNumber::Normal { index: 0 },
         ]);
-        assert!(path.is_bip44(Network::Dash));
+        assert!(path.is_bip44(Network::Mainnet));
         assert!(!path.is_bip44(Network::Testnet));
     }
 
@@ -3237,7 +3237,7 @@ mod tests {
         ]);
         assert!(path.is_bip44(Network::Testnet));
         assert!(path.is_bip44(Network::Devnet));
-        assert!(!path.is_bip44(Network::Dash));
+        assert!(!path.is_bip44(Network::Mainnet));
     }
 
     #[test]
@@ -3276,7 +3276,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
         ]);
         assert!(path.is_asset_lock_funding(Network::Testnet));
-        assert!(!path.is_asset_lock_funding(Network::Dash));
+        assert!(!path.is_asset_lock_funding(Network::Mainnet));
     }
 
     #[test]
@@ -3290,7 +3290,7 @@ mod tests {
             ChildNumber::Normal { index: 0 },
         ]);
         assert!(path.is_platform_payment(Network::Testnet));
-        assert!(!path.is_platform_payment(Network::Dash));
+        assert!(!path.is_platform_payment(Network::Mainnet));
     }
 
     #[test]
@@ -3369,7 +3369,7 @@ mod tests {
 
     #[test]
     fn test_networks_address_compatible() {
-        assert!(networks_address_compatible(&Network::Dash, &Network::Dash));
+        assert!(networks_address_compatible(&Network::Mainnet, &Network::Mainnet));
         assert!(networks_address_compatible(
             &Network::Testnet,
             &Network::Testnet
@@ -3383,12 +3383,12 @@ mod tests {
             &Network::Regtest
         ));
         assert!(!networks_address_compatible(
-            &Network::Dash,
+            &Network::Mainnet,
             &Network::Testnet
         ));
         assert!(!networks_address_compatible(
             &Network::Testnet,
-            &Network::Dash
+            &Network::Mainnet
         ));
     }
 

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -3369,7 +3369,10 @@ mod tests {
 
     #[test]
     fn test_networks_address_compatible() {
-        assert!(networks_address_compatible(&Network::Mainnet, &Network::Mainnet));
+        assert!(networks_address_compatible(
+            &Network::Mainnet,
+            &Network::Mainnet
+        ));
         assert!(networks_address_compatible(
             &Network::Testnet,
             &Network::Testnet

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1333,7 +1333,7 @@ impl SpvManager {
 
         let host = config.core_host.as_str();
         let port = match self.network {
-            Network::Dash => 9999,
+            Network::Mainnet => 9999,
             Network::Testnet => 19999,
             Network::Devnet => 20001,
             Network::Regtest => 19899,
@@ -1355,7 +1355,7 @@ fn build_spv_data_dir(
     fs::create_dir_all(&base).map_err(|e| format!("Failed to create SPV base dir: {e}"))?;
 
     let network_dir = match network {
-        Network::Dash => "mainnet".to_string(),
+        Network::Mainnet => "mainnet".to_string(),
         Network::Testnet => "testnet".to_string(),
         Network::Devnet => {
             let name = config

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -177,7 +177,7 @@ pub fn add_left_panel(
                     // Reserve a fixed area at the bottom for the logo and labels,
                     // and make the button list above it vertically scrollable.
                     let mut bottom_reserved = Spacing::SM + 20.0; // spacing + logo height
-                    if app_context.network != Network::Dash {
+                    if app_context.network != Network::Mainnet {
                         bottom_reserved += 22.0; // network label + spacing
                     }
                     if app_context.is_developer_mode() {
@@ -311,7 +311,7 @@ pub fn add_left_panel(
                                         // Dash logo at the very bottom
                                         // Use 100x40 for rendering (2x for crisp display), then scale down
                                         if let Some(dash_texture) = load_svg_icon(ctx, "dashlogo.svg", 100, 40) {
-                                            if app_context.network == Network::Dash {
+                                            if app_context.network == Network::Mainnet {
                                                 ui.add_space(Spacing::SM);
                                             }
                                             let logo_size = egui::vec2(50.0, 20.0);
@@ -334,7 +334,7 @@ pub fn add_left_panel(
                                         }
 
                                         // Network label (if not on mainnet)
-                                        if app_context.network != Network::Dash {
+                                        if app_context.network != Network::Mainnet {
                                             let (network_name, network_color) = match app_context.network {
                                                 Network::Testnet => (
                                                     "Testnet",

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -621,7 +621,7 @@ impl ScreenLike for DocumentQueryScreen {
             DesiredAppAction::AddScreenType(Box::new(ScreenType::GroupActions)),
         );
         let mut action = AppAction::None;
-        if self.app_context.network == Network::Dash {
+        if self.app_context.network == Network::Mainnet {
             action |= add_top_panel(
                 ctx,
                 &self.app_context,

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -249,7 +249,7 @@ impl TransferScreen {
                 egui::TextEdit::singleline(&mut self.platform_address_input)
                     .hint_text(
                         if self.app_context.network
-                            == dash_sdk::dashcore_rpc::dashcore::Network::Dash
+                            == dash_sdk::dashcore_rpc::dashcore::Network::Mainnet
                         {
                             "Enter Platform address (dash1...)"
                         } else {

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -147,7 +147,7 @@ impl WithdrawalScreen {
             ui.horizontal(|ui| {
                 ui.label("Address:");
 
-                let hint = if self.app_context.network == Network::Dash {
+                let hint = if self.app_context.network == Network::Mainnet {
                     "Enter Core address (X.../7...)"
                 } else {
                     "Enter Core address (y.../8...)"

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -129,7 +129,7 @@ impl NetworkChooserScreen {
         }
 
         let current_context = match current_network {
-            Network::Dash => mainnet_app_context,
+            Network::Mainnet => mainnet_app_context,
             Network::Testnet => testnet_app_context.unwrap_or(mainnet_app_context),
             Network::Devnet => devnet_app_context.unwrap_or(mainnet_app_context),
             Network::Regtest => local_app_context.unwrap_or(mainnet_app_context),
@@ -157,7 +157,7 @@ impl NetworkChooserScreen {
             .unwrap_or(true);
 
         let mut backend_modes = HashMap::new();
-        backend_modes.insert(Network::Dash, mainnet_app_context.core_backend_mode());
+        backend_modes.insert(Network::Mainnet, mainnet_app_context.core_backend_mode());
         backend_modes.insert(
             Network::Testnet,
             testnet_app_context
@@ -210,7 +210,7 @@ impl NetworkChooserScreen {
 
     pub fn context_for_network(&self, network: Network) -> &Arc<AppContext> {
         match network {
-            Network::Dash => &self.mainnet_app_context,
+            Network::Mainnet => &self.mainnet_app_context,
             Network::Testnet if self.testnet_app_context.is_some() => {
                 self.testnet_app_context.as_ref().unwrap()
             }
@@ -354,7 +354,7 @@ impl NetworkChooserScreen {
                     };
 
                     let network_text = match self.current_network {
-                        Network::Dash => "Mainnet",
+                        Network::Mainnet => "Mainnet",
                         Network::Testnet => "Testnet",
                         Network::Devnet => "Devnet",
                         Network::Regtest => "Local",
@@ -371,12 +371,12 @@ impl NetworkChooserScreen {
                                 if ui
                                     .selectable_value(
                                         &mut self.current_network,
-                                        Network::Dash,
+                                        Network::Mainnet,
                                         "Mainnet",
                                     )
                                     .clicked()
                                 {
-                                    app_action = AppAction::SwitchNetwork(Network::Dash);
+                                    app_action = AppAction::SwitchNetwork(Network::Mainnet);
                                 }
                                 if self.testnet_app_context.is_some()
                                     && ui
@@ -1064,7 +1064,7 @@ impl NetworkChooserScreen {
                             if self.mainnet_app_context.core_backend_mode() == CoreBackendMode::Spv {
                                 self.mainnet_app_context.set_core_backend_mode(CoreBackendMode::Rpc);
                             }
-                            self.backend_modes.insert(Network::Dash, CoreBackendMode::Rpc);
+                            self.backend_modes.insert(Network::Mainnet, CoreBackendMode::Rpc);
 
                             if let Some(ref ctx) = self.testnet_app_context {
                                 ctx.stop_spv();
@@ -1753,7 +1753,7 @@ impl NetworkChooserScreen {
 
     fn current_network_label(&self) -> &'static str {
         match self.current_network {
-            Network::Dash => "Mainnet",
+            Network::Mainnet => "Mainnet",
             Network::Testnet => "Testnet",
             Network::Devnet => "Devnet",
             Network::Regtest => "Local",
@@ -1930,7 +1930,7 @@ impl NetworkChooserScreen {
 
     fn has_context_for(&self, network: Network) -> bool {
         match network {
-            Network::Dash => true,
+            Network::Mainnet => true,
             Network::Testnet => self.testnet_app_context.is_some(),
             Network::Devnet => self.devnet_app_context.is_some(),
             Network::Regtest => self.local_app_context.is_some(),
@@ -2032,7 +2032,7 @@ impl ScreenLike for NetworkChooserScreen {
         }
 
         self.backend_modes
-            .insert(Network::Dash, self.mainnet_app_context.core_backend_mode());
+            .insert(Network::Mainnet, self.mainnet_app_context.core_backend_mode());
         if let Some(ctx) = &self.testnet_app_context {
             self.backend_modes
                 .insert(Network::Testnet, ctx.core_backend_mode());

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -2031,8 +2031,10 @@ impl ScreenLike for NetworkChooserScreen {
             self.theme_preference = settings.theme_mode;
         }
 
-        self.backend_modes
-            .insert(Network::Mainnet, self.mainnet_app_context.core_backend_mode());
+        self.backend_modes.insert(
+            Network::Mainnet,
+            self.mainnet_app_context.core_backend_mode(),
+        );
         if let Some(ctx) = &self.testnet_app_context {
             self.backend_modes
                 .insert(Network::Testnet, ctx.core_backend_mode());

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -477,7 +477,7 @@ impl DashColors {
         dark_mode: bool,
     ) -> Color32 {
         match network {
-            dash_sdk::dashcore_rpc::dashcore::Network::Dash => {
+            dash_sdk::dashcore_rpc::dashcore::Network::Mainnet => {
                 if dark_mode {
                     Self::DASH_BLUE_DARK
                 } else {

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -3263,7 +3263,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3577,7 +3577,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);
@@ -3705,7 +3705,7 @@ mod tests {
             wallet_index: None,
             top_ups: BTreeMap::new(),
             status: IdentityStatus::Active,
-            network: Network::Dash,
+            network: Network::Mainnet,
         };
 
         token_creator_ui.selected_identity = Some(mock_identity);

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -91,7 +91,7 @@ impl MnListData {
     fn new(app_context: &Arc<AppContext>) -> Self {
         let mut mnlist_diffs = BTreeMap::new();
         let masternode_list_engine = match app_context.network {
-            Network::Dash => {
+            Network::Mainnet => {
                 use std::env;
                 tracing::debug!(
                     "Current working directory: {:?}",
@@ -108,18 +108,18 @@ impl MnListData {
                             MasternodeListEngine::initialize_with_diff_to_height(
                                 diff,
                                 2227096,
-                                Network::Dash,
+                                Network::Mainnet,
                             )
                             .expect("expected to start engine")
                         }
                         Err(e) => {
                             tracing::error!("Failed to read MNListDiff file: {}", e);
-                            MasternodeListEngine::default_for_network(Network::Dash)
+                            MasternodeListEngine::default_for_network(Network::Mainnet)
                         }
                     }
                 } else {
                     tracing::warn!("MNListDiff file not found: {}", file_path);
-                    MasternodeListEngine::default_for_network(Network::Dash)
+                    MasternodeListEngine::default_for_network(Network::Mainnet)
                 }
             }
             Network::Testnet => {
@@ -145,7 +145,7 @@ impl MnListData {
                     }
                 } else {
                     tracing::warn!("MNListDiff file not found: {}", file_path);
-                    MasternodeListEngine::default_for_network(Network::Dash)
+                    MasternodeListEngine::default_for_network(Network::Mainnet)
                 }
             }
             _ => MasternodeListEngine::default_for_network(app_context.network),
@@ -1285,7 +1285,7 @@ impl MasternodeListDiffScreen {
         let max_blocks = 2000;
 
         let loaded_list_height = match self.app_context.network {
-            Network::Dash => 2227096,
+            Network::Mainnet => 2227096,
             Network::Testnet => 1296600,
             _ => 0,
         };

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -153,7 +153,7 @@ impl WalletsBalancesScreen {
             .open(&mut open)
             .show(ctx, |ui| {
                 ui.label("Recipient Address");
-                let hint = if self.app_context.network == Network::Dash {
+                let hint = if self.app_context.network == Network::Mainnet {
                     "Enter Core address (X.../7...)"
                 } else {
                     "Enter Core address (y.../8...)"


### PR DESCRIPTION
## Summary

- Bumps `dash-sdk` to platform rev `3286fcfc` (contains [dashpay/platform#3376](https://github.com/dashpay/platform/pull/3376))
- Renames `Network::Dash` → `Network::Mainnet` per upstream rust-dashcore

**This PR intentionally does NOT compile.** It exists as proof that PR #3376 ("extract retry logic from trait default methods to fix HRTB Send issue") paradoxically *introduces* 4 Send bound errors in evo-tool's backend task dispatch:

```
error: implementation of `Send` is not general enough
  = note: `Send` would have to be implemented for the type `&DataContract`,
          for some specific lifetime `'0`
```

## What changed upstream

PR #3376 extracted inline retry+closure logic from `#[async_trait]` trait default methods (`fetch_with_metadata_and_proof`, `fetch_many_with_metadata_and_proof`) into standalone `async fn` helpers. This adds an **opaque future boundary** that the compiler cannot see through, defeating HRTB Send inference ([rust-lang/rust#100013](https://github.com/rust-lang/rust/issues/100013)).

## Proof

- **Old rev** (`aa86b74f`, current `v1.0-dev`): compiles clean, no workaround needed
- **New rev** (`3286fcfc`, this PR): 4 Send errors, does not compile

## Workaround

`unsafe { transmute }` to assert Send on the pinned boxed future — implemented separately in the `feat/mempool-support` branch.

See: https://github.com/dashpay/platform/pull/3376
See: https://github.com/rust-lang/rust/issues/100013

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core SDK dependency to a newer revision.
  * Consolidated network identification to treat Mainnet as the primary network across the app.
* **New Features / UI**
  * Refined network display labels and core address input hints to reflect the Mainnet default.
  * Adjusted network-related defaults and connectivity behavior for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->