### PR TITLE
feat(mcp): add core_wallet_import and core_wallet_delete tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,6 +2026,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tz-rs",
+ "unicode-normalization",
  "urlencoding",
  "which 8.0.2",
  "winres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1.46.1", features = ["full"] }
 bincode = { version = "=2.0.1", features = ["serde"] }
 hex = { version = "0.4.3" }
 itertools = "0.14.0"
+unicode-normalization = "0.1.25"
 enum-iterator = "2.1.0"
 futures = "0.3.31"
 tracing = "0.1.41"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -132,6 +132,48 @@ det-cli tool-describe name=core_funds_send
 # Send 0.01 DASH (1,000,000 duffs) to an address (network is required)
 det-cli core-funds-send wallet-id=savings address=yXyz... amount-duffs=1000000 network=testnet
 
+# Import a wallet from a BIP39 mnemonic. Quote the phrase so the shell
+# does not split on whitespace. `network` is required.
+det-cli core-wallet-import \
+  mnemonic="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about" \
+  alias="savings" \
+  network=testnet
+
+# Same import with a BIP39 passphrase ("25th word") and an at-rest
+# encryption password. If the app already has a main password set,
+# `encryption-password` MUST match it — mismatched passwords are rejected.
+det-cli core-wallet-import \
+  mnemonic="..." \
+  passphrase="trezor" \
+  encryption-password="the-existing-main-password" \
+  alias="primary" \
+  network=testnet
+
+# Delete a wallet by alias. `confirm-seed-hash` must match the target
+# wallet's hex seed_hash exactly — use `core-wallets-list` first to copy
+# the correct value. Deletion is permanent and scoped to the specified
+# network.
+det-cli core-wallet-delete \
+  wallet-id="savings" \
+  confirm-seed-hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  network=testnet
+
+# Delete by passing the hex seed_hash as both the lookup id and the
+# confirmation — the confirmation is always required.
+det-cli core-wallet-delete \
+  wallet-id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  confirm-seed-hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  network=testnet
+
+# Allow deleting a wallet that still holds a non-zero balance. Use only
+# when the mnemonic is backed up safely elsewhere; on-chain funds remain
+# but are inaccessible without the mnemonic.
+det-cli core-wallet-delete \
+  wallet-id="savings" \
+  confirm-seed-hash=... \
+  allow-delete-with-balance=true \
+  network=testnet
+
 # Run as stdio MCP server for Claude Desktop or Claude Code
 det-cli serve
 ```

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -71,6 +71,8 @@ Set these in the app's `.env` file (see `.env.example`) or as environment variab
 | `network_reinit_sdk` | `network` | `det-cli network-reinit-sdk` | Rebuild Core RPC client and Platform SDK with current config (use after changing credentials) |
 | `network_switch` | `network` | `det-cli network-switch` | Switch the active network (creates context if needed, may take a few seconds) |
 | `core_wallets_list` | `network`? | `det-cli core-wallets-list` | List wallets loaded in the app (alias + seed hash) |
+| `core_wallet_import` | `mnemonic`, `passphrase`?, `encryption_password`?, `alias`?, `core_wallet_name`?, `network` | `det-cli core-wallet-import` | Import a wallet from a BIP39 mnemonic (sanitises input, honours app main password) |
+| `core_wallet_delete` | `wallet_id`, `confirm_seed_hash`, `allow_delete_with_balance`?, `network` | `det-cli core-wallet-delete` | Delete a wallet from the local device (irreversible, network-scoped) |
 | `core_address_create` | `wallet_id`, `network`? | `det-cli core-address-create` | Generate a new receive address for a wallet |
 | `core_balances_get` | `wallet_id`, `network`? | `det-cli core-balances-get` | Show wallet balances (total, confirmed, unconfirmed) in duffs |
 | `platform_addresses_list` | `wallet_id`, `network`? | `det-cli platform-addresses-list` | Fetch platform address balances (credits and nonces) |
@@ -94,7 +96,18 @@ Parameters marked `?` are optional. The `det-cli` column shows the equivalent CL
 
 All wallet-facing tools wait for SPV to fully sync before executing. This includes both core-chain tools (`core_address_create`, `core_balances_get`, `core_funds_send`) and platform tools (`platform_addresses_list`, `identity_credits_topup`, `shielded_shield_from_core`). Even DAPI-only operations need SPV because the SDK verifies DAPI proofs against quorum and masternode list data from the synced chain. When another DET instance is already running, SPV falls back to a temporary directory and must sync from scratch.
 
-Only metadata tools that make no network calls (`core_wallets_list`, `network_info`, `tool_describe`) skip the SPV gate.
+Only metadata tools that make no network calls (`core_wallets_list`, `network_info`, `tool_describe`) skip the SPV gate. `core_wallet_import` and `core_wallet_delete` also skip the SPV gate — they operate on local metadata only.
+
+### **Wallet import/delete security model**
+
+`core_wallet_import` and `core_wallet_delete` handle the most sensitive operations the MCP server exposes. Read this section before exposing the server beyond your local machine.
+
+- **The MCP API key grants wallet-tier access.** Any caller with `MCP_API_KEY` can import a mnemonic, change which wallet is the active target of downstream tool calls, and delete wallet metadata. Treat the key as a password, not an API identifier — rotate it if it leaks.
+- **MCP HTTP must stay on loopback.** The default `MCP_LISTEN=127.0.0.1:9527` binds to localhost only. Do **not** change `MCP_LISTEN` to a non-loopback address: `core_wallet_import` accepts the mnemonic as a plaintext JSON field, so sending it over a non-loopback connection without TLS (there is no TLS terminator in the server today) would expose the seed to anyone on the path.
+- **`encryption_password` ≠ app main password.** If the app already has a main password configured, `encryption_password` must *match* it — importing with a different value is rejected. `core_wallet_import` never calls `update_main_password`; it cannot create, change, or remove the app's main password. Set the main password through the GUI before importing over MCP if you want wallet-at-rest encryption.
+- **`encryption_password` ≠ BIP39 passphrase.** The BIP39 passphrase (`passphrase` parameter) is part of the seed derivation — a different passphrase yields a different wallet. The at-rest password (`encryption_password`) only affects how the seed is stored on disk. Conflating them corrupts access; the tool docs call this out.
+- **`core_wallet_delete` is permanent and per-network.** Deletion removes the wallet from the selected network only. If the same mnemonic is imported on another network (e.g. mainnet + testnet), the other copy is untouched — the response's `other_networks_with_same_seed` field lists them so you can repeat the deletion explicitly. On-chain funds are not moved; access is lost unless you have the mnemonic backed up elsewhere.
+- **Back up mnemonics externally.** DET is not a recovery service. Before calling `core_wallet_delete`, confirm the mnemonic is safely stored outside the app. Before calling `core_wallet_import`, confirm the mnemonic is the correct one for the network — mistaken imports waste SPV sync time but are not dangerous; mistaken deletes are irreversible.
 
 ## CLI interface (det-cli)
 

--- a/docs/MCP_TOOL_DEVELOPMENT.md
+++ b/docs/MCP_TOOL_DEVELOPMENT.md
@@ -6,6 +6,8 @@ Reference guide for adding new MCP tools that expose existing `BackendTask` vari
 
 1. **Tools live in `src/mcp/tools/`** — never in the CLI binary (`src/bin/det_cli/`). The CLI discovers tools dynamically; it requires zero code changes when a tool is added.
 2. **Tools must not contain business logic.** A tool is a thin adapter: validate parameters, resolve context, dispatch a `BackendTask`, reshape the result. All domain logic stays in `BackendTask` handlers (e.g. `run_identity_task()`, `run_wallet_task()`).
+
+   *Exception:* administrative/provisioning tools that only mutate `AppContext` registrations (wallet lifecycle, settings) may call atomic `AppContext` methods directly when no `BackendTask` variant exists. Adding a `BackendTask` variant just to wrap a synchronous `AppContext` method adds boilerplate with no reuse benefit. `core_wallet_import` and `core_wallet_delete` are the reference examples — both dispatch to `AppContext::register_wallet` / `AppContext::remove_wallet` directly.
 3. **One tool struct = one `BackendTask` dispatch.** If a feature needs multiple backend calls, compose them in the backend layer, not in the tool.
 4. **Errors flow through `McpToolError`** — never return raw strings or SDK errors to the client. Use `McpToolError::TaskFailed(e)` for backend errors, `McpToolError::InvalidParam { message }` for input validation.
 5. **No GUI dependencies.** Tool code must not reference `egui`, screens, UI components, or `AppAction`. The only bridge to the app is `AppContext` + `BackendTask`.
@@ -112,6 +114,22 @@ This is the only registration step. The CLI, `list_tools`, and `tool_describe` p
 ### 7. Update `docs/MCP.md`
 
 Add the tool to the tool reference table with its name, parameters, and description.
+
+## Handling secret parameters
+
+Tools that accept passwords, mnemonics, API keys, or any other sensitive material must follow the rules below. These apply whether the secret is used once and discarded, forwarded to another subsystem, or held for the lifetime of the call.
+
+1. **Use `Secret`, never `String`.** The parameter type for any sensitive field is `crate::model::secret::Secret`. It zeroes its backing storage on drop, best-effort `mlock`s the page, and renders as `"***"` in `Debug`. `Secret` implements `Deserialize` and `JsonSchema` (rendered as `{"type": "string"}`) so JSON parameters just work.
+
+2. **Never derive `Debug` on a param struct that holds a `Secret`.** `#[derive(Debug)]` respects `Secret`'s redacted `Debug` impl, but the presence of the derived impl silently accepts any future field without review. Write a hand-rolled `impl fmt::Debug` that lists each field explicitly and redacts every secret. See `ImportWalletParams` in `src/mcp/tools/wallet.rs` for the pattern.
+
+3. **Never include secret values in error messages.** `McpToolError::InvalidParam { message }` is forwarded to the client verbatim. Do not echo the sanitized text, derived values, or any substring that could leak the original input. Refer to the offending category ("checksum rejected", "wrong word count"), not the content.
+
+4. **Never store secret material in `TaskError` variants.** `TaskError` variants end up in logs and JSON-RPC `data` payloads. If a new variant is needed, add one that contains only typed source errors and structured metadata — never a `String` derived from the secret.
+
+5. **Do not pass `Secret` contents into `tracing::` macros.** `tracing` formats arguments eagerly and may route them to distant subscribers. Log the category (e.g. `"wallet imported"`) and structured metadata (alias, hex seed hash) — never the mnemonic, passphrase, or at-rest password.
+
+6. **Drop secrets as soon as they are used.** Scope the binding narrowly: derive the seed, register the wallet, drop the `Secret`. Avoid holding `Secret` across long-lived awaits.
 
 ## Don'ts
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1027,8 +1027,20 @@ As a developer, I want to fund multiple addresses in one operation so that I can
 As a developer, I want to manage wallets via CLI so that I can automate deployment and testing operations.
 
 - List wallets, check balances, generate addresses, and send funds from the command line.
