### PR TITLE
fix(test): avoid DNS discovery hang in SPV lifecycle tests

### DIFF
--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -39,6 +39,9 @@ fn create_test_manager() -> (Arc<SpvManager>, Arc<TaskManager>, tempfile::TempDi
         task_manager.clone(),
     )
     .expect("SpvManager::new should succeed");
+    // Use explicit local peer to avoid DNS seed discovery which hangs in tests
+    // (upstream bug: dashpay/rust-dashcore#577).
+    manager.set_use_local_node(true);
     (manager, task_manager, tmp_dir)
 }
 
@@ -150,11 +153,14 @@ async fn test_double_stop_does_not_panic() {
 async fn test_use_local_node_toggle() {
     let (manager, _tm, _tmp_dir) = create_test_manager();
 
-    assert!(!manager.use_local_node(), "Default should be false");
+    assert!(
+        manager.use_local_node(),
+        "Test helper sets use_local_node to true"
+    );
+    manager.set_use_local_node(false);
+    assert!(!manager.use_local_node(), "Should be false after clear");
     manager.set_use_local_node(true);
     assert!(manager.use_local_node(), "Should be true after set");
-    manager.set_use_local_node(false);
-    assert!(!manager.use_local_node(), "Should be false after reset");
 }
 
 // ── clear_data_dir when idle ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Set `use_local_node(true)` in the SPV test helper `create_test_manager()` so all lifecycle tests use the explicit localhost peer address (`127.0.0.1:19999`) instead of DNS seed discovery
- Previously, tests with no explicit peers triggered DNS seed discovery in the upstream `dash-spv` library, which hangs because `DashSpvClient::run()` doesn't check the cancellation token during its startup phase (upstream bug: [dashpay/rust-dashcore#577](https://github.com/dashpay/rust-dashcore/issues/577))
- `test_start_stop_clean_shutdown` now completes in ~0.3s instead of timing out at 10s

### User story

Imagine you are a developer running `cargo test` on the project. Previously, `test_start_stop_clean_shutdown` would hang for 10 seconds and then fail — every time. Now all 20 SPV tests pass in ~1.4 seconds.

## Test plan

- [x] `cargo test --all-features spv::tests::` — all 20 tests pass (1.37s)
- [x] `test_start_stop_clean_shutdown` — previously timed out, now passes in ~0.3s
- [x] `test_use_local_node_toggle` — updated assertions match new default from test helper

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to establish consistent default behavior for local peer handling in test scenarios, ensuring reliable test execution and clearer assertion expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->