### PR TITLE
fix: wallet UTXO filter, SPV IS lock relay, asset lock DB store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "dpp",
  "drive",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "heck",
  "quote",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2118,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -2143,12 +2143,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2161,7 +2161,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2465,7 +2465,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4447,7 +4447,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4895,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4917,7 +4917,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
 dependencies = [
  "async-trait",
  "dashcore",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6284,7 +6284,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "aes",
  "cbc",
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6315,7 +6315,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6550,7 +6550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -6571,7 +6571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "backon",
  "chrono",
@@ -7242,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "arc-swap",
  "dash-context-provider",
@@ -8471,7 +8471,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9847,7 +9847,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10661,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=94cefb30d9d8ad84b1d45e0a152341a2425f920b#94cefb30d9d8ad84b1d45e0a152341a2425f920b"
+source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "dpp",
  "drive",
@@ -2039,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "heck",
  "quote",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2201,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2212,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2465,7 +2465,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2476,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3151,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4930,7 +4930,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6284,7 +6284,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "aes",
  "cbc",
@@ -6295,7 +6295,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6304,7 +6304,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6315,7 +6315,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6335,7 +6335,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
@@ -6346,7 +6346,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "backon",
  "chrono",
@@ -7242,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "arc-swap",
  "dash-context-provider",
@@ -8471,7 +8471,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9270,7 +9270,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10661,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=51346ccac7a955d1ea48f061ad2e12a42d3c8c37#51346ccac7a955d1ea48f061ad2e12a42d3c8c37"
+source = "git+https://github.com/dashpay/platform?rev=b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3#b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "51346ccac7a955d1ea48f061ad2e12a42d3c8c37", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -28,7 +28,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "51346ccac7a955d
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "51346ccac7a955d1ea48f061ad2e12a42d3c8c37" }
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3" }
 zip32 = "0.2.0"
 grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "5b9e289cca54c79b1305d5f4f40bf1148f1eb0e3" }
 rayon = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "9d799d339f961bed5aa21d3e3e3efe9374b7929c", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -28,7 +28,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "b56bbc3ee60ce89
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "b56bbc3ee60ce8925ffa63c58dea60a187ce7fe3" }
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "9d799d339f961bed5aa21d3e3e3efe9374b7929c" }
 zip32 = "0.2.0"
 grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "5b9e289cca54c79b1305d5f4f40bf1148f1eb0e3" }
 rayon = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "94cefb30d9d8ad84b1d45e0a152341a2425f920b", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "51346ccac7a955d1ea48f061ad2e12a42d3c8c37", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -28,7 +28,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "94cefb30d9d8ad8
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "94cefb30d9d8ad84b1d45e0a152341a2425f920b" }
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "51346ccac7a955d1ea48f061ad2e12a42d3c8c37" }
 zip32 = "0.2.0"
 grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "5b9e289cca54c79b1305d5f4f40bf1148f1eb0e3" }
 rayon = "1.8"

--- a/src/backend_task/core/create_asset_lock.rs
+++ b/src/backend_task/core/create_asset_lock.rs
@@ -3,6 +3,7 @@ use crate::backend_task::error::TaskError;
 use crate::context::AppContext;
 use crate::model::wallet::Wallet;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
+use dash_sdk::dpp::dashcore::hashes::Hash;
 use dash_sdk::dpp::fee::Credits;
 use std::sync::{Arc, RwLock};
 
