### PR TITLE
test: add backend E2E tests for masternode identity features (TC-084 to TC-090)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1950,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "dpp",
  "drive",
@@ -2039,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "heck",
  "quote",
@@ -2049,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2085,12 +2104,9 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
- "anyhow",
  "async-trait",
- "bincode 2.0.1",
- "blsful",
  "chrono",
  "clap",
  "dashcore",
@@ -2098,10 +2114,8 @@ dependencies = [
  "futures",
  "hex",
  "hickory-resolver",
- "indexmap 2.13.0",
  "key-wallet",
  "key-wallet-manager",
- "log",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -2118,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -2128,40 +2142,41 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
+ "cbindgen",
  "dashcore-private",
  "dashcore_hashes",
  "ed25519-dalek",
  "hex",
  "hex_lit",
- "log",
  "rustversion",
  "secp256k1",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
  "jsonrpc",
- "log",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2176,12 +2191,11 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
  "rs-x11-hash",
- "secp256k1",
  "serde",
 ]
 
@@ -2201,7 +2215,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2212,7 +2226,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2465,7 +2479,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2476,7 +2490,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2536,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2561,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3151,7 +3165,7 @@ dependencies = [
 [[package]]
 name = "feature-flags-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4895,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4917,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=309fac869bb96a6c7f5812a594c0ce28baa1ea71#309fac869bb96a6c7f5812a594c0ce28baa1ea71"
 dependencies = [
  "async-trait",
  "dashcore",
@@ -4930,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5136,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6284,7 +6298,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "aes",
  "cbc",
@@ -6295,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6304,7 +6318,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6315,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6335,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
@@ -6346,7 +6360,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7216,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "backon",
  "chrono",
@@ -7242,7 +7256,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "arc-swap",
  "dash-context-provider",
@@ -7718,6 +7732,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -8471,7 +8494,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8591,9 +8614,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8603,6 +8641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -8633,7 +8680,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.7.15",
 ]
@@ -8658,6 +8705,12 @@ checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -9270,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10661,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=9d799d339f961bed5aa21d3e3e3efe9374b7929c#9d799d339f961bed5aa21d3e3e3efe9374b7929c"
+source = "git+https://github.com/dashpay/platform?rev=2cc4cdcf85ce62b437031671336bf622b3aafaa5#2cc4cdcf85ce62b437031671336bf622b3aafaa5"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "9d799d339f961bed5aa21d3e3e3efe9374b7929c", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "2cc4cdcf85ce62b437031671336bf622b3aafaa5", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -28,7 +28,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "9d799d339f961be
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "9d799d339f961bed5aa21d3e3e3efe9374b7929c" }
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "2cc4cdcf85ce62b437031671336bf622b3aafaa5" }
 zip32 = "0.2.0"
 grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "5b9e289cca54c79b1305d5f4f40bf1148f1eb0e3" }
 rayon = "1.8"

