### PR TITLE
fix(spv): atomically extend BIP44 receive pool on wallet import

### DIFF
--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -297,8 +297,41 @@ impl AppContext {
 
     fn queue_spv_wallet_load(self: &Arc<Self>, seed_hash: WalletSeedHash, seed_bytes: [u8; 64]) {
         let spv = Arc::clone(&self.spv_manager);
+        // Compute the BIP44 receive pool target *before* spawning so the
+        // target is bound to the current DB state. The pool is extended
+        // atomically inside `load_wallet_from_seed` while it still holds the
+        // WalletManager write lock, closing the race where the SPV filter
+        // scan could observe the imported wallet before lookahead addresses
+        // were registered.
+        //
+        // The target combines:
+        //   - the highest BIP44 receive index already persisted in DB (covers
+        //     indices generated in prior sessions via `GenerateReceiveAddress`
+        //     and the initial bootstrap), and
+        //   - a lookahead slack so a wallet with a single historical UTXO at
+        //     an index beyond the default gap limit (e.g. a reference testnet
+        //     wallet with historical UTXOs at indices 32-40) is discovered in
+        //     a single SPV scan instead of requiring repeated app restarts.
+        const LOOKAHEAD_SLACK: u32 = 100;
+        let min_receive_index = self
+            .db
+            .max_bip44_receive_index(&seed_hash)
+            .map_err(|e| {
+                tracing::warn!(
+                    seed = %hex::encode(seed_hash),
+                    error = %e,
+                    "Failed to query max BIP44 address index from database; using lookahead slack only"
+                );
+            })
+            .ok()
+            .flatten()
+            .unwrap_or(0)
+            .saturating_add(LOOKAHEAD_SLACK);
         self.subtasks.spawn_sync("spv_wallet_load", async move {
-            if let Err(error) = spv.load_wallet_from_seed(seed_hash, seed_bytes).await {
+            if let Err(error) = spv
+                .load_wallet_from_seed(seed_hash, seed_bytes, min_receive_index)
+                .await
+            {
                 tracing::error!(seed = %hex::encode(seed_hash), %error, "Failed to load SPV wallet from seed");
             }
         });

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -92,6 +92,30 @@ impl Database {
         tx.commit()
     }
 
+    /// Get the highest BIP44 external (receive) address index stored for a wallet.
+    /// Returns `None` if no BIP44 receive addresses are stored.
+    ///
+    /// BIP44 external addresses have derivation paths like `m/44'/X'/0'/0/N`
+    /// where N is the address index. This method parses the last path component
+    /// from all matching rows.
+    pub fn max_bip44_receive_index(&self, seed_hash: &[u8; 32]) -> rusqlite::Result<Option<u32>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT derivation_path FROM wallet_addresses
+             WHERE seed_hash = ? AND derivation_path LIKE 'm/44''/%''/0''/0/%'",
+        )?;
+        let rows = stmt.query_map([seed_hash.as_slice()], |row| row.get::<_, String>(0))?;
+        let mut max_index: Option<u32> = None;
+        for path in rows.flatten() {
+            if let Some(last) = path.rsplit('/').next()
+                && let Ok(idx) = last.parse::<u32>()
+            {
+                max_index = Some(max_index.map_or(idx, |m: u32| m.max(idx)));
+            }
+        }
+        Ok(max_index)
+    }
+
     /// Update the Dash Core wallet name for an HD wallet.
     ///
     /// Returns `Ok(true)` if exactly one row was updated, `Ok(false)` if no
@@ -1883,5 +1907,106 @@ mod tests {
             )
             .expect("Failed to query total_received");
         assert_eq!(total_received, 10_000_000);
+    }
+
+    /// Insert a dummy wallet row for test purposes.
+    fn insert_test_wallet(db: &Database, seed_hash: &[u8; 32], network: Network) {
+        let network_str = network.to_string();
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO wallet (seed_hash, encrypted_seed, salt, nonce, master_ecdsa_bip44_account_0_epk, uses_password, network)
+             VALUES (?, ?, ?, ?, ?, 0, ?)",
+            rusqlite::params![
+                seed_hash.as_slice(),
+                vec![0u8; 64],
+                vec![0u8; 16],
+                vec![0u8; 12],
+                vec![0u8; 78],
+                network_str,
+            ],
+        )
+        .expect("Failed to insert test wallet");
+    }
+
+    /// Derive a valid test address by walking a deterministic BIP32 chain.
+    fn derive_test_address(network: Network, bump: u32) -> Address {
+        let seed = [42u8; 64];
+        let secp = Secp256k1::new();
+        let master = ExtendedPrivKey::new_master(network, &seed).expect("master key");
+        let path = DerivationPath::from(vec![ChildNumber::Normal { index: bump }]);
+        let derived = master.derive_priv(&secp, &path).expect("derive");
+        let pubkey = dash_sdk::dpp::dashcore::PublicKey::new(
+            ExtendedPubKey::from_priv(&secp, &derived).public_key,
+        );
+        Address::p2pkh(&pubkey, network)
+    }
+
+    fn insert_bip44_receive_row(db: &Database, seed_hash: &[u8; 32], network: Network, index: u32) {
+        let address = derive_test_address(network, index);
+        let path = format!("m/44'/1'/0'/0/{index}");
+        let derivation_path = DerivationPath::from_str(&path).unwrap();
+        db.add_address_if_not_exists(
+            seed_hash,
+            &address,
+            &network,
+            &derivation_path,
+            DerivationPathReference::BIP44,
+            DerivationPathType::CLEAR_FUNDS,
+            None,
+        )
+        .expect("add_address_if_not_exists");
+    }
+
+    #[test]
+    fn test_max_bip44_receive_index_none_when_empty() {
+        let db = create_test_database().expect("create db");
+        let seed_hash = create_test_seed_hash();
+        assert_eq!(
+            db.max_bip44_receive_index(&seed_hash).expect("query"),
+            None,
+            "no rows should yield None"
+        );
+    }
+
+    #[test]
+    fn test_max_bip44_receive_index_returns_highest() {
+        let db = create_test_database().expect("create db");
+        let seed_hash = create_test_seed_hash();
+        insert_test_wallet(&db, &seed_hash, Network::Testnet);
+        for index in [0, 1, 5, 31, 15] {
+            insert_bip44_receive_row(&db, &seed_hash, Network::Testnet, index);
+        }
+        assert_eq!(
+            db.max_bip44_receive_index(&seed_hash).expect("query"),
+            Some(31),
+            "should return the largest stored index"
+        );
+    }
+
+    #[test]
+    fn test_max_bip44_receive_index_ignores_change_chain() {
+        let db = create_test_database().expect("create db");
+        let seed_hash = create_test_seed_hash();
+        insert_test_wallet(&db, &seed_hash, Network::Testnet);
+        insert_bip44_receive_row(&db, &seed_hash, Network::Testnet, 0);
+        insert_bip44_receive_row(&db, &seed_hash, Network::Testnet, 10);
+        // Also inject a change-chain (m/.../1/99) row that should NOT count.
+        let address = derive_test_address(Network::Testnet, 999_999);
+        let derivation_path = DerivationPath::from_str("m/44'/1'/0'/1/99").unwrap();
+        db.add_address_if_not_exists(
+            &seed_hash,
+            &address,
+            &Network::Testnet,
+            &derivation_path,
+            DerivationPathReference::BIP44,
+            DerivationPathType::CLEAR_FUNDS,
+            None,
+        )
+        .expect("add change address");
+        assert_eq!(
+            db.max_bip44_receive_index(&seed_hash).expect("query"),
+            Some(10),
+            "change-chain (m/.../1/*) rows must not influence the receive-chain max"
+        );
     }
 }

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -14,7 +14,7 @@ use dash_sdk::dash_spv::sync::SyncState;
 use dash_sdk::dash_spv::types::ValidationMode;
 use dash_sdk::dash_spv::{ClientConfig, DashSpvClient, Hash, LLMQType, QuorumHash};
 use dash_sdk::dpp::dashcore::{Address, InstantLock, Network, Transaction, Txid};
