### PR TITLE
fix(ci): derive version from Cargo.toml in release artifacts

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -44,8 +44,10 @@ jobs:
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1
           fi
-          # Use tag date for releases, current date for manual/PR builds
-          if [ "${{ github.ref_type }}" = "tag" ]; then
+          # Use release published date when available, tag commit date for tag pushes, current date otherwise
+          if [ -n "${{ github.event.release.published_at }}" ]; then
+            DATE=$(echo "${{ github.event.release.published_at }}" | cut -dT -f1)
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
             DATE=$(git log -1 --format=%cs "${{ github.ref }}")
           else
             DATE=$(date +%Y-%m-%d)

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Sync metainfo version from Cargo.toml
         run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "dash-evo-tool") | .version')
           if [ -z "$VERSION" ]; then
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Sync metainfo version from Cargo.toml
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          DATE=$(date +%Y-%m-%d)
+          sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"|<release version=\"${VERSION}\" date=\"${DATE}\"|" \
+            flatpak/org.dash.DashEvoTool.metainfo.xml
+          echo "Metainfo version set to ${VERSION}, date ${DATE}"
+
       - name: Install Flatpak and Flatpak Builder
         run: |
           sudo apt-get update

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Install Rust toolchain (for cargo metadata)
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Sync metainfo version from Cargo.toml
         run: |
           VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "dash-evo-tool") | .version')
@@ -55,8 +58,8 @@ jobs:
           sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"|<release version=\"${VERSION}\" date=\"${DATE}\"|" \
             flatpak/org.dash.DashEvoTool.metainfo.xml
           # Verify replacement applied
-          if ! grep -q "version=\"${VERSION}\"" flatpak/org.dash.DashEvoTool.metainfo.xml; then
-            echo "::error::Failed to update metainfo.xml with version ${VERSION}"
+          if ! grep -q "version=\"${VERSION}\" date=\"${DATE}\"" flatpak/org.dash.DashEvoTool.metainfo.xml; then
+            echo "::error::Failed to update metainfo.xml with version ${VERSION} and date ${DATE}"
             exit 1
           fi
           echo "Metainfo version set to ${VERSION}, date ${DATE}"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -40,9 +40,23 @@ jobs:
       - name: Sync metainfo version from Cargo.toml
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          DATE=$(date +%Y-%m-%d)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to extract version from Cargo.toml"
+            exit 1
+          fi
+          # Use tag date for releases, current date for manual/PR builds
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            DATE=$(git log -1 --format=%cs "${{ github.ref }}")
+          else
+            DATE=$(date +%Y-%m-%d)
+          fi
           sed -i "s|<release version=\"[^\"]*\" date=\"[^\"]*\"|<release version=\"${VERSION}\" date=\"${DATE}\"|" \
             flatpak/org.dash.DashEvoTool.metainfo.xml
+          # Verify replacement applied
+          if ! grep -q "version=\"${VERSION}\"" flatpak/org.dash.DashEvoTool.metainfo.xml; then
+            echo "::error::Failed to update metainfo.xml with version ${VERSION}"
+            exit 1
+          fi
           echo "Metainfo version set to ${VERSION}, date ${DATE}"
 
       - name: Install Flatpak and Flatpak Builder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,12 @@ jobs:
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1
           fi
-          # Strip prerelease suffix for macOS plist (Apple requires numeric-only)
-          PLIST_VERSION=$(echo "$VERSION" | sed 's/-.*//')
+          # Strip prerelease and build metadata suffixes for macOS plist (Apple requires numeric-only)
+          PLIST_VERSION=$(echo "$VERSION" | sed 's/[-+].*//')
+          if ! echo "$PLIST_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "::error::Invalid plist version '$PLIST_VERSION' derived from Cargo version '$VERSION'. Expected numeric x[.y[.z]]."
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"
@@ -490,8 +494,12 @@ jobs:
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1
           fi
-          # Strip prerelease suffix for macOS plist (Apple requires numeric-only)
-          PLIST_VERSION=$(echo "$VERSION" | sed 's/-.*//')
+          # Strip prerelease and build metadata suffixes for macOS plist (Apple requires numeric-only)
+          PLIST_VERSION=$(echo "$VERSION" | sed 's/[-+].*//')
+          if ! echo "$PLIST_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){0,2}$'; then
+            echo "::error::Invalid plist version '$PLIST_VERSION' derived from Cargo version '$VERSION'. Expected numeric x[.y[.z]]."
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,15 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to extract version from Cargo.toml"
+            exit 1
+          fi
+          # Strip prerelease suffix for macOS plist (Apple requires numeric-only)
+          PLIST_VERSION=$(echo "$VERSION" | sed 's/-.*//')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -276,9 +284,9 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>${{ steps.version.outputs.version }}</string>
+            <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundleShortVersionString</key>
-            <string>${{ steps.version.outputs.version }}</string>
+            <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>CFBundleSignature</key>
@@ -478,7 +486,15 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to extract version from Cargo.toml"
+            exit 1
+          fi
+          # Strip prerelease suffix for macOS plist (Apple requires numeric-only)
+          PLIST_VERSION=$(echo "$VERSION" | sed 's/-.*//')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -575,9 +591,9 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>${{ steps.version.outputs.version }}</string>
+            <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundleShortVersionString</key>
-            <string>${{ steps.version.outputs.version }}</string>
+            <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>CFBundleSignature</key>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,8 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"
+          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION (plist: $PLIST_VERSION, build: ${{ github.run_number }})"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -288,7 +289,7 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>${{ steps.version.outputs.plist_version }}</string>
+            <string>${{ steps.version.outputs.build_number }}</string>
             <key>CFBundleShortVersionString</key>
             <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundlePackageType</key>
