### PR TITLE
fix(ui): throttle system theme detection to prevent white flash

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1104,9 +1104,10 @@ impl App for AppState {
             let now = Instant::now();
             if now.duration_since(self.theme_last_checked) >= Duration::from_secs(2) {
                 self.theme_last_checked = now;
-                let new_resolved = crate::ui::theme::resolve_theme_mode(self.theme_preference);
-                if new_resolved != self.resolved_theme {
-                    self.resolved_theme = new_resolved;
+                if let Some(detected) = crate::ui::theme::try_detect_system_theme()
+                    && detected != self.resolved_theme
+                {
+                    self.resolved_theme = detected;
                 }
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -87,6 +87,8 @@ pub struct AppState {
     pub task_result_sender: egui_mpsc::SenderAsync<TaskResult>, // Channel sender for sending task results
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
+    resolved_theme: ThemeMode, // Cached resolved theme (Light/Dark, never System)
+    theme_last_checked: Instant, // Last time we polled the OS for system theme
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
     last_repaint_request: Instant,      // Throttle periodic repaint scheduling to once per second
     pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
@@ -720,6 +722,8 @@ impl AppState {
             core_message_receiver,
             task_result_sender,
             task_result_receiver,
+            resolved_theme: crate::ui::theme::resolve_theme_mode(theme_preference),
+            theme_last_checked: Instant::now(),
             theme_preference,
             last_scheduled_vote_check: Instant::now(),
             last_repaint_request: Instant::now(),
@@ -1089,8 +1093,19 @@ impl App for AppState {
             return;
         }
 
-        // Apply Dash theme with user preference
-        crate::ui::theme::apply_theme(ctx, self.theme_preference);
+        // Throttle OS theme detection to every 2 s to prevent white flash from
+        // transient dark_light::detect() glitches during high-frequency repaints.
+        if self.theme_preference == ThemeMode::System {
+            let now = Instant::now();
+            if now.duration_since(self.theme_last_checked) > Duration::from_secs(2) {
+                self.theme_last_checked = now;
+                let new_resolved = crate::ui::theme::resolve_theme_mode(self.theme_preference);
+                if new_resolved != self.resolved_theme {
+                    self.resolved_theme = new_resolved;
+                }
+            }
+        }
+        crate::ui::theme::apply_theme(ctx, self.resolved_theme);
 
         self.enforce_network_context_invariant();
         let active_context = self.current_app_context().clone();
@@ -1132,6 +1147,9 @@ impl App for AppState {
                         }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
+                            self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
+                            self.theme_last_checked = Instant::now();
+                            crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             MessageBanner::set_global(
                                 ctx,
                                 "Theme preference updated successfully",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1102,7 +1102,7 @@ impl App for AppState {
         // transient dark_light::detect() glitches during high-frequency repaints.
         if self.theme_preference == ThemeMode::System {
             let now = Instant::now();
-            if now.duration_since(self.theme_last_checked) > Duration::from_secs(2) {
+            if now.duration_since(self.theme_last_checked) >= Duration::from_secs(2) {
                 self.theme_last_checked = now;
                 let new_resolved = crate::ui::theme::resolve_theme_mode(self.theme_preference);
                 if new_resolved != self.resolved_theme {
@@ -1157,8 +1157,6 @@ impl App for AppState {
                             self.theme_preference = new_theme;
                             self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
                             self.theme_last_checked = Instant::now();
-                            // Force immediate re-apply even if resolved colour didn't change.
-                            self.last_applied_theme = None;
                             crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             self.last_applied_theme = Some(self.resolved_theme);
                             MessageBanner::set_global(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1157,20 +1157,34 @@ impl App for AppState {
                         }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
+                            let mut detection_failed = false;
                             self.resolved_theme = if new_theme == ThemeMode::System {
-                                crate::ui::theme::try_detect_system_theme()
-                                    .unwrap_or(self.resolved_theme)
+                                match crate::ui::theme::try_detect_system_theme() {
+                                    Some(detected) => detected,
+                                    None => {
+                                        detection_failed = true;
+                                        self.resolved_theme
+                                    }
+                                }
                             } else {
                                 new_theme
                             };
                             self.theme_last_checked = Instant::now();
                             crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             self.last_applied_theme = Some(self.resolved_theme);
-                            MessageBanner::set_global(
-                                ctx,
-                                "Theme preference updated successfully",
-                                MessageType::Success,
-                            );
+                            if detection_failed {
+                                MessageBanner::set_global(
+                                    ctx,
+                                    "Could not detect your system theme. Using the previous theme for now — it will update automatically when detection succeeds.",
+                                    MessageType::Warning,
+                                );
+                            } else {
+                                MessageBanner::set_global(
+                                    ctx,
+                                    "Theme preference updated successfully",
+                                    MessageType::Success,
+                                );
+                            }
                             self.visible_screen_mut().display_message(
                                 "Theme preference updated successfully",
                                 MessageType::Success,

--- a/src/app.rs
+++ b/src/app.rs
@@ -88,7 +88,8 @@ pub struct AppState {
     pub task_result_receiver: tokiompsc::Receiver<TaskResult>, // Channel receiver for receiving task results
     pub theme_preference: ThemeMode,                           // Current theme preference
     resolved_theme: ThemeMode, // Cached resolved theme (Light/Dark, never System)
-    theme_last_checked: Instant, // Last time we polled the OS for system theme
+    last_applied_theme: Option<ThemeMode>, // Last theme passed to apply_theme; None = force on next frame
+    theme_last_checked: Instant,           // Last time we polled the OS for system theme
     last_scheduled_vote_check: Instant, // Last time we checked if there are scheduled masternode votes to cast
     last_repaint_request: Instant,      // Throttle periodic repaint scheduling to once per second
     pub subtasks: Arc<TaskManager>,     // Subtasks manager for graceful shutdown
@@ -723,6 +724,7 @@ impl AppState {
             task_result_sender,
             task_result_receiver,
             resolved_theme: crate::ui::theme::resolve_theme_mode(theme_preference),
+            last_applied_theme: None,
             theme_last_checked: Instant::now(),
             theme_preference,
             last_scheduled_vote_check: Instant::now(),
@@ -1073,7 +1075,10 @@ impl App for AppState {
                 ctx.request_repaint();
             }
             // Render a minimal UI that shows the shutdown banner.
-            crate::ui::theme::apply_theme(ctx, self.theme_preference);
+            if self.last_applied_theme != Some(self.resolved_theme) {
+                crate::ui::theme::apply_theme(ctx, self.resolved_theme);
+                self.last_applied_theme = Some(self.resolved_theme);
+            }
             crate::ui::components::styled::island_central_panel(ctx, |_ui| {});
             return;
         }
@@ -1105,7 +1110,10 @@ impl App for AppState {
                 }
             }
         }
-        crate::ui::theme::apply_theme(ctx, self.resolved_theme);
+        if self.last_applied_theme != Some(self.resolved_theme) {
+            crate::ui::theme::apply_theme(ctx, self.resolved_theme);
+            self.last_applied_theme = Some(self.resolved_theme);
+        }
 
         self.enforce_network_context_invariant();
         let active_context = self.current_app_context().clone();
@@ -1149,7 +1157,10 @@ impl App for AppState {
                             self.theme_preference = new_theme;
                             self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
                             self.theme_last_checked = Instant::now();
+                            // Force immediate re-apply even if resolved colour didn't change.
+                            self.last_applied_theme = None;
                             crate::ui::theme::apply_theme(ctx, self.resolved_theme);
+                            self.last_applied_theme = Some(self.resolved_theme);
                             MessageBanner::set_global(
                                 ctx,
                                 "Theme preference updated successfully",

--- a/src/app.rs
+++ b/src/app.rs
@@ -1157,7 +1157,12 @@ impl App for AppState {
                         }
                         BackendTaskSuccessResult::UpdatedThemePreference(new_theme) => {
                             self.theme_preference = new_theme;
-                            self.resolved_theme = crate::ui::theme::resolve_theme_mode(new_theme);
+                            self.resolved_theme = if new_theme == ThemeMode::System {
+                                crate::ui::theme::try_detect_system_theme()
+                                    .unwrap_or(self.resolved_theme)
+                            } else {
+                                new_theme
+                            };
                             self.theme_last_checked = Instant::now();
                             crate::ui::theme::apply_theme(ctx, self.resolved_theme);
                             self.last_applied_theme = Some(self.resolved_theme);

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1016,7 +1016,6 @@ impl ResponseExt for egui::Response {
     }
 }
 
-/// Configure fonts for the application
 /// Apply the modern Dash theme to the egui context
 pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     // Resolve the actual theme to use

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -18,6 +18,17 @@ pub fn detect_system_theme() -> Result<ThemeMode, String> {
     }
 }
 
+/// Detect system theme, returning `None` on error or ambiguous result.
+/// Use this for polling: a `None` means "keep the previous theme" rather than
+/// flipping to an arbitrary default.
+pub fn try_detect_system_theme() -> Option<ThemeMode> {
+    match dark_light::detect() {
+        Ok(dark_light::Mode::Dark) => Some(ThemeMode::Dark),
+        Ok(dark_light::Mode::Light) => Some(ThemeMode::Light),
+        _ => None,
+    }
+}
+
 /// Resolve the actual theme to use based on preference
 pub fn resolve_theme_mode(preference: ThemeMode) -> ThemeMode {
     match preference {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1153,7 +1153,7 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
 
     let fonts_key = egui::Id::new("dash_fonts_initialized");
     let already_set = ctx.data_mut(|d| {
-        let flag = d.get_persisted_mut_or_default::<bool>(fonts_key);
+        let flag = d.get_temp_mut_or_default::<bool>(fonts_key);
         let was = *flag;
         *flag = true;
         was

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1153,7 +1153,7 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
 
     let fonts_key = egui::Id::new("dash_fonts_initialized");
     let already_set = ctx.data_mut(|d| {
-        let flag = d.get_temp_mut_or_default::<bool>(fonts_key);
+        let flag = d.get_persisted_mut_or_default::<bool>(fonts_key);
         let was = *flag;
         *flag = true;
         was

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,7 +1,4 @@
-use egui::{
-    Button, Color32, CursorIcon, FontData, FontDefinitions, FontFamily, FontId, RichText, Stroke,
-    Vec2, WidgetText,
-};
+use egui::{Button, Color32, CursorIcon, FontFamily, FontId, RichText, Stroke, Vec2, WidgetText};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1009,28 +1006,6 @@ impl ResponseExt for egui::Response {
 }
 
 /// Configure fonts for the application
-pub fn configure_fonts() -> FontDefinitions {
-    let mut fonts = FontDefinitions::default();
-
-    // Load Noto Sans font for better international support
-    fonts.font_data.insert(
-        "NotoSans".to_owned(),
-        FontData::from_static(include_bytes!(
-            "../../assets/Fonts/Noto_Sans/NotoSans-VariableFont.ttf"
-        ))
-        .into(),
-    );
-
-    // Add NotoSans to the proportional font family (used for UI text)
-    fonts
-        .families
-        .get_mut(&FontFamily::Proportional)
-        .unwrap()
-        .insert(0, "NotoSans".to_owned());
-
-    fonts
-}
-
 /// Apply the modern Dash theme to the egui context
 pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     // Resolve the actual theme to use
@@ -1150,15 +1125,4 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
     ctx.set_style(style);
-
-    let fonts_key = egui::Id::new("dash_fonts_initialized");
-    let already_set = ctx.data_mut(|d| {
-        let flag = d.get_temp_mut_or_default::<bool>(fonts_key);
-        let was = *flag;
-        *flag = true;
-        was
-    });
-    if !already_set {
-        ctx.set_fonts(configure_fonts());
-    }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,6 +2,7 @@ use egui::{
     Button, Color32, CursorIcon, FontData, FontDefinitions, FontFamily, FontId, RichText, Stroke,
     Vec2, WidgetText,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1150,5 +1151,9 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
     ctx.set_style(style);
-    ctx.set_fonts(configure_fonts());
+
+    static FONTS_INITIALIZED: AtomicBool = AtomicBool::new(false);
+    if !FONTS_INITIALIZED.swap(true, Ordering::Relaxed) {
+        ctx.set_fonts(configure_fonts());
+    }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -26,7 +26,10 @@ pub fn try_detect_system_theme() -> Option<ThemeMode> {
     match dark_light::detect() {
         Ok(dark_light::Mode::Dark) => Some(ThemeMode::Dark),
         Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) => Some(ThemeMode::Light),
-        Err(_) => None,
+        Err(e) => {
+            tracing::debug!("OS theme detection failed: {e}");
+            None
+        }
     }
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -18,14 +18,15 @@ pub fn detect_system_theme() -> Result<ThemeMode, String> {
     }
 }
 
-/// Detect system theme, returning `None` on error or ambiguous result.
+/// Detect system theme, returning `None` only on detection errors.
 /// Use this for polling: a `None` means "keep the previous theme" rather than
-/// flipping to an arbitrary default.
+/// flipping to an arbitrary default. `Unspecified` maps to Light (common on
+/// Linux where `dark_light` often can't determine the theme).
 pub fn try_detect_system_theme() -> Option<ThemeMode> {
     match dark_light::detect() {
         Ok(dark_light::Mode::Dark) => Some(ThemeMode::Dark),
-        Ok(dark_light::Mode::Light) => Some(ThemeMode::Light),
-        _ => None,
+        Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) => Some(ThemeMode::Light),
+        Err(_) => None,
     }
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -2,7 +2,6 @@ use egui::{
     Button, Color32, CursorIcon, FontData, FontDefinitions, FontFamily, FontId, RichText, Stroke,
     Vec2, WidgetText,
 };
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -1152,8 +1151,14 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
 
     ctx.set_style(style);
 
-    static FONTS_INITIALIZED: AtomicBool = AtomicBool::new(false);
-    if !FONTS_INITIALIZED.swap(true, Ordering::Relaxed) {
+    let fonts_key = egui::Id::new("dash_fonts_initialized");
+    let already_set = ctx.data_mut(|d| {
+        let flag = d.get_temp_mut_or_default::<bool>(fonts_key);
+        let was = *flag;
+        *flag = true;
+        was
+    });
+    if !already_set {
         ctx.set_fonts(configure_fonts());
     }
 }


### PR DESCRIPTION
## Summary

- Throttle `dark_light::detect()` to once every 2 seconds when using System theme — prevents transient OS detection glitches from causing brief Light/Dark flips (visible as white flashes during high-frequency repaints like SPV sync)
- Cache resolved theme in `AppState` and only reapply when it actually changes (skip per-frame `apply_theme` when theme is unchanged)
- Use cached `resolved_theme` consistently — including the shutdown branch, which previously bypassed the throttle
- Replace process-global `FONTS_INITIALIZED` static with a per-`egui::Context` guard so fonts are correctly initialized for each Context instance (tests, multiple viewports)
- Use non-persisted (`temp`) storage for the font-init flag — persisted storage caused fonts to be skipped on app restart because the flag survived in `app.ron`

## Root Cause

`apply_theme()` was called on every frame. For System theme mode, each call queried the OS via `dark_light::detect()`. During rapid repaints (e.g. SPV sync progress), the detection could transiently return the wrong value → momentary theme flip → white flash.

## Test plan

- [ ] Start app with System color theme in a dark OS environment
- [ ] Trigger SPV sync and observe — no white flashes
- [ ] Switch theme preference (Light → Dark → System) — changes apply immediately
- [ ] Verify Light and Dark explicit modes still work correctly (no throttling needed)
- [ ] Verify shutdown banner renders with correct theme (no flash)
- [ ] Kill and restart app — verify custom Dash fonts load correctly (not default egui fonts)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduce redundant theme reapplications so the UI updates only when the active theme changes
  * Throttle system-theme detection to avoid rapid toggling and unnecessary checks
  * Ensure the shutdown screen preserves the selected theme and applies preference changes immediately

* **Behavior Change**
  * Stop altering font definitions during theme updates to avoid resetting fonts unexpectedly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->