-use dash_sdk::dpp::key_wallet::bip32::{DerivationPath, ExtendedPrivKey};
+use dash_sdk::dpp::key_wallet::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey};
 use dash_sdk::dpp::key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::{
     ManagedWalletInfo, transaction_building::AccountTypePreference,
@@ -923,6 +923,7 @@ impl SpvManager {
         &self,
         seed_hash: WalletSeedHash,
         mut seed_bytes: [u8; 64],
+        min_bip44_receive_index: u32,
     ) -> Result<WalletId, String> {
         let existing_wallet_id = {
             let map = self.det_wallets.read().map_err(|e| e.to_string())?;
@@ -935,6 +936,21 @@ impl SpvManager {
             if let Some(wallet) = wm.get_wallet(&wallet_id)
                 && wallet.can_sign()
             {
+                // Still extend the pool atomically under the write lock so the
+                // monitored address set reflects the DB-known max index before
+                // the SPV filter scan observes the wallet.
+                if let Err(e) = Self::extend_bip44_receive_pool_locked(
+                    &mut wm,
+                    wallet_id,
+                    min_bip44_receive_index,
+                ) {
+                    tracing::warn!(
+                        seed = %hex::encode(seed_hash),
+                        target = min_bip44_receive_index,
+                        error = %e,
+                        "Failed to extend BIP44 receive pool on already-loaded wallet"
+                    );
+                }
                 seed_bytes.zeroize();
                 return Ok(wallet_id);
             }
@@ -972,12 +988,89 @@ impl SpvManager {
             }
         };
 
+        // Extend the BIP44 receive pool BEFORE releasing the write lock. This
+        // guarantees the monitored address set is populated before any other
+        // observer (notably `run_spv_loop`'s wait-for-wallets loop) sees
+        // `wallet_count` increment. Without this, the SPV filter scan can
+        // start with only the default gap-limit pool and miss historical UTXOs
+        // at higher indices — requiring multiple app restarts to converge.
+        if let Err(e) =
+            Self::extend_bip44_receive_pool_locked(&mut wm, wallet_id, min_bip44_receive_index)
+        {
+            tracing::warn!(
+                seed = %hex::encode(seed_hash),
+                target = min_bip44_receive_index,
+                error = %e,
+                "Failed to extend BIP44 receive pool during wallet import"
+            );
+        }
+
         drop(wm);
 
         let mut map = self.det_wallets.write().map_err(|e| e.to_string())?;
         map.insert(seed_hash, wallet_id);
 
         Ok(wallet_id)
+    }
+
+    /// Extend the BIP44 receive address pool for `wallet_id` so at least
+    /// `target_index` is covered. Must be called with the caller already
+    /// holding the `self.wallet` write lock.
+    ///
+    /// Each iteration marks the generated address as used, which advances
+    /// the pool's `highest_used` and triggers gap-limit refill. The caller
+    /// supplies a target that includes desired lookahead slack.
+    fn extend_bip44_receive_pool_locked(
+        wm: &mut WalletManager<ManagedWalletInfo>,
+        wallet_id: WalletId,
+        target_index: u32,
+    ) -> Result<u32, String> {
+        const MAX_ITERATIONS: u32 = 2_000;
+        let mut generated = 0u32;
+        loop {
+            let result = wm
+                .get_receive_address(&wallet_id, 0, AccountTypePreference::BIP44, true)
+                .map_err(|e| format!("get_receive_address failed: {e}"))?;
+            let address = result
+                .address
+                .ok_or_else(|| "wallet manager returned no address".to_string())?;
+            let info = wm
+                .get_wallet_info(&wallet_id)
+                .ok_or_else(|| "wallet info missing".to_string())?;
+            let path = info
+                .accounts()
+                .standard_bip44_accounts
+                .get(&0)
+                .and_then(|acc| acc.get_address_info(&address))
+                .map(|meta| meta.path.clone())
+                .ok_or_else(|| "address metadata unavailable".to_string())?;
+            let current_index = path
+                .as_ref()
+                .last()
+                .and_then(|c| match c {
+                    ChildNumber::Normal { index } => Some(*index),
+                    _ => None,
+                })
+                .unwrap_or(0);
+            generated += 1;
+            if current_index >= target_index {
+                break;
+            }
+            if generated >= MAX_ITERATIONS {
+                return Err(format!(
+                    "address pool extension exceeded safety limit of {MAX_ITERATIONS}"
+                ));
+            }
+        }
+        if generated > 0 {
+            tracing::info!(
+                wallet = %hex::encode(wallet_id),
+                generated,
+                target_index,
+                "Extended SPV BIP44 receive pool"
+            );
+        }
+        Ok(generated)
     }
 
     pub async fn next_bip44_receive_address(


### PR DESCRIPTION
## Summary

Fixes the second of the four layers behind the zero-balance-on-import bug tracked in [#829](https://github.com/dashpay/dash-evo-tool/issues/829): addresses generated via the UI beyond the WalletManager's default BIP44 gap limit (30) are not re-registered into the live monitored set on startup, so SPV filter matching misses any UTXO at those higher indices.

This PR is now **narrowly focused on the bug-2 fix only**. The platform pin bump and `clear_data_dir` fix have been extracted into [#834](https://github.com/dashpay/dash-evo-tool/pull/834) and must land first.

## Reproduction

1. In an existing wallet, use the UI to generate 35+ receive addresses (indices 0–34).
2. Restart DET.
3. Send a testnet transaction to the address at an index ≥ 30 (beyond the WalletManager default gap limit).
4. Wait for the transaction to confirm, then observe the wallet balance in the UI.

**Expected:** The balance at the receiving address appears, because the WalletManager's monitored address set should include every index that exists in DET's local database.

**Actual:** The address shows zero balance. On restart, the WalletManager is reconstructed with `WalletAccountCreationOptions::Default` which pre-generates BIP44 indices 0–29 only. Any indices DET previously stored in `wallet_addresses` beyond 29 are never re-registered into the WalletManager, so the live monitored address set is narrower than DET's on-disk state. SPV filter matching misses any UTXO at indices ≥ 30.

Observed with a reference testnet wallet that has a multi-output transaction at BIP44 indices 0 and 32–40 (motivating tx: `56bdab0ac5dfefc47e136eedeede07a83ff0f2cb753683578fd41677975f8b32` in block 1,459,352). Only index 0 shows balance; 32–40 do not.

## Root cause

Upstream's BIP44 gap-limit reactive extension works as designed: if at least one address within the current gap is observed, the pool extends. But DET stores more addresses in its local DB than it restores to the live monitored set on startup, and there's no code path that reconciles the two.

There's also a second, subtler race: earlier drafts extended the pool *after* `load_wallet_from_seed` returned, meaning `wm.wallet_count()` could cross the threshold that `run_spv_loop` waits on while the pool was still at its default size — SPV's filter pipeline then started matching against an incomplete set.

## Fix

`extend_bip44_receive_pool_locked` runs **inside the WalletManager write lock held by `load_wallet_from_seed`**. `wm.wallet_count()` does not increment until the pool is final, closing the race. The extension target is `max_db_idx` (the highest BIP44 receive index present in the `wallet_addresses` DB table), plus a small slack (`LOOKAHEAD_SLACK = 100`).

### Supporting helpers

- `Database::max_bip44_receive_index()` — reads the DB's `wallet_addresses` table for the highest receive index known for a given wallet.
- `SpvManager::extend_bip44_receive_pool_locked` — called under the existing write lock; iterates `get_receive_address(wallet_id, i, BIP44, mark_used=true)` up to `max_db_idx + LOOKAHEAD_SLACK`. Uses upstream's existing gap-limit reactive extension without adding new API surface.

## Files

| File | Lines | Purpose |
|------|------:|---------|
| `src/context/wallet_lifecycle.rs` | +35 | Pool extension plumbing inside `load_wallet_from_seed`'s write lock |
| `src/database/wallet.rs` | +125 | `Database::max_bip44_receive_index` helper + 3 unit tests |
| `src/spv/manager.rs` | +95 | `SpvManager::extend_bip44_receive_pool_locked` |

Total: **+253 / -2 lines**. Single commit.

## Test plan

### Automated (all green)

- [x] `cargo build --all-features` — clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo test --all-features --workspace --lib` — 455 / 455 pass

### Manual on testnet

- [ ] **Cold start with existing wallet containing indices ≥ 30.** Launch DET against a DB that already has addresses generated up to e.g. index 40. Expected: on first sync, balance on indices ≥ 30 appears without manual clear-and-resync. Log contains `Extended SPV BIP44 receive pool wallet=… generated=<N> target_index=<max_db_idx>`.
- [ ] **Fresh install regression.** `rm -rf ~/.config/dash-evo-tool/data.db ~/.config/dash-evo-tool/spv/` → launch → fresh wallet with no historical UTXOs. Expected: no crash, standard checkpoint sync, balance = 0.

## What this PR does **not** carry

- **Platform bump & `clear_data_dir` fix** — moved to [#834](https://github.com/dashpay/dash-evo-tool/pull/834) for focused review. That PR must land first (this branch is otherwise cleanly independent but relies on the bumped platform for its build).
- **Bug 1 (startup init-order race)** — [#833](https://github.com/dashpay/dash-evo-tool/pull/833).
- **Bug 3 (mid-session import rescan workaround)** — previously on this branch; stripped because it's blocked upstream by [rust-dashcore#651 constraint #4](https://github.com/dashpay/rust-dashcore/issues/651). Preserved on [`archive/spv-wallet-address-sync-2026-04-20`](https://github.com/dashpay/dash-evo-tool/tree/archive/spv-wallet-address-sync-2026-04-20) for future reference. Until upstream #651 lands, the sanctioned workaround for mid-session imports is **"Clear SPV Data"**.

## Merge order

1. [#834](https://github.com/dashpay/dash-evo-tool/pull/834) (platform bump + `clear_data_dir` fix)
2. [#833](https://github.com/dashpay/dash-evo-tool/pull/833) (bug 1 startup race — independent, can land first or alongside)
3. This PR (bug 2 pool extension)

## Related

- Issue: [#829](https://github.com/dashpay/dash-evo-tool/issues/829) — four-layer root cause.
- Sibling PR: [#834](https://github.com/dashpay/dash-evo-tool/pull/834) — platform bump + `clear_data_dir` fix.
- Sibling PR: [#833](https://github.com/dashpay/dash-evo-tool/pull/833) — bug 1 startup init-order race.
- Upstream: [rust-dashcore#651](https://github.com/dashpay/rust-dashcore/issues/651) — tracks bugs 3 & 4.
- Archive: [`archive/spv-wallet-address-sync-2026-04-20`](https://github.com/dashpay/dash-evo-tool/tree/archive/spv-wallet-address-sync-2026-04-20) — preserved pre-strip state.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
