### PR TITLE
fix(mcp): use PlatformAddress in PlatformAddressBalances backend task result

### DIFF
--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -10,8 +10,7 @@ use crate::backend_task::platform_info::{PlatformInfoTaskRequestType, PlatformIn
 use crate::backend_task::system_task::SystemTask;
 use crate::backend_task::wallet::WalletTask;
 use crate::context::AppContext;
-use dash_sdk::dpp::dashcore::Address;
-use dash_sdk::dpp::dashcore::address::NetworkChecked;
+use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::dashcore::bls_sig_utils::BLSSignature;
 use dash_sdk::dpp::dashcore::network::message_qrinfo::QRInfo;
 use dash_sdk::dpp::dashcore::BlockHash;
@@ -193,8 +192,8 @@ pub enum BackendTaskSuccessResult {
     /// Platform address balances fetched from Platform
     PlatformAddressBalances {
         seed_hash: WalletSeedHash,
-        /// Map of address to (balance, nonce)
-        balances: BTreeMap<Address<NetworkChecked>, (u64, u32)>,
+        /// Map of platform address to (balance, nonce)
+        balances: BTreeMap<PlatformAddress, (u64, u32)>,
     },
     /// Platform credits transferred between addresses
     PlatformCreditsTransferred {

--- a/src/backend_task/wallet/fetch_platform_address_balances.rs
+++ b/src/backend_task/wallet/fetch_platform_address_balances.rs
@@ -5,6 +5,7 @@ use crate::model::wallet::{
     WalletSeedHash,
 };
 use dash_sdk::RequestSettings;
+use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use dash_sdk::platform::address_sync::AddressSyncConfig;
@@ -169,7 +170,11 @@ impl AppContext {
             wallet
                 .platform_address_info
                 .iter()
-                .map(|(addr, info)| (addr.clone(), (info.balance, info.nonce)))
+                .filter_map(|(addr, info)| {
+                    PlatformAddress::try_from(addr.clone())
+                        .ok()
+                        .map(|pa| (pa, (info.balance, info.nonce)))
+                })
                 .collect()
         };
 

--- a/src/mcp/tools/wallet.rs
+++ b/src/mcp/tools/wallet.rs
@@ -351,10 +351,11 @@ impl AsyncTool<DashMcpService> for FetchPlatformBalances {
 
         match result {
             BackendTaskSuccessResult::PlatformAddressBalances { balances, .. } => {
+                let network = ctx.network();
                 let entries = balances
                     .into_iter()
                     .map(|(addr, (balance, nonce))| PlatformAddressBalance {
-                        address: addr.to_string(),
+                        address: addr.to_bech32m_string(network),
                         balance,
                         nonce,
                     })

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2881,9 +2881,11 @@ impl ScreenLike for WalletsBalancesScreen {
                     && let Ok(mut wallet) = selected.write()
                     && wallet.seed_hash() == seed_hash
                 {
-                    // Update balances in the wallet
-                    for (addr, (balance, nonce)) in balances {
-                        wallet.set_platform_address_info(addr, balance, nonce);
+                    // Convert PlatformAddress back to Core Address for wallet storage
+                    let network = self.app_context.network();
+                    for (platform_addr, (balance, nonce)) in balances {
+                        let core_addr = platform_addr.to_address_with_network(network);
+                        wallet.set_platform_address_info(core_addr, balance, nonce);
                     }
                 }
                 self.refresh_platform_sync_info_cache(&seed_hash);


### PR DESCRIPTION
## Summary

- **Bug**: `platform_addresses_list` MCP tool returned Core address format (`yXxx...`) instead of Platform bech32m format (`tdash1...` / `dash1...`)
- **Root cause**: `BackendTaskSuccessResult::PlatformAddressBalances` carried `BTreeMap<Address<NetworkChecked>, ...>` (Core addresses), forcing every consumer to convert independently
- **Fix**: Changed the backend task result to carry `BTreeMap<PlatformAddress, ...>` — conversion happens once at the source, not at every consumer

### Changes (4 files)

1. **`backend_task/mod.rs`** — `PlatformAddressBalances` variant now uses `PlatformAddress` keys
2. **`backend_task/wallet/fetch_platform_address_balances.rs`** — Converts Core→Platform at the source via `PlatformAddress::try_from()`
3. **`mcp/tools/wallet.rs`** — Simplified to direct `addr.to_bech32m_string(network)` call
4. **`ui/wallets/wallets_screen/mod.rs`** — Converts Platform→Core via `to_address_with_network()` for wallet storage (model still uses Core keys internally)

## Test plan

- [ ] Call `platform_addresses_list` MCP tool and verify addresses are returned in bech32m format (`tdash1...` on testnet, `dash1...` on mainnet)
- [ ] Verify wallet screen still displays platform address balances correctly after refresh
- [ ] `cargo clippy --all-features --all-targets -- -D warnings` passes

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>