### PR TITLE
fix(macos): order windows out on exit to prevent KVO crash

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1646,6 +1646,11 @@ impl App for AppState {
     }
 
     fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        // On macOS, order windows out before winit tears down the event
+        // handler. This lets AppKit properly clean up display-related KVO
+        // observers (TouchBar, etc.) while views are still alive.
+        crate::platform::order_out_all_windows();
+
         // If shutdown_receiver is Some, the async shutdown was already initiated
         // in update(). Skip the blocking fallback to avoid double-shutdown.
         // The blocking path only runs when the window was force-closed without

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -2,6 +2,43 @@ use objc2::MainThreadMarker;
 use objc2::msg_send;
 use objc2::runtime::{AnyClass, AnyObject};
 
+/// Orders all application windows out (hides them) so that AppKit can
+/// properly tear down display-related observations — in particular
+/// `_NSTouchBarFinderObservation` KVO observers — while the windows and
+/// their views are still alive.
+///
+/// Without this, winit's event handler teardown triggers a display cycle
+/// flush that finds KVO observers on inconsistent objects, causing a
+/// SIGILL crash via `_crashOnException:`.
+///
+/// Must be called from `on_exit()` before returning control to the
+/// eframe/winit shutdown path.
+pub fn order_out_all_windows(_mtm: MainThreadMarker) {
+    unsafe {
+        let Some(cls) = AnyClass::get(c"NSApplication") else {
+            return;
+        };
+        let app: *mut AnyObject = msg_send![cls, sharedApplication];
+        if app.is_null() {
+            return;
+        }
+
+        let windows: *mut AnyObject = msg_send![app, windows];
+        if windows.is_null() {
+            return;
+        }
+
+        let count: usize = msg_send![windows, count];
+        for i in 0..count {
+            let window: *mut AnyObject = msg_send![windows, objectAtIndex: i];
+            if !window.is_null() {
+                let _: () = msg_send![window, orderOut: std::ptr::null::<AnyObject>()];
+            }
+        }
+        tracing::debug!("Ordered out {count} windows for clean shutdown");
+    }
+}
+
 /// Queries `accessibilityChildren` on the key window's content view to force
 /// macOS to call the AccessKit adapter's subclassed method, which transitions
 /// the adapter from `Inactive` to `Active`. Without this, tools like Peekaboo

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -29,3 +29,16 @@ pub fn force_accessibility_activation() -> bool {
         true
     }
 }
+
+/// Orders all windows out before shutdown so macOS can clean up
+/// display-related observations. No-op on non-macOS platforms.
+pub fn order_out_all_windows() {
+    #[cfg(target_os = "macos")]
+    {
+        let Some(mtm) = objc2::MainThreadMarker::new() else {
+            tracing::error!("order_out_all_windows called from non-main thread");
+            return;
+        };
+        macos::order_out_all_windows(mtm);
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a SIGILL crash on macOS during shutdown caused by `_NSTouchBarFinderObservation` KVO observers on inconsistent objects
- Calls `[window orderOut:nil]` on all windows as the first action in `on_exit()`, giving AppKit a chance to properly tear down display-related observations while windows and views are still alive
- No-op on non-macOS platforms

### Root cause

During shutdown, winit's event handler teardown triggers a display cycle flush (`CATransaction commit`). This causes `_NSTouchBarFinderObservation invalidate` to remove KVO observers from objects that are already in an inconsistent state, throwing an NSException that AppKit catches and deliberately crashes on via `_crashOnException:`.

### Fix

By ordering all windows out before returning from `on_exit()`, AppKit processes the window removal while everything is still alive and consistent — the KVO observers are properly detached during this orderly removal rather than during the chaotic winit teardown.

## Test plan

- [ ] Launch on macOS, close the app window — no crash on exit
- [ ] Launch on macOS, verify the app still shuts down cleanly (background tasks stop, no hang)
- [ ] Build on Linux — compiles without warnings (no-op path)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown on macOS to ensure all windows are properly ordered out and handled before the app completes its exit sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->