+- Import and delete wallets via MCP without touching the GUI.
 - CLI discovers tools dynamically via MCP protocol.
 - Shell completion for tool names and parameters.
+
+### MCP-003: Provision wallets via MCP [Implemented]
+**Persona:** Jordan
+
+As a developer / AI agent, I want to import and delete wallets through MCP so that I can fully automate wallet lifecycle without manual GUI steps.
+
+- Import a BIP39 mnemonic with optional passphrase, at-rest encryption password, alias, and Core wallet name (`core_wallet_import`).
+- Mnemonic input is sanitised (numbered lists, case, whitespace, fullwidth glyphs normalised; homoglyphs rejected) before BIP39 parsing.
+- At-rest encryption is refused if it does not match the app's existing main password — the tool cannot create or change the main password.
+- Delete a wallet by alias or hex seed hash, guarded by a mandatory `confirm_seed_hash` match and a balance-protection flag (`core_wallet_delete`).
+- Deletion surfaces orphaned-identity count and other networks where the same seed is still imported.
 
 ### MCP-002: MCP server access for AI agents [Implemented]
 **Persona:** Jordan

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -862,6 +862,13 @@ pub enum TaskError {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// The supplied encryption password did not match the app's main password.
+    #[error(
+        "Provided encryption_password does not match the app's main password. \
+         Omit the field to import without at-rest encryption, or provide the correct existing password."
+    )]
+    MainPasswordMismatch,
+
     // ──────────────────────────────────────────────────────────────────────────
     // Shielded pool errors
     // ──────────────────────────────────────────────────────────────────────────

