### PR TITLE
feat: default to SPV connection; gate Dash Core RPC behind Expert mode

### DIFF
--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1023,8 +1023,8 @@ As a developer, I want to fund multiple addresses in one operation so that I can
 As an everyday user, I want to install and use Dash Evo Tool without having to run or configure a local Dash Core node.
 
 - Fresh install connects to the Dash network via the built-in SPV light client with zero configuration.
-- The user sees sync progress and status clearly; no mention of SPV, RPC, or nodes in the default UI.
-- Dash Core RPC remains available as an opt-in under Expert mode for users who do run a local node.
+- The user sees sync progress and status clearly; the default everyday-user UI avoids mentions of SPV, RPC, or nodes.
+- Technical/protocol terminology may appear in Expert mode or advanced settings, where Dash Core RPC remains available as an opt-in for users who do run a local node.
 
 ---
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1017,6 +1017,15 @@ As a developer, I want to fund multiple addresses in one operation so that I can
 - Specify N addresses and amount per address.
 - Single action distributes funds.
 
+### NET-015: Use Dash Evo Tool without a local Dash Core node [Implemented]
+**Persona:** Alex (Everyday User)
+
+As an everyday user, I want to install and use Dash Evo Tool without having to run or configure a local Dash Core node.
+
+- Fresh install connects to the Dash network via the built-in SPV light client with zero configuration.
+- The user sees sync progress and status clearly; no mention of SPV, RPC, or nodes in the default UI.
+- Dash Core RPC remains available as an opt-in under Expert mode for users who do run a local node.
+
 ---
 
 ## Programmatic Access (MCP)

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ use crate::context::connection_status::{ConnectionStatus, OverallConnectionState
 use crate::database::Database;
 #[cfg(not(feature = "testing"))]
 use crate::logging::initialize_logger;
+use crate::model::feature_gate::FeatureGate;
 use crate::model::settings::Settings;
 use crate::spv::CoreBackendMode;
 use crate::ui::components::{BannerHandle, MessageBanner, OptionBannerExt};
@@ -721,6 +722,12 @@ impl AppState {
         if disable {
             return None;
         }
+        // SPV mode has no local Dash Core node to talk to over ZMQ. Gate the
+        // listener spawn through FeatureGate so the common (SPV) path doesn't
+        // burn a socket + retry loop waiting for a node that isn't there.
+        if !FeatureGate::RpcBackend.is_available(ctx) {
+            return None;
+        }
         CoreZMQListener::spawn_listener(
             network,
             &endpoint,
@@ -918,15 +925,12 @@ impl AppState {
             .ok();
     }
 
-    /// Auto-start SPV sync if the conditions are met: auto-start enabled,
-    /// developer mode on, and backend mode is SPV.
-    // TODO: SPV auto-start is gated behind developer mode while SPV is in development.
-    // Remove the is_developer_mode() check once SPV is production-ready.
+    /// Auto-start SPV sync if the conditions are met: auto-start enabled and
+    /// backend mode is SPV.
     fn try_auto_start_spv(&self) {
         let ctx = self.current_app_context();
         let auto_start = ctx.db.get_auto_start_spv().unwrap_or(false);
-        if auto_start && ctx.is_developer_mode() && ctx.core_backend_mode() == CoreBackendMode::Spv
-        {
+        if auto_start && FeatureGate::SpvBackend.is_available(ctx) {
             if let Err(e) = ctx.start_spv() {
                 tracing::warn!("Failed to auto-start SPV sync: {e}");
             } else {

--- a/src/context/connection_status.rs
+++ b/src/context/connection_status.rs
@@ -75,7 +75,7 @@ impl ConnectionStatus {
             rpc_online: AtomicBool::new(false),
             zmq_status: Mutex::new(ZMQConnectionEvent::Disconnected),
             spv_status: AtomicU8::new(SpvStatus::Idle as u8),
-            backend_mode: AtomicU8::new(CoreBackendMode::Rpc.as_u8()),
+            backend_mode: AtomicU8::new(CoreBackendMode::Spv.as_u8()),
             disable_zmq: AtomicBool::new(false),
             overall_state: AtomicU8::new(OverallConnectionState::Disconnected as u8),
             spv_last_error: Mutex::new(None),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -448,6 +448,23 @@ impl AppContext {
     }
 
     fn set_core_backend_mode_inner(self: &Arc<Self>, mode: CoreBackendMode, persist: bool) {
+        // TODO: mid-session mode switches here do not manage ZMQ listener
+        // lifecycle.
+        //   - RPC → SPV: any listener spawned at startup or on the last
+        //     network switch keeps running, burning a socket + retry loop
+        //     against a Core node that is no longer in use (pre-existing
+        //     bug, predates the SPV-default flip).
+        //   - SPV → RPC: no listener is spawned here, so Expert users
+        //     toggling to Local Dash Core node mid-session lose ZMQ
+        //     real-time events until restart or network switch (the
+        //     FeatureGate::RpcBackend gate in spawn_zmq_listener blocks
+        //     the startup spawn while in SPV mode).
+        // Fixing this requires an AppContext → AppState signal so the
+        // listener map (owned by AppState) can be torn down or spawned
+        // in response to mode changes. Cross-module refactor, deliberately
+        // scoped out of PR #836.
+        // Ref: CR-1 on dashpay/dash-evo-tool#836.
+
         // Switch SDK context provider to match the selected backend.
         // Only store/persist the mode after binding succeeds — otherwise the app
         // would report the new mode while still wired to the old provider.

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -312,20 +312,16 @@ impl AppContext {
         // Wire up push-based SPV status updates to ConnectionStatus
         spv_manager.set_connection_status(Arc::clone(&connection_status));
 
-        // Load the core backend mode from settings, defaulting to RPC if not set
+        // Load the core backend mode from settings. The DB column default is
+        // SPV (=1), and the v34 migration pins every existing user who does
+        // not have a configured local Dash Core node onto SPV. Developer mode
+        // is a visibility toggle — it does not override the persisted choice.
         let saved_core_backend_mode = db
             .get_settings()
             .ok()
             .flatten()
             .map(|s| s.7) // core_backend_mode is the 8th element (index 7)
-            .unwrap_or(CoreBackendMode::Rpc.as_u8());
-
-        // If not in developer mode, force RPC mode (SPV is gated behind dev mode)
-        let saved_core_backend_mode = if developer_mode_enabled {
-            saved_core_backend_mode
-        } else {
-            CoreBackendMode::Rpc.as_u8()
-        };
+            .unwrap_or(CoreBackendMode::Spv.as_u8());
 
         // Load saved wallet selection, validating that the wallets still exist
         let (saved_wallet_hash, saved_single_key_hash) =
@@ -376,8 +372,10 @@ impl AppContext {
         };
 
         let app_context = Arc::new(app_context);
-        // Bind providers to the newly created app_context.
-        // Only the active provider is registered with the SDK here (SPV by default).
+        // Bind providers to the newly created app_context. The saved mode in
+        // `settings.core_backend_mode` is the single source of truth: we bind
+        // SPV first to ensure a provider is always registered, then rebind to
+        // RPC only if that is the saved choice.
         if let Err(e) = app_context
             .spv_context_provider
             .read()
@@ -388,7 +386,7 @@ impl AppContext {
             return None;
         }
 
-        // If defaulting to RPC, rebind the RPC provider (overrides SPV registration above).
+        // If the saved mode is RPC, rebind the RPC provider (overrides SPV registration above).
         if app_context.core_backend_mode() == CoreBackendMode::Rpc
             && let Err(e) = app_context
                 .rpc_context_provider
@@ -863,6 +861,8 @@ pub(crate) const fn default_platform_version(network: &Network) -> &'static Plat
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn wallet_name_with_spaces_is_url_encoded() {
         let base = "http://127.0.0.1:9998";
@@ -871,5 +871,40 @@ mod tests {
         let url = format!("{}/wallet/{}", base, encoded);
         assert_eq!(url, "http://127.0.0.1:9998/wallet/my%20test%20wallet");
         assert!(!url.contains(' '));
+    }
+
+    /// A fresh data directory (no pre-existing settings) must resolve to the
+    /// SPV backend — both because the `settings.core_backend_mode` column
+    /// defaults to 1 (SPV) and because `AppContext::new()`'s `unwrap_or`
+    /// fallback now uses SPV. This is the non-network-dependent replacement
+    /// for a full `AppContext::new()` integration test: it exercises the same
+    /// DB-column/unwrap pathway that drives the stored mode at startup.
+    #[test]
+    fn fresh_db_resolves_to_spv_backend_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_file_path = tmp.path().join("test_data.db");
+        let db = crate::database::Database::new(&db_file_path).unwrap();
+        db.initialize(&db_file_path).unwrap();
+
+        // Column default path: a freshly initialized DB reports SPV (=1).
+        let settings = db
+            .get_settings()
+            .expect("settings read")
+            .expect("settings row present");
+        // Settings tuple: index 7 is core_backend_mode (see AppContext::new).
+        assert_eq!(
+            settings.7,
+            CoreBackendMode::Spv.as_u8(),
+            "fresh DB should default to SPV"
+        );
+
+        // Default-fallback path: if settings were missing/unreadable, the
+        // fallback used by `AppContext::new()` must also resolve to SPV. Guard
+        // against silent drift of both the enum default and the as_u8 mapping.
+        assert_eq!(CoreBackendMode::default(), CoreBackendMode::Spv);
+        assert_eq!(
+            CoreBackendMode::from(CoreBackendMode::Spv.as_u8()),
+            CoreBackendMode::Spv
+        );
     }
 }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -58,7 +58,7 @@ fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSna
         let (key, value) = item.map_err(std::io::Error::other)?;
         if key.eq_ignore_ascii_case("DEVELOPER_MODE") {
             developer_mode = matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
-        } else if key.ends_with("core_rpc_password") && !value.is_empty() {
+        } else if key.to_ascii_lowercase().ends_with("core_rpc_password") && !value.is_empty() {
             has_any_rpc_password = true;
         }
     }
@@ -2534,6 +2534,27 @@ mod test {
             assert!(result.is_ok(), "migration failed: {:?}", result.err());
             assert_eq!(db.db_schema_version().unwrap(), 34);
             // Mode preserved as RPC (0) — user's existing choice respected.
+            assert_eq!(read_core_backend_mode(&db), 0);
+        }
+
+        /// Same as `v34_preserves_mode_when_local_core_configured`, but the
+        /// password key is fully uppercase (`MAINNET_CORE_RPC_PASSWORD`). The
+        /// suffix match must be case-insensitive so these users are not
+        /// silently flipped to SPV during the v34 migration.
+        #[test]
+        fn v34_preserves_mode_with_uppercase_password_key() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            write_env(
+                tmp.path(),
+                "DEVELOPER_MODE=true\n\
+                 MAINNET_CORE_RPC_PASSWORD=hunter2\n",
+            );
+
+            let result = db.try_perform_migration(33, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "migration failed: {:?}", result.err());
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+            // Mode preserved as RPC (0) — uppercase password key must count.
             assert_eq!(read_core_backend_mode(&db), 0);
         }
 

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -35,7 +35,51 @@ impl<T> MigrationResultExt<T> for rusqlite::Result<T> {
     }
 }
 
-pub const DEFAULT_DB_VERSION: u16 = 33;
+pub const DEFAULT_DB_VERSION: u16 = 34;
+
+/// Minimal view of `.env` values the v34 migration needs.
+struct V34EnvSnapshot {
+    developer_mode: bool,
+    /// True if any `{NETWORK}_core_rpc_password` is set and non-empty.
+    has_any_rpc_password: bool,
+}
+
+/// Parse `<data_dir>/.env` just enough to decide the v34 migration outcome.
+///
+/// Intentionally independent of `Config::load_from()` — that helper mutates
+/// the process environment via `dotenvy::from_path_override`, which is not
+/// appropriate inside a migration (parallel test runs, other tools may race).
+fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSnapshot> {
+    let env_path = data_dir.join(".env");
+    let contents = std::fs::read_to_string(&env_path)?;
+
+    let mut developer_mode = false;
+    let mut has_any_rpc_password = false;
+
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        // Strip surrounding single or double quotes but keep inner content as-is.
+        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+
+        if key.eq_ignore_ascii_case("DEVELOPER_MODE") {
+            developer_mode = matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
+        } else if key.ends_with("core_rpc_password") && !value.is_empty() {
+            has_any_rpc_password = true;
+        }
+    }
+
+    Ok(V34EnvSnapshot {
+        developer_mode,
+        has_any_rpc_password,
+    })
+}
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
 
@@ -67,7 +111,13 @@ impl Database {
             let current_version = self.db_schema_version()?;
             if current_version != DEFAULT_DB_VERSION {
                 self.backup_db(db_file_path)?;
-                if let Err(e) = self.try_perform_migration(current_version, DEFAULT_DB_VERSION) {
+                // Migrations may need to read `.env` from the data directory
+                // (see v34 for one such arm). The DB file typically lives at
+                // `<data_dir>/<db_file>`, so its parent is the data dir.
+                let data_dir = db_file_path.parent();
+                if let Err(e) =
+                    self.try_perform_migration(current_version, DEFAULT_DB_VERSION, data_dir)
+                {
                     let version_after_migration = self.db_schema_version().unwrap_or(0);
                     return Err(rusqlite::Error::InvalidParameterName(format!(
                         "Database migration from version {} to {} failed (database is at version {}): {}",
@@ -80,8 +130,52 @@ impl Database {
         Ok(())
     }
 
-    fn apply_version_changes(&self, version: u16, tx: &Connection) -> Result<(), MigrationError> {
+    fn apply_version_changes(
+        &self,
+        version: u16,
+        tx: &Connection,
+        data_dir: Option<&Path>,
+    ) -> Result<(), MigrationError> {
         match version {
+            34 => {
+                // SPV is now the default Core-level backend. Users who have a
+                // configured local Dash Core node (Expert mode + at least one
+                // network's `core_rpc_password` set) keep their existing mode;
+                // everyone else is pinned to SPV. No new persisted flag — the
+                // DB version bump itself is the one-shot gate.
+                //
+                // We parse `.env` directly instead of going through
+                // `Config::load_from()`: the latter uses `dotenvy::from_path_override`
+                // which mutates the process environment and is therefore unfit
+                // for migrations that may run in parallel with other tests /
+                // tools (and more importantly, we have no business leaking
+                // one-shot migration state into the live process env).
+                let migrate_to_spv = match data_dir {
+                    Some(dir) => match read_env_file_for_v34_migration(dir) {
+                        Ok(env_snapshot) => {
+                            !(env_snapshot.developer_mode && env_snapshot.has_any_rpc_password)
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "v34 migration: .env unreadable ({e}); defaulting to SPV"
+                            );
+                            true
+                        }
+                    },
+                    // Tests or headless contexts without a data dir: safest default is SPV.
+                    None => true,
+                };
+
+                if migrate_to_spv {
+                    tx.execute("UPDATE settings SET core_backend_mode = 1 WHERE id = 1", [])
+                        .migration_err("settings", "v34: pin SPV as default backend")?;
+                } else {
+                    tracing::info!(
+                        "v34 migration: preserving existing core_backend_mode \
+                         (local Dash Core node configured)"
+                    );
+                }
+            }
             // Versions 28-32 were consolidated into v33 to resolve migration
             // numbering conflicts between the zk and v1.0-dev branches.
             // If migrating from < 28, these are no-ops that just bump the version.
@@ -276,6 +370,7 @@ impl Database {
         &self,
         original_version: u16,
         to_version: u16,
+        data_dir: Option<&Path>,
     ) -> Result<bool, MigrationError> {
         match original_version.cmp(&to_version) {
             std::cmp::Ordering::Equal => {
@@ -307,7 +402,7 @@ impl Database {
                         source: e,
                     })?;
                     let result = self
-                        .apply_version_changes(version, &tx)
+                        .apply_version_changes(version, &tx, data_dir)
                         .and_then(|()| {
                             self.update_database_version(version, &tx).migration_err(
                                 "settings",
@@ -1575,7 +1670,7 @@ mod test {
         db.set_db_version(START_VERSION).unwrap();
 
         // Simulate a migration failure by trying to apply an invalid change
-        let result = db.try_perform_migration(START_VERSION, DEFAULT_DB_VERSION);
+        let result = db.try_perform_migration(START_VERSION, DEFAULT_DB_VERSION, None);
         assert!(result.is_err());
         println!("Migration failed as expected: {}", result.unwrap_err());
 
@@ -1615,7 +1710,6 @@ mod test {
             )
             .unwrap();
         assert_eq!(version, DEFAULT_DB_VERSION);
-        assert_eq!(version, 33);
 
         assert_v33_schema(&conn);
     }
@@ -1724,7 +1818,7 @@ mod test {
         assert_eq!(db.db_schema_version().unwrap(), 27);
 
         // Run migration from v27 to current
-        let result = db.try_perform_migration(27, DEFAULT_DB_VERSION);
+        let result = db.try_perform_migration(27, DEFAULT_DB_VERSION, None);
         assert!(
             result.is_ok(),
             "migration from v27 to v{DEFAULT_DB_VERSION} failed: {:?}",
@@ -1732,7 +1826,7 @@ mod test {
         );
 
         // Verify final version
-        assert_eq!(db.db_schema_version().unwrap(), 33);
+        assert_eq!(db.db_schema_version().unwrap(), DEFAULT_DB_VERSION);
 
         // Verify full v33 schema
         let conn = db.conn.lock().unwrap();
@@ -1987,7 +2081,7 @@ mod test {
         assert_eq!(db.db_schema_version().unwrap(), 27);
 
         // Run migration with orphaned FK rows present
-        let result = db.try_perform_migration(27, DEFAULT_DB_VERSION);
+        let result = db.try_perform_migration(27, DEFAULT_DB_VERSION, None);
         assert!(
             result.is_ok(),
             "migration with orphaned FK rows failed: {:?}",
@@ -2335,7 +2429,7 @@ mod test {
         assert_eq!(db.db_schema_version().unwrap(), 5);
 
         // Run full migration from v5 to current
-        let result = db.try_perform_migration(5, DEFAULT_DB_VERSION);
+        let result = db.try_perform_migration(5, DEFAULT_DB_VERSION, None);
         assert!(
             result.is_ok(),
             "migration from v0.9.0 (v5) to v{DEFAULT_DB_VERSION} failed: {:?}",
@@ -2389,5 +2483,127 @@ mod test {
             )
             .unwrap();
         assert_eq!(lock_identity, Some(vec![0xBBu8; 32]));
+    }
+
+    // ── v34 migration: SPV-default backend ──────────────────────────
+    //
+    // The migration parses `.env` directly (see `read_env_file_for_v34_migration`)
+    // instead of going through `Config::load_from`, so these tests are
+    // self-contained: they do not touch the process environment and can run in
+    // parallel with each other and with anything else in the test suite.
+    mod v34 {
+        fn write_env(dir: &std::path::Path, contents: &str) {
+            std::fs::write(dir.join(".env"), contents).expect("write .env");
+        }
+
+        /// Set up a fresh v33 database in `dir` with `core_backend_mode = 0` (RPC),
+        /// returning the `Database`.
+        fn fresh_v33_db(dir: &std::path::Path) -> super::super::Database {
+            let db_file = dir.join("test_data.db");
+            let db = super::super::Database::new(&db_file).unwrap();
+            db.create_tables().unwrap();
+            db.set_default_version().unwrap();
+            // Set starting state: v33 with the legacy RPC default.
+            db.set_db_version(33).unwrap();
+            {
+                let conn = db.conn.lock().unwrap();
+                conn.execute("UPDATE settings SET core_backend_mode = 0 WHERE id = 1", [])
+                    .unwrap();
+            }
+            db
+        }
+
+        fn read_core_backend_mode(db: &super::super::Database) -> u8 {
+            let conn = db.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT core_backend_mode FROM settings WHERE id = 1",
+                [],
+                |row| row.get::<_, u8>(0),
+            )
+            .unwrap()
+        }
+
+        /// developer_mode=true + a non-empty core_rpc_password on at least one
+        /// network → migration leaves the saved mode untouched.
+        #[test]
+        fn v34_preserves_mode_when_local_core_configured() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            write_env(
+                tmp.path(),
+                "DEVELOPER_MODE=true\n\
+                 MAINNET_core_rpc_password=hunter2\n",
+            );
+
+            let result = db.try_perform_migration(33, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "migration failed: {:?}", result.err());
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+            // Mode preserved as RPC (0) — user's existing choice respected.
+            assert_eq!(read_core_backend_mode(&db), 0);
+        }
+
+        /// developer_mode=true but no password on any network → SPV.
+        #[test]
+        fn v34_migrates_to_spv_when_no_rpc_password() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            write_env(tmp.path(), "DEVELOPER_MODE=true\n");
+
+            let result = db.try_perform_migration(33, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "migration failed: {:?}", result.err());
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+            assert_eq!(read_core_backend_mode(&db), 1);
+        }
+
+        /// developer_mode=false (regardless of password) → SPV.
+        #[test]
+        fn v34_migrates_to_spv_when_developer_mode_off() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            write_env(
+                tmp.path(),
+                "DEVELOPER_MODE=false\n\
+                 MAINNET_core_rpc_password=hunter2\n",
+            );
+
+            let result = db.try_perform_migration(33, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "migration failed: {:?}", result.err());
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+            assert_eq!(read_core_backend_mode(&db), 1);
+        }
+
+        /// No `.env` at all (or unreadable) → SPV (safest default).
+        #[test]
+        fn v34_migrates_to_spv_when_env_missing() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            // Deliberately do not write `.env`.
+
+            let result = db.try_perform_migration(33, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "migration failed: {:?}", result.err());
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+            assert_eq!(read_core_backend_mode(&db), 1);
+        }
+
+        /// Re-running the migration on an already-migrated DB is a no-op.
+        #[test]
+        fn v34_rerun_is_noop() {
+            let tmp = tempfile::tempdir().unwrap();
+            let db = fresh_v33_db(tmp.path());
+            write_env(tmp.path(), "DEVELOPER_MODE=false\n");
+
+            // First run: 33 -> 34
+            db.try_perform_migration(33, 34, Some(tmp.path())).unwrap();
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+
+            // Second run: 34 -> 34 is a no-op.
+            let result = db.try_perform_migration(34, 34, Some(tmp.path()));
+            assert!(result.is_ok(), "re-run should be no-op: {:?}", result.err());
+            assert!(
+                !result.unwrap(),
+                "try_perform_migration should report no migration needed"
+            );
+            assert_eq!(db.db_schema_version().unwrap(), 34);
+        }
     }
 }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -65,8 +65,7 @@ fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSna
             continue;
         };
         let key = key.trim();
-        // Strip surrounding single or double quotes but keep inner content as-is.
-        let value = value.trim().trim_matches(|c| c == '"' || c == '\'');
+        let value = parse_env_value(value);
 
         if key.eq_ignore_ascii_case("DEVELOPER_MODE") {
             developer_mode = matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
@@ -79,6 +78,52 @@ fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSna
         developer_mode,
         has_any_rpc_password,
     })
+}
+
+/// Parse the RHS of a `KEY=...` line the way dotenvy does, minus features we
+/// don't need (variable substitution, backslash escapes). Specifically:
+///
+/// * leading whitespace is stripped
+/// * if the value starts with `'` or `"`, the matching closing quote ends the
+///   value and inner content (including `#`) is preserved verbatim
+/// * outside of quotes, the first whitespace-then-`#` sequence starts an
+///   inline comment and is dropped (e.g. `value # note` → `value`)
+/// * a `#` with no preceding whitespace is a literal character, matching
+///   dotenvy (`value#nohash` → `value#nohash`)
+/// * trailing whitespace is trimmed
+///
+/// Backslash escapes are intentionally not interpreted — the v34 migration only
+/// looks at a boolean flag and whether a password is non-empty, so the cost of
+/// a full escape-aware parser isn't worth it.
+fn parse_env_value(raw: &str) -> String {
+    let trimmed = raw.trim_start();
+
+    // Quoted value — mirror dotenvy: inside quotes, `#` is a literal character.
+    if let Some(rest) = trimmed.strip_prefix('"') {
+        if let Some(end) = rest.find('"') {
+            return rest[..end].to_string();
+        }
+        // Unterminated quote — fall back to the naive strip so we don't lose data.
+        return rest.to_string();
+    }
+    if let Some(rest) = trimmed.strip_prefix('\'') {
+        if let Some(end) = rest.find('\'') {
+            return rest[..end].to_string();
+        }
+        return rest.to_string();
+    }
+
+    // Unquoted value — strip the first whitespace-then-`#` inline comment.
+    let mut end = trimmed.len();
+    let mut prev_ws = false;
+    for (i, c) in trimmed.char_indices() {
+        if c == '#' && prev_ws {
+            end = i;
+            break;
+        }
+        prev_ws = c.is_whitespace();
+    }
+    trimmed[..end].trim_end().to_string()
 }
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
@@ -1711,6 +1756,21 @@ mod test {
             .unwrap();
         assert_eq!(version, DEFAULT_DB_VERSION);
 
+        // Fresh installs must land on SPV (core_backend_mode = 1). This is the
+        // user-visible contract of the v34 default-flip: non-Expert users never
+        // see an RPC config UI, so anything other than SPV here would strand them.
+        let core_backend_mode: u8 = conn
+            .query_row(
+                "SELECT core_backend_mode FROM settings WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            core_backend_mode, 1,
+            "fresh install must default to SPV (core_backend_mode = 1)"
+        );
+
         assert_v33_schema(&conn);
     }
 
@@ -2604,6 +2664,46 @@ mod test {
                 "try_perform_migration should report no migration needed"
             );
             assert_eq!(db.db_schema_version().unwrap(), 34);
+        }
+
+        // ── parse_env_value: dotenvy-style inline comment + quote handling ──
+        //
+        // These exercise the helper directly so regressions show up as unit
+        // failures with a clear message, not as mysterious migration behaviour.
+        use super::super::parse_env_value;
+
+        #[test]
+        fn parse_env_value_strips_inline_comment() {
+            assert_eq!(parse_env_value("value # trailing note"), "value");
+            assert_eq!(parse_env_value("value\t# tab then hash"), "value");
+            // Whitespace between value and `#` is what enables the comment.
+            assert_eq!(parse_env_value("hunter2  # password comment"), "hunter2");
+        }
+
+        #[test]
+        fn parse_env_value_preserves_hash_inside_quotes() {
+            // Double quotes preserve the `#` and inner whitespace verbatim.
+            assert_eq!(
+                parse_env_value("\"value # with hash\""),
+                "value # with hash"
+            );
+            // Single quotes behave the same.
+            assert_eq!(parse_env_value("'value # with hash'"), "value # with hash");
+            // And content before/after the quoted region is not our concern —
+            // dotenvy only supports a single quoted span for the value.
+            assert_eq!(parse_env_value(" \"quoted\" "), "quoted");
+        }
+
+        #[test]
+        fn parse_env_value_hash_without_whitespace_is_literal() {
+            // Matches dotenvy: a `#` with no preceding whitespace stays in the value.
+            assert_eq!(parse_env_value("value#nohash"), "value#nohash");
+            assert_eq!(
+                parse_env_value("hunter2#still-password"),
+                "hunter2#still-password"
+            );
+            // And a plain unquoted value trims trailing whitespace only.
+            assert_eq!(parse_env_value("  plain  "), "plain");
         }
     }
 }

--- a/src/database/initialization.rs
+++ b/src/database/initialization.rs
@@ -44,29 +44,18 @@ struct V34EnvSnapshot {
     has_any_rpc_password: bool,
 }
 
-/// Parse `<data_dir>/.env` just enough to decide the v34 migration outcome.
-///
-/// Intentionally independent of `Config::load_from()` — that helper mutates
-/// the process environment via `dotenvy::from_path_override`, which is not
-/// appropriate inside a migration (parallel test runs, other tools may race).
+/// Parse `<data_dir>/.env` via `dotenvy::from_path_iter` to decide the v34
+/// migration outcome. The iterator API does not mutate process env (unlike
+/// `Config::load_from` / `dotenvy::from_path_override`), so this is safe to
+/// call from inside the migration transaction and from parallel test runs.
 fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSnapshot> {
     let env_path = data_dir.join(".env");
-    let contents = std::fs::read_to_string(&env_path)?;
+    let iter = dotenvy::from_path_iter(&env_path).map_err(std::io::Error::other)?;
 
     let mut developer_mode = false;
     let mut has_any_rpc_password = false;
-
-    for raw_line in contents.lines() {
-        let line = raw_line.trim();
-        if line.is_empty() || line.starts_with('#') {
-            continue;
-        }
-        let Some((key, value)) = line.split_once('=') else {
-            continue;
-        };
-        let key = key.trim();
-        let value = parse_env_value(value);
-
+    for item in iter {
+        let (key, value) = item.map_err(std::io::Error::other)?;
         if key.eq_ignore_ascii_case("DEVELOPER_MODE") {
             developer_mode = matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes");
         } else if key.ends_with("core_rpc_password") && !value.is_empty() {
@@ -78,52 +67,6 @@ fn read_env_file_for_v34_migration(data_dir: &Path) -> std::io::Result<V34EnvSna
         developer_mode,
         has_any_rpc_password,
     })
-}
-
-/// Parse the RHS of a `KEY=...` line the way dotenvy does, minus features we
-/// don't need (variable substitution, backslash escapes). Specifically:
-///
-/// * leading whitespace is stripped
-/// * if the value starts with `'` or `"`, the matching closing quote ends the
-///   value and inner content (including `#`) is preserved verbatim
-/// * outside of quotes, the first whitespace-then-`#` sequence starts an
-///   inline comment and is dropped (e.g. `value # note` → `value`)
-/// * a `#` with no preceding whitespace is a literal character, matching
-///   dotenvy (`value#nohash` → `value#nohash`)
-/// * trailing whitespace is trimmed
-///
-/// Backslash escapes are intentionally not interpreted — the v34 migration only
-/// looks at a boolean flag and whether a password is non-empty, so the cost of
-/// a full escape-aware parser isn't worth it.
-fn parse_env_value(raw: &str) -> String {
-    let trimmed = raw.trim_start();
-
-    // Quoted value — mirror dotenvy: inside quotes, `#` is a literal character.
-    if let Some(rest) = trimmed.strip_prefix('"') {
-        if let Some(end) = rest.find('"') {
-            return rest[..end].to_string();
-        }
-        // Unterminated quote — fall back to the naive strip so we don't lose data.
-        return rest.to_string();
-    }
-    if let Some(rest) = trimmed.strip_prefix('\'') {
-        if let Some(end) = rest.find('\'') {
-            return rest[..end].to_string();
-        }
-        return rest.to_string();
-    }
-
-    // Unquoted value — strip the first whitespace-then-`#` inline comment.
-    let mut end = trimmed.len();
-    let mut prev_ws = false;
-    for (i, c) in trimmed.char_indices() {
-        if c == '#' && prev_ws {
-            end = i;
-            break;
-        }
-        prev_ws = c.is_whitespace();
-    }
-    trimmed[..end].trim_end().to_string()
 }
 
 pub const DEFAULT_NETWORK: &str = "mainnet";
@@ -188,13 +131,6 @@ impl Database {
                 // network's `core_rpc_password` set) keep their existing mode;
                 // everyone else is pinned to SPV. No new persisted flag — the
                 // DB version bump itself is the one-shot gate.
-                //
-                // We parse `.env` directly instead of going through
-                // `Config::load_from()`: the latter uses `dotenvy::from_path_override`
-                // which mutates the process environment and is therefore unfit
-                // for migrations that may run in parallel with other tests /
-                // tools (and more importantly, we have no business leaking
-                // one-shot migration state into the live process env).
                 let migrate_to_spv = match data_dir {
                     Some(dir) => match read_env_file_for_v34_migration(dir) {
                         Ok(env_snapshot) => {
@@ -2547,10 +2483,9 @@ mod test {
 
     // ── v34 migration: SPV-default backend ──────────────────────────
     //
-    // The migration parses `.env` directly (see `read_env_file_for_v34_migration`)
-    // instead of going through `Config::load_from`, so these tests are
-    // self-contained: they do not touch the process environment and can run in
-    // parallel with each other and with anything else in the test suite.
+    // The migration reads `.env` via `dotenvy::from_path_iter`, which does
+    // not mutate the process environment, so these tests are self-contained
+    // and can run in parallel with each other and the rest of the suite.
     mod v34 {
         fn write_env(dir: &std::path::Path, contents: &str) {
             std::fs::write(dir.join(".env"), contents).expect("write .env");
@@ -2664,46 +2599,6 @@ mod test {
                 "try_perform_migration should report no migration needed"
             );
             assert_eq!(db.db_schema_version().unwrap(), 34);
-        }
-
-        // ── parse_env_value: dotenvy-style inline comment + quote handling ──
-        //
-        // These exercise the helper directly so regressions show up as unit
-        // failures with a clear message, not as mysterious migration behaviour.
-        use super::super::parse_env_value;
-
-        #[test]
-        fn parse_env_value_strips_inline_comment() {
-            assert_eq!(parse_env_value("value # trailing note"), "value");
-            assert_eq!(parse_env_value("value\t# tab then hash"), "value");
-            // Whitespace between value and `#` is what enables the comment.
-            assert_eq!(parse_env_value("hunter2  # password comment"), "hunter2");
-        }
-
-        #[test]
-        fn parse_env_value_preserves_hash_inside_quotes() {
-            // Double quotes preserve the `#` and inner whitespace verbatim.
-            assert_eq!(
-                parse_env_value("\"value # with hash\""),
-                "value # with hash"
-            );
-            // Single quotes behave the same.
-            assert_eq!(parse_env_value("'value # with hash'"), "value # with hash");
-            // And content before/after the quoted region is not our concern —
-            // dotenvy only supports a single quoted span for the value.
-            assert_eq!(parse_env_value(" \"quoted\" "), "quoted");
-        }
-
-        #[test]
-        fn parse_env_value_hash_without_whitespace_is_literal() {
-            // Matches dotenvy: a `#` with no preceding whitespace stays in the value.
-            assert_eq!(parse_env_value("value#nohash"), "value#nohash");
-            assert_eq!(
-                parse_env_value("hunter2#still-password"),
-                "hunter2#still-password"
-            );
-            // And a plain unquoted value trims trailing whitespace only.
-            assert_eq!(parse_env_value("  plain  "), "plain");
         }
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -255,8 +255,11 @@ pub async fn init_app_context() -> Result<Arc<AppContext>, McpError> {
         )
     })?;
 
-    // Headless mode has no Dash Core RPC — force SPV backend so wallet
-    // tools work without a local node.
+    // Headless mode has no Dash Core RPC credentials — force SPV backend so
+    // wallet tools work without a local node. This is defence-in-depth even
+    // after the v34 migration: a user could point `det_cli` at a GUI data dir
+    // where someone explicitly chose RPC. We flip the in-memory mode only
+    // (volatile) so the GUI's saved preference is never overwritten.
     if app_context.core_backend_mode() != CoreBackendMode::Spv {
         tracing::info!("Headless mode: forcing SPV backend (was RPC)");
         app_context.set_core_backend_mode_volatile(CoreBackendMode::Spv);

--- a/src/model/feature_gate.rs
+++ b/src/model/feature_gate.rs
@@ -44,6 +44,10 @@ pub enum FeatureGate {
     DeveloperMode,
     /// SPV backend mode — active when the app is running in SPV (light client) mode
     SpvBackend,
+    /// Dash Core RPC backend mode — active when the app is running against a local Dash Core node.
+    /// Use this gate for functionality that requires the Core RPC / ZMQ surface (e.g. the ZMQ
+    /// listener) instead of reaching for a raw `core_backend_mode() == Rpc` comparison.
+    RpcBackend,
 }
 
 impl FeatureGate {
@@ -71,6 +75,7 @@ impl FeatureGate {
             FeatureGate::DashPay => true, // Always for now; future: network/version gate
             FeatureGate::DeveloperMode => ctx.is_developer_mode(),
             FeatureGate::SpvBackend => ctx.core_backend_mode() == CoreBackendMode::Spv,
+            FeatureGate::RpcBackend => ctx.core_backend_mode() == CoreBackendMode::Rpc,
         }
     }
 }

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -36,10 +36,15 @@ use tokio_util::sync::CancellationToken;
 use zeroize::Zeroize;
 
 /// Preferred backend for Core-level operations.
+///
+/// SPV is the default for both fresh installs and unknown/invalid persisted
+/// values. The enum-level default and the `From<u8>` fallback intentionally
+/// match the DB column default and the runtime default in `AppContext` — they
+/// must be kept in sync to avoid silent contradictions at startup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CoreBackendMode {
-    #[default]
     Rpc = 0,
+    #[default]
     Spv = 1,
 }
 
@@ -52,8 +57,8 @@ impl CoreBackendMode {
 impl From<u8> for CoreBackendMode {
     fn from(value: u8) -> Self {
         match value {
-            1 => CoreBackendMode::Spv,
-            _ => CoreBackendMode::Rpc,
+            0 => CoreBackendMode::Rpc,
+            _ => CoreBackendMode::Spv,
         }
     }
 }

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -42,6 +42,7 @@ use zeroize::Zeroize;
 /// match the DB column default and the runtime default in `AppContext` — they
 /// must be kept in sync to avoid silent contradictions at startup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u8)]
 pub enum CoreBackendMode {
     Rpc = 0,
     #[default]

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -501,14 +501,16 @@ async fn test_broadcast_transaction_fails_when_not_running() {
 
 /// Given CoreBackendMode variants,
 /// When converting between u8 and enum via From<u8> and as_u8(),
-/// Then roundtrip is correct (0 = Rpc, 1 = Spv, unknown defaults to Rpc).
+/// Then roundtrip is correct (0 = Rpc, 1 = Spv, unknown defaults to Spv — the
+/// DB column default and the app's runtime default).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_core_backend_mode_roundtrip() {
     use crate::spv::CoreBackendMode;
 
     assert_eq!(CoreBackendMode::from(0), CoreBackendMode::Rpc);
     assert_eq!(CoreBackendMode::from(1), CoreBackendMode::Spv);
-    assert_eq!(CoreBackendMode::from(99), CoreBackendMode::Rpc); // default
+    assert_eq!(CoreBackendMode::from(99), CoreBackendMode::Spv); // default fallback
+    assert_eq!(CoreBackendMode::default(), CoreBackendMode::Spv);
 
     assert_eq!(CoreBackendMode::Rpc.as_u8(), 0);
     assert_eq!(CoreBackendMode::Spv.as_u8(), 1);

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -5,6 +5,7 @@ use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
 use crate::config::Config;
 use crate::context::AppContext;
 use crate::context::connection_status::{ConnectionStatus, OverallConnectionState};
+use crate::model::feature_gate::FeatureGate;
 use crate::model::wallet::DerivationPathHelpers;
 use crate::spv::{CoreBackendMode, SpvStatus, SpvStatusSnapshot};
 use crate::ui::components::component_trait::Component;
@@ -653,10 +654,7 @@ impl NetworkChooserScreen {
                 }
             });
 
-            // TODO: SPV sync progress is hidden when developer mode is OFF.
-            // Remove the developer_mode check once SPV is production-ready.
-            if self.developer_mode
-                && current_backend_mode == CoreBackendMode::Spv
+            if FeatureGate::SpvBackend.is_available(self.current_app_context())
                 && let Some(snap) = snapshot.as_ref()
                 && (snap.status == SpvStatus::Syncing || snap.status == SpvStatus::Starting)
             {
@@ -1215,8 +1213,8 @@ impl NetworkChooserScreen {
                     );
                 });
 
-                // TODO: SPV settings are hidden when developer mode is OFF.
-                // Remove the developer_mode checks once SPV is production-ready.
+                // Advanced SPV peer source configuration is Expert-only —
+                // fresh-install users get auto-discovery, which is the correct default.
                 if self.developer_mode {
                     ui.add_space(12.0);
                     ui.separator();
@@ -1381,9 +1379,9 @@ impl NetworkChooserScreen {
                     app_action |= self.show_database_clear_confirmation(ui);
                 }
 
-                // SPV Maintenance section
-                // TODO: SPV maintenance is hidden when developer mode is OFF.
-                // Remove the developer_mode check once SPV is production-ready.
+                // SPV maintenance (clear data, rescan) is Expert-only — these are
+                // diagnostic tools that can destroy wallet sync state and should not
+                // be exposed to fresh-install users.
                 if self.developer_mode {
                     let current_backend_mode = self.current_app_context().core_backend_mode();
                     if current_backend_mode == CoreBackendMode::Spv {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -524,7 +524,7 @@ impl NetworkChooserScreen {
             let current_backend_mode = *self
                 .backend_modes
                 .entry(self.current_network)
-                .or_insert(CoreBackendMode::Rpc);
+                .or_insert(CoreBackendMode::Spv);
 
             let ctx = self.current_app_context().clone();
             let status = ctx.connection_status();

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -253,24 +253,22 @@ impl NetworkChooserScreen {
                 .spacing([40.0, 12.0])
                 .striped(false)
                 .show(ui, |ui| {
-                    // TODO: SPV is currently hidden behind Developer Mode while still in development.
-                    // Once SPV is production-ready, remove this developer_mode check and make SPV
-                    // the default/primary connection method, with RPC as a fallback option.
                     let current_backend_mode = *self
                         .backend_modes
                         .entry(self.current_network)
-                        .or_insert(CoreBackendMode::Rpc);
+                        .or_insert(CoreBackendMode::Spv);
 
                     if self.developer_mode {
-                        // Row 1: Connection Type (only shown in developer mode)
+                        // Row 1: Connection Type (only shown in Expert mode — the
+                        // connection backend is an advanced power-user choice).
                         ui.label(
                             egui::RichText::new("Connection Type:")
                                 .color(DashColors::text_primary(dark_mode)),
                         );
 
                         let connection_text = match current_backend_mode {
-                            CoreBackendMode::Spv => "SPV Client",
-                            CoreBackendMode::Rpc => "Dash Core RPC",
+                            CoreBackendMode::Spv => "Built-in (SPV)",
+                            CoreBackendMode::Rpc => "Local Dash Core node",
                         };
 
                         let mut connection_mode = current_backend_mode;
@@ -282,7 +280,7 @@ impl NetworkChooserScreen {
                                     .selectable_value(
                                         &mut connection_mode,
                                         CoreBackendMode::Spv,
-                                        "SPV Client",
+                                        "Built-in (SPV)",
                                     )
                                     .changed()
                                 {
@@ -295,7 +293,7 @@ impl NetworkChooserScreen {
                                     .selectable_value(
                                         &mut connection_mode,
                                         CoreBackendMode::Rpc,
-                                        "Dash Core RPC",
+                                        "Local Dash Core node",
                                     )
                                     .changed()
                                 {
@@ -308,33 +306,6 @@ impl NetworkChooserScreen {
                             });
 
                         ui.end_row();
-
-                        // Show experimental warning when SPV mode is selected
-                        if current_backend_mode == CoreBackendMode::Spv {
-                            ui.label(""); // Empty label for grid alignment
-                            egui::Frame::new()
-                                .fill(DashColors::WARNING.gamma_multiply(0.15))
-                                .inner_margin(egui::Margin::symmetric(8, 4))
-                                .stroke(egui::Stroke::new(1.0, DashColors::WARNING))
-                                .corner_radius(4.0)
-                                .show(ui, |ui| {
-                                    ui.horizontal(|ui| {
-                                        ui.label(
-                                            egui::RichText::new("⚠")
-                                                .color(DashColors::WARNING)
-                                                .size(14.0),
-                                        );
-                                        ui.label(
-                                            egui::RichText::new(
-                                                "SPV mode is experimental and still in development",
-                                            )
-                                            .color(DashColors::WARNING)
-                                            .size(12.0),
-                                        );
-                                    });
-                                });
-                            ui.end_row();
-                        }
                     }
 
                     // Row 2: Network
@@ -440,7 +411,7 @@ impl NetworkChooserScreen {
             let current_backend_mode = *self
                 .backend_modes
                 .entry(self.current_network)
-                .or_insert(CoreBackendMode::Rpc);
+                .or_insert(CoreBackendMode::Spv);
             if current_backend_mode == CoreBackendMode::Rpc {
                 ui.add_space(20.0);
                 ui.separator();
@@ -1108,7 +1079,10 @@ impl NetworkChooserScreen {
                 ui.horizontal(|ui| {
                     if StyledCheckbox::new(&mut self.developer_mode, "Expert mode")
                         .show(ui)
-                        .clickable_tooltip("Show advanced options for power users and developers")
+                        .clickable_tooltip(
+                            "Show advanced options for experienced users, including \
+                             Dash Core RPC, developer tools, and signing overrides.",
+                        )
                         .clicked()
                     {
                         for ctx in self.network_contexts.values() {
@@ -1120,18 +1094,6 @@ impl NetworkChooserScreen {
                             config.developer_mode = Some(self.developer_mode);
                             if let Err(e) = config.save(&self.data_dir) {
                                 tracing::error!("Failed to save config: {e}");
-                            }
-                        }
-
-                        // TODO: When developer mode is disabled, stop SPV and switch to RPC.
-                        // Remove this block once SPV is production-ready.
-                        if !self.developer_mode {
-                            for (&network, ctx) in &self.network_contexts {
-                                ctx.stop_spv();
-                                if ctx.core_backend_mode() == CoreBackendMode::Spv {
-                                    ctx.set_core_backend_mode(CoreBackendMode::Rpc);
-                                }
-                                self.backend_modes.insert(network, CoreBackendMode::Rpc);
                             }
                         }
                     }


### PR DESCRIPTION
## User Story

Imagine you are a new user installing Dash Evo Tool for the first time. You want to check your balance, send a payment, or register a DPNS name — but you don't run a full Dash Core node, don't know what RPC is, and don't want to install `dashd`.

Today, Dash Evo Tool would silently require you to have a local Dash Core node running and complain when it can't connect. After this PR, it just works: the built-in SPV light client connects you to the Dash network directly. No node, no port forwarding, no RPC credentials. For experienced users who *do* run a local node, Expert mode still exposes the Dash Core RPC option.

## Summary

Flips the default connection axis in Dash Evo Tool:

- **SPV is the default for every user.** New installs start syncing via the built-in light client out of the box.
- **Dash Core RPC moves behind the Expert mode checkbox.** Power users who run a local node still get full control.
- **Existing Dash Core users are preserved automatically.** A one-shot DB migration (v33 → v34) keeps their RPC connection if they had it configured (`developer_mode=true` + a `core_rpc_password` in `.env`). Everyone else is migrated to SPV.
- **Expert mode becomes a pure visibility toggle.** Turning it off no longer mutates the stored connection mode — the user's explicit choice is preserved across the toggle.

### Key code changes

- `CoreBackendMode::default()` flipped from `Rpc` to `Spv`; `From<u8>` unknown-byte fallback flipped accordingly.
- `AppContext::new()` no longer silently force-flips SPV → RPC when developer mode is off.
- New `FeatureGate::RpcBackend` variant so connection-mode predicates go through the central registry (Phase 5 DRY rule).
- `spawn_zmq_listener` gated on `FeatureGate::RpcBackend` — no burning a socket + retry loop for SPV-only users.
- `try_auto_start_spv` no longer requires developer mode.
- New DB migration v33 → v34 in `initialization.rs`. Reads `.env` via `dotenvy::from_path_iter` (the non-mutating iterator API) to avoid polluting process environment during DB init — important for test parallelism and one-shot migration hygiene. `Config::load_from()` / `dotenvy::from_path_override` would have set_var'd every key and raced across parallel migration tests.
- UX regression fix: SPV sync progress in the Network Chooser no longer hides from non-Expert users. They *are* the default SPV cohort now; they need to see it.
- Three stale "once SPV is production-ready" TODOs retired. Two remaining dev-mode gates (advanced SPV peer config + SPV maintenance diagnostics) now have comments explaining why they are legitimately Expert-only.

### Follow-up TODOs (filed as deferred work)

- Migrate existing ~25 raw `ctx.is_developer_mode()` call sites across tokens, wallets, identities, etc. to `FeatureGate::DeveloperMode`. Pure refactor.
- Migrate predicate-style `core_backend_mode() == …` comparisons (`backend_task/core/`, `context/connection_status.rs`, etc.) to `FeatureGate::RpcBackend` / `SpvBackend`. Leave genuine two-branch `match` dispatches alone.
- Diziet's full Connection card redesign (jargon-free Everyday User status line, parity-gap micro-notices, read-only RPC endpoint display, Reconnect button).
- Consider splitting `developer_mode` into two orthogonal flags: one for the node-operator case, one for signing/security overrides.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo test --all-features --workspace` — 461 lib + 10 e2e + 72 kittest + 3 doctest; 0 failed, 2 ignored (testnet-bound)
- [x] 5 v34 migration unit tests covering: preserve-mode for Expert+RPC configured, flip-to-SPV when `developer_mode=false`, flip-to-SPV when Expert but no RPC password set, flip-to-SPV when `.env` missing, idempotence on re-run
- [x] 1 fresh-DB integration test asserting `core_backend_mode == Spv` post-init
- [x] Phase 5 DRY / layering audit: 8/8 pass
- [ ] Manual QA — fresh install UX: connects via SPV without any configuration; no mention of "SPV" or "RPC" in default UI
- [ ] Manual QA — existing Dash Core user (Expert + `core_rpc_password` set): mode preserved after migration; app connects via RPC as before
- [ ] Manual QA — existing non-Expert user: migrated to SPV; can turn on Expert mode and switch to Local Dash Core node
- [ ] Manual QA — Expert toggle lifecycle: turn on → selector appears → pick Local Dash Core node; turn off → selector hides; turn on → mode still Local Dash Core node (not silently flipped to SPV)
- [ ] Manual QA — MCP headless (\`det_cli\`): forces SPV via volatile override, no RPC attempts
- [ ] Manual QA — SPV sync progress widget visible in Network Chooser for default (non-Expert) users

## Rollback

Revert as a single-PR revert. Existing v34 databases do not auto-downgrade — users needing full rollback must restore the backup (timestamped backups are created automatically by the migration framework before each version bump).

## Migration

Runs once inside the existing DB migration framework (v33 → v34, inside a transaction, with automatic DB backup). Rules:

| Conditions                                                                    | Outcome                               |
|-------------------------------------------------------------------------------|---------------------------------------|
| \`developer_mode == false\` (or unset in \`.env\`)                                | \`core_backend_mode = Spv\`             |
| \`developer_mode == true\` AND no network has \`core_rpc_password\` set           | \`core_backend_mode = Spv\`             |
| \`developer_mode == true\` AND at least one network has \`core_rpc_password\` set | *leave \`core_backend_mode\` untouched* |

No new tracking variables; the DB schema version bump is the one-shot gate.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SPV (built-in light client) now defaults for fresh installs and new connections
  * Simplified connection type labels: "Built-in (SPV)" and "Local Dash Core node"
  * Added capability-based feature gating for RPC functionality

* **Documentation**
  * Updated user story documenting fresh-install experience with SPV backend and zero-configuration setup

* **Tests**
  * Updated backend mode tests to reflect SPV as the new default

<!-- end of auto-generated comment: release notes by coderabbit.ai -->