### PR TITLE
fix(db): consolidate migrations v28-v32 into v33

### DIFF
--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -970,6 +970,7 @@ impl Database {
                 wallet_seed_hash BLOB NOT NULL,
                 network TEXT NOT NULL,
                 last_nullifier_sync_height INTEGER NOT NULL DEFAULT 0,
+                last_nullifier_sync_timestamp INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (wallet_seed_hash, network)
             )",
             [],
@@ -979,13 +980,11 @@ impl Database {
 
     /// Add last_nullifier_sync_timestamp column to shielded_wallet_meta. Idempotent.
     fn add_nullifier_sync_timestamp_column(&self, conn: &Connection) -> rusqlite::Result<()> {
-        let has_column: bool = conn
-            .query_row(
-                "SELECT COUNT(*) FROM pragma_table_info('shielded_wallet_meta') WHERE name='last_nullifier_sync_timestamp'",
-                [],
-                |row| row.get::<_, i32>(0).map(|count| count > 0),
-            )
-            .unwrap_or(false);
+        let has_column: bool = conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('shielded_wallet_meta') WHERE name='last_nullifier_sync_timestamp'",
+            [],
+            |row| row.get::<_, i32>(0).map(|count| count > 0),
+        )?;
         if !has_column {
             conn.execute(
                 "ALTER TABLE shielded_wallet_meta ADD COLUMN last_nullifier_sync_timestamp INTEGER NOT NULL DEFAULT 0",
@@ -1014,6 +1013,8 @@ impl Database {
             "wallet_transactions",
             "single_key_wallet",
             "token",
+            "shielded_notes",
+            "shielded_wallet_meta",
         ];
         for table in tables {
             conn.execute(

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -4,7 +4,7 @@ use rusqlite::{Connection, params};
 use std::fs;
 use std::path::Path;
 
-pub const DEFAULT_DB_VERSION: u16 = 29;
+pub const DEFAULT_DB_VERSION: u16 = 33;
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
 
@@ -51,13 +51,22 @@ impl Database {
 
     fn apply_version_changes(&self, version: u16, tx: &Connection) -> rusqlite::Result<()> {
         match version {
-            29 => {
-                self.rename_network_dash_to_mainnet(tx)?;
-                self.add_wallet_transaction_status_column(tx)?;
-            }
-            28 => {
+            // Versions 28-32 were consolidated into v33 to resolve migration
+            // numbering conflicts between the zk and v1.0-dev branches.
+            // If migrating from < 28, these are no-ops that just bump the version.
+            28..=32 => {}
+            33 => {
+                // Consolidated migration: all changes from v28-v32 in one step.
+                // Every sub-migration is idempotent (IF NOT EXISTS / column checks),
+                // so this is safe to run on any DB that already applied some or all
+                // of the individual steps.
                 self.add_core_wallet_name_column(tx)?;
                 self.init_contacts_tables(tx)?;
+                self.create_shielded_tables(tx)?;
+                self.create_shielded_wallet_meta_table(tx)?;
+                self.add_nullifier_sync_timestamp_column(tx)?;
+                self.rename_network_dash_to_mainnet(tx)?;
+                self.add_wallet_transaction_status_column(tx)?;
             }
             27 => {
                 self.add_network_indexes(tx)?;
@@ -515,6 +524,10 @@ impl Database {
         // Initialize single key wallet table
         self.initialize_single_key_wallet_table(&conn)?;
 
+        // Initialize shielded pool tables
+        self.create_shielded_tables(&conn)?;
+        self.create_shielded_wallet_meta_table(&conn)?;
+
         Ok(())
     }
 
@@ -918,6 +931,64 @@ impl Database {
         if !has_status {
             conn.execute(
                 "ALTER TABLE wallet_transactions ADD COLUMN status INTEGER NOT NULL DEFAULT 2",
+                [],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Create shielded pool tables. Idempotent (IF NOT EXISTS).
+    fn create_shielded_tables(&self, conn: &Connection) -> rusqlite::Result<()> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS shielded_notes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                wallet_seed_hash BLOB NOT NULL,
+                note_data BLOB NOT NULL,
+                position INTEGER NOT NULL,
+                cmx BLOB NOT NULL,
+                nullifier BLOB NOT NULL,
+                block_height INTEGER NOT NULL,
+                is_spent INTEGER NOT NULL DEFAULT 0,
+                value INTEGER NOT NULL,
+                network TEXT NOT NULL,
+                UNIQUE(wallet_seed_hash, nullifier, network)
+            )",
+            [],
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_shielded_notes_wallet_network
+             ON shielded_notes (wallet_seed_hash, network)",
+            [],
+        )?;
+        Ok(())
+    }
+
+    /// Create shielded wallet metadata table. Idempotent (IF NOT EXISTS).
+    fn create_shielded_wallet_meta_table(&self, conn: &Connection) -> rusqlite::Result<()> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS shielded_wallet_meta (
+                wallet_seed_hash BLOB NOT NULL,
+                network TEXT NOT NULL,
+                last_nullifier_sync_height INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (wallet_seed_hash, network)
+            )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    /// Add last_nullifier_sync_timestamp column to shielded_wallet_meta. Idempotent.
+    fn add_nullifier_sync_timestamp_column(&self, conn: &Connection) -> rusqlite::Result<()> {
+        let has_column: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('shielded_wallet_meta') WHERE name='last_nullifier_sync_timestamp'",
+                [],
+                |row| row.get::<_, i32>(0).map(|count| count > 0),
+            )
+            .unwrap_or(false);
+        if !has_column {
+            conn.execute(
+                "ALTER TABLE shielded_wallet_meta ADD COLUMN last_nullifier_sync_timestamp INTEGER NOT NULL DEFAULT 0",
                 [],
             )?;
         }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -951,7 +951,8 @@ impl Database {
                 is_spent INTEGER NOT NULL DEFAULT 0,
                 value INTEGER NOT NULL,
                 network TEXT NOT NULL,
-                UNIQUE(wallet_seed_hash, nullifier, network)
+                UNIQUE(wallet_seed_hash, nullifier, network),
+                FOREIGN KEY (wallet_seed_hash) REFERENCES wallet(seed_hash) ON DELETE CASCADE
             )",
             [],
         )?;
@@ -971,7 +972,8 @@ impl Database {
                 network TEXT NOT NULL,
                 last_nullifier_sync_height INTEGER NOT NULL DEFAULT 0,
                 last_nullifier_sync_timestamp INTEGER NOT NULL DEFAULT 0,
-                PRIMARY KEY (wallet_seed_hash, network)
+                PRIMARY KEY (wallet_seed_hash, network),
+                FOREIGN KEY (wallet_seed_hash) REFERENCES wallet(seed_hash) ON DELETE CASCADE
             )",
             [],
         )?;


### PR DESCRIPTION
## Summary

- Consolidates DB migrations v28–v32 into a single idempotent v33 step
- Prevents version-collision issues when users switch between `v1.0-dev` and `zk-fixes` branches (both used v28 for different migrations)
- All sub-migrations use `IF NOT EXISTS` / column-existence checks, safe to re-run on databases that already applied some or all steps
- Adds forward-compatible shielded table definitions (`shielded_notes`, `shielded_wallet_meta`) so v1.0-dev databases are ready for the ZK feature branch

### Migrations included in v33

1. `add_core_wallet_name_column` — adds `core_wallet_name` to `wallets`
2. `init_contacts_tables` — creates contact request tables
3. `create_shielded_tables` — creates `shielded_notes` table
4. `create_shielded_wallet_meta_table` — creates `shielded_wallet_meta` table
5. `rename_network_dash_to_mainnet` — renames "dash" network to "mainnet"
6. `add_wallet_transaction_status_column` — adds `status` to `wallet_transactions`
7. `add_nullifier_sync_timestamp_column` — adds `last_nullifier_sync_timestamp` to `shielded_wallet_meta`

## Test plan

- [ ] Fresh install: `create_tables()` sets version to 33, all tables exist
- [ ] Upgrade from v27 (pre-fork): v28–v32 are no-ops, v33 applies all migrations
- [ ] Upgrade from v29 (v1.0-dev user): v30–v32 no-ops, v33 re-applies idempotently
- [ ] Upgrade from v32 (zk-fixes user): v33 re-applies idempotently, no errors
- [ ] `cargo test --all-features --workspace` passes (72 tests verified)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds initial support for shielded wallet data and contact tables to enable private transaction handling and contact management.

* **Chores**
  * Database schema version upgraded to 33 with consolidated migrations, network value normalization, added transaction status tracking, and a last-nullifier sync timestamp to improve migration safety and wallet synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->