--- a/src/context/settings_db.rs
+++ b/src/context/settings_db.rs
@@ -1,6 +1,11 @@
 use super::{AppContext, SettingsCacheGuard};
+use crate::backend_task::error::TaskError;
+use crate::model::secret::Secret;
 use crate::model::settings::Settings;
+use crate::model::wallet::encryption::{DASH_SECRET_MESSAGE, derive_password_key};
 use crate::ui::RootScreenType;
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use rusqlite::Result;
 
 impl AppContext {
@@ -51,6 +56,45 @@ impl AppContext {
         let mut guard = self.cached_settings.write().unwrap();
         *guard = None;
         guard
+    }
+
+    /// Whether the app has a main password configured.
+    ///
+    /// The main password is set once via the wallet creation/import UI and
+    /// protects wallet seeds at rest. Its presence is derived from whether
+    /// a `password_check` blob and its Argon2 salt / AES-GCM nonce have been
+    /// stored in the settings row.
+    pub fn has_main_password(&self) -> bool {
+        self.password_info.is_some()
+    }
+
+    /// Verify that the supplied password matches the app's main password.
+    ///
+    /// Fails with `MainPasswordMismatch` if no main password is set or the
+    /// supplied password does not decrypt the `password_check` blob back to
+    /// `DASH_SECRET_MESSAGE`. Argon2 + AES-GCM make this operation slow on
+    /// purpose — callers should not put it inside tight loops.
+    pub fn verify_main_password(&self, candidate: &Secret) -> std::result::Result<(), TaskError> {
+        let info = self
+            .password_info
+            .as_ref()
+            .ok_or(TaskError::MainPasswordMismatch)?;
+
+        let key = derive_password_key(candidate.expose_secret(), &info.salt)
+            .map_err(|_| TaskError::MainPasswordMismatch)?;
+
+        let cipher =
+            Aes256Gcm::new_from_slice(&key).map_err(|_| TaskError::MainPasswordMismatch)?;
+        let nonce = Nonce::from_slice(&info.nonce);
+        let plaintext = cipher
+            .decrypt(nonce, info.password_checker.as_slice())
+            .map_err(|_| TaskError::MainPasswordMismatch)?;
+
+        if plaintext.as_slice() == DASH_SECRET_MESSAGE.as_slice() {
+            Ok(())
+        } else {
+            Err(TaskError::MainPasswordMismatch)
+        }
     }
 
     /// Retrieves the current settings

--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -92,6 +92,38 @@ impl Database {
         tx.commit()
     }
 
+    /// List every network that currently stores a wallet with the given seed hash.
+    ///
+    /// A single mnemonic can be imported across multiple networks (mainnet + testnet
+    /// is the common case). This helper surfaces that information so callers can
+    /// warn the user that deleting a wallet on one network will not affect the
+    /// other network's copy. Returns the raw `network` column values as strings —
+    /// e.g. `"mainnet"`, `"testnet"`.
+    pub fn wallet_seed_hash_networks(&self, seed_hash: &[u8; 32]) -> rusqlite::Result<Vec<String>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt =
+            conn.prepare("SELECT network FROM wallet WHERE seed_hash = ? ORDER BY network")?;
+        let rows = stmt.query_map([seed_hash.as_slice()], |row| row.get::<_, String>(0))?;
+        rows.collect()
+    }
+
+    /// Count the local identities linked to a given wallet seed hash on a network.
+    ///
+    /// Used before deletion to warn the user how many identity records will be
+    /// removed alongside the wallet (CASCADE drops them automatically).
+    pub fn identity_count_for_wallet(
+        &self,
+        seed_hash: &[u8; 32],
+        network: &Network,
+    ) -> rusqlite::Result<u32> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT COUNT(*) FROM identity WHERE wallet = ? AND network = ?",
+            params![seed_hash.as_slice(), network.to_string()],
+            |row| row.get(0),
+        )
+    }
+
     /// Update the Dash Core wallet name for an HD wallet.
     ///
     /// Returns `Ok(true)` if exactly one row was updated, `Ok(false)` if no

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -121,6 +121,8 @@ impl DashMcpService {
             .with_async_tool::<tools::network::NetworkReinitSdk>()
             .with_async_tool::<tools::network::NetworkSwitch>()
             .with_async_tool::<tools::wallet::ListWalletsTool>()
+            .with_async_tool::<tools::wallet::ImportWalletTool>()
+            .with_async_tool::<tools::wallet::DeleteWalletTool>()
             .with_async_tool::<tools::wallet::GenerateReceiveAddress>()
             .with_async_tool::<tools::wallet::WalletBalancesQuery>()
             .with_async_tool::<tools::wallet::FetchPlatformBalances>()

--- a/src/mcp/tools/wallet.rs
+++ b/src/mcp/tools/wallet.rs
@@ -1,20 +1,28 @@
-//! Wallet-related MCP tools: address generation, balances, sending funds.
+//! Wallet-related MCP tools: address generation, balances, sending funds,
+//! and wallet lifecycle (import, delete).
 
 use std::borrow::Cow;
+use std::fmt;
 
+use bip39::Mnemonic;
 use rmcp::handler::server::router::tool::{AsyncTool, ToolBase};
 use rmcp::model::ToolAnnotations;
 use rmcp::schemars;
 use serde::{Deserialize, Serialize};
 
 use crate::backend_task::core::{CoreTask, PaymentRecipient, WalletPaymentRequest};
+use crate::backend_task::error::TaskError;
 use crate::backend_task::wallet::WalletTask;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::mcp::dispatch::dispatch_task;
 use crate::mcp::error::McpToolError;
 use crate::mcp::resolve;
-use crate::mcp::server::DashMcpService;
+use crate::mcp::server::{DashMcpService, network_display_name};
 use crate::mcp::tools::{NetworkParams, WalletIdParams};
+use crate::model::secret::Secret;
+use crate::model::wallet::Wallet;
+use crate::model::wallet::mnemonic::sanitize_mnemonic_input;
+use crate::spv::CoreBackendMode;
 
 // ---------------------------------------------------------------------------
 // GenerateReceiveAddress
@@ -430,5 +438,409 @@ impl AsyncTool<DashMcpService> for ListWalletsTool {
             })
             .collect();
         Ok(ListWalletsOutput { wallets: entries })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ImportWalletTool