--- a/src/backend_task/contested_names/mod.rs
+++ b/src/backend_task/contested_names/mod.rs
@@ -73,7 +73,7 @@ impl AppContext {
                                 platform_results
                             }
                             Err(det_err) => {
-                                vec![(name.clone(), *vote_choice, Err(det_err.to_string()))]
+                                vec![(name.clone(), *vote_choice, Err(Arc::new(det_err)))]
                             }
                             Ok(_) => {
                                 vec![(name.clone(), *vote_choice, Ok(()))]

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -21,14 +21,14 @@ use dash_sdk::platform::transition::vote::PutVote;
 use dash_sdk::query_types::ContestedResource;
 use std::sync::Arc;
 
-/// Build `[Value::from("dash"), Value::Text(normalized_label)]` for a DPNS vote poll.
+/// Build `[Value::from("dash"), Value::Text(normalized_label.to_owned())]` for a DPNS vote poll.
 ///
-/// Label is normalized via `convert_to_homograph_safe_chars` (`alice` → `a11ce`);
-/// Platform indexes polls under the normalized form.
-fn dpns_vote_poll_index_values(name: &str) -> Vec<Value> {
+/// Caller must pre-normalize the label via `convert_to_homograph_safe_chars`
+/// (`alice` → `a11ce`); Platform indexes polls under the normalized form.
+fn dpns_vote_poll_index_values(normalized_label: &str) -> Vec<Value> {
     vec![
         Value::from("dash"),
-        Value::Text(convert_to_homograph_safe_chars(name)),
+        Value::Text(normalized_label.to_owned()),
     ]
 }
 
@@ -58,7 +58,7 @@ impl AppContext {
         };
 
         let normalized_label = convert_to_homograph_safe_chars(name);
-        let index_values = dpns_vote_poll_index_values(name);
+        let index_values = dpns_vote_poll_index_values(&normalized_label);
 
         let vote_poll = ContestedDocumentResourceVotePoll {
             index_name: contested_index.name.clone(),
@@ -134,29 +134,39 @@ mod tests {
     use super::*;
 
     #[test]
-    fn index_values_normalizes_homograph_chars() {
-        // Given: a label containing i/l/o homograph characters.
-        let label = "alice";
+    fn index_values_uses_the_given_normalized_label() {
+        // Given: a pre-normalized DPNS label (homographs already substituted).
+        let normalized = "a11ce";
 
         // When: constructing the vote poll index values.
-        let values = dpns_vote_poll_index_values(label);
+        let values = dpns_vote_poll_index_values(normalized);
 
-        // Then: first element is always the `"dash"` parent, second is the
-        // normalized label (i/l → 1, o → 0).
+        // Then: first element is the `"dash"` parent, second is the label as-given.
         assert_eq!(values.len(), 2);
         assert_eq!(values[0], Value::from("dash"));
         assert_eq!(values[1], Value::Text("a11ce".to_owned()));
     }
 
     #[test]
-    fn index_values_preserve_non_homograph_label() {
-        // Given: a label with no homograph characters (e.g. `bar22`).
-        let label = "bar22";
+    fn index_values_do_not_renormalize_the_label() {
+        // Given: a label that still contains homograph characters.
+        let not_yet_normalized = "alice";
 
-        // When: constructing the vote poll index values.
-        let values = dpns_vote_poll_index_values(label);
+        // When: passing it directly to the helper (violating the contract).
+        let values = dpns_vote_poll_index_values(not_yet_normalized);
 
-        // Then: normalization leaves it unchanged.
-        assert_eq!(values[1], Value::Text("bar22".to_owned()));
+        // Then: the helper does NOT renormalize — the raw label is returned as-is.
+        // (Caller is responsible for normalizing before calling.)
+        assert_eq!(values[1], Value::Text("alice".to_owned()));
+    }
+
+    #[test]
+    fn convert_to_homograph_safe_chars_maps_alice_to_a11ce() {
+        // Given: the canonical DPNS homograph substitutions (i/l → 1, o → 0).
+        // When: normalizing a label with i/l/o.
+        let normalized = convert_to_homograph_safe_chars("alice");
+
+        // Then: the result matches the constant used by the vote poll tests.
+        assert_eq!(normalized, "a11ce");
     }
 }

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -21,16 +21,10 @@ use dash_sdk::platform::transition::vote::PutVote;
 use dash_sdk::query_types::ContestedResource;
 use std::sync::Arc;
 
-/// Build the DPNS contested-index values for a vote poll.
+/// Build `[Value::from("dash"), Value::Text(normalized_label)]` for a DPNS vote poll.
 ///
-/// Platform stores the vote poll under the homograph-safe **normalized** label,
-/// not the raw user input (e.g. `"alice"` → `"a11ce"`, with `i`→`1`, `l`→`1`,
-/// `o`→`0`, and `to_lowercase`). Any caller that constructs a vote poll with
-/// the raw label hits `VotePollNotFoundError` at `PrepareProposal`, which
-/// surfaces as an opaque ~70 s timeout.
-///
-/// Pure helper — no `AppContext`/`Sdk` dependency, trivially unit-testable.
-/// Returns `[Value::from("dash"), Value::Text(normalized_label)]`.
+/// Label is normalized via `convert_to_homograph_safe_chars` (`alice` → `a11ce`);
+/// Platform indexes polls under the normalized form.
 fn dpns_vote_poll_index_values(name: &str) -> Vec<Value> {
     vec![
         Value::from("dash"),
@@ -73,11 +67,8 @@ impl AppContext {
             contract_id: data_contract.id(),
         };
 
-        // Pre-flight existence check. Confirm Platform actually has an open
-        // vote poll for `(dash, normalized_label)` before broadcasting any
-        // signed vote state transitions. This short-circuits the ~70 s
-        // retry chain triggered by `VotePollNotFoundError` at
-        // `PrepareProposal` when the poll is missing or already resolved.
+        // Pre-flight: confirm Platform has an open poll for this label before
+        // broadcasting — avoids the ~70 s retry chain on a missing poll.
         let existence_query = VotePollsByDocumentTypeQuery {
             contract_id: data_contract.id(),
             document_type_name: document_type.name().to_string(),
@@ -142,22 +133,30 @@ impl AppContext {
 mod tests {
     use super::*;
 
-    /// Homograph substitutions must apply — Platform indexes the poll under
-    /// the normalized label, so a raw label produces a `VotePollNotFound`
-    /// mismatch at `PrepareProposal` time.
     #[test]
     fn index_values_normalizes_homograph_chars() {
-        let values = dpns_vote_poll_index_values("alice");
+        // Given: a label containing i/l/o homograph characters.
+        let label = "alice";
+
+        // When: constructing the vote poll index values.
+        let values = dpns_vote_poll_index_values(label);
+
+        // Then: first element is always the `"dash"` parent, second is the
+        // normalized label (i/l → 1, o → 0).
         assert_eq!(values.len(), 2);
         assert_eq!(values[0], Value::from("dash"));
         assert_eq!(values[1], Value::Text("a11ce".to_owned()));
     }
 
-    /// Labels that contain no homograph characters must round-trip unchanged —
-    /// except for `to_lowercase`, which is part of the normalization pipeline.
     #[test]
     fn index_values_preserve_non_homograph_label() {
-        let values = dpns_vote_poll_index_values("bar22");
+        // Given: a label with no homograph characters (e.g. `bar22`).
+        let label = "bar22";
+
+        // When: constructing the vote poll index values.
+        let values = dpns_vote_poll_index_values(label);
+
+        // Then: normalization leaves it unchanged.
         assert_eq!(values[1], Value::Text("bar22".to_owned()));
     }
 }

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -9,13 +9,34 @@ use dash_sdk::dpp::data_contract::document_type::accessors::DocumentTypeV0Getter
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::dpp::util::strings::convert_to_homograph_safe_chars;
 use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
 use dash_sdk::dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
 use dash_sdk::dpp::voting::votes::Vote;
 use dash_sdk::dpp::voting::votes::resource_vote::ResourceVote;
 use dash_sdk::dpp::voting::votes::resource_vote::v0::ResourceVoteV0;
+use dash_sdk::drive::query::vote_polls_by_document_type_query::VotePollsByDocumentTypeQuery;
+use dash_sdk::platform::FetchMany;
 use dash_sdk::platform::transition::vote::PutVote;
+use dash_sdk::query_types::ContestedResource;
 use std::sync::Arc;
+
+/// Build the DPNS contested-index values for a vote poll.
+///
+/// Platform stores the vote poll under the homograph-safe **normalized** label,
+/// not the raw user input (e.g. `"alice"` → `"a11ce"`, with `i`→`1`, `l`→`1`,
+/// `o`→`0`, and `to_lowercase`). Any caller that constructs a vote poll with
+/// the raw label hits `VotePollNotFoundError` at `PrepareProposal`, which
+/// surfaces as an opaque ~70 s timeout.
+///
+/// Pure helper — no `AppContext`/`Sdk` dependency, trivially unit-testable.
+/// Returns `[Value::from("dash"), Value::Text(normalized_label)]`.
+fn dpns_vote_poll_index_values(name: &str) -> Vec<Value> {
+    vec![
+        Value::from("dash"),
+        Value::Text(convert_to_homograph_safe_chars(name)),
+    ]
+}
 
 impl AppContext {
     pub(super) async fn vote_on_dpns_name(
@@ -42,14 +63,46 @@ impl AppContext {
             });
         };
 
-        let index_values = [Value::from("dash"), Value::Text(name.to_owned())];
+        let normalized_label = convert_to_homograph_safe_chars(name);
+        let index_values = dpns_vote_poll_index_values(name);
 
         let vote_poll = ContestedDocumentResourceVotePoll {
             index_name: contested_index.name.clone(),
-            index_values: index_values.to_vec(),
+            index_values,
             document_type_name: document_type.name().to_string(),
             contract_id: data_contract.id(),
         };
+
+        // Pre-flight existence check. Confirm Platform actually has an open
+        // vote poll for `(dash, normalized_label)` before broadcasting any
+        // signed vote state transitions. This short-circuits the ~70 s
+        // retry chain triggered by `VotePollNotFoundError` at
+        // `PrepareProposal` when the poll is missing or already resolved.
+        let existence_query = VotePollsByDocumentTypeQuery {
+            contract_id: data_contract.id(),
+            document_type_name: document_type.name().to_string(),
+            index_name: contested_index.name.clone(),
+            start_index_values: vec![Value::from("dash")],
+            end_index_values: vec![],
+            // Start exactly at our normalized label (inclusive) — a single
+            // row is enough to confirm the poll exists.
+            start_at_value: Some((Value::Text(normalized_label.clone()), true)),
+            limit: Some(1),
+            order_ascending: true,
+        };
+
+        let resources = ContestedResource::fetch_many(sdk, existence_query)
+            .await
+            .map_err(TaskError::from)?;
+        let poll_exists = resources
+            .0
+            .iter()
+            .any(|r| r.0.as_str() == Some(normalized_label.as_str()));
+        if !poll_exists {
+            return Err(TaskError::VotePollNotFound {
+                name: name.to_owned(),
+            });
+        }
 
         let mut vote_results = vec![];
 
@@ -82,5 +135,29 @@ impl AppContext {
         }
 
         Ok(BackendTaskSuccessResult::DPNSVoteResults(vote_results))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Homograph substitutions must apply — Platform indexes the poll under
+    /// the normalized label, so a raw label produces a `VotePollNotFound`
+    /// mismatch at `PrepareProposal` time.
+    #[test]
+    fn index_values_normalizes_homograph_chars() {
+        let values = dpns_vote_poll_index_values("alice");
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0], Value::from("dash"));
+        assert_eq!(values[1], Value::Text("a11ce".to_owned()));
+    }
+
+    /// Labels that contain no homograph characters must round-trip unchanged —
+    /// except for `to_lowercase`, which is part of the normalization pipeline.
+    #[test]
+    fn index_values_preserve_non_homograph_label() {
+        let values = dpns_vote_poll_index_values("bar22");
+        assert_eq!(values[1], Value::Text("bar22".to_owned()));
     }
 }

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -71,7 +71,7 @@ impl AppContext {
                     )
                     .await
                     .map(|_| ())
-                    .map_err(|e| TaskError::from(e).to_string());
+                    .map_err(|e| Arc::new(TaskError::from(e)));
 
                 vote_results.push((name.to_owned(), vote_choice, result));
             } else {

--- a/src/backend_task/contested_names/vote_on_dpns_name.rs
+++ b/src/backend_task/contested_names/vote_on_dpns_name.rs
@@ -68,7 +68,7 @@ impl AppContext {
         };
 
         // Pre-flight: confirm Platform has an open poll for this label before
-        // broadcasting — avoids the ~70 s retry chain on a missing poll.
+        // broadcasting — fails fast with VotePollNotFound if it doesn't.
         let existence_query = VotePollsByDocumentTypeQuery {
             contract_id: data_contract.id(),
             document_type_name: document_type.name().to_string(),

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -842,6 +842,16 @@ pub enum TaskError {
     )]
     NoVotingIdentity { identity_id: String },
 
+    /// No open vote poll was found on Platform for the given DPNS name.
+    ///
+    /// Surfaced by the pre-flight existence check in `vote_on_dpns_name`,
+    /// before any state transition is broadcast. Short-circuits a ~70 s
+    /// retry chain that would otherwise expire with an opaque timeout.
+    #[error(
+        "The contested name \"{name}\" is not currently open for voting. It may have been resolved or may not exist. Refresh the contested names list and try again."
+    )]
+    VotePollNotFound { name: String },
+
     /// The identity does not have an authentication key required to sign documents.
     #[error(
         "This identity does not have a key for signing documents. Please add an authentication key."

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -155,7 +155,10 @@ pub enum BackendTaskSuccessResult {
     ToppedUpIdentity(QualifiedIdentity, FeeResult),
     #[allow(dead_code)] // May be used for reporting successful votes
     SuccessfulVotes(Vec<Vote>),
-    DPNSVoteResults(Vec<(String, ResourceVoteChoice, Result<(), String>)>),
+    // Per-vote errors are wrapped in `Arc` because `BackendTaskSuccessResult`
+    // derives `Clone` for UI fan-out (see `dashpay_screen::display_task_result`),
+    // while `TaskError` intentionally does not implement `Clone`.
+    DPNSVoteResults(Vec<(String, ResourceVoteChoice, Result<(), Arc<TaskError>>)>),
     CastScheduledVote(ScheduledDPNSVote),
     FetchedContract(DataContract),
     FetchedContractWithTokenPosition(

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -9,6 +9,7 @@ use crate::database::{Database, WalletError};
 use crate::model::secret::Secret;
 use dash_sdk::dpp::ProtocolError;
 use dash_sdk::dpp::address_funds::{AddressWitness, PlatformAddress};
+use dash_sdk::dpp::async_trait::async_trait;
 use dash_sdk::dpp::identity::signer::Signer;
 use dash_sdk::dpp::key_wallet::account::AccountType;
 use dash_sdk::dpp::key_wallet::bip32::{
@@ -2644,6 +2645,7 @@ impl WalletAddressProvider {
     }
 }
 
+#[async_trait]
 impl AddressProvider for WalletAddressProvider {
     fn gap_limit(&self) -> AddressIndex {
         self.gap_limit
@@ -2657,7 +2659,7 @@ impl AddressProvider for WalletAddressProvider {
             .collect()
     }
 
-    fn on_address_found(&mut self, index: AddressIndex, _key: &[u8], funds: AddressFunds) {
+    async fn on_address_found(&mut self, index: AddressIndex, _key: &[u8], funds: AddressFunds) {
         self.resolved.insert(index);
 
         // Log what the SDK is returning
@@ -2698,7 +2700,7 @@ impl AddressProvider for WalletAddressProvider {
         }
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, _key: &[u8]) {
+    async fn on_address_absent(&mut self, index: AddressIndex, _key: &[u8]) {
         self.resolved.insert(index);
     }
 

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -813,14 +813,19 @@ impl SpvManager {
             wallet_map.clear();
         }
 
-        // Reset the in-memory WalletManager's synced_height so the next SPV session
-        // scans filters from genesis instead of the stale height from the previous run.
+        // Reset the in-memory WalletManager's filter_committed_height so the next
+        // SPV session scans filters from genesis instead of the stale height from the
+        // previous run. We reset filter_committed_height (not synced_height) because at
+        // rust-dashcore 309fac8 these became independent fields — FiltersManager::new()
+        // reads filter_committed_height() for its "already synced" guard.
         match self.wallet.try_write() {
             Ok(mut wm) => {
-                wm.update_synced_height(0);
+                wm.update_filter_committed_height(0);
             }
             Err(_) => {
-                tracing::warn!("Failed to reset WalletManager synced_height during SPV data clear");
+                tracing::warn!(
+                    "Failed to reset WalletManager filter_committed_height during SPV data clear"
+                );
             }
         }
 

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -5,6 +5,7 @@ use crate::spv::SpvStatus;
 use crate::spv::manager::SpvManager;
 use crate::utils::tasks::TaskManager;
 use dash_sdk::dpp::dashcore::Network;
+use dash_sdk::dpp::key_wallet_manager::WalletInterface;
 use std::sync::{Arc, RwLock};
 use tokio::time::{Duration, timeout};
 
@@ -636,4 +637,50 @@ async fn test_live_testnet_sync_and_shutdown() {
     );
 
     let _ = task_manager.shutdown();
+}
+
+/// Regression test: clear_data_dir must reset filter_committed_height (not just synced_height).
+///
+/// At rust-dashcore 309fac8, WalletManager gained an independent filter_committed_height
+/// field. FiltersManager::new() reads filter_committed_height() for its "already synced"
+/// guard — the field is no longer derived from synced_height. Calling update_synced_height(0)
+/// alone leaves filter_committed_height stale and causes the next SPV session to declare
+/// itself "already synced" and skip the rescan, producing zero balance after a Clear SPV Data.
+///
+/// Given a manager with a non-zero filter_committed_height,
+/// When clear_data_dir() is called,
+/// Then filter_committed_height is reset to 0.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_clear_data_dir_resets_filter_committed_height() {
+    let (manager, _tm, _tmp_dir) = create_test_manager();
+
+    // Pre-seed a non-zero filter_committed_height to simulate a previous session.
+    const PRESEED_HEIGHT: u32 = 5_000;
+    let wallet_arc = manager.wallet();
+    {
+        let mut wm = wallet_arc.write().await;
+        wm.update_filter_committed_height(PRESEED_HEIGHT);
+    }
+
+    // Verify pre-condition.
+    {
+        let wm = wallet_arc.read().await;
+        assert_eq!(
+            wm.filter_committed_height(),
+            PRESEED_HEIGHT,
+            "pre-condition: filter_committed_height should be PRESEED_HEIGHT"
+        );
+    }
+
+    manager
+        .clear_data_dir()
+        .expect("clear_data_dir should succeed");
+
+    // After clearing, filter_committed_height must be 0.
+    let wm = wallet_arc.read().await;
+    assert_eq!(
+        wm.filter_committed_height(),
+        0,
+        "clear_data_dir must reset filter_committed_height to 0"
+    );
 }

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -1853,7 +1853,7 @@ impl ScreenLike for DPNSScreen {
             BackendTaskSuccessResult::DPNSVoteResults(results) => {
                 let errors: Vec<String> = results
                     .iter()
-                    .filter_map(|(_, _, r)| r.as_ref().err().cloned())
+                    .filter_map(|(_, _, r)| r.as_ref().err().map(|e| e.to_string()))
                     .collect();
                 let successes: Vec<String> = results
                     .iter()

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -23,14 +23,13 @@ use dash_sdk::dpp::dashcore::sml::llmq_entry_verification::LLMQEntryVerification
 use dash_sdk::dpp::dashcore::sml::llmq_type::LLMQType;
 use dash_sdk::dpp::dashcore::sml::masternode_list::MasternodeList;
 use dash_sdk::dpp::dashcore::sml::masternode_list_engine::{
-    MasternodeListEngine, MasternodeListEngineBlockContainer,
+    MasternodeListEngine, MasternodeListEngineBlockContainer, QRInfoBlockData, WORK_DIFF_DEPTH,
 };
 use dash_sdk::dpp::dashcore::sml::masternode_list_entry::EntryMasternodeType;
 use dash_sdk::dpp::dashcore::sml::masternode_list_entry::qualified_masternode_list_entry::QualifiedMasternodeListEntry;
 use dash_sdk::dpp::dashcore::sml::quorum_entry::qualified_quorum_entry::{
     QualifiedQuorumEntry, VerifyingChainLockSignaturesType,
 };
-use dash_sdk::dpp::dashcore::sml::quorum_validation_error::ClientDataRetrievalError;
 use dash_sdk::dpp::dashcore::transaction::special_transaction::quorum_commitment::QuorumEntry;
 use dash_sdk::dpp::dashcore::{
     Block, BlockHash as BlockHash2, ChainLock, InstantLock, Transaction,
@@ -405,6 +404,47 @@ impl MasternodeListDiffScreen {
             return Ok(*height);
         };
         Ok(height)
+    }
+
+    /// Build the hash↔height bundle the engine requires in [`MasternodeListEngine::feed_qr_info`].
+    ///
+    /// Walks the hash sets the engine enumerates from the QRInfo and resolves each from
+    /// our local cache first, then via Core RPC (populating the cache on success). Cycle
+    /// boundary blocks (`work_height + WORK_DIFF_DEPTH`) are fetched from Core by height.
+    fn build_qr_info_block_data(&mut self, qr_info: &QRInfo) -> Result<QRInfoBlockData, String> {
+        let mut block_data = QRInfoBlockData::default();
+
+        for hash in MasternodeListEngine::qr_info_referenced_block_hashes(qr_info) {
+            if hash.as_byte_array() == &[0; 32] {
+                continue;
+            }
+            let height = self.get_height_and_cache(&hash)?;
+            block_data.insert_height(hash, height);
+        }
+
+        for work_hash in MasternodeListEngine::qr_info_work_block_hashes(qr_info) {
+            if work_hash.as_byte_array() == &[0; 32] {
+                continue;
+            }
+            let work_height = self.get_height_and_cache(&work_hash)?;
+            let cycle_boundary_height = work_height + WORK_DIFF_DEPTH;
+            let cycle_boundary_hash = match self
+                .app_context
+                .core_client
+                .read()
+                .unwrap()
+                .get_block_hash(cycle_boundary_height)
+            {
+                Ok(hash) => hash,
+                Err(e) => return Err(e.to_string()),
+            };
+            block_data.insert_hash(cycle_boundary_height, cycle_boundary_hash);
+            self.cache
+                .block_height_cache
+                .insert(cycle_boundary_hash, cycle_boundary_height);
+        }
+
+        Ok(block_data)
     }
 
     #[allow(dead_code)]
@@ -1356,37 +1396,20 @@ impl MasternodeListDiffScreen {
             Some(core_p2phandler) => core_p2phandler,
         };
 
-        // Extracting immutable references before calling `feed_qr_info`
-        let get_height_fn = {
-            let block_height_cache = &self.cache.block_height_cache;
-            let app_context = &self.app_context;
-
-            move |block_hash: &BlockHash| {
-                if block_hash.as_byte_array() == &[0; 32] {
-                    return Ok(0);
-                }
-                if let Some(height) = block_height_cache.get(block_hash) {
-                    return Ok(*height);
-                }
-                match app_context
-                    .core_client
-                    .read()
-                    .unwrap()
-                    .get_block_header_info(
-                        &(BlockHash2::from_byte_array(block_hash.to_byte_array())),
-                    ) {
-                    Ok(block_info) => Ok(block_info.height as CoreBlockHeight),
-                    Err(_) => Err(ClientDataRetrievalError::RequiredBlockNotPresent(
-                        *block_hash,
-                    )),
-                }
+        // Pre-populate hash↔height data the engine needs (cycle boundary hashes are
+        // not carried in the QRInfo message and must be resolved locally).
+        let block_data = match self.build_qr_info_block_data(&qr_info) {
+            Ok(data) => data,
+            Err(e) => {
+                self.ui_state.error = Some(e);
+                return;
             }
         };
 
         if let Err(e) =
             self.data
                 .masternode_list_engine
-                .feed_qr_info(qr_info, false, true, Some(get_height_fn))
+                .feed_qr_info(qr_info, false, true, &block_data)
         {
             self.ui_state.error = Some(e.to_string());
             return;
@@ -3558,7 +3581,7 @@ impl MasternodeListDiffScreen {
                 cycle_hash
             ));
         }
-        for (index, commitment) in cycle_quorums.iter().enumerate() {
+        for (quorum_index, commitment) in cycle_quorums.iter() {
             // Determine the appropriate symbol based on verification status
             let verification_symbol = match commitment.verified {
                 LLMQEntryVerificationStatus::Verified => "✔", // Checkmark
@@ -3568,16 +3591,16 @@ impl MasternodeListDiffScreen {
                 } // Box
             };
 
-            let label_text = format!("{} Quorum at Index {}", verification_symbol, index);
+            let label_text = format!("{} Quorum at Index {}", verification_symbol, quorum_index);
 
             if ui
                 .selectable_label(
-                    self.selection.selected_qr_list_index == Some(index.to_string()),
+                    self.selection.selected_qr_list_index == Some(quorum_index.to_string()),
                     label_text,
                 )
                 .clicked()
             {
-                self.selection.selected_qr_list_index = Some(index.to_string());
+                self.selection.selected_qr_list_index = Some(quorum_index.to_string());
                 self.selection.selected_qr_item =
                     Some(SelectedQRItem::QuorumEntry(Box::new(commitment.clone())));
             }
@@ -4241,34 +4264,20 @@ impl ScreenLike for MasternodeListDiffScreen {
                     self.insert_mn_list_diff(d);
                 }
 
-                // Apply to engine using the same closure as before to resolve heights
-                let block_height_cache = self.cache.block_height_cache.clone();
-                let app_context = self.app_context.clone();
-                let get_height_fn = move |block_hash: &BlockHash| {
-                    if block_hash.as_byte_array() == &[0; 32] {
-                        return Ok(0);
-                    }
-                    if let Some(height) = block_height_cache.get(block_hash) {
-                        return Ok(*height);
-                    }
-                    match app_context
-                        .core_client
-                        .read()
-                        .unwrap()
-                        .get_block_header_info(
-                            &(BlockHash2::from_byte_array(block_hash.to_byte_array())),
-                        ) {
-                        Ok(block_info) => Ok(block_info.height as CoreBlockHeight),
-                        Err(_) => Err(ClientDataRetrievalError::RequiredBlockNotPresent(
-                            *block_hash,
-                        )),
+                // Pre-populate hash↔height data the engine needs (cycle boundary hashes
+                // are not carried in the QRInfo message and must be resolved locally).
+                let block_data = match self.build_qr_info_block_data(&qr_info) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        self.ui_state.error = Some(e);
+                        return;
                     }
                 };
                 if let Err(e) = self.data.masternode_list_engine.feed_qr_info(
                     qr_info.clone(),
                     false,
                     true,
-                    Some(get_height_fn),
+                    &block_data,
                 ) {
                     self.ui_state.error = Some(e.to_string());
                 }

--- a/tests/backend-e2e/README.md
+++ b/tests/backend-e2e/README.md
@@ -33,6 +33,10 @@ cargo test --test backend-e2e --all-features -- --ignored --nocapture test_creat
 | Variable | Required | Description |
 |---|---|---|
 | `E2E_WALLET_MNEMONIC` | Yes | BIP-39 mnemonic for the framework wallet. Must be a pre-funded testnet wallet with at least 10 tDASH. Can be set as a shell env var or in the project root `.env` file (see below). If not set, the test fails with an error message and instructions. |
+| `E2E_MN_PROTX_HASH` | No | Hex ProRegTx hash (64 chars) of a registered testnet masternode/evonode. Required for TC-084 to TC-090 (except TC-088). Tests skip gracefully when unset. |
+| `E2E_MN_VOTING_KEY` | No | WIF private key for the MN's voting address. Required for voting tests (TC-086, TC-090). |
+| `E2E_MN_OWNER_KEY` | No | WIF private key for the MN's owner address. |
+| `E2E_MN_PAYOUT_KEY` | No | WIF private key for the MN's payout address. |
 
 ### `.env` file handling
 
@@ -182,6 +186,7 @@ Located in `tests/backend-e2e/framework/`:
 | `identity_create` | Identity registration funded from a wallet |
 | `register_dpns` | Full flow: identity creation, DPNS name registration, name search verification |
 | `identity_withdraw` | Identity credit withdrawal to a Core address |
+| `masternode_identity_tasks` | MN/Evonode identity loading, refresh, error cases, DPNS voting (TC-084 to TC-090) |
 
 ## Writing new tests
 

--- a/tests/backend-e2e/README.md
+++ b/tests/backend-e2e/README.md
@@ -187,6 +187,74 @@ Located in `tests/backend-e2e/framework/`:
 | `identity_withdraw` | Identity credit withdrawal to a Core address |
 | `masternode_identity_tasks` | MN/Evonode identity loading, refresh, error cases, DPNS voting (TC-084 to TC-090) |
 
+## Test guidelines
+
+### Independence and parallel execution
+
+All tests **must** be independent and run in parallel. Never use
+`--test-threads=1` unless debugging a specific issue.
+
+- **No ordering dependencies.** Every test must pass regardless of which other
+  tests run (or don't run) and in any execution order.
+- **No cross-test shared mutable state.** The `BackendTestContext` singleton and
+  `OnceCell` fixtures (e.g., `shared_identity()`) are read-only after init —
+  they are safe to share. But one test must never rely on *another test* having
+  populated a fixture or modified state.
+- **Self-contained setup.** If a test needs a funded wallet, identity, or DPNS
+  name, it creates its own. Shared fixtures from `fixtures.rs` are acceptable
+  for expensive setup (identity registration, token deployment) because any test
+  can trigger their init via `OnceCell` — they don't depend on test ordering.
+- **Graceful skip, not panic.** When optional env vars (e.g., `E2E_MN_PROTX_HASH`)
+  are missing, log a warning and return — never `panic!` or `skip!`.
+
+### Tracing and log output
+
+Use `#[tracing::instrument]` on every test function. This creates a tracing span
+named after the function, so every log line in parallel output is tagged with the
+originating test:
+
+```
+2026-04-16T10:30:00Z  INFO tc_084_load_masternode_identity: loaded MN identity id=...
+2026-04-16T10:30:00Z  INFO tc_088_load_mn_invalid_protx: got expected error error=...
+```
+
+Use structured tracing fields instead of string-interpolated prefixes:
+
+```rust
+// Good — structured, grep-friendly
+tracing::info!(id = ?qi.identity.id(), identity_type = %qi.identity_type, "loaded identity");
+
+// Avoid — redundant with span name, harder to parse
+tracing::info!("TC-084: loaded identity {:?}, type={}", qi.identity.id(), qi.identity_type);
+```
+
+### State transitions and nonce handling
+
+Use `run_task_with_nonce_retry()` (not `run_task()`) for any task that submits a
+state transition to Platform. This includes identity registration, top-up, key
+addition, DPNS registration, token operations, DashPay mutations, and voting.
+
+Nonce conflicts are expected under parallel execution — the retry wrapper handles
+`IdentityNonceOverflow` and `IdentityNonceNotFound` with 3 retries and 2s delay.
+
+### Assertions
+
+- **Assert on specific tracked values**, not just "any match". If you registered
+  an identity in step 1, assert on *that* identity's ID in step 2 — don't just
+  check that *some* identity exists.
+- **Filter collections by known identifiers.** When checking incoming contact
+  requests, filter by sender `identity_id` instead of taking `[0]`.
+- **Use `FeatureGate`** for proactive feature support checks. If a Platform
+  feature may not be enabled on the current network, check before attempting the
+  operation — don't wait for a cryptic error.
+
+### Error path testing
+
+- **Log errors via Display (`{}`), not Debug (`{:?}`).** Debug output may include
+  raw key bytes or internal SDK state. Display is safe and user-facing.
+- **Error tests need no env vars when possible.** E.g., TC-088 uses a fake ProTx
+  hash and always runs — no credentials needed.
+
 ## Writing new tests
 
 ### Step 1: Create a test module
@@ -209,6 +277,7 @@ use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn test_my_feature() {
     let ctx = ctx().await;
     let app_context = &ctx.app_context;
@@ -240,10 +309,11 @@ Key points:
   that are bound to the runtime that created them. With `#[tokio::test]`, each test
   creates its own runtime; when the first test exits, its runtime drops and kills
   the SPV tasks, causing "channel closed" errors in later tests.
+- Always use `#[tracing::instrument]` for identifiable parallel log output.
 - Call `ctx().await` as the first line -- it initializes SPV and the framework
   wallet on first use.
-- Use `run_task()` to execute backend tasks. It creates a throwaway MPSC channel
-  and returns the `Result<BackendTaskSuccessResult, TaskError>` directly.
+- Use `run_task()` for read-only queries. Use `run_task_with_nonce_retry()` for
+  state transitions.
 - Match on the specific `BackendTaskSuccessResult` variant you expect. Panic on
   unexpected variants to get clear failure messages.
 

--- a/tests/backend-e2e/README.md
+++ b/tests/backend-e2e/README.md
@@ -36,7 +36,6 @@ cargo test --test backend-e2e --all-features -- --ignored --nocapture test_creat
 | `E2E_MN_PROTX_HASH` | No | Hex ProRegTx hash (64 chars) of a registered testnet masternode/evonode. Required for TC-084 to TC-090 (except TC-088). Tests skip gracefully when unset. |
 | `E2E_MN_VOTING_KEY` | No | WIF private key for the MN's voting address. Required for voting tests (TC-086, TC-090). |
 | `E2E_MN_OWNER_KEY` | No | WIF private key for the MN's owner address. |
-| `E2E_MN_PAYOUT_KEY` | No | WIF private key for the MN's payout address. |
 
 ### `.env` file handling
 

--- a/tests/backend-e2e/framework/harness.rs
+++ b/tests/backend-e2e/framework/harness.rs
@@ -522,6 +522,54 @@ impl BackendTestContext {
 
         (seed_hash, wallet_arc)
     }
+
+    /// Create a new wallet registered with SPV but NOT funded.
+    ///
+    /// Generates a fresh BIP-39 mnemonic, registers the wallet in AppContext,
+    /// waits for SPV to pick it up, and waits for the bloom filter rebuild tick.
+    /// Returns the seed hash and wallet arc — caller is responsible for funding.
+    pub async fn create_empty_test_wallet(
+        &self,
+    ) -> (
+        WalletSeedHash,
+        Arc<std::sync::RwLock<dash_evo_tool::model::wallet::Wallet>>,
+    ) {
+        let app_context = &self.app_context;
+
+        let mnemonic =
+            Mnemonic::generate_in(Language::English, 12).expect("Mnemonic generation failed");
+        let seed = mnemonic.to_seed("");
+
+        let wallet = dash_evo_tool::model::wallet::Wallet::new_from_seed(
+            seed,
+            Network::Testnet,
+            Some("E2E Test Wallet (unfunded)".to_string()),
+            None,
+        )
+        .expect("Failed to create test wallet");
+
+        let (seed_hash, wallet_arc) = app_context
+            .register_wallet(wallet)
+            .expect("Failed to register test wallet");
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            "create_empty_test_wallet: registered new wallet"
+        );
+
+        wait::wait_for_wallet_in_spv(app_context, seed_hash, Duration::from_secs(30))
+            .await
+            .expect("Test wallet not picked up by SPV");
+
+        // Allow mempool manager tick to detect wallet address change
+        // and rebuild bloom filter before any broadcast targets this wallet.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        tracing::trace!(
+            seed_hash = ?&seed_hash[..4],
+            "create_empty_test_wallet: ready (SPV synced, bloom filter rebuilt)"
+        );
+
+        (seed_hash, wallet_arc)
+    }
 }
 
 /// Pick a deterministic workdir, acquiring an exclusive lock file.

--- a/tests/backend-e2e/framework/harness.rs
+++ b/tests/backend-e2e/framework/harness.rs
@@ -89,13 +89,17 @@ impl BackendTestContext {
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
 
-        // Initialize tracing for test output
+        // Initialize tracing for test output.
+        // Span events are enabled so that `#[tracing::instrument]` on test
+        // functions tags every log line with the test name — essential for
+        // distinguishing interleaved output during parallel execution.
         let _ = tracing_subscriber::fmt()
             .with_env_filter(
                 tracing_subscriber::EnvFilter::try_from_default_env()
                     .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("backend_e2e=info")),
             )
             .with_target(false)
+            .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ENTER)
             .try_init();
 
         // Load .env from the project root so E2E_WALLET_MNEMONIC is available.

--- a/tests/backend-e2e/framework/identity_helpers.rs
+++ b/tests/backend-e2e/framework/identity_helpers.rs
@@ -95,3 +95,4 @@ pub fn get_receive_address(app_context: &AppContext, wallet_arc: &Arc<RwLock<Wal
         .expect("Failed to get receive address")
         .to_string()
 }
+

--- a/tests/backend-e2e/framework/identity_helpers.rs
+++ b/tests/backend-e2e/framework/identity_helpers.rs
@@ -95,4 +95,3 @@ pub fn get_receive_address(app_context: &AppContext, wallet_arc: &Arc<RwLock<Wal
         .expect("Failed to get receive address")
         .to_string()
 }
-

--- a/tests/backend-e2e/framework/mn_helpers.rs
+++ b/tests/backend-e2e/framework/mn_helpers.rs
@@ -1,0 +1,49 @@
+//! Helpers for loading masternode/evonode identity credentials from env vars.
+
+use dash_evo_tool::backend_task::identity::IdentityInputToLoad;
+use dash_evo_tool::model::qualified_identity::IdentityType;
+use dash_evo_tool::model::secret::Secret;
+
+/// Credentials for a registered testnet masternode/evonode, loaded from env vars.
+pub struct MnCredentials {
+    pub protx_hash: String,
+    pub voting_key: Option<String>,
+    pub owner_key: Option<String>,
+    pub payout_key: Option<String>,
+}
+
+/// Read `E2E_MN_*` env vars. Returns `None` if `E2E_MN_PROTX_HASH` is not set.
+pub fn load_mn_credentials() -> Option<MnCredentials> {
+    let protx_hash = std::env::var("E2E_MN_PROTX_HASH").ok()?;
+    if protx_hash.is_empty() {
+        return None;
+    }
+    Some(MnCredentials {
+        protx_hash,
+        voting_key: non_empty_env("E2E_MN_VOTING_KEY"),
+        owner_key: non_empty_env("E2E_MN_OWNER_KEY"),
+        payout_key: non_empty_env("E2E_MN_PAYOUT_KEY"),
+    })
+}
+
+/// Build an `IdentityInputToLoad` from masternode credentials.
+pub fn build_mn_identity_input(
+    creds: &MnCredentials,
+    identity_type: IdentityType,
+) -> IdentityInputToLoad {
+    IdentityInputToLoad {
+        identity_id_input: creds.protx_hash.clone(),
+        identity_type,
+        alias_input: String::new(),
+        voting_private_key_input: Secret::new(creds.voting_key.as_deref().unwrap_or("")),
+        owner_private_key_input: Secret::new(creds.owner_key.as_deref().unwrap_or("")),
+        payout_address_private_key_input: Secret::new(creds.payout_key.as_deref().unwrap_or("")),
+        keys_input: vec![],
+        derive_keys_from_wallets: false,
+        selected_wallet_id: None,
+    }
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}

--- a/tests/backend-e2e/framework/mn_helpers.rs
+++ b/tests/backend-e2e/framework/mn_helpers.rs
@@ -9,7 +9,6 @@ pub struct MnCredentials {
     pub protx_hash: String,
     pub voting_key: Option<String>,
     pub owner_key: Option<String>,
-    pub payout_key: Option<String>,
 }
 
 /// Read `E2E_MN_*` env vars. Returns `None` if `E2E_MN_PROTX_HASH` is not set.
@@ -22,7 +21,6 @@ pub fn load_mn_credentials() -> Option<MnCredentials> {
         protx_hash,
         voting_key: non_empty_env("E2E_MN_VOTING_KEY"),
         owner_key: non_empty_env("E2E_MN_OWNER_KEY"),
-        payout_key: non_empty_env("E2E_MN_PAYOUT_KEY"),
     })
 }
 
@@ -37,7 +35,7 @@ pub fn build_mn_identity_input(
         alias_input: String::new(),
         voting_private_key_input: Secret::new(creds.voting_key.as_deref().unwrap_or("")),
         owner_private_key_input: Secret::new(creds.owner_key.as_deref().unwrap_or("")),
-        payout_address_private_key_input: Secret::new(creds.payout_key.as_deref().unwrap_or("")),
+        payout_address_private_key_input: Secret::new(""),
         keys_input: vec![],
         derive_keys_from_wallets: false,
         selected_wallet_seed_hash: None,

--- a/tests/backend-e2e/framework/mn_helpers.rs
+++ b/tests/backend-e2e/framework/mn_helpers.rs
@@ -12,7 +12,11 @@ pub struct MnCredentials {
 }
 
 /// Read `E2E_MN_*` env vars. Returns `None` if `E2E_MN_PROTX_HASH` is not set.
+///
+/// Loads the project root `.env` file first (idempotent) so that env vars
+/// defined there are visible even before `ctx().await` initializes the harness.
 pub fn load_mn_credentials() -> Option<MnCredentials> {
+    let _ = dotenvy::dotenv();
     let protx_hash = std::env::var("E2E_MN_PROTX_HASH").ok()?;
     if protx_hash.is_empty() {
         return None;

--- a/tests/backend-e2e/framework/mn_helpers.rs
+++ b/tests/backend-e2e/framework/mn_helpers.rs
@@ -40,7 +40,7 @@ pub fn build_mn_identity_input(
         payout_address_private_key_input: Secret::new(creds.payout_key.as_deref().unwrap_or("")),
         keys_input: vec![],
         derive_keys_from_wallets: false,
-        selected_wallet_id: None,
+        selected_wallet_seed_hash: None,
     }
 }
 

--- a/tests/backend-e2e/framework/mod.rs
+++ b/tests/backend-e2e/framework/mod.rs
@@ -7,6 +7,8 @@ pub mod funding;
 pub mod harness;
 pub mod identity_helpers;
 #[allow(dead_code)]
+pub mod mn_helpers;
+#[allow(dead_code)]
 pub mod mnlist_helpers;
 #[allow(dead_code)]
 pub mod shielded_helpers;

--- a/tests/backend-e2e/main.rs
+++ b/tests/backend-e2e/main.rs
@@ -4,7 +4,7 @@
 //! network. They are marked `#[ignore]` and must be run explicitly:
 //!
 //! ```bash
-//! RUST_MIN_STACK=16777216 cargo test --test backend-e2e --all-features -- --ignored --nocapture --test-threads=1
+//! RUST_MIN_STACK=16777216 cargo test --test backend-e2e --all-features -- --ignored --nocapture
 //! ```
 //!
 //! The `RUST_MIN_STACK=16777216` (16 MB) is required because the Dash Platform SDK

--- a/tests/backend-e2e/main.rs
+++ b/tests/backend-e2e/main.rs
@@ -25,6 +25,7 @@ mod tx_is_ours;
 mod core_tasks;
 mod dashpay_tasks;
 mod identity_tasks;
+mod masternode_identity_tasks;
 mod mnlist_tasks;
 mod shielded_tasks;
 mod token_tasks;

--- a/tests/backend-e2e/main.rs
+++ b/tests/backend-e2e/main.rs
@@ -17,6 +17,7 @@ mod cleanup_only;
 mod fetch_contract;
 mod identity_create;
 mod identity_withdraw;
+mod multi_output_payment;
 mod register_dpns;
 mod send_funds;
 mod spv_wallet;

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -499,6 +499,20 @@ async fn tc_090_vote_with_mn_voter() {
     )
     .await;
 
+    // Step 2c: Re-confirm the contest is still live immediately before voting.
+    // Step 2b proves the poll was ever created; this second, short check
+    // (single query, 5 s cap) catches poll cleanup between registration and
+    // voting — e.g. on testnets with short voting windows, or if an earlier
+    // vote already resolved the contest. Cheap belt-and-suspenders against
+    // opaque vote timeouts.
+    tracing::info!(name = %name, "re-confirming contest is live before voting");
+    wait_for_dpns_contest(
+        &ctx.app_context.sdk(),
+        &name,
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+
     // Step 3: Vote Lock on the contested name using the MN voter identity.
     tracing::info!(name = %name, "voting Lock with MN voter");
 

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -167,7 +167,7 @@ async fn tc_086_load_mn_voting_key_only() {
         payout_address_private_key_input: Secret::new(""),
         keys_input: vec![],
         derive_keys_from_wallets: false,
-        selected_wallet_id: None,
+        selected_wallet_seed_hash: None,
     };
 
     let result = run_task(
@@ -273,7 +273,7 @@ async fn tc_088_load_mn_invalid_protx() {
         payout_address_private_key_input: Secret::new(""),
         keys_input: vec![],
         derive_keys_from_wallets: false,
-        selected_wallet_id: None,
+        selected_wallet_seed_hash: None,
     };
 
     let result = run_task(
@@ -320,7 +320,7 @@ async fn tc_089_load_mn_wrong_voting_key() {
         payout_address_private_key_input: Secret::new(""),
         keys_input: vec![],
         derive_keys_from_wallets: false,
-        selected_wallet_id: None,
+        selected_wallet_seed_hash: None,
     };
 
     let result = run_task(

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -15,8 +15,15 @@ use dash_evo_tool::backend_task::identity::{
 use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
 use dash_evo_tool::model::qualified_identity::{IdentityType, PrivateKeyTarget, QualifiedIdentity};
 use dash_evo_tool::model::secret::Secret;
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::platform_value::Value;
+use dash_sdk::dpp::system_data_contracts::{SystemDataContract, load_system_data_contract};
+use dash_sdk::dpp::util::strings::convert_to_homograph_safe_chars;
 use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
+use dash_sdk::drive::query::vote_polls_by_document_type_query::VotePollsByDocumentTypeQuery;
+use dash_sdk::platform::FetchMany;
+use dash_sdk::query_types::ContestedResource;
 
 /// Load a masternode identity from env credentials. Returns `None` if creds missing.
 #[tracing::instrument(skip_all, fields(identity_type = %identity_type))]
@@ -31,6 +38,85 @@ async fn load_mn_from_env(identity_type: IdentityType) -> Option<QualifiedIdenti
     match result {
         BackendTaskSuccessResult::LoadedIdentity(qi) => Some(qi),
         other => panic!("expected LoadedIdentity, got: {:?}", other),
+    }
+}
+
+/// Generate a DPNS label that is guaranteed to match the contested-resource
+/// regex `^[a-zA-Z01-]{3,19}$` — i.e. 3–19 chars drawn only from
+/// `[a-zA-Z01-]`. Only names matching this regex trigger a vote contest;
+/// length alone (< 20 chars) is not sufficient.
+///
+/// Prefix is a recognisable tag so humans browsing testnet state can tell
+/// these are test-generated names; suffix is random from `[a-z01]`.
+fn generate_contested_dpns_name() -> String {
+    // `e0emn` replaces the previous `e2emn` — `2` is not in the contested
+    // alphabet, so the old prefix slipped names past the regex.
+    const PREFIX: &str = "e0emn";
+    const POOL: &[u8] = b"abcdefghijklmnopqrstuvwxyz01";
+    const SUFFIX_LEN: usize = 8;
+    let suffix: String = (0..SUFFIX_LEN)
+        .map(|_| POOL[rand::random::<u8>() as usize % POOL.len()] as char)
+        .collect();
+    // 5 + 8 = 13 chars, comfortably within the 3..=19 bound.
+    format!("{PREFIX}{suffix}")
+}
+
+/// Poll Platform until the vote poll for `(dash, normalized_label)` exists on
+/// the DPNS contract, up to `timeout`. Panics with a diagnostic message if the
+/// contest does not appear in time — this catches regressions where the
+/// generator produces a name that silently registers as an uncontested domain
+/// document, which would otherwise surface as an opaque voting timeout.
+async fn wait_for_dpns_contest(sdk: &dash_sdk::Sdk, label: &str, timeout: std::time::Duration) {
+    let platform_version = sdk.version();
+    let dpns_contract = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+        .expect("load DPNS system contract");
+    let normalized = convert_to_homograph_safe_chars(label);
+    let poll_interval = std::time::Duration::from_secs(2);
+    let start = std::time::Instant::now();
+
+    loop {
+        let query = VotePollsByDocumentTypeQuery {
+            contract_id: dpns_contract.id(),
+            document_type_name: "domain".to_string(),
+            index_name: "parentNameAndLabel".to_string(),
+            // Start exactly at our normalized label (inclusive) so a single
+            // returned row is enough to confirm the contest exists.
+            start_at_value: Some((Value::Text(normalized.clone()), true)),
+            start_index_values: vec!["dash".into()],
+            end_index_values: vec![],
+            limit: Some(1),
+            order_ascending: true,
+        };
+
+        match ContestedResource::fetch_many(sdk, query).await {
+            Ok(resources) => {
+                let found = resources
+                    .0
+                    .iter()
+                    .any(|r| r.0.as_str() == Some(&normalized));
+                if found {
+                    tracing::info!(
+                        elapsed_ms = start.elapsed().as_millis(),
+                        label = label,
+                        normalized = normalized.as_str(),
+                        "contested vote poll is live",
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                tracing::warn!("contested-resource query failed (will retry): {}", e);
+            }
+        }
+
+        if start.elapsed() >= timeout {
+            panic!(
+                "DPNS name {label} registered but did not enter contest state within {:?} — \
+                 check that the name matches regex ^[a-zA-Z01-]{{3,19}}$",
+                timeout,
+            );
+        }
+        tokio::time::sleep(poll_interval).await;
     }
 }
 
@@ -377,8 +463,11 @@ async fn tc_090_vote_with_mn_voter() {
         other => panic!("expected RegisteredIdentity, got: {:?}", other),
     };
 
-    // Step 2: Register a short contested DPNS name (< 20 chars triggers contest).
-    let name = format!("e2emn{:08x}", rand::random::<u32>());
+    // Step 2: Register a short DPNS name composed only of [a-zA-Z01-] so the
+    // normalizedLabel matches the contested regex ^[a-zA-Z01-]{3,19}$ and a
+    // masternode vote contest is triggered. Both length AND alphabet must
+    // match — < 20 chars alone is not sufficient.
+    let name = generate_contested_dpns_name();
     tracing::info!(name = %name, "registering contested DPNS name");
 
     let dpns_result = run_task_with_nonce_retry(
@@ -396,6 +485,19 @@ async fn tc_090_vote_with_mn_voter() {
         "expected RegisteredDpnsName, got: {:?}",
         dpns_result
     );
+
+    // Step 2b: Precheck — wait until the vote poll actually exists on
+    // Platform before attempting to vote. DPNS registration → contest state
+    // can take a block or two; failing fast here (instead of waiting out the
+    // opaque vote timeout) makes regressions in the name generator or
+    // registration path obvious.
+    tracing::info!(name = %name, "waiting for DPNS contest to go live");
+    wait_for_dpns_contest(
+        &ctx.app_context.sdk(),
+        &name,
+        std::time::Duration::from_secs(30),
+    )
+    .await;
 
     // Step 3: Vote Lock on the contested name using the MN voter identity.
     tracing::info!(name = %name, "voting Lock with MN voter");

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -1,0 +1,433 @@
+//! Masternode identity backend E2E tests: TC-084 to TC-090.
+
+use crate::framework::harness::ctx;
+use crate::framework::identity_helpers::build_identity_registration;
+use crate::framework::mn_helpers::{build_mn_identity_input, load_mn_credentials};
+use crate::framework::task_runner::{run_task, run_task_with_nonce_retry};
+use dash_evo_tool::backend_task::contested_names::ContestedResourceTask;
+use dash_evo_tool::backend_task::identity::{
+    IdentityInputToLoad, IdentityTask, RegisterDpnsNameInput,
+};
+use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
+use dash_evo_tool::model::qualified_identity::{IdentityType, PrivateKeyTarget, QualifiedIdentity};
+use dash_evo_tool::model::secret::Secret;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
+
+/// Load a masternode identity from env credentials. Returns `None` if creds missing.
+async fn load_mn_from_env(identity_type: IdentityType) -> Option<QualifiedIdentity> {
+    let creds = load_mn_credentials()?;
+    let ctx = ctx().await;
+    let input = build_mn_identity_input(&creds, identity_type);
+    let task = BackendTask::IdentityTask(IdentityTask::LoadIdentity(input));
+    let result = run_task(&ctx.app_context, task)
+        .await
+        .expect("load_mn_from_env: LoadIdentity failed");
+    match result {
+        BackendTaskSuccessResult::LoadedIdentity(qi) => Some(qi),
+        other => panic!(
+            "load_mn_from_env: expected LoadedIdentity, got: {:?}",
+            other
+        ),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-084: Load Masternode Identity (all keys)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_084_load_masternode_identity() {
+    let Some(creds) = load_mn_credentials() else {
+        tracing::warn!("Skipping TC-084: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    let ctx = ctx().await;
+
+    let input = build_mn_identity_input(&creds, IdentityType::Masternode);
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
+    )
+    .await
+    .expect("TC-084: LoadIdentity should succeed");
+
+    match result {
+        BackendTaskSuccessResult::LoadedIdentity(qi) => {
+            tracing::info!(
+                "TC-084: loaded MN identity {:?}, type={}, keys={}",
+                qi.identity.id(),
+                qi.identity_type,
+                qi.private_keys.private_keys.len()
+            );
+            assert_eq!(
+                qi.identity_type,
+                IdentityType::Masternode,
+                "TC-084: identity_type should be Masternode"
+            );
+            if creds.voting_key.is_some() {
+                assert!(
+                    qi.associated_voter_identity.is_some(),
+                    "TC-084: voter identity should be present when voting key provided"
+                );
+                let has_voter_key = qi
+                    .private_keys
+                    .private_keys
+                    .keys()
+                    .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnVoterIdentity);
+                assert!(
+                    has_voter_key,
+                    "TC-084: private_keys should contain PrivateKeyOnVoterIdentity entry"
+                );
+            }
+            if creds.owner_key.is_some() || creds.payout_key.is_some() {
+                let has_main_key = qi
+                    .private_keys
+                    .private_keys
+                    .keys()
+                    .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnMainIdentity);
+                assert!(
+                    has_main_key,
+                    "TC-084: private_keys should contain PrivateKeyOnMainIdentity entry"
+                );
+            }
+        }
+        other => panic!("TC-084: expected LoadedIdentity, got: {:?}", other),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-085: Load Evonode Identity
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_085_load_evonode_identity() {
+    let Some(creds) = load_mn_credentials() else {
+        tracing::warn!("Skipping TC-085: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    let ctx = ctx().await;
+
+    let input = build_mn_identity_input(&creds, IdentityType::Evonode);
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
+    )
+    .await
+    .expect("TC-085: LoadIdentity should succeed");
+
+    match result {
+        BackendTaskSuccessResult::LoadedIdentity(qi) => {
+            tracing::info!(
+                "TC-085: loaded Evonode identity {:?}, type={}",
+                qi.identity.id(),
+                qi.identity_type
+            );
+            assert_eq!(
+                qi.identity_type,
+                IdentityType::Evonode,
+                "TC-085: identity_type should be Evonode"
+            );
+            if creds.voting_key.is_some() {
+                assert!(
+                    qi.associated_voter_identity.is_some(),
+                    "TC-085: voter identity should be present when voting key provided"
+                );
+            }
+        }
+        other => panic!("TC-085: expected LoadedIdentity, got: {:?}", other),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-086: Load MN with Voting Key Only
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_086_load_mn_voting_key_only() {
+    let Some(creds) = load_mn_credentials() else {
+        tracing::warn!("Skipping TC-086: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    let Some(ref _voting_key) = creds.voting_key else {
+        tracing::warn!("Skipping TC-086: E2E_MN_VOTING_KEY not set");
+        return;
+    };
+    let ctx = ctx().await;
+
+    let input = IdentityInputToLoad {
+        identity_id_input: creds.protx_hash.clone(),
+        identity_type: IdentityType::Masternode,
+        alias_input: String::new(),
+        voting_private_key_input: Secret::new(creds.voting_key.as_deref().unwrap_or("")),
+        owner_private_key_input: Secret::new(""),
+        payout_address_private_key_input: Secret::new(""),
+        keys_input: vec![],
+        derive_keys_from_wallets: false,
+        selected_wallet_id: None,
+    };
+
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
+    )
+    .await
+    .expect("TC-086: LoadIdentity should succeed");
+
+    match result {
+        BackendTaskSuccessResult::LoadedIdentity(qi) => {
+            tracing::info!(
+                "TC-086: loaded MN (voting only) {:?}, voter={:?}",
+                qi.identity.id(),
+                qi.associated_voter_identity.as_ref().map(|(id, _)| id.id())
+            );
+            assert!(
+                qi.associated_voter_identity.is_some(),
+                "TC-086: voter identity should be present"
+            );
+            let has_main_key = qi
+                .private_keys
+                .private_keys
+                .keys()
+                .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnMainIdentity);
+            assert!(
+                !has_main_key,
+                "TC-086: should have no PrivateKeyOnMainIdentity entries (no owner/payout keys)"
+            );
+            let has_voter_key = qi
+                .private_keys
+                .private_keys
+                .keys()
+                .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnVoterIdentity);
+            assert!(
+                has_voter_key,
+                "TC-086: should have PrivateKeyOnVoterIdentity entry"
+            );
+        }
+        other => panic!("TC-086: expected LoadedIdentity, got: {:?}", other),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-087: Refresh MN Identity
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_087_refresh_mn_identity() {
+    let Some(qi) = load_mn_from_env(IdentityType::Masternode).await else {
+        tracing::warn!("Skipping TC-087: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    let ctx = ctx().await;
+    let original_id = qi.identity.id();
+
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::RefreshIdentity(qi)),
+    )
+    .await
+    .expect("TC-087: RefreshIdentity should succeed");
+
+    match result {
+        BackendTaskSuccessResult::RefreshedIdentity(refreshed) => {
+            tracing::info!(
+                "TC-087: refreshed MN {:?}, type={}",
+                refreshed.identity.id(),
+                refreshed.identity_type
+            );
+            assert_eq!(
+                refreshed.identity.id(),
+                original_id,
+                "TC-087: identity ID should be unchanged after refresh"
+            );
+            assert_eq!(
+                refreshed.identity_type,
+                IdentityType::Masternode,
+                "TC-087: identity_type should be preserved as Masternode"
+            );
+        }
+        other => panic!("TC-087: expected RefreshedIdentity, got: {:?}", other),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-088: Load MN with Invalid ProTx (error case)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_088_load_mn_invalid_protx() {
+    let ctx = ctx().await;
+
+    let fake_protx = "0".repeat(64);
+    let input = IdentityInputToLoad {
+        identity_id_input: fake_protx,
+        identity_type: IdentityType::Masternode,
+        alias_input: String::new(),
+        voting_private_key_input: Secret::new(""),
+        owner_private_key_input: Secret::new(""),
+        payout_address_private_key_input: Secret::new(""),
+        keys_input: vec![],
+        derive_keys_from_wallets: false,
+        selected_wallet_id: None,
+    };
+
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "TC-088: loading identity with all-zeros ProTx should return an error, got: {:?}",
+        result
+    );
+    tracing::info!("TC-088: got expected error: {:?}", result.unwrap_err());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-089: Load MN with Wrong Voting Key (error case)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_089_load_mn_wrong_voting_key() {
+    let Some(creds) = load_mn_credentials() else {
+        tracing::warn!("Skipping TC-089: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    let ctx = ctx().await;
+
+    let random_bytes: [u8; 32] = rand::random();
+    let fake_key = dash_sdk::dpp::dashcore::PrivateKey::from_byte_array(
+        &random_bytes,
+        dash_sdk::dpp::dashcore::Network::Testnet,
+    )
+    .expect("valid random private key");
+    let fake_wif = fake_key.to_wif();
+
+    let input = IdentityInputToLoad {
+        identity_id_input: creds.protx_hash.clone(),
+        identity_type: IdentityType::Masternode,
+        alias_input: String::new(),
+        voting_private_key_input: Secret::new(&fake_wif),
+        owner_private_key_input: Secret::new(""),
+        payout_address_private_key_input: Secret::new(""),
+        keys_input: vec![],
+        derive_keys_from_wallets: false,
+        selected_wallet_id: None,
+    };
+
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "TC-089: loading MN with wrong voting key should return an error, got: {:?}",
+        result
+    );
+    tracing::info!("TC-089: got expected error: {:?}", result.unwrap_err());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-090: Vote with MN Voter Identity
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn tc_090_vote_with_mn_voter() {
+    let Some(mn_qi) = load_mn_from_env(IdentityType::Masternode).await else {
+        tracing::warn!("Skipping TC-090: E2E_MN_PROTX_HASH not set");
+        return;
+    };
+    if mn_qi.associated_voter_identity.is_none() {
+        tracing::warn!("Skipping TC-090: no voter identity (E2E_MN_VOTING_KEY not set)");
+        return;
+    }
+
+    let ctx = ctx().await;
+
+    // Step 1: Create a funded test wallet and register a User identity for DPNS.
+    tracing::info!("TC-090: creating funded wallet and registering User identity...");
+    let (seed_hash, wallet_arc) = ctx.create_funded_test_wallet(30_000_000).await;
+    let (reg_info, _key_bytes) =
+        build_identity_registration(&ctx.app_context, &wallet_arc, seed_hash);
+    let reg_result = run_task_with_nonce_retry(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::RegisterIdentity(reg_info)),
+    )
+    .await
+    .expect("TC-090: identity registration should succeed");
+
+    let user_qi = match reg_result {
+        BackendTaskSuccessResult::RegisteredIdentity(qi, _) => {
+            tracing::info!("TC-090: registered User identity {:?}", qi.identity.id());
+            qi
+        }
+        other => panic!("TC-090: expected RegisteredIdentity, got: {:?}", other),
+    };
+
+    // Step 2: Register a short contested DPNS name (< 20 chars triggers contest).
+    let name = format!("e2emn{:06x}", rand::random::<u32>() % 0xFFFFFF);
+    tracing::info!("TC-090: registering contested DPNS name '{}'...", name);
+
+    let dpns_result = run_task_with_nonce_retry(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::RegisterDpnsName(RegisterDpnsNameInput {
+            qualified_identity: user_qi,
+            name_input: name.clone(),
+        })),
+    )
+    .await
+    .expect("TC-090: DPNS name registration should succeed");
+
+    assert!(
+        matches!(dpns_result, BackendTaskSuccessResult::RegisteredDpnsName(_)),
+        "TC-090: expected RegisteredDpnsName, got: {:?}",
+        dpns_result
+    );
+
+    // Step 3: Vote Lock on the contested name using the MN voter identity.
+    tracing::info!("TC-090: voting Lock on '{}' with MN voter...", name);
+
+    let vote_result = run_task_with_nonce_retry(
+        &ctx.app_context,
+        BackendTask::ContestedResourceTask(ContestedResourceTask::VoteOnDPNSNames(
+            vec![(name.clone(), ResourceVoteChoice::Lock)],
+            vec![mn_qi],
+        )),
+    )
+    .await
+    .expect("TC-090: VoteOnDPNSNames should succeed");
+
+    match vote_result {
+        BackendTaskSuccessResult::DPNSVoteResults(results) => {
+            tracing::info!("TC-090: vote results = {:?}", results);
+            assert!(
+                !results.is_empty(),
+                "TC-090: should have at least one vote result"
+            );
+            let (voted_name, choice, outcome) = &results[0];
+            assert_eq!(voted_name, &name, "TC-090: voted name mismatch");
+            assert_eq!(
+                *choice,
+                ResourceVoteChoice::Lock,
+                "TC-090: vote choice mismatch"
+            );
+            assert!(
+                outcome.is_ok(),
+                "TC-090: vote should succeed, got error: {:?}",
+                outcome
+            );
+        }
+        other => panic!("TC-090: expected DPNSVoteResults, got: {:?}", other),
+    }
+}

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -2,7 +2,7 @@
 
 use crate::framework::harness::ctx;
 use crate::framework::identity_helpers::build_identity_registration;
-use crate::framework::mn_helpers::{build_mn_identity_input, load_mn_credentials};
+use crate::framework::mn_helpers::{MnCredentials, build_mn_identity_input, load_mn_credentials};
 use crate::framework::task_runner::{run_task, run_task_with_nonce_retry};
 use dash_evo_tool::backend_task::contested_names::ContestedResourceTask;
 use dash_evo_tool::backend_task::identity::{
@@ -152,23 +152,20 @@ async fn tc_086_load_mn_voting_key_only() {
         tracing::warn!("Skipping TC-086: E2E_MN_PROTX_HASH not set");
         return;
     };
-    let Some(ref _voting_key) = creds.voting_key else {
+    if creds.voting_key.is_none() {
         tracing::warn!("Skipping TC-086: E2E_MN_VOTING_KEY not set");
         return;
     };
     let ctx = ctx().await;
 
-    let input = IdentityInputToLoad {
-        identity_id_input: creds.protx_hash.clone(),
-        identity_type: IdentityType::Masternode,
-        alias_input: String::new(),
-        voting_private_key_input: Secret::new(creds.voting_key.as_deref().unwrap_or("")),
-        owner_private_key_input: Secret::new(""),
-        payout_address_private_key_input: Secret::new(""),
-        keys_input: vec![],
-        derive_keys_from_wallets: false,
-        selected_wallet_seed_hash: None,
+    // Build input with only voting key — strip owner/payout to test partial load.
+    let voting_only_creds = MnCredentials {
+        protx_hash: creds.protx_hash.clone(),
+        voting_key: creds.voting_key.clone(),
+        owner_key: None,
+        payout_key: None,
     };
+    let input = build_mn_identity_input(&voting_only_creds, IdentityType::Masternode);
 
     let result = run_task(
         &ctx.app_context,
@@ -287,7 +284,7 @@ async fn tc_088_load_mn_invalid_protx() {
         "TC-088: loading identity with all-zeros ProTx should return an error, got: {:?}",
         result
     );
-    tracing::info!("TC-088: got expected error: {:?}", result.unwrap_err());
+    tracing::info!("TC-088: got expected error: {}", result.unwrap_err());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -334,7 +331,7 @@ async fn tc_089_load_mn_wrong_voting_key() {
         "TC-089: loading MN with wrong voting key should return an error, got: {:?}",
         result
     );
-    tracing::info!("TC-089: got expected error: {:?}", result.unwrap_err());
+    tracing::info!("TC-089: got expected error: {}", result.unwrap_err());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -376,7 +373,7 @@ async fn tc_090_vote_with_mn_voter() {
     };
 
     // Step 2: Register a short contested DPNS name (< 20 chars triggers contest).
-    let name = format!("e2emn{:06x}", rand::random::<u32>() % 0xFFFFFF);
+    let name = format!("e2emn{:08x}", rand::random::<u32>());
     tracing::info!("TC-090: registering contested DPNS name '{}'...", name);
 
     let dpns_result = run_task_with_nonce_retry(

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -81,7 +81,7 @@ async fn tc_084_load_masternode_identity() {
                     "TC-084: private_keys should contain PrivateKeyOnVoterIdentity entry"
                 );
             }
-            if creds.owner_key.is_some() || creds.payout_key.is_some() {
+            if creds.owner_key.is_some() {
                 let has_main_key = qi
                     .private_keys
                     .private_keys
@@ -163,7 +163,6 @@ async fn tc_086_load_mn_voting_key_only() {
         protx_hash: creds.protx_hash.clone(),
         voting_key: creds.voting_key.clone(),
         owner_key: None,
-        payout_key: None,
     };
     let input = build_mn_identity_input(&voting_only_creds, IdentityType::Masternode);
 

--- a/tests/backend-e2e/masternode_identity_tasks.rs
+++ b/tests/backend-e2e/masternode_identity_tasks.rs
@@ -1,4 +1,8 @@
 //! Masternode identity backend E2E tests: TC-084 to TC-090.
+//!
+//! Tests run in parallel — each is fully independent. Tracing spans
+//! (`#[tracing::instrument]`) tag every log line with the test name,
+//! making interleaved output easy to filter.
 
 use crate::framework::harness::ctx;
 use crate::framework::identity_helpers::build_identity_registration;
@@ -15,6 +19,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
 
 /// Load a masternode identity from env credentials. Returns `None` if creds missing.
+#[tracing::instrument(skip_all, fields(identity_type = %identity_type))]
 async fn load_mn_from_env(identity_type: IdentityType) -> Option<QualifiedIdentity> {
     let creds = load_mn_credentials()?;
     let ctx = ctx().await;
@@ -22,13 +27,10 @@ async fn load_mn_from_env(identity_type: IdentityType) -> Option<QualifiedIdenti
     let task = BackendTask::IdentityTask(IdentityTask::LoadIdentity(input));
     let result = run_task(&ctx.app_context, task)
         .await
-        .expect("load_mn_from_env: LoadIdentity failed");
+        .expect("LoadIdentity failed");
     match result {
         BackendTaskSuccessResult::LoadedIdentity(qi) => Some(qi),
-        other => panic!(
-            "load_mn_from_env: expected LoadedIdentity, got: {:?}",
-            other
-        ),
+        other => panic!("expected LoadedIdentity, got: {:?}", other),
     }
 }
 
@@ -38,9 +40,10 @@ async fn load_mn_from_env(identity_type: IdentityType) -> Option<QualifiedIdenti
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_084_load_masternode_identity() {
     let Some(creds) = load_mn_credentials() else {
-        tracing::warn!("Skipping TC-084: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     let ctx = ctx().await;
@@ -51,25 +54,25 @@ async fn tc_084_load_masternode_identity() {
         BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
     )
     .await
-    .expect("TC-084: LoadIdentity should succeed");
+    .expect("LoadIdentity should succeed");
 
     match result {
         BackendTaskSuccessResult::LoadedIdentity(qi) => {
             tracing::info!(
-                "TC-084: loaded MN identity {:?}, type={}, keys={}",
-                qi.identity.id(),
-                qi.identity_type,
-                qi.private_keys.private_keys.len()
+                id = ?qi.identity.id(),
+                identity_type = %qi.identity_type,
+                key_count = qi.private_keys.private_keys.len(),
+                "loaded MN identity"
             );
             assert_eq!(
                 qi.identity_type,
                 IdentityType::Masternode,
-                "TC-084: identity_type should be Masternode"
+                "identity_type should be Masternode"
             );
             if creds.voting_key.is_some() {
                 assert!(
                     qi.associated_voter_identity.is_some(),
-                    "TC-084: voter identity should be present when voting key provided"
+                    "voter identity should be present when voting key provided"
                 );
                 let has_voter_key = qi
                     .private_keys
@@ -78,7 +81,7 @@ async fn tc_084_load_masternode_identity() {
                     .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnVoterIdentity);
                 assert!(
                     has_voter_key,
-                    "TC-084: private_keys should contain PrivateKeyOnVoterIdentity entry"
+                    "private_keys should contain PrivateKeyOnVoterIdentity entry"
                 );
             }
             if creds.owner_key.is_some() {
@@ -89,11 +92,11 @@ async fn tc_084_load_masternode_identity() {
                     .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnMainIdentity);
                 assert!(
                     has_main_key,
-                    "TC-084: private_keys should contain PrivateKeyOnMainIdentity entry"
+                    "private_keys should contain PrivateKeyOnMainIdentity entry"
                 );
             }
         }
-        other => panic!("TC-084: expected LoadedIdentity, got: {:?}", other),
+        other => panic!("expected LoadedIdentity, got: {:?}", other),
     }
 }
 
@@ -103,9 +106,10 @@ async fn tc_084_load_masternode_identity() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_085_load_evonode_identity() {
     let Some(creds) = load_mn_credentials() else {
-        tracing::warn!("Skipping TC-085: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     let ctx = ctx().await;
@@ -116,28 +120,28 @@ async fn tc_085_load_evonode_identity() {
         BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
     )
     .await
-    .expect("TC-085: LoadIdentity should succeed");
+    .expect("LoadIdentity should succeed");
 
     match result {
         BackendTaskSuccessResult::LoadedIdentity(qi) => {
             tracing::info!(
-                "TC-085: loaded Evonode identity {:?}, type={}",
-                qi.identity.id(),
-                qi.identity_type
+                id = ?qi.identity.id(),
+                identity_type = %qi.identity_type,
+                "loaded Evonode identity"
             );
             assert_eq!(
                 qi.identity_type,
                 IdentityType::Evonode,
-                "TC-085: identity_type should be Evonode"
+                "identity_type should be Evonode"
             );
             if creds.voting_key.is_some() {
                 assert!(
                     qi.associated_voter_identity.is_some(),
-                    "TC-085: voter identity should be present when voting key provided"
+                    "voter identity should be present when voting key provided"
                 );
             }
         }
-        other => panic!("TC-085: expected LoadedIdentity, got: {:?}", other),
+        other => panic!("expected LoadedIdentity, got: {:?}", other),
     }
 }
 
@@ -147,18 +151,19 @@ async fn tc_085_load_evonode_identity() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_086_load_mn_voting_key_only() {
     let Some(creds) = load_mn_credentials() else {
-        tracing::warn!("Skipping TC-086: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     if creds.voting_key.is_none() {
-        tracing::warn!("Skipping TC-086: E2E_MN_VOTING_KEY not set");
+        tracing::warn!("Skipping: E2E_MN_VOTING_KEY not set");
         return;
     };
     let ctx = ctx().await;
 
-    // Build input with only voting key — strip owner/payout to test partial load.
+    // Build input with only voting key — strip owner to test partial load.
     let voting_only_creds = MnCredentials {
         protx_hash: creds.protx_hash.clone(),
         voting_key: creds.voting_key.clone(),
@@ -171,18 +176,18 @@ async fn tc_086_load_mn_voting_key_only() {
         BackendTask::IdentityTask(IdentityTask::LoadIdentity(input)),
     )
     .await
-    .expect("TC-086: LoadIdentity should succeed");
+    .expect("LoadIdentity should succeed");
 
     match result {
         BackendTaskSuccessResult::LoadedIdentity(qi) => {
             tracing::info!(
-                "TC-086: loaded MN (voting only) {:?}, voter={:?}",
-                qi.identity.id(),
-                qi.associated_voter_identity.as_ref().map(|(id, _)| id.id())
+                id = ?qi.identity.id(),
+                voter = ?qi.associated_voter_identity.as_ref().map(|(id, _)| id.id()),
+                "loaded MN (voting only)"
             );
             assert!(
                 qi.associated_voter_identity.is_some(),
-                "TC-086: voter identity should be present"
+                "voter identity should be present"
             );
             let has_main_key = qi
                 .private_keys
@@ -191,19 +196,16 @@ async fn tc_086_load_mn_voting_key_only() {
                 .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnMainIdentity);
             assert!(
                 !has_main_key,
-                "TC-086: should have no PrivateKeyOnMainIdentity entries (no owner/payout keys)"
+                "should have no PrivateKeyOnMainIdentity entries (no owner keys)"
             );
             let has_voter_key = qi
                 .private_keys
                 .private_keys
                 .keys()
                 .any(|(target, _)| *target == PrivateKeyTarget::PrivateKeyOnVoterIdentity);
-            assert!(
-                has_voter_key,
-                "TC-086: should have PrivateKeyOnVoterIdentity entry"
-            );
+            assert!(has_voter_key, "should have PrivateKeyOnVoterIdentity entry");
         }
-        other => panic!("TC-086: expected LoadedIdentity, got: {:?}", other),
+        other => panic!("expected LoadedIdentity, got: {:?}", other),
     }
 }
 
@@ -213,9 +215,10 @@ async fn tc_086_load_mn_voting_key_only() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_087_refresh_mn_identity() {
     let Some(qi) = load_mn_from_env(IdentityType::Masternode).await else {
-        tracing::warn!("Skipping TC-087: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     let ctx = ctx().await;
@@ -226,27 +229,27 @@ async fn tc_087_refresh_mn_identity() {
         BackendTask::IdentityTask(IdentityTask::RefreshIdentity(qi)),
     )
     .await
-    .expect("TC-087: RefreshIdentity should succeed");
+    .expect("RefreshIdentity should succeed");
 
     match result {
         BackendTaskSuccessResult::RefreshedIdentity(refreshed) => {
             tracing::info!(
-                "TC-087: refreshed MN {:?}, type={}",
-                refreshed.identity.id(),
-                refreshed.identity_type
+                id = ?refreshed.identity.id(),
+                identity_type = %refreshed.identity_type,
+                "refreshed MN identity"
             );
             assert_eq!(
                 refreshed.identity.id(),
                 original_id,
-                "TC-087: identity ID should be unchanged after refresh"
+                "identity ID should be unchanged after refresh"
             );
             assert_eq!(
                 refreshed.identity_type,
                 IdentityType::Masternode,
-                "TC-087: identity_type should be preserved as Masternode"
+                "identity_type should be preserved as Masternode"
             );
         }
-        other => panic!("TC-087: expected RefreshedIdentity, got: {:?}", other),
+        other => panic!("expected RefreshedIdentity, got: {:?}", other),
     }
 }
 
@@ -256,6 +259,7 @@ async fn tc_087_refresh_mn_identity() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_088_load_mn_invalid_protx() {
     let ctx = ctx().await;
 
@@ -280,10 +284,10 @@ async fn tc_088_load_mn_invalid_protx() {
 
     assert!(
         result.is_err(),
-        "TC-088: loading identity with all-zeros ProTx should return an error, got: {:?}",
+        "loading identity with all-zeros ProTx should return an error, got: {:?}",
         result
     );
-    tracing::info!("TC-088: got expected error: {}", result.unwrap_err());
+    tracing::info!(error = %result.unwrap_err(), "got expected error");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -292,9 +296,10 @@ async fn tc_088_load_mn_invalid_protx() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_089_load_mn_wrong_voting_key() {
     let Some(creds) = load_mn_credentials() else {
-        tracing::warn!("Skipping TC-089: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     let ctx = ctx().await;
@@ -327,10 +332,10 @@ async fn tc_089_load_mn_wrong_voting_key() {
 
     assert!(
         result.is_err(),
-        "TC-089: loading MN with wrong voting key should return an error, got: {:?}",
+        "loading MN with wrong voting key should return an error, got: {:?}",
         result
     );
-    tracing::info!("TC-089: got expected error: {}", result.unwrap_err());
+    tracing::info!(error = %result.unwrap_err(), "got expected error");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -339,20 +344,21 @@ async fn tc_089_load_mn_wrong_voting_key() {
 
 #[ignore]
 #[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
 async fn tc_090_vote_with_mn_voter() {
     let Some(mn_qi) = load_mn_from_env(IdentityType::Masternode).await else {
-        tracing::warn!("Skipping TC-090: E2E_MN_PROTX_HASH not set");
+        tracing::warn!("Skipping: E2E_MN_PROTX_HASH not set");
         return;
     };
     if mn_qi.associated_voter_identity.is_none() {
-        tracing::warn!("Skipping TC-090: no voter identity (E2E_MN_VOTING_KEY not set)");
+        tracing::warn!("Skipping: no voter identity (E2E_MN_VOTING_KEY not set)");
         return;
     }
 
     let ctx = ctx().await;
 
     // Step 1: Create a funded test wallet and register a User identity for DPNS.
-    tracing::info!("TC-090: creating funded wallet and registering User identity...");
+    tracing::info!("creating funded wallet and registering User identity...");
     let (seed_hash, wallet_arc) = ctx.create_funded_test_wallet(30_000_000).await;
     let (reg_info, _key_bytes) =
         build_identity_registration(&ctx.app_context, &wallet_arc, seed_hash);
@@ -361,19 +367,19 @@ async fn tc_090_vote_with_mn_voter() {
         BackendTask::IdentityTask(IdentityTask::RegisterIdentity(reg_info)),
     )
     .await
-    .expect("TC-090: identity registration should succeed");
+    .expect("identity registration should succeed");
 
     let user_qi = match reg_result {
         BackendTaskSuccessResult::RegisteredIdentity(qi, _) => {
-            tracing::info!("TC-090: registered User identity {:?}", qi.identity.id());
+            tracing::info!(id = ?qi.identity.id(), "registered User identity");
             qi
         }
-        other => panic!("TC-090: expected RegisteredIdentity, got: {:?}", other),
+        other => panic!("expected RegisteredIdentity, got: {:?}", other),
     };
 
     // Step 2: Register a short contested DPNS name (< 20 chars triggers contest).
     let name = format!("e2emn{:08x}", rand::random::<u32>());
-    tracing::info!("TC-090: registering contested DPNS name '{}'...", name);
+    tracing::info!(name = %name, "registering contested DPNS name");
 
     let dpns_result = run_task_with_nonce_retry(
         &ctx.app_context,
@@ -383,16 +389,16 @@ async fn tc_090_vote_with_mn_voter() {
         })),
     )
     .await
-    .expect("TC-090: DPNS name registration should succeed");
+    .expect("DPNS name registration should succeed");
 
     assert!(
         matches!(dpns_result, BackendTaskSuccessResult::RegisteredDpnsName(_)),
-        "TC-090: expected RegisteredDpnsName, got: {:?}",
+        "expected RegisteredDpnsName, got: {:?}",
         dpns_result
     );
 
     // Step 3: Vote Lock on the contested name using the MN voter identity.
-    tracing::info!("TC-090: voting Lock on '{}' with MN voter...", name);
+    tracing::info!(name = %name, "voting Lock with MN voter");
 
     let vote_result = run_task_with_nonce_retry(
         &ctx.app_context,
@@ -402,28 +408,21 @@ async fn tc_090_vote_with_mn_voter() {
         )),
     )
     .await
-    .expect("TC-090: VoteOnDPNSNames should succeed");
+    .expect("VoteOnDPNSNames should succeed");
 
     match vote_result {
         BackendTaskSuccessResult::DPNSVoteResults(results) => {
-            tracing::info!("TC-090: vote results = {:?}", results);
-            assert!(
-                !results.is_empty(),
-                "TC-090: should have at least one vote result"
-            );
+            tracing::info!(?results, "vote completed");
+            assert!(!results.is_empty(), "should have at least one vote result");
             let (voted_name, choice, outcome) = &results[0];
-            assert_eq!(voted_name, &name, "TC-090: voted name mismatch");
-            assert_eq!(
-                *choice,
-                ResourceVoteChoice::Lock,
-                "TC-090: vote choice mismatch"
-            );
+            assert_eq!(voted_name, &name, "voted name mismatch");
+            assert_eq!(*choice, ResourceVoteChoice::Lock, "vote choice mismatch");
             assert!(
                 outcome.is_ok(),
-                "TC-090: vote should succeed, got error: {:?}",
+                "vote should succeed, got error: {:?}",
                 outcome
             );
         }
-        other => panic!("TC-090: expected DPNSVoteResults, got: {:?}", other),
+        other => panic!("expected DPNSVoteResults, got: {:?}", other),
     }
 }

--- a/tests/backend-e2e/multi_output_payment.rs
+++ b/tests/backend-e2e/multi_output_payment.rs
@@ -1,0 +1,125 @@
+//! Test: Multi-output payment — proves that a single Core transaction sending
+//! equal amounts to multiple never-used addresses only makes one output
+//! spendable via InstantSend lock.
+
+use crate::framework::harness::{MAX_TEST_TIMEOUT, ctx};
+use crate::framework::identity_helpers::get_receive_address;
+use crate::framework::task_runner::run_task;
+use crate::framework::wait::{wait_for_balance, wait_for_spendable_balance};
+use dash_evo_tool::backend_task::core::{CoreTask, PaymentRecipient, WalletPaymentRequest};
+use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
+
+/// Send one transaction with 3 equal outputs to 3 fresh wallets.
+///
+/// Expected (correct) behavior: all 3 wallets should have spendable balance.
+/// Actual (buggy) behavior: only 1 wallet gets spendable funds; the other 2
+/// see `total_balance` but `spendable_balance` remains 0.
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
+async fn test_multi_output_payment_spendable() {
+    let ctx = ctx().await;
+    let app_context = &ctx.app_context;
+
+    let per_wallet_amount: u64 = 2_000_000;
+    let total_send: u64 = per_wallet_amount * 3;
+
+    // 1. Create a funded source wallet
+    let (source_hash, source_wallet) = ctx.create_funded_test_wallet(10_000_000).await;
+    tracing::info!("Source wallet funded");
+
+    // 2. Create 3 empty destination wallets
+    let mut dest_wallets = Vec::with_capacity(3);
+    for i in 0..3 {
+        let (hash, wallet) = ctx.create_empty_test_wallet().await;
+        tracing::info!(wallet_idx = i, seed_hash = ?&hash[..4], "Destination wallet created");
+        dest_wallets.push((hash, wallet));
+    }
+
+    // 3. Get receive addresses from each destination
+    let recipients: Vec<PaymentRecipient> = dest_wallets
+        .iter()
+        .enumerate()
+        .map(|(i, (_hash, wallet))| {
+            let address = get_receive_address(app_context, wallet);
+            tracing::info!(wallet_idx = i, address = %address, "Receive address derived");
+            PaymentRecipient {
+                address,
+                amount_duffs: per_wallet_amount,
+            }
+        })
+        .collect();
+
+    // 4. Wait for source wallet to have spendable funds
+    wait_for_spendable_balance(app_context, source_hash, total_send, MAX_TEST_TIMEOUT / 3)
+        .await
+        .expect("Source wallet funds should be spendable");
+
+    // 5. Send ONE transaction to all 3 destinations
+    let request = WalletPaymentRequest {
+        recipients,
+        subtract_fee_from_amount: false,
+        memo: Some("E2E multi-output payment test".to_string()),
+        override_fee: None,
+    };
+
+    let task = BackendTask::CoreTask(CoreTask::SendWalletPayment {
+        wallet: source_wallet.clone(),
+        request,
+    });
+
+    let result = run_task(app_context, task)
+        .await
+        .expect("Multi-output payment should succeed");
+
+    match &result {
+        BackendTaskSuccessResult::WalletPayment {
+            txid, total_amount, ..
+        } => {
+            tracing::info!(txid = %txid, total_amount, "Multi-output tx broadcast");
+        }
+        other => panic!("Expected WalletPayment result, got: {:?}", other),
+    }
+
+    // 6. Wait for each wallet to see total balance (unconfirmed is fine here)
+    for (i, (hash, _wallet)) in dest_wallets.iter().enumerate() {
+        let balance = wait_for_balance(app_context, *hash, per_wallet_amount, MAX_TEST_TIMEOUT / 3)
+            .await
+            .unwrap_or_else(|e| panic!("Wallet {i} should see total balance: {e}"));
+        tracing::info!(wallet_idx = i, balance, "Total balance visible");
+    }
+
+    // 7. Check spendable balance for each wallet — this is where the bug manifests
+    let mut spendable_results = Vec::with_capacity(3);
+    for (i, (hash, _wallet)) in dest_wallets.iter().enumerate() {
+        let spendable =
+            wait_for_spendable_balance(app_context, *hash, per_wallet_amount, MAX_TEST_TIMEOUT / 3)
+                .await;
+        match &spendable {
+            Ok(balance) => {
+                tracing::info!(wallet_idx = i, balance, "Spendable balance confirmed");
+            }
+            Err(e) => {
+                tracing::error!(wallet_idx = i, error = %e, "Spendable balance NOT reached");
+            }
+        }
+        spendable_results.push((i, spendable));
+    }
+
+    // 8. Assert all wallets have spendable funds
+    let mut failures = Vec::new();
+    for (i, result) in &spendable_results {
+        if let Err(e) = result {
+            failures.push(format!("Wallet {i}: {e}"));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Multi-output IS lock bug: only some wallets got spendable balance.\n\
+         Failures:\n  {}",
+        failures.join("\n  ")
+    );
+
+    tracing::info!("All 3 wallets have spendable balance — multi-output IS lock works correctly");
+}

--- a/tests/backend-e2e/multi_output_payment.rs
+++ b/tests/backend-e2e/multi_output_payment.rs
@@ -183,9 +183,14 @@ async fn test_multi_output_single_wallet_spendable() {
     );
 
     // 4. Wait for source to have spendable funds
-    wait_for_spendable_balance(app_context, source_hash, total_expected, MAX_TEST_TIMEOUT / 3)
-        .await
-        .expect("Source wallet funds should be spendable");
+    wait_for_spendable_balance(
+        app_context,
+        source_hash,
+        total_expected,
+        MAX_TEST_TIMEOUT / 3,
+    )
+    .await
+    .expect("Source wallet funds should be spendable");
 
     // 5. Send ONE transaction with 3 outputs to the same wallet's addresses
     let recipients: Vec<PaymentRecipient> = addresses

--- a/tests/backend-e2e/multi_output_payment.rs
+++ b/tests/backend-e2e/multi_output_payment.rs
@@ -7,6 +7,7 @@ use crate::framework::identity_helpers::get_receive_address;
 use crate::framework::task_runner::run_task;
 use crate::framework::wait::{wait_for_balance, wait_for_spendable_balance};
 use dash_evo_tool::backend_task::core::{CoreTask, PaymentRecipient, WalletPaymentRequest};
+use dash_evo_tool::backend_task::wallet::WalletTask;
 use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
 
 /// Send one transaction with 3 equal outputs to 3 fresh wallets.
@@ -122,4 +123,140 @@ async fn test_multi_output_payment_spendable() {
     );
 
     tracing::info!("All 3 wallets have spendable balance — multi-output IS lock works correctly");
+}
+
+/// Send one transaction with 3 outputs to 3 distinct addresses of the SAME wallet.
+///
+/// This is the primary bug reproduction: a single Core transaction sends equal
+/// amounts to 3 never-used receive addresses within one wallet. Expected behavior
+/// is that the wallet's spendable balance equals the sum of all 3 outputs.
+/// Actual (buggy) behavior: only 1 output becomes spendable via InstantSend lock.
+#[ignore]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+#[tracing::instrument]
+async fn test_multi_output_single_wallet_spendable() {
+    let ctx = ctx().await;
+    let app_context = &ctx.app_context;
+
+    let num_outputs: usize = 3;
+    let per_output_amount: u64 = 1_000_000;
+    let total_expected: u64 = per_output_amount * num_outputs as u64;
+
+    // 1. Create a funded source wallet
+    let (source_hash, source_wallet) = ctx.create_funded_test_wallet(10_000_000).await;
+    tracing::info!("Source wallet funded");
+
+    // 2. Create one empty destination wallet
+    let (dest_hash, _dest_wallet) = ctx.create_empty_test_wallet().await;
+    tracing::info!(seed_hash = ?&dest_hash[..4], "Destination wallet created");
+
+    // 3. Generate 3 distinct receive addresses from the SAME wallet via backend task.
+    //    Each call to GenerateReceiveAddress advances the BIP44 index, yielding a
+    //    new never-used address.
+    let mut addresses = Vec::with_capacity(num_outputs);
+    for i in 0..num_outputs {
+        let result = run_task(
+            app_context,
+            BackendTask::WalletTask(WalletTask::GenerateReceiveAddress {
+                seed_hash: dest_hash,
+            }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("GenerateReceiveAddress {i} failed: {e}"));
+
+        match result {
+            BackendTaskSuccessResult::GeneratedReceiveAddress { address, .. } => {
+                tracing::info!(idx = i, address = %address, "Generated receive address");
+                addresses.push(address);
+            }
+            other => panic!("Expected GeneratedReceiveAddress, got: {:?}", other),
+        }
+    }
+
+    // Verify all addresses are distinct
+    let unique: std::collections::HashSet<&String> = addresses.iter().collect();
+    assert_eq!(
+        unique.len(),
+        num_outputs,
+        "Expected {num_outputs} distinct addresses, got {} unique",
+        unique.len()
+    );
+
+    // 4. Wait for source to have spendable funds
+    wait_for_spendable_balance(app_context, source_hash, total_expected, MAX_TEST_TIMEOUT / 3)
+        .await
+        .expect("Source wallet funds should be spendable");
+
+    // 5. Send ONE transaction with 3 outputs to the same wallet's addresses
+    let recipients: Vec<PaymentRecipient> = addresses
+        .iter()
+        .map(|addr| PaymentRecipient {
+            address: addr.clone(),
+            amount_duffs: per_output_amount,
+        })
+        .collect();
+
+    let request = WalletPaymentRequest {
+        recipients,
+        subtract_fee_from_amount: false,
+        memo: Some("E2E multi-output single-wallet test".to_string()),
+        override_fee: None,
+    };
+
+    let task = BackendTask::CoreTask(CoreTask::SendWalletPayment {
+        wallet: source_wallet.clone(),
+        request,
+    });
+
+    let result = run_task(app_context, task)
+        .await
+        .expect("Multi-output payment should succeed");
+
+    let txid = match &result {
+        BackendTaskSuccessResult::WalletPayment {
+            txid, total_amount, ..
+        } => {
+            tracing::info!(txid = %txid, total_amount, "Multi-output tx broadcast");
+            txid.clone()
+        }
+        other => panic!("Expected WalletPayment result, got: {:?}", other),
+    };
+
+    // 6. Wait for total balance to appear (unconfirmed is fine)
+    let total_balance =
+        wait_for_balance(app_context, dest_hash, total_expected, MAX_TEST_TIMEOUT / 3)
+            .await
+            .unwrap_or_else(|e| panic!("Dest wallet should see total balance: {e}"));
+    tracing::info!(total_balance, "Total balance visible in destination wallet");
+
+    // 7. Wait for spendable balance — this is where the bug manifests.
+    //    If only 1 of 3 outputs is IS-locked, spendable will be per_output_amount
+    //    instead of total_expected.
+    let spendable_result =
+        wait_for_spendable_balance(app_context, dest_hash, total_expected, MAX_TEST_TIMEOUT / 3)
+            .await;
+
+    match spendable_result {
+        Ok(spendable) => {
+            tracing::info!(spendable, "All outputs spendable — no bug!");
+            assert!(
+                spendable >= total_expected,
+                "Spendable balance {spendable} should be >= {total_expected}"
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                txid = %txid,
+                expected = total_expected,
+                num_outputs,
+                error = %e,
+                "BUG: multi-output IS lock — not all outputs spendable"
+            );
+            panic!(
+                "Multi-output IS lock bug (single wallet): sent {num_outputs} outputs \
+                 of {per_output_amount} duffs each to the same wallet, but spendable \
+                 balance never reached {total_expected}. Error: {e}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add 7 backend E2E tests covering masternode/evonode identity operations (TC-084 → TC-090).
- New `framework/mn_helpers.rs` module for credential loading from env vars.
- Tests are gated on `E2E_MN_*` env vars and skip gracefully when credentials unavailable.
- Each test is fully independent — no shared fixtures, no ordering dependencies.
- **Includes a production fix** (commit `d17cfae8`, filed standalone as [#835](https://github.com/dashpay/dash-evo-tool/pull/835)) surfaced while developing TC-090 — see the "Production fix" section below.

## Test Catalog

| TC | Name | Description |
|----|------|-------------|
| TC-084 | Load Masternode identity | Load by ProTx hash with all 3 keys (voting, owner, payout) |
| TC-085 | Load Evonode identity | Same ProTx loaded as Evonode type (tests type label propagation) |
| TC-086 | Load MN voting key only | Partial key load — only voting key, no owner/payout |
| TC-087 | Refresh MN identity | Load then refresh round-trip, verify ID and type preserved |
| TC-088 | Invalid ProTx (error) | All-zeros ProTx — always runs, no env vars needed |
| TC-089 | Wrong voting key (error) | Valid ProTx + random key — expects identity-not-found error |
| TC-090 | Vote with MN voter | Registers contested DPNS name, votes Lock with MN voter identity |

## Environment Variables

| Variable | Required for | Description |
|----------|-------------|-------------|
| `E2E_MN_PROTX_HASH` | All MN tests | Hex ProRegTx hash of a registered testnet masternode/evonode |
| `E2E_MN_VOTING_KEY` | Voting tests | WIF private key for the MN's voting address |
| `E2E_MN_OWNER_KEY` | Owner key tests | WIF private key for the MN's owner address |
| `E2E_MN_PAYOUT_KEY` | Payout tests | WIF private key for the MN's payout address |

## Production fix discovered during TC-090 development

TC-090 failed three consecutive times against testnet with an opaque ~70 s "unexpected error" on every masternode vote. Drive-abci server logs (correlated by block height across runs at 318950 / 319048 / 319073) revealed the real cause: `VotePollNotFoundError` at `PrepareProposal`.

Root cause: `src/backend_task/contested_names/vote_on_dpns_name.rs` was building the vote poll's `index_values` from the **raw** DPNS label. Platform indexes contested polls under the homograph-safe **normalized** label (`convert_to_homograph_safe_chars`: `i`→`1`, `l`→`1`, `o`→`0`, then lowercase). Any label containing `i`/`l`/`o` silently mismatched the index. The tx passed `CheckTx` because `validates_full_state_on_check_tx()` for `MasternodeVote` was only added to Platform in December 2025 (v3.1.0-dev.1 onward); testnet v3.0.x predates it.

The fix — commit `d17cfae8` on this branch — normalizes the label at the backend boundary, adds a pre-flight existence check via `ContestedResource::fetch_many` that short-circuits the retry chain, and introduces a typed `TaskError::VotePollNotFound { name }` variant with an Everyday-User-persona actionable message. After the fix, TC-090 passes in ~30 s end-to-end (previously: 3 × ~70 s failures).

That same commit is filed as **#835** against `v1.0-dev` for cherry-pick review. On rebase of this branch after #835 merges, git will deduplicate.

Also on this branch:
- `ca46282a` — wraps per-vote `TaskError` in `Arc` inside `BackendTaskSuccessResult::DPNSVoteResults` (required because `TaskError` is deliberately non-`Clone`).
- `76339e55` — test hardening: TC-090 re-confirms the contested vote poll exists immediately before the vote dispatch via `wait_for_dpns_contest`, catching poll-disappearance races.

## Full-suite verification

Ran the full backend-e2e suite (68 tests, `--release`, `--ignored`) against this branch tip (`76339e55`) in 408 s (~7 min) on testnet.

**PR 827 canaries — all PASS**:

| Test | Status |
|------|--------|
| TC-084 Load Masternode | PASS |
| TC-085 Load Evonode | PASS |
| TC-086 Load MN voting key only | PASS |
| TC-087 Refresh MN identity | PASS |
| TC-088 Invalid ProTx | PASS |
| TC-089 Wrong voting key | PASS |
| TC-090 Vote with MN voter | PASS |

**Other suite failures — pre-existing, not regressions**:

| Test | Failure shape |
|------|---------------|
| core_tasks::tc_003 / tc_006 / tc_009 | Core-RPC `ConnectionRefused` — SPV-only single-key wallet tasks still call `dashd` without SPV fallback |
| wallet_tasks::tc_014 / tc_018 | Asset-lock IS proof `ConfirmationTimeout` in SPV mode |
| identity_tasks::tc_020 | `AddKeyToIdentity` → `InvalidIdentityRevisionError` (stale revision) |
| dashpay_tasks::tc_037 / tc_043 | Cross-run DashPay contact pollution — Platform inboxes persist between runs |
| z_broadcast_st_tasks::tc_066 | Broadcast success but key missing on read-after-write |

None of these failures touch code modified by this PR. They live in test modules introduced in #818 (the framework PR) and fail against `v1.0-dev` directly. Filing them as follow-ups is out of scope for #827.

## Test plan

- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes
- [x] `cargo +nightly fmt --all -- --check` passes
- [x] TC-088 (invalid ProTx) runs without env vars — always exercises error path
- [x] TC-084–TC-090 skip gracefully when `E2E_MN_PROTX_HASH` is unset
- [x] TC-090 passes against testnet with the normalization fix (30.11 s, isolated run)
- [x] Full backend-e2e suite: all 7 PR 827 canaries PASS (408 s, release mode)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>