### PR TITLE
fix(dashpay): read label instead of normalizedLabel and use records.identity in profile search

### DIFF
--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -571,24 +571,7 @@ async fn resolve_username_to_identity(
 
     // Extract the identity ID from records.identity — this is the authoritative
     // identity reference, which may differ from owner_id() after name transfers.
-    let identity_id = document
-        .get("records")
-        .and_then(|records| {
-            if let Value::Map(map) = records {
-                map.iter()
-                    .find(|(k, _)| matches!(k, Value::Text(key) if key == "identity"))
-                    .map(|(_, v)| v.clone())
-            } else {
-                None
-            }
-        })
-        .and_then(|id_value| {
-            if let Value::Identifier(id_bytes) = id_value {
-                Some(Identifier::from(id_bytes))
-            } else {
-                None
-            }
-        })
+    let identity_id = crate::model::dpns::extract_identity_id_from_dpns_document(document)
         .ok_or_else(|| {
             TaskError::DashPay(DashPayError::InvalidDocument {
                 reason: format!(

--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -485,24 +485,7 @@ pub async fn search_profiles(
         if let Some(document) = doc {
             // Extract identity ID from records.identity — the authoritative
             // reference, which may differ from owner_id() after name transfers.
-            let identity_id = document
-                .get("records")
-                .and_then(|records| {
-                    if let Value::Map(map) = records {
-                        map.iter()
-                            .find(|(k, _)| matches!(k, Value::Text(key) if key == "identity"))
-                            .map(|(_, v)| v.clone())
-                    } else {
-                        None
-                    }
-                })
-                .and_then(|id_value| {
-                    if let Value::Identifier(id_bytes) = id_value {
-                        Some(Identifier::from(id_bytes))
-                    } else {
-                        None
-                    }
-                });
+            let identity_id = crate::model::dpns::extract_identity_id_from_dpns_document(&document);
 
             let Some(identity_id) = identity_id else {
                 continue;

--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -483,11 +483,33 @@ pub async fn search_profiles(
     let mut identity_usernames: Vec<(Identifier, String)> = Vec::new();
     for (_, doc) in dpns_results {
         if let Some(document) = doc {
-            let identity_id = document.owner_id();
+            // Extract identity ID from records.identity — the authoritative
+            // reference, which may differ from owner_id() after name transfers.
+            let identity_id = document
+                .get("records")
+                .and_then(|records| {
+                    if let Value::Map(map) = records {
+                        map.iter()
+                            .find(|(k, _)| matches!(k, Value::Text(key) if key == "identity"))
+                            .map(|(_, v)| v.clone())
+                    } else {
+                        None
+                    }
+                })
+                .and_then(|id_value| {
+                    if let Value::Identifier(id_bytes) = id_value {
+                        Some(Identifier::from(id_bytes))
+                    } else {
+                        None
+                    }
+                });
 
-            // Get the label (username) from the document
+            let Some(identity_id) = identity_id else {
+                continue;
+            };
+
             let username = document
-                .get("normalizedLabel")
+                .get("label")
                 .and_then(|v| v.as_text())
                 .map(|s| format!("{}.dash", s))
                 .unwrap_or_else(|| format!("{}.dash", identity_id.to_string(Encoding::Base58)));

--- a/src/backend_task/identity/load_identity_by_dpns_name.rs
+++ b/src/backend_task/identity/load_identity_by_dpns_name.rs
@@ -9,7 +9,7 @@ use dash_sdk::Sdk;
 use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::drive::query::{WhereClause, WhereOperator};
-use dash_sdk::platform::{Document, DocumentQuery, Fetch, FetchMany, Identifier, Identity};
+use dash_sdk::platform::{Document, DocumentQuery, Fetch, FetchMany, Identity};
 
 impl AppContext {
     /// Load an identity by its DPNS name
@@ -54,30 +54,7 @@ impl AppContext {
             .ok_or(TaskError::IdentityNotFound)?;
 
         // Extract the identity ID from the records.identity field
-        let identity_id = domain_doc
-            .get("records")
-            .and_then(|records| {
-                if let Value::Map(map) = records {
-                    map.iter()
-                        .find(|(k, _)| {
-                            if let Value::Text(key) = k {
-                                key == "identity"
-                            } else {
-                                false
-                            }
-                        })
-                        .map(|(_, v)| v.clone())
-                } else {
-                    None
-                }
-            })
-            .and_then(|id_value| {
-                if let Value::Identifier(id_bytes) = id_value {
-                    Some(Identifier::from(id_bytes))
-                } else {
-                    None
-                }
-            })
+        let identity_id = crate::model::dpns::extract_identity_id_from_dpns_document(domain_doc)
             .ok_or(TaskError::IdentityNotFound)?;
 
         // Fetch the identity

--- a/src/model/dpns.rs
+++ b/src/model/dpns.rs
@@ -1,9 +1,13 @@
-//! DPNS name normalization helpers.
+//! DPNS name normalization and document helpers.
 //!
 //! Centralizes the "trim → strip `.dash` suffix → homograph-safe normalize"
-//! pipeline so every DPNS lookup uses the same logic.
+//! pipeline so every DPNS lookup uses the same logic, and provides shared
+//! extraction utilities for DPNS domain documents.
 
+use dash_sdk::dpp::document::DocumentV0Getters;
+use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::dpp::util::strings::convert_to_homograph_safe_chars;
+use dash_sdk::platform::{Document, Identifier};
 
 /// The `.dash` parent domain suffix (case-insensitive match target).
 const DASH_SUFFIX: &str = ".dash";
@@ -65,6 +69,33 @@ pub fn has_dash_suffix(input: &str) -> bool {
         && trimmed
             .get(suffix_start..)
             .is_some_and(|tail| tail.eq_ignore_ascii_case(DASH_SUFFIX))
+}
+
+/// Extract the identity ID from a DPNS domain document's `records.identity` field.
+///
+/// This is the authoritative identity reference for a DPNS name — unlike
+/// `document.owner_id()`, it correctly reflects ownership after name transfers.
+///
+/// Returns `None` if the document lacks the `records` map or the `identity` entry.
+pub fn extract_identity_id_from_dpns_document(document: &Document) -> Option<Identifier> {
+    document
+        .get("records")
+        .and_then(|records| {
+            if let Value::Map(map) = records {
+                map.iter()
+                    .find(|(k, _)| matches!(k, Value::Text(key) if key == "identity"))
+                    .map(|(_, v)| v.clone())
+            } else {
+                None
+            }
+        })
+        .and_then(|id_value| {
+            if let Value::Identifier(id_bytes) = id_value {
+                Some(Identifier::from(id_bytes))
+            } else {
+                None
+            }
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes two bugs in `search_profiles()` (`src/backend_task/dashpay/profile.rs`) that were missed by PR #810's DPNS fixes.

### Bug 1: `normalizedLabel` displayed instead of `label`

The profile search reads `normalizedLabel` from DPNS documents to build display names. `normalizedLabel` applies DPNS homograph-safe conversions (`o`→`0`, `i`/`l`→`1` + lowercase), so users see mangled names:

- `"alice"` → displayed as `"a11ce.dash"`
- `"olivia22"` → displayed as `"011v1a22.dash"`

**Fix:** Read `label` instead — the original human-readable username.

### Bug 2: `owner_id()` instead of `records.identity`

Same bug fixed in `contact_requests.rs` by PR #810, but missed here. After a DPNS name transfer, `document.owner_id()` still points to the original registrant. `records.identity` is the authoritative reference for the current owner.

**Fix:** Extract identity ID from `records.identity` using the same `Value::Map` pattern established in `contact_requests.rs`. Documents missing `records.identity` are silently skipped.

## Test plan

- [ ] Search for a username containing `o`, `i`, or `l` — verify the display name shows the original characters, not homograph replacements
- [ ] `cargo clippy --all-features --all-targets -- -D warnings` clean

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed profile search functionality to correctly extract and display identity information and usernames from updated data structures in profile documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->