+// ---------------------------------------------------------------------------
+
+/// BIP-39 word counts that correspond to valid entropy sizes (128–256 bits).
+const VALID_MNEMONIC_WORD_COUNTS: &[usize] = &[12, 15, 18, 21, 24];
+
+/// Import a wallet from a BIP39 mnemonic.
+pub struct ImportWalletTool;
+
+/// Parameters for `core_wallet_import`.
+///
+/// This struct deliberately does **not** derive `Debug`. The hand-rolled impl
+/// below redacts every secret field so logs that print the params — or a
+/// future macro that captures the whole struct — cannot leak the mnemonic.
+/// `Default` is required by the rmcp tool trait; the generated empty mnemonic
+/// will fail the word-count pre-check if ever dispatched.
+#[derive(Default, Deserialize, schemars::JsonSchema)]
+pub struct ImportWalletParams {
+    /// BIP39 mnemonic seed phrase, separated by spaces. Extra whitespace,
+    /// digits, and punctuation are tolerated — the tool sanitizes the input
+    /// before parsing. This is the only recovery material for the wallet:
+    /// back it up before calling this tool.
+    pub mnemonic: Secret,
+
+    /// Optional BIP39 passphrase — the "25th word" that modifies the seed
+    /// derivation. Distinct from `encryption_password`; conflating them will
+    /// corrupt seed access. Pass the exact string used when the mnemonic was
+    /// originally generated (commonly empty).
+    #[serde(default)]
+    pub passphrase: Option<Secret>,
+
+    /// Optional password used to encrypt the wallet seed at rest on this
+    /// device. If the app already has a main password configured, this value
+    /// must match — providing a different password is rejected. Does **not**
+    /// change the app's main password.
+    #[serde(default)]
+    pub encryption_password: Option<Secret>,
+
+    /// Human-friendly alias shown in the wallet list. Auto-generated if
+    /// omitted.
+    #[serde(default)]
+    pub alias: Option<String>,
+
+    /// Dash Core wallet name for multi-wallet RPC installations. Ignored when
+    /// the app is running in SPV-only mode; supplying it in SPV mode is an
+    /// error so that the caller is aware the value would be discarded.
+    #[serde(default)]
+    pub core_wallet_name: Option<String>,
+
+    /// Expected active network (`"mainnet"`, `"testnet"`, `"devnet"`,
+    /// `"local"`). The tool rejects the request if it does not match.
+    pub network: String,
+}
+
+impl fmt::Debug for ImportWalletParams {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImportWalletParams")
+            .field("mnemonic", &"***")
+            .field("passphrase", &self.passphrase.as_ref().map(|_| "***"))
+            .field(
+                "encryption_password",
+                &self.encryption_password.as_ref().map(|_| "***"),
+            )
+            .field("alias", &self.alias)
+            .field("core_wallet_name", &self.core_wallet_name)
+            .field("network", &self.network)
+            .finish()
+    }
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub struct ImportWalletOutput {
+    /// Hex-encoded SHA-256 hash of the BIP39 seed. Stable across networks
+    /// for the same mnemonic.
+    pub seed_hash: String,
+    /// Effective alias stored on disk (matches `alias` when supplied,
+    /// otherwise auto-generated).
+    pub alias: String,
+    /// Network the wallet was imported onto.
+    pub network: String,
+}
+
+impl ToolBase for ImportWalletTool {
+    type Parameter = ImportWalletParams;
+    type Output = ImportWalletOutput;
+    type Error = McpToolError;
+
+    fn name() -> Cow<'static, str> {
+        "core_wallet_import".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "Import a wallet using a BIP39 mnemonic. \
+             Stores the wallet locally and adds it to the SPV monitoring set. \
+             The mnemonic is the only recovery material — back it up before calling this tool. \
+             Re-importing the same mnemonic returns an error. \
+             The optional `encryption_password` encrypts the wallet seed at rest and \
+             must match the app's existing main password if one is already set."
+                .into(),
+        )
+    }
+
+    fn annotations() -> Option<ToolAnnotations> {
+        Some(
+            ToolAnnotations::default()
+                .read_only(false)
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        )
+    }
+}
+
+/// Generate a fallback wallet alias when the caller did not provide one.
+///
+/// Mirrors the GUI convention in `import_mnemonic_screen::save_wallet` so
+/// wallets imported via MCP look the same as GUI-imported wallets.
+fn default_wallet_alias(ctx: &crate::context::AppContext) -> String {
+    let existing_wallet_count = ctx.wallets.read().map(|w| w.len()).unwrap_or(0);
+    format!("Wallet {}", existing_wallet_count + 1)
+}
+
+impl AsyncTool<DashMcpService> for ImportWalletTool {
+    async fn invoke(
+        service: &DashMcpService,
+        param: ImportWalletParams,
+    ) -> Result<ImportWalletOutput, McpToolError> {
+        let ctx = service
+            .ctx()
+            .await
+            .map_err(|e| McpToolError::Internal(e.to_string()))?;
+
+        // Network is mandatory — importing onto the wrong network corrupts
+        // the caller's expectation of which keys derive which addresses.
+        if param.network.is_empty() {
+            return Err(McpToolError::InvalidParam {
+                message: "The 'network' parameter must not be empty. \
+                          Use \"mainnet\", \"testnet\", \"devnet\", or \"local\"."
+                    .to_owned(),
+            });
+        }
+        resolve::require_network(&ctx, Some(&param.network))?;
+
+        // Core wallet name is only meaningful when talking to an RPC-backed
+        // Dash Core. Rejecting it up-front in SPV mode surfaces the mismatch
+        // to the caller instead of silently discarding the value.
+        let rpc_mode = ctx.core_backend_mode() == CoreBackendMode::Rpc;
+        if param.core_wallet_name.is_some() && !rpc_mode {
+            return Err(McpToolError::InvalidParam {
+                message: "core_wallet_name is only supported in Dash Core RPC mode. \
+                          Remove the field or switch the app to RPC-backed Core."
+                    .to_owned(),
+            });
+        }
+
+        // 1. Sanitize the mnemonic input.
+        let sanitized = sanitize_mnemonic_input(param.mnemonic.expose_secret());
+
+        // 2. Word-count pre-check. Must run before BIP39 parsing so we do not
+        //    include the sanitized phrase in the error message.
+        let word_count = sanitized.split_whitespace().count();
+        if !VALID_MNEMONIC_WORD_COUNTS.contains(&word_count) {
+            return Err(McpToolError::InvalidParam {
+                message: format!("Expected 12, 15, 18, 21, or 24 words; got {word_count}."),
+            });
+        }
+
+        // 3. Parse the mnemonic. Do not propagate bip39::Error details —
+        //    they can echo pieces of the sanitized phrase.
+        let mnemonic =
+            Mnemonic::parse_normalized(&sanitized).map_err(|_| McpToolError::InvalidParam {
+                message: "Invalid mnemonic: word list, spelling, or checksum rejected.".into(),
+            })?;
+
+        // 4. Derive the seed. Pass the BIP39 passphrase (if any) through
+        //    verbatim; it is a distinct secret from encryption_password.
+        let passphrase = param
+            .passphrase
+            .as_ref()
+            .map(|s| s.expose_secret())
+            .unwrap_or("");
+        let seed = mnemonic.to_seed(passphrase);
+
+        // 5. SEC-010 main-password guard — if the app already has a main
+        //    password configured, the supplied encryption_password must
+        //    match it. We never touch `update_main_password`: MCP callers
+        //    cannot change the app-wide password through this tool.
+        if let Some(ref enc_pw) = param.encryption_password
+            && ctx.has_main_password()
+        {
+            ctx.verify_main_password(enc_pw)
+                .map_err(McpToolError::TaskFailed)?;
+        }
+
+        // 6. Build the wallet.
+        let alias_value = param
+            .alias
+            .clone()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| default_wallet_alias(&ctx));
+
+        let mut wallet = Wallet::new_from_seed(
+            seed,
+            ctx.network(),
+            Some(alias_value.clone()),
+            param.encryption_password.as_ref(),
+        )
+        .map_err(McpToolError::TaskFailed)?;
+
+        if rpc_mode {
+            wallet.core_wallet_name = param.core_wallet_name.clone();
+        }
+
+        // 7. Register with the app context.
+        let (seed_hash, _wallet_arc) = ctx.register_wallet(wallet).map_err(|e| match e {
+            // Preserve the distinct WalletAlreadyImported signal; callers
+            // commonly want to match on it to offer "already there" UX.
+            TaskError::WalletAlreadyImported => McpToolError::TaskFailed(e),
+            other => McpToolError::TaskFailed(other),
+        })?;
+
+        tracing::info!(
+            seed = %hex::encode(seed_hash),
+            alias = %alias_value,
+            network = %param.network,
+            "wallet imported via MCP"
+        );
+
+        Ok(ImportWalletOutput {
+            seed_hash: hex::encode(seed_hash),
+            alias: alias_value,
+            network: network_display_name(ctx.network()).to_owned(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DeleteWalletTool
+// ---------------------------------------------------------------------------
+
+/// Delete a wallet from the local device.
+pub struct DeleteWalletTool;
+
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
+pub struct DeleteWalletParams {
+    /// Wallet alias or 64-char hex seed hash.
+    pub wallet_id: String,
+    /// Expected active network. Required for destructive operations.
+    pub network: String,
+    /// Hex seed hash of the wallet to confirm deletion. Must exactly match
+    /// the resolved wallet's `seed_hash` — this avoids alias collisions
+    /// silently deleting the wrong wallet.
+    pub confirm_seed_hash: String,
+    /// Allow deletion even when the wallet still holds a non-zero balance.
+    /// Defaults to `false` — balance-carrying wallets are kept unless the
+    /// caller explicitly opts in.
+    #[serde(default)]
+    pub allow_delete_with_balance: bool,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+pub struct DeleteWalletOutput {
+    /// Hex seed hash of the deleted wallet.
+    pub seed_hash: String,
+    /// Alias the wallet had on disk, if any.
+    pub alias: Option<String>,
+    /// Network from which the wallet was removed.
+    pub network: String,
+    /// Count of local identities linked to the wallet that were cascaded out.
+    pub orphaned_identities: u32,
+    /// Other networks where the same mnemonic is still imported. The caller
+    /// may want to repeat the deletion there.
+    pub other_networks_with_same_seed: Vec<String>,
+}
+
+impl ToolBase for DeleteWalletTool {
+    type Parameter = DeleteWalletParams;
+    type Output = DeleteWalletOutput;
+    type Error = McpToolError;
+
+    fn name() -> Cow<'static, str> {
+        "core_wallet_delete".into()
+    }
+
+    fn description() -> Option<Cow<'static, str>> {
+        Some(
+            "DELETE a wallet from this device. \
+             Removes local metadata (addresses, UTXOs, identity links) but leaves \
+             on-chain funds untouched — however, you will lose access unless you \
+             have the original mnemonic. \
+             Operation is irreversible and scoped to the selected network. \
+             Requires `confirm_seed_hash` to exactly match the target wallet's \
+             hex seed_hash; refuses deletion of wallets with non-zero balance \
+             unless `allow_delete_with_balance=true`."
+                .into(),
+        )
+    }
+
+    fn annotations() -> Option<ToolAnnotations> {
+        Some(
+            ToolAnnotations::default()
+                .read_only(false)
+                .destructive(true)
+                .idempotent(false)
+                .open_world(false),
+        )
+    }
+}
+
+impl AsyncTool<DashMcpService> for DeleteWalletTool {
+    async fn invoke(
+        service: &DashMcpService,
+        param: DeleteWalletParams,
+    ) -> Result<DeleteWalletOutput, McpToolError> {
+        let ctx = service
+            .ctx()
+            .await
+            .map_err(|e| McpToolError::Internal(e.to_string()))?;
+
+        if param.network.is_empty() {
+            return Err(McpToolError::InvalidParam {
+                message: "The 'network' parameter must not be empty. \
+                          Use \"mainnet\", \"testnet\", \"devnet\", or \"local\"."
+                    .to_owned(),
+            });
+        }
+        resolve::require_network(&ctx, Some(&param.network))?;
+
+        let seed_hash = resolve::wallet(&ctx, &param.wallet_id)?;
+
+        // Strict hex seed-hash confirmation — prevents "oops, wrong alias"
+        // from deleting the wrong wallet.
+        if !param
+            .confirm_seed_hash
+            .eq_ignore_ascii_case(&hex::encode(seed_hash))
+        {
+            return Err(McpToolError::InvalidParam {
+                message:
+                    "confirm_seed_hash must exactly match the resolved wallet's hex seed_hash. \
+                          Call core_wallets_list to look it up."
+                        .to_owned(),
+            });
+        }
+
+        // Snapshot alias + balance before deletion.
+        let wallet_arc = resolve::wallet_arc(&ctx, seed_hash)?;
+        let (alias, total_balance_duffs) = {
+            let w = wallet_arc.read().unwrap_or_else(|e| e.into_inner());
+            (w.alias.clone(), w.total_balance_duffs())
+        };
+        drop(wallet_arc);
+
+        if total_balance_duffs > 0 && !param.allow_delete_with_balance {
+            return Err(McpToolError::InvalidParam {
+                message: format!(
+                    "Wallet has non-zero balance ({total_balance_duffs} duffs). \
+                     Pass allow_delete_with_balance=true to proceed."
+                ),
+            });
+        }
+
+        // Identity count and other-network presence (for the response snapshot).
+        let orphaned_identities = ctx
+            .db
+            .identity_count_for_wallet(&seed_hash, &ctx.network())
+            .map_err(|e| McpToolError::TaskFailed(TaskError::from(e)))?;
+
+        let current_network_name = network_display_name(ctx.network()).to_owned();
+        let other_networks_with_same_seed = ctx
+            .db
+            .wallet_seed_hash_networks(&seed_hash)
+            .map_err(|e| McpToolError::TaskFailed(TaskError::from(e)))?
+            .into_iter()
+            .filter(|n| n != &current_network_name)
+            .collect::<Vec<_>>();
+
+        // Perform the deletion.
+        ctx.remove_wallet(&seed_hash).map_err(|e| match e {
+            TaskError::WalletNotFound => McpToolError::WalletNotFound {
+                id: hex::encode(seed_hash),
+            },
+            other => McpToolError::TaskFailed(other),
+        })?;
+
+        tracing::info!(
+            seed = %hex::encode(seed_hash),
+            alias = ?alias,
+            network = %current_network_name,
+            orphaned_identities,
+            "wallet deleted via MCP"
+        );
+
+        Ok(DeleteWalletOutput {
+            seed_hash: hex::encode(seed_hash),
+            alias,
+            network: current_network_name,
+            orphaned_identities,
+            other_networks_with_same_seed,
+        })
     }
 }

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::ops::Range;
 
 use egui::TextBuffer;
+use serde::de::{Deserialize, Deserializer, Error as DeError, Visitor};
 use zeroize::{Zeroize, Zeroizing};
 
 /// Default pre-allocation capacity for `Secret` buffers.
@@ -270,6 +271,72 @@ impl From<&str> for Secret {
     }
 }
 
+// -- Deserialize -------------------------------------------------------------
+//
+// Secrets are accepted from JSON as plain strings. The intermediate `String`
+// created by the visitor is zeroized before the visitor returns so no
+// unprotected copy of the plaintext lingers on the stack. Callers should
+// arrange for the surrounding serde machinery to drop its copy promptly.
+
+struct SecretVisitor;
+
+impl<'de> Visitor<'de> for SecretVisitor {
+    type Value = Secret;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a string containing the secret value")
+    }
+
+    fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
+        // `&str` is a borrow from the deserializer's buffer — wrap it in a
+        // Secret directly; there is no heap allocation of our own to wipe.
+        Ok(Secret::new(v))
+    }
+
+    fn visit_string<E: DeError>(self, mut v: String) -> Result<Self::Value, E> {
+        let secret = Secret::new(v.as_str());
+        // Wipe the interstitial owned String before it drops.
+        v.zeroize();
+        Ok(secret)
+    }
+}
+
+impl<'de> Deserialize<'de> for Secret {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(SecretVisitor)
+    }
+}
+
+// -- JsonSchema (for MCP tool parameters) ------------------------------------
+
+#[cfg(any(feature = "mcp", feature = "cli"))]
+const _: () = {
+    use rmcp::schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
+    use std::borrow::Cow;
+
+    impl JsonSchema for Secret {
+        fn schema_name() -> Cow<'static, str> {
+            Cow::Borrowed("Secret")
+        }
+
+        fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+            // Rendered as a plain JSON string. Callers must never log or echo
+            // the value — Secret's Debug impl redacts to "***".
+            json_schema!({
+                "type": "string",
+                "description": "Sensitive string value (e.g. password, mnemonic). Treated as a secret — never logged."
+            })
+        }
+
+        fn inline_schema() -> bool {
+            true
+        }
+    }
+};
+
 // -- Tests -------------------------------------------------------------------
 
 #[cfg(test)]