@@ -16,10 +17,11 @@ impl AppContext {
     ) -> Result<BackendTaskSuccessResult, TaskError> {
         let amount_duffs = amount / CREDITS_PER_DUFF;
 
-        let (asset_lock_transaction, _private_key, _change_address, _used_utxos) = {
+        let (asset_lock_transaction, _private_key, _change_address, _used_utxos, seed_hash) = {
             let mut wallet_guard = wallet.write()?;
+            let seed_hash = wallet_guard.seed_hash();
 
-            wallet_guard
+            let result = wallet_guard
                 .registration_asset_lock_transaction(
                     self,
                     self.network,
@@ -28,7 +30,9 @@ impl AppContext {
                     identity_index,
                     None,
                 )
-                .map_err(|e| TaskError::AssetLockTransactionBuildFailed { detail: e })?
+                .map_err(|e| TaskError::AssetLockTransactionBuildFailed { detail: e })?;
+
+            (result.0, result.1, result.2, result.3, seed_hash)
         };
 
         let tx_id = asset_lock_transaction.txid();
@@ -37,6 +41,16 @@ impl AppContext {
             let mut proofs = self.transactions_waiting_for_finality.lock()?;
             proofs.insert(tx_id, None);
         }
+
+        // Store the asset lock in the DB before broadcast so the SPV finality
+        // listener can look it up when the IS lock arrives.
+        self.db.store_asset_lock_transaction(
+            &asset_lock_transaction,
+            amount_duffs,
+            None,
+            &seed_hash,
+            self.network,
+        )?;
 
         if let Err(e) = self
             .broadcast_raw_transaction(&asset_lock_transaction)
@@ -49,6 +63,7 @@ impl AppContext {
                     "Failed to clean up finality tracking for tx {tx_id}: Mutex poisoned"
                 );
             }
+            let _ = self.db.delete_asset_lock_transaction(tx_id.as_byte_array());
             return Err(e);
         }
 
@@ -68,10 +83,11 @@ impl AppContext {
     ) -> Result<BackendTaskSuccessResult, TaskError> {
         let amount_duffs = amount / CREDITS_PER_DUFF;
 
-        let (asset_lock_transaction, _private_key, _change_address, _used_utxos) = {
+        let (asset_lock_transaction, _private_key, _change_address, _used_utxos, seed_hash) = {
             let mut wallet_guard = wallet.write()?;
+            let seed_hash = wallet_guard.seed_hash();
 
-            wallet_guard
+            let result = wallet_guard
                 .top_up_asset_lock_transaction(
                     self,
                     self.network,
@@ -81,7 +97,9 @@ impl AppContext {
                     top_up_index,
                     None,
                 )
-                .map_err(|e| TaskError::AssetLockTransactionBuildFailed { detail: e })?
+                .map_err(|e| TaskError::AssetLockTransactionBuildFailed { detail: e })?;
+
+            (result.0, result.1, result.2, result.3, seed_hash)
         };
 
         let tx_id = asset_lock_transaction.txid();
@@ -90,6 +108,16 @@ impl AppContext {
             let mut proofs = self.transactions_waiting_for_finality.lock()?;
             proofs.insert(tx_id, None);
         }
+
+        // Store the asset lock in the DB before broadcast so the SPV finality
+        // listener can look it up when the IS lock arrives.
+        self.db.store_asset_lock_transaction(
+            &asset_lock_transaction,
+            amount_duffs,
+            None,
+            &seed_hash,
+            self.network,
+        )?;
 
         if let Err(e) = self
             .broadcast_raw_transaction(&asset_lock_transaction)
@@ -102,6 +130,7 @@ impl AppContext {
                     "Failed to clean up finality tracking for tx {tx_id}: Mutex poisoned"
                 );
             }
+            let _ = self.db.delete_asset_lock_transaction(tx_id.as_byte_array());
             return Err(e);
         }
 

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -598,7 +598,7 @@ impl AppContext {
             // Notify the wallet about the outgoing tx while still holding the
             // write lock. This marks spent UTXOs immediately so concurrent
             // callers don't select the same inputs (double-spend prevention).
-            let _ = wm.process_mempool_transaction(&signed, false).await;
+            let _ = wm.process_mempool_transaction(&signed, None).await;
             signed
         };
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -833,10 +833,20 @@ impl AppContext {
                     dash_sdk::dpp::dashcore::TxOut,
                 >,
             > = Default::default();
+            // Track unconfirmed/non-IS-locked outpoints so UTXO selection can
+            // skip them — spending unconfirmed UTXOs causes failures for
+            // asset-lock transactions that require IS-locked inputs.
+            let mut new_unconfirmed: std::collections::HashSet<dash_sdk::dpp::dashcore::OutPoint> =
+                Default::default();
 
             for u in utxos {
                 let outpoint = u.outpoint;
                 let tx_out = u.txout.clone();
+
+                // Track unconfirmed/non-IS-locked outpoints
+                if !u.is_confirmed && !u.is_instantlocked {
+                    new_unconfirmed.insert(outpoint);
+                }
 
                 // Derive address from script
                 let address = match Address::from_script(&tx_out.script_pubkey, self.network) {
@@ -921,8 +931,9 @@ impl AppContext {
             if let Some(wref) = wallets_guard.get(seed_hash)
                 && let Ok(mut w) = wref.write()
             {
-                // Update in-memory UTXOs map
+                // Update in-memory UTXOs map and unconfirmed outpoints
                 w.utxos = new_utxos;
+                w.unconfirmed_outpoints = new_unconfirmed;
 
                 // Zero out balances for known addresses that no longer have any UTXOs.
                 // Without this, spent addresses retain stale non-zero balances because

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -959,29 +959,21 @@ impl AppContext {
             let wallet_transactions: Vec<WalletTransaction> = history
                 .into_iter()
                 .map(|record| {
-                    let status = TransactionStatus::from_height(record.height);
+                    let height = record.height();
+                    let block_info = record.block_info();
+                    let status = TransactionStatus::from_height(height);
                     WalletTransaction {
                         txid: record.txid,
                         transaction: record.transaction.clone(),
-                        timestamp: record.timestamp,
-                        height: record.height,
-                        block_hash: record.block_hash,
+                        timestamp: block_info.map(|bi| bi.timestamp() as u64).unwrap_or(0),
+                        height,
+                        block_hash: block_info.map(|bi| bi.block_hash()),
                         net_amount: record.net_amount,
                         fee: record.fee,
-                        label: record.label.clone(),
+                        label: Some(record.label.clone()).filter(|s| !s.is_empty()),
                         // SPV transaction history is per-wallet — all entries
-                        // involve our addresses. Upstream sets is_ours only for
-                        // sends (net_amount < 0); we override to true for all.
-                        is_ours: {
-                            if !record.is_ours && record.net_amount >= 0 {
-                                tracing::debug!(
-                                    txid = %record.txid,
-                                    net_amount = record.net_amount,
-                                    "SPV: overriding is_ours to true for receive transaction"
-                                );
-                            }
-                            true
-                        },
+                        // involve our addresses, so is_ours is always true.
+                        is_ours: true,
                         status,
                     }
                 })

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -64,6 +64,8 @@ pub struct Database {
 impl Database {
     pub fn new<P: AsRef<std::path::Path>>(path: P) -> rusqlite::Result<Self> {
         let conn = Connection::open(path)?;
+        // WAL mode allows concurrent reads during writes and reduces lock contention.
+        conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
         })

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -20,7 +20,7 @@ use dash_sdk::dpp::key_wallet::bip32::{DerivationPath, ExtendedPubKey};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::{AssetLockProof, CoreBlockHeight};
 use rusqlite::{Connection, params};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
 
 impl Database {
@@ -575,6 +575,7 @@ impl Database {
                     alias,
                     identities: HashMap::new(),
                     utxos: HashMap::new(),
+                    unconfirmed_outpoints: HashSet::new(),
                     transactions: Vec::new(),
                     is_main,
                     confirmed_balance: confirmed_balance as u64,

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -3111,6 +3111,67 @@ mod tests {
         assert!(!wallet.utxos.contains_key(&addr));
     }
 
+    /// When SPV reports all funds as spendable (confirmed >= total > 0),
+    /// UTXOs that are still in `unconfirmed_outpoints` must be selected anyway —
+    /// the per-UTXO set may be stale relative to the aggregate balance snapshot.
+    #[test]
+    fn test_select_utxos_all_confirmed_skips_stale_unconfirmed_set() {
+        let mut wallet = test_wallet_with_utxo(100_000);
+        let outpoint = test_outpoint(1, 0);
+
+        // Mark the UTXO as unconfirmed (stale state)
+        wallet.unconfirmed_outpoints.insert(outpoint);
+
+        // Without SPV data: selection fails (UTXO is filtered out)
+        let result = wallet.select_unspent_utxos_for(90_000, 10_000, false, None);
+        assert!(
+            result.is_none(),
+            "should fail when UTXO is unconfirmed and no SPV override"
+        );
+
+        // SPV says everything is confirmed/spendable
+        wallet.update_spv_balances(100_000, 0, 100_000);
+
+        // Now selection must succeed — stale unconfirmed_outpoints is bypassed
+        let result = wallet.select_unspent_utxos_for(90_000, 10_000, false, None);
+        assert!(
+            result.is_some(),
+            "should succeed when SPV reports all funds confirmed, even if per-UTXO set is stale"
+        );
+        let (utxos, _) = result.unwrap();
+        assert_eq!(utxos.len(), 1);
+    }
+
+    /// Fast-path must NOT fire when there is still an unconfirmed portion —
+    /// i.e. `confirmed_balance < total_balance`. The per-UTXO filter must stay active.
+    #[test]
+    fn test_select_utxos_partial_confirmed_keeps_unconfirmed_filter() {
+        let mut wallet = test_wallet();
+        let addr = test_address(1);
+
+        // Two UTXOs: one confirmed, one not yet
+        add_utxo(&mut wallet, &addr, 1, 0, 60_000);
+        add_utxo(&mut wallet, &addr, 2, 0, 40_000);
+        let unconfirmed_outpoint = test_outpoint(2, 0);
+        wallet.unconfirmed_outpoints.insert(unconfirmed_outpoint);
+
+        // SPV: 60k confirmed, 40k unconfirmed — NOT all confirmed
+        wallet.update_spv_balances(60_000, 40_000, 100_000);
+
+        // Should only be able to select the confirmed 60k UTXO
+        let result = wallet.select_unspent_utxos_for(50_000, 10_000, false, None);
+        assert!(
+            result.is_some(),
+            "should succeed selecting from confirmed UTXO"
+        );
+        let (utxos, _) = result.unwrap();
+        // Must not include the unconfirmed outpoint
+        assert!(
+            !utxos.contains_key(&unconfirmed_outpoint),
+            "unconfirmed UTXO must remain filtered when partial confirmation"
+        );
+    }
+
     // ========================================================================
     // Platform address info tests
     // ========================================================================

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -26,7 +26,7 @@ use dash_sdk::dpp::dashcore::{
 };
 use dash_sdk::dpp::platform_value::BinaryData;
 use std::cmp;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::{Arc, RwLock};
@@ -358,6 +358,11 @@ pub struct Wallet {
     pub alias: Option<String>,
     pub identities: HashMap<u32, Identity>,
     pub utxos: HashMap<Address, HashMap<OutPoint, TxOut>>,
+    /// Outpoints that are not yet confirmed or IS-locked.
+    /// `select_unspent_utxos_for()` skips these to prevent spending unconfirmed
+    /// funds, which would fail for asset-lock transactions that need IS-locked inputs.
+    /// Populated by `reconcile_spv_wallets()` from upstream UTXO confirmation flags.
+    pub unconfirmed_outpoints: HashSet<OutPoint>,
     pub transactions: Vec<WalletTransaction>,
     pub is_main: bool,
     pub confirmed_balance: u64,
@@ -441,6 +446,7 @@ impl Wallet {
             alias,
             identities: Default::default(),
             utxos: Default::default(),
+            unconfirmed_outpoints: Default::default(),
             transactions: Vec::new(),
             is_main: true,
             confirmed_balance: 0,
@@ -2773,6 +2779,7 @@ mod tests {
             alias: Some("Test Wallet".to_string()),
             identities: HashMap::new(),
             utxos: HashMap::new(),
+            unconfirmed_outpoints: HashSet::new(),
             transactions: Vec::new(),
             is_main: true,
             confirmed_balance: 0,

--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -35,6 +35,13 @@ impl Wallet {
         let mut required: i64 = i64::try_from(target).ok()?;
         let mut selected_utxos = BTreeMap::new();
 
+        // When SPV reports all funds as confirmed/spendable, skip per-UTXO
+        // confirmation checks — the unconfirmed_outpoints set may be stale
+        // relative to the aggregate balance snapshot (updated independently).
+        let all_confirmed = self.spv_balance_known
+            && self.confirmed_balance > 0
+            && self.confirmed_balance >= self.total_balance;
+
         let iter: Box<dyn Iterator<Item = (&Address, &HashMap<OutPoint, TxOut>)>> =
             match source_address {
                 Some(addr) => Box::new(self.utxos.get(addr).into_iter().map(move |m| (addr, m))),
@@ -47,7 +54,9 @@ impl Wallet {
                 }
                 // Skip unconfirmed/non-IS-locked UTXOs — they cannot be spent
                 // reliably (e.g. asset lock transactions require IS-locked inputs).
-                if self.unconfirmed_outpoints.contains(outpoint) {
+                // Exception: if SPV reports all funds confirmed, the per-UTXO set
+                // may be stale — trust the aggregate balance instead.
+                if !all_confirmed && self.unconfirmed_outpoints.contains(outpoint) {
                     continue;
                 }
                 selected_utxos.insert(*outpoint, (tx_out.clone(), address.clone()));

--- a/src/model/wallet/utxos.rs
+++ b/src/model/wallet/utxos.rs
@@ -45,6 +45,11 @@ impl Wallet {
                 if required <= 0 {
                     break;
                 }
+                // Skip unconfirmed/non-IS-locked UTXOs — they cannot be spent
+                // reliably (e.g. asset lock transactions require IS-locked inputs).
+                if self.unconfirmed_outpoints.contains(outpoint) {
+                    continue;
+                }
                 selected_utxos.insert(*outpoint, (tx_out.clone(), address.clone()));
                 required -= tx_out.value as i64;
             }
@@ -188,6 +193,10 @@ impl Wallet {
             new_outpoints.difference(&old_outpoints).cloned().collect();
 
         let changed = !removed_outpoints.is_empty() || !added_outpoints.is_empty();
+
+        // RPC list_unspent returns only confirmed UTXOs by default, so
+        // clear the unconfirmed set — all returned UTXOs are spendable.
+        self.unconfirmed_outpoints.clear();
 
         // Now update self.utxos by removing UTXOs not present in new_outpoints
         let current_utxos = &mut self.utxos;

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -282,11 +282,11 @@ impl EventHandler for SpvEventHandler {
         // For MempoolManager-tracked txs this is a harmless no-op — the
         // WalletManager deduplicates via its instant_send_locks HashSet.
         if let SyncEvent::InstantLockReceived { instant_lock, .. } = event {
-            let txid = instant_lock.txid;
             let wallet = Arc::clone(&self.wallet);
+            let islock = instant_lock.clone();
             tokio::spawn(async move {
                 let mut wm = wallet.write().await;
-                wm.process_instant_send_lock(txid);
+                wm.process_instant_send_lock(islock);
             });
         }
 
@@ -1511,7 +1511,7 @@ async fn notify_wallet_after_broadcast(
 ) {
     {
         let mut wm = wallet.write().await;
-        let _ = wm.process_mempool_transaction(tx, false).await;
+        let _ = wm.process_mempool_transaction(tx, None).await;
     }
     if let Some(ch) = reconcile_tx {
         let _ = ch.try_send(());

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1268,6 +1268,18 @@ impl SpvManager {
                                         reconcile_tx.as_ref(),
                                     )
                                     .await;
+
+                                    // TODO(workaround): Remove once
+                                    // dashpay/rust-dashcore#487 is fixed.
+                                    // Re-request IS locks after a delay so peers
+                                    // dump INVs that include our broadcast tx's
+                                    // IS lock (created by quorum ~1-2s after
+                                    // broadcast).
+                                    tokio::spawn(re_request_is_locks_after_broadcast(
+                                        Arc::clone(&wallet),
+                                        Arc::clone(&network_manager),
+                                        tx.txid(),
+                                    ));
                                 }
 
                                 let _ = response_tx.send(result);
@@ -1505,6 +1517,103 @@ async fn notify_wallet_after_broadcast(
         let _ = ch.try_send(());
     }
     tracing::debug!("Notified wallet about broadcast tx {}", tx.txid());
+}
+
+/// Re-request IS locks from peers after a broadcast delay.
+///
+/// Because we connect with `relay: false`, peers don't spontaneously relay IS lock
+/// INVs for transactions we broadcast. The MempoolManager's initial bloom filter
+/// reload (triggered by `notify_wallet_after_broadcast`) races with IS lock
+/// creation by the quorum (~1-2s). This function waits for the quorum to create
+/// the lock, then re-sends `filterload` + `mempool` to all peers, causing them
+/// to dump current IS lock INVs -- the same mechanism that works during initial sync.
+///
+/// TODO(rust-dashcore-upgrade): Replace this workaround with upstream `dispatch_local()`
+/// once rust-dashcore PR #626 (commit 88e8a9a) is merged and pinned.
+/// The proper fix injects self-broadcast transactions into the local SPV message pipeline
+/// via `dispatch_local(NetworkMessage::Tx(tx))`, which makes the MempoolManager aware of
+/// the transaction and enables IS lock matching. With that fix:
+/// 1. Remove this function entirely
+/// 2. Use `DashSpvClient::broadcast_transaction()` instead of direct `PeerNetworkManager::broadcast()`
+/// 3. Remove the `notify_wallet_after_broadcast()` workaround
+///
+/// See: <https://github.com/dashpay/rust-dashcore/issues/487>
+/// See: <https://github.com/dashpay/rust-dashcore/pull/626>
+async fn re_request_is_locks_after_broadcast(
+    wallet: Arc<AsyncRwLock<WalletManager<ManagedWalletInfo>>>,
+    network_manager: Arc<AsyncRwLock<Option<PeerNetworkManager>>>,
+    txid: Txid,
+) {
+    use dash_sdk::dpp::dashcore::address::Payload;
+    use dash_sdk::dpp::dashcore::bloom::BloomFilter;
+    use dash_sdk::dpp::dashcore::consensus::Encodable;
+    use dash_sdk::dpp::dashcore::network::message::NetworkMessage;
+    use dash_sdk::dpp::dashcore::network::message_bloom::BloomFlags;
+    use rand::Rng;
+
+    const IS_LOCK_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+    const BLOOM_FP_RATE: f64 = 0.0005;
+
+    tokio::time::sleep(IS_LOCK_DELAY).await;
+
+    let (addresses, outpoints) = {
+        let wm = wallet.read().await;
+        (wm.monitored_addresses(), wm.watched_outpoints())
+    };
+
+    let element_count = addresses.len() + outpoints.len();
+    if element_count == 0 {
+        tracing::debug!("No addresses/outpoints for IS lock re-request (tx {txid})");
+        return;
+    }
+
+    let tweak: u32 = rand::rng().random();
+    let Ok(mut filter) =
+        BloomFilter::new(element_count as u32, BLOOM_FP_RATE, tweak, BloomFlags::All)
+    else {
+        tracing::warn!("Failed to create bloom filter for IS lock re-request (tx {txid})");
+        return;
+    };
+
+    for addr in &addresses {
+        let payload = match addr.payload() {
+            Payload::PubkeyHash(hash) => <[u8; 20]>::from(*hash).to_vec(),
+            Payload::ScriptHash(hash) => <[u8; 20]>::from(*hash).to_vec(),
+            _ => continue,
+        };
+        filter.insert(&payload);
+    }
+
+    for outpoint in &outpoints {
+        let mut buf = Vec::new();
+        if outpoint.consensus_encode(&mut buf).is_ok() {
+            filter.insert(&buf);
+        }
+    }
+
+    let filter_load =
+        dash_sdk::dpp::dashcore::network::message_bloom::FilterLoad::from_bloom_filter(&filter);
+
+    let nm_guard = network_manager.read().await;
+    let Some(ref nm) = *nm_guard else {
+        tracing::debug!("Network manager gone before IS lock re-request (tx {txid})");
+        return;
+    };
+
+    let filter_results = nm.broadcast(NetworkMessage::FilterLoad(filter_load)).await;
+    let filter_ok = filter_results.iter().any(|r| r.is_ok());
+
+    if filter_ok {
+        let _ = nm.broadcast(NetworkMessage::MemPool).await;
+        tracing::info!(
+            "Re-requested IS locks from peers after broadcast (tx {txid}, \
+             {} addresses, {} outpoints)",
+            addresses.len(),
+            outpoints.len(),
+        );
+    } else {
+        tracing::warn!("Failed to re-send bloom filter for IS lock re-request (tx {txid})");
+    }
 }
 
 impl fmt::Debug for SpvManager {


### PR DESCRIPTION
## Summary

Production fixes discovered during backend E2E test development (PR #818). Cherry-picked to ship independently — no test code included.

- **WAL mode** for SQLite — enables concurrent readers during writes, reducing lock contention under async load
- **UTXO unconfirmed filter** — `select_unspent_utxos_for()` skips UTXOs that are neither confirmed nor IS-locked, preventing asset-lock failures from spending unconfirmed inputs
- **Stale filter bypass** — when SPV aggregate balance reports all funds confirmed, bypass the per-UTXO `unconfirmed_outpoints` check (which may be stale relative to the balance snapshot). Includes regression tests.
- **IS lock re-request after broadcast** — workaround for `relay:false` in SPV handshake: after broadcasting, wait 2s then re-send `filterload` + `mempool` to trigger peers to dump IS lock INVs (tracks dashpay/rust-dashcore#487, migration path documented)
- **SDK rev bump** to v3.1-dev (`9d799d33`) — adapts to API changes: `process_mempool_transaction(bool → Option<InstantLock>)`, `process_instant_send_lock(Txid → InstantLock)`, `TransactionRecord` fields → methods
- **Asset lock DB store before broadcast** — `CreateRegistrationAssetLock` and `CreateTopUpAssetLock` now store the tx in DB before broadcasting, so the SPV finality listener can look it up when the IS lock arrives. Cleans up on broadcast failure.

## Test plan

- [x] `cargo build --all-features` passes
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo +nightly fmt --all --check` passes
- [x] All 72 unit/integration tests pass (includes 2 new UTXO filter regression tests)
- [ ] Backend E2E suite passes (tested via PR #818 with same production code)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>