### PR TITLE
ci: skip Claude review when auth token is unavailable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,10 +26,12 @@ jobs:
       id-token: write
     env:
       ANTHROPIC_MODEL: ${{ vars.CLAUDE_MODEL || 'opus' }}
+      CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
     steps:
       - name: Claudius Review
+        if: ${{ env.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK != '' }}
         uses: lklimek/claudius-review-action@main
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
+          claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
           memcan_url: ${{ vars.MEMCAN_URL }}
           memcan_api_key: ${{ secrets.MEMCAN_API_KEY }}


### PR DESCRIPTION
# PR summary

- Add an auth-availability preflight step before running the Claudius
  review action.
- Skip the review action cleanly when the OAuth token secret is unavailable
  in fork `pull_request` runs.
- Preserve existing review behavior when the token is present.

Closes #825.

## Validation

- Parsed `.github/workflows/claude-code-review.yml` with `python3` and
  `yaml.safe_load(...)`.
- Ran the local pre-PR code review gate on
  `upstream/v1.0-dev..ci/skip-claude-review-without-auth` and got `ship`.
- Manually verified the workflow still triggers only for non-draft PRs with
  the `claudius-review` label, and now exits successfully before invoking the
  review action when the token is missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to enhance credential handling by conditionally executing the code review step only when required authentication credentials are available, improving workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->