@@ -371,6 +438,26 @@ mod tests {
         let original = Secret::new("clone me");
         let cloned = original.clone();
         assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn test_deserialize_from_json_string() {
+        let s: Secret =
+            serde_json::from_str("\"correct-horse-battery-staple\"").expect("deserialize");
+        assert_eq!(s.expose_secret(), "correct-horse-battery-staple");
+    }
+
+    #[test]
+    fn test_deserialize_rejects_non_string() {
+        assert!(serde_json::from_str::<Secret>("123").is_err());
+        assert!(serde_json::from_str::<Secret>("null").is_err());
+        assert!(serde_json::from_str::<Secret>("{}").is_err());
+    }
+
+    #[test]
+    fn test_deserialize_preserves_unicode() {
+        let s: Secret = serde_json::from_str(r#""päzwörd""#).expect("deserialize");
+        assert_eq!(s.expose_secret(), "päzwörd");
     }
 
     #[test]

--- a/src/model/wallet/mnemonic.rs
+++ b/src/model/wallet/mnemonic.rs
@@ -1,0 +1,139 @@
+//! BIP-39 mnemonic input sanitization.
+//!
+//! Users paste mnemonics from many places — numbered lists, word processors,
+//! terminals with trailing whitespace, IMEs that emit fullwidth or combining
+//! characters, and lookalike homoglyphs. This module normalizes that input into
+//! a clean lowercase ASCII form that `Mnemonic::parse_normalized` can consume.
+//!
+//! The pipeline is deliberately strict: drop anything that is not an ASCII
+//! letter or ASCII whitespace. A silent "almost matches" is worse than a clear
+//! failure — a wrong word in a seed phrase loses funds.
+
+use unicode_normalization::UnicodeNormalization;
+
+/// Clean up user-supplied mnemonic input for BIP-39 parsing.
+///
+/// Pipeline (order matters):
+/// 1. Apply NFKD Unicode normalization. This decomposes compatibility forms
+///    like fullwidth Latin letters (`ａ` → `a`) and separates combining marks
+///    (`á` → `a` + U+0301). Doing this **before** filtering is essential —
+///    filtering first would drop the fullwidth glyph entirely.
+/// 2. Keep only ASCII alphabetic bytes and ASCII whitespace. Cyrillic
+///    lookalikes, digits, punctuation, emoji, combining marks, and anything
+///    exotic are all discarded. `is_ascii_alphabetic` is used deliberately
+///    instead of `char::is_alphabetic`, which would accept combining marks
+///    and non-ASCII letters.
+/// 3. Collapse runs of whitespace (spaces, tabs, CR, LF) into single spaces.
+/// 4. Lowercase via `to_ascii_lowercase` — BIP-39 word lists are lowercase
+///    ASCII.
+///
+/// The output is always lowercase ASCII words separated by single spaces, or
+/// the empty string if the input contained no usable letters.
+pub fn sanitize_mnemonic_input(raw: &str) -> String {
+    // 1. NFKD normalization.
+    let nfkd: String = raw.nfkd().collect();
+
+    // 2. Retain only ASCII letters and ASCII whitespace.
+    let filtered: String = nfkd
+        .chars()
+        .filter(|c| c.is_ascii_alphabetic() || (c.is_ascii() && c.is_whitespace()))
+        .collect();
+
+    // 3. Collapse whitespace into single spaces.
+    let joined = filtered.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // 4. Lowercase (ASCII only at this point).
+    joined.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_numbered_list_prefixes() {
+        assert_eq!(
+            sanitize_mnemonic_input("1. abandon 2. ability 3. able"),
+            "abandon ability able",
+        );
+    }
+
+    #[test]
+    fn lowercases_uppercase_input() {
+        assert_eq!(
+            sanitize_mnemonic_input("ABANDON ABILITY"),
+            "abandon ability"
+        );
+    }
+
+    #[test]
+    fn collapses_mixed_whitespace() {
+        assert_eq!(
+            sanitize_mnemonic_input("abandon\r\nability\table   legal"),
+            "abandon ability able legal",
+        );
+    }
+
+    #[test]
+    fn fullwidth_decomposes_to_ascii() {
+        // U+FF41 FULLWIDTH LATIN SMALL LETTER A etc. NFKD maps them to ASCII.
+        assert_eq!(
+            sanitize_mnemonic_input("\u{FF41}\u{FF42}\u{FF41}\u{FF4E}\u{FF44}\u{FF4F}\u{FF4E}"),
+            "abandon"
+        );
+    }
+
+    #[test]
+    fn combining_marks_are_stripped() {
+        // "á bility" where á = U+0061 U+0301 (a + combining acute).
+        // NFKD keeps the ASCII 'a' and emits the standalone combining mark,
+        // which the filter then drops.
+        let input = "a\u{0301} bility";
+        assert_eq!(sanitize_mnemonic_input(input), "a bility");
+    }
+
+    #[test]
+    fn cyrillic_homoglyphs_are_dropped_not_substituted() {
+        // U+0430 CYRILLIC SMALL LETTER A looks like ASCII 'a' but is not.
+        // The sanitizer must drop it, not silently substitute — a wrong word
+        // will then fail BIP-39 parsing rather than derive a different seed.
+        let input = "\u{0430} bandon";
+        // The Cyrillic 'a' is removed, leaving "bandon" which will fail
+        // BIP-39 word-list parsing downstream. The sanitizer itself is not
+        // responsible for that check — it just produces clean ASCII.
+        assert_eq!(sanitize_mnemonic_input(input), "bandon");
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        assert_eq!(sanitize_mnemonic_input(""), "");
+    }
+
+    #[test]
+    fn all_digits_input_yields_empty_output() {
+        assert_eq!(sanitize_mnemonic_input("12345 6789"), "");
+    }
+
+    #[test]
+    fn preserves_multi_word_phrase() {
+        let phrase =
+            "abandon ability able about above absent absorb abstract absurd abuse access accident";
+        assert_eq!(sanitize_mnemonic_input(phrase), phrase);
+    }
+
+    #[test]
+    fn strips_leading_and_trailing_whitespace() {
+        assert_eq!(
+            sanitize_mnemonic_input("  \n\t abandon ability  \r\n"),
+            "abandon ability",
+        );
+    }
+
+    #[test]
+    fn drops_punctuation_and_symbols() {
+        assert_eq!(
+            sanitize_mnemonic_input("abandon, ability! able? legal."),
+            "abandon ability able legal",
+        );
+    }
+}

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -1,5 +1,6 @@
 mod asset_lock_transaction;
 pub mod encryption;
+pub mod mnemonic;
 pub mod shielded;
 pub mod single_key;
 mod utxos;

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -573,7 +573,9 @@ impl ScreenLike for ImportMnemonicScreen {
 
                             // Check seed phrase validity whenever all words are filled
                             if self.seed_phrase_words.iter().all(|string| !string.is_empty()) {
-                                match Mnemonic::parse_normalized(self.seed_phrase_words.join(" ").as_str()) {
+                                let joined = self.seed_phrase_words.join(" ");
+                                let sanitized = crate::model::wallet::mnemonic::sanitize_mnemonic_input(&joined);
+                                match Mnemonic::parse_normalized(&sanitized) {
                                     Ok(mnemonic) => {
                                         self.seed_phrase = Some(mnemonic);
                                         // Clear any existing seed phrase error


### PR DESCRIPTION
## Summary

Adds two new MCP tools for wallet provisioning, plus a reusable BIP-39 mnemonic sanitizer shared with the GUI.

- **`core_wallet_import`** — import a wallet from a BIP-39 mnemonic. Accepts optional BIP-39 passphrase, optional at-rest encryption password, alias, and Core RPC wallet name.
- **`core_wallet_delete`** — delete a wallet, scoped to a single network. Requires exact `confirm_seed_hash` match and refuses non-zero balance without `allow_delete_with_balance=true`.
- **`sanitize_mnemonic_input`** (new `src/model/wallet/mnemonic.rs`) — NFKD normalize → ASCII-alpha filter → whitespace collapse → lowercase. Handles numbered paste (`"1. abandon 2. ability …"`), fullwidth input, combining marks, Cyrillic homoglyphs. The GUI import screen now uses the same helper so MCP and GUI stay aligned.

## Design decisions

- **Direct `AppContext` calls**, not new `BackendTask` variants — follows `ListWalletsTool` precedent. The architectural carve-out is documented in `docs/MCP_TOOL_DEVELOPMENT.md`: administrative/provisioning tools that only mutate `AppContext` registrations may skip the `BackendTask` indirection when it adds no reuse value.
- **`Secret` type for mnemonic, BIP-39 passphrase, and encryption password** — implemented `Deserialize` + feature-gated `JsonSchema` for `Secret`. Custom redacting `Debug` on both params structs; no `#[derive(Debug)]` on anything holding secrets.
- **No SPV gate** on these provisioning tools (they do not query chain data).

## Security (from pre-implementation audit)

HIGH findings addressed in-PR:
- **SEC-001** Secret-wrapped params, redacting Debug, never stored in `TaskError`.
- **SEC-003** passphrase stays in `Secret` until `to_seed()`, dropped immediately.
- **SEC-005** no new `TaskError` variant holds secret bytes.
- **SEC-010** `encryption_password` never calls `update_main_password`; must match existing main password if one is set, otherwise rejected (`TaskError::MainPasswordMismatch`).

MEDIUM findings addressed in-PR:
- **SEC-004** sanitizer order (NFKD before filter) with explicit tests for fullwidth, combining marks, homoglyphs, digits.
- **SEC-008** delete requires exact `confirm_seed_hash` and refuses balance > 0 without opt-in.
- **SEC-009** delete response includes `other_networks_with_same_seed` so callers can report honestly.

## Deferred to a follow-up MCP hardening PR

- SEC-002 `MCP_LISTEN` loopback-only enforcement (hard-fail on non-loopback binds).
- SEC-006 Host/Origin header validation middleware (DNS-rebinding belt-and-braces).
- SEC-007 `.env` permission tightening (chmod 0600 + keyring migration).
- SEC-012 rate limiting on the MCP router.
- Refactor `Wallet::new_from_seed` to take `&[u8; 64]` for caller-controlled zeroization.
- Separate `TaskError` Debug from JSON-RPC `data` payload (opaque diagnostic IDs).
- Backend E2E coverage (`tests/backend-e2e/`) for both new tools — hooked up manually today.

## Files

- `src/model/wallet/mnemonic.rs` — new, 140 lines (function + 11 unit tests)
- `src/model/secret.rs` — `Deserialize` + `JsonSchema` impls + 3 tests
- `src/mcp/tools/wallet.rs` — both tools, params, outputs
- `src/mcp/server.rs` — registration
- `src/ui/wallets/import_mnemonic_screen.rs` — GUI adopts sanitizer
- `src/backend_task/error.rs` — `MainPasswordMismatch` variant
- `src/context/settings_db.rs` — `has_main_password` + `verify_main_password`
- `src/database/wallet.rs` — `wallet_seed_hash_networks`, `identity_count_for_wallet`
- `docs/MCP.md`, `docs/MCP_TOOL_DEVELOPMENT.md`, `docs/CLI.md`, `docs/user-stories.md`
- `Cargo.toml` — `unicode-normalization` (already transitively present via `bip39`)

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo test --all-features --workspace` — 14 new tests pass, no regressions
- [ ] Manual: call `core_wallet_import` via CLI with `"1. abandon 2. ability … 12. about"` paste-format mnemonic and verify the wallet appears in the GUI.
- [ ] Manual: call `core_wallet_delete` with wrong `confirm_seed_hash` and verify rejection; then with correct hash and balance > 0 and verify rejection; then with `allow_delete_with_balance=true` and verify success.
- [ ] Manual: attempt import with `encryption_password` when app main password is already set and differs — expect `MainPasswordMismatch`.
- [ ] Manual: import the same mnemonic on mainnet + testnet, delete on one network, verify the other survives and `other_networks_with_same_seed` lists it.