@@ -502,7 +503,8 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION (plist: $PLIST_VERSION)"
+          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION (plist: $PLIST_VERSION, build: ${{ github.run_number }})"
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -599,7 +601,7 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>${{ steps.version.outputs.plist_version }}</string>
+            <string>${{ steps.version.outputs.build_number }}</string>
             <key>CFBundleShortVersionString</key>
             <string>${{ steps.version.outputs.plist_version }}</string>
             <key>CFBundlePackageType</key>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -270,9 +276,9 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>1.0.0</string>
+            <string>${{ steps.version.outputs.version }}</string>
             <key>CFBundleShortVersionString</key>
-            <string>1.0.0</string>
+            <string>${{ steps.version.outputs.version }}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>CFBundleSignature</key>
@@ -468,6 +474,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -563,9 +575,9 @@ jobs:
             <key>CFBundleDisplayName</key>
             <string>Dash Evo Tool</string>
             <key>CFBundleVersion</key>
-            <string>1.0.0</string>
+            <string>${{ steps.version.outputs.version }}</string>
             <key>CFBundleShortVersionString</key>
-            <string>1.0.0</string>
+            <string>${{ steps.version.outputs.version }}</string>
             <key>CFBundlePackageType</key>
             <string>APPL</string>
             <key>CFBundleSignature</key>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust target
+        run: rustup target add aarch64-apple-darwin
+
       - name: Extract version from Cargo.toml
         id: version
         run: |
@@ -185,16 +191,10 @@ jobs:
             echo "::error::Invalid plist version '$PLIST_VERSION' derived from Cargo version '$VERSION'. Expected numeric x[.y[.z]]."
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
-          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "plist_version=$PLIST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION (plist: $PLIST_VERSION, build: ${{ github.run_number }})"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Add Rust target
-        run: rustup target add aarch64-apple-darwin
 
       - name: Initial disk cleanup
         run: |
@@ -487,6 +487,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust target
+        run: rustup target add x86_64-apple-darwin
+
       - name: Extract version from Cargo.toml
         id: version
         run: |
@@ -501,16 +507,10 @@ jobs:
             echo "::error::Invalid plist version '$PLIST_VERSION' derived from Cargo version '$VERSION'. Expected numeric x[.y[.z]]."
             exit 1
           fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "plist_version=$PLIST_VERSION" >> $GITHUB_OUTPUT
-          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "plist_version=$PLIST_VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION (plist: $PLIST_VERSION, build: ${{ github.run_number }})"
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Add Rust target
-        run: rustup target add x86_64-apple-darwin
 
       - name: Initial disk cleanup
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Extract version from Cargo.toml
         id: version
         run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "dash-evo-tool") | .version')
           if [ -z "$VERSION" ]; then
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1
@@ -485,7 +485,7 @@ jobs:
       - name: Extract version from Cargo.toml
         id: version
         run: |
-          VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "dash-evo-tool") | .version')
           if [ -z "$VERSION" ]; then
             echo "::error::Failed to extract version from Cargo.toml"
             exit 1

--- a/flatpak/org.dash.DashEvoTool.metainfo.xml
+++ b/flatpak/org.dash.DashEvoTool.metainfo.xml
@@ -43,6 +43,7 @@
     <name>Dash Core Group</name>
   </developer>
 
+  <!-- Version and date are auto-synced from Cargo.toml by CI (flatpak.yml) -->
   <releases>
     <release version="1.0.0-dev" date="2026-02-17" type="development" />
   </releases>


### PR DESCRIPTION
## Summary

- macOS `Info.plist` version fields now derived from `Cargo.toml` at build time instead of hardcoded `1.0.0`
  - `CFBundleShortVersionString` (marketing version): stripped semver from Cargo.toml (e.g., `1.0.0`)
  - `CFBundleVersion` (build number): CI `github.run_number` — monotonically increasing, distinguishes dev/rc/release builds
- Flatpak `metainfo.xml` release version auto-synced from `Cargo.toml` by CI
- Version extraction uses `cargo metadata` + `jq` — proper TOML parsing, zero new dependencies
- Prerelease and build metadata suffixes stripped for Apple plist compliance with format validation
- Flatpak date uses `release.published_at` for release events, commit date for tags, current date otherwise
- Validation with fast-fail error handling on all extraction steps

## Test plan

- [ ] Trigger release workflow — verify macOS `.app` bundle has `CFBundleShortVersionString=1.0.0` and `CFBundleVersion=<run_number>`
- [ ] Trigger flatpak workflow — verify `metainfo.xml` contains `version="1.0.0-dev"` with correct date
- [ ] Verify prerelease suffix stripping: `1.0.0-dev` → plist gets `1.0.0`
- [ ] Verify build metadata stripping: version with `+build` → plist gets clean numeric
- [ ] Verify failure mode: malformed version → workflow fails with clear error

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically extract the app version from the project manifest for macOS and Flatpak builds.
  * Populate macOS build version fields dynamically instead of a fixed value; include build number as CFBundleVersion.
  * Synchronize and update release version/date metadata across artifacts; added CI-origin note in Flatpak metadata.
  * Validate extracted version and fail the build if the value is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->