### PR TITLE
fix(tokens): user-friendly error messages for 3 token operations

### DIFF
--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -622,6 +622,35 @@ pub enum TaskError {
     #[error("Could not retrieve token information from the platform. Please retry.")]
     TokenQueryError { detail: String },
 
+    /// The token does not have a perpetual distribution configured — no rewards to claim.
+    #[error("This token does not have perpetual distribution, so there are no rewards to claim.")]
+    TokenNoPerpetualDistribution,
+
+    /// The recipient identity does not exist on Platform (e.g. during a token mint).
+    #[error(
+        "The recipient identity `{recipient_id}` does not exist on the platform. \
+         Check the ID and try again, or create the identity first."
+    )]
+    TokenRecipientIdentityNotFound {
+        recipient_id: String,
+        #[source]
+        source_error: Box<SdkError>,
+    },
+
+    /// The identity's token account is not frozen, so an unfreeze / destroy-frozen action
+    /// cannot proceed.
+    #[error(
+        "Identity `{identity_id}` is not frozen for token `{token_id}`, so `{action}` cannot proceed. \
+         Refresh the frozen-account list and try again."
+    )]
+    TokenAccountNotFrozen {
+        identity_id: String,
+        token_id: String,
+        action: String,
+        #[source]
+        source_error: Box<SdkError>,
+    },
+
     // ──────────────────────────────────────────────────────────────────────────
     // Contract schema errors
     // ──────────────────────────────────────────────────────────────────────────
@@ -1265,6 +1294,14 @@ impl From<SdkError> for TaskError {
             InvalidTokenBaseSupply {
                 base_supply: u64,
             },
+            RecipientIdentityNotFound {
+                recipient_id: String,
+            },
+            TokenAccountNotFrozen {
+                identity_id: String,
+                token_id: String,
+                action: String,
+            },
         }
 
         let kind: Option<ConsensusKind> = {
@@ -1340,6 +1377,18 @@ impl From<SdkError> for TaskError {
                             base_supply: e.base_supply(),
                         })
                     }
+                    ConsensusError::StateError(StateError::RecipientIdentityDoesNotExistError(
+                        e,
+                    )) => Some(ConsensusKind::RecipientIdentityNotFound {
+                        recipient_id: e.recipient_id().to_string(Encoding::Base58),
+                    }),
+                    ConsensusError::StateError(StateError::IdentityTokenAccountNotFrozenError(
+                        e,
+                    )) => Some(ConsensusKind::TokenAccountNotFrozen {
+                        identity_id: e.identity_id().to_string(Encoding::Base58),
+                        token_id: e.token_id().to_string(Encoding::Base58),
+                        action: e.action().to_string(),
+                    }),
                     _ => None,
                 })
                 .or_else(|| {
@@ -1437,6 +1486,22 @@ impl From<SdkError> for TaskError {
                     source_error: boxed,
                 }
             }
+            Some(ConsensusKind::RecipientIdentityNotFound { recipient_id }) => {
+                TaskError::TokenRecipientIdentityNotFound {
+                    recipient_id,
+                    source_error: boxed,
+                }
+            }
+            Some(ConsensusKind::TokenAccountNotFrozen {
+                identity_id,
+                token_id,
+                action,
+            }) => TaskError::TokenAccountNotFrozen {
+                identity_id,
+                token_id,
+                action,
+                source_error: boxed,
+            },
             None => {
                 // Extract timeout duration before consuming boxed.
                 let timeout_secs = if let SdkError::TimeoutReached(d, _) = &*boxed {
@@ -2685,6 +2750,105 @@ mod tests {
         assert!(
             msg.contains("smaller value"),
             "Expected actionable guidance, got: {msg}"
+        );
+    }
+
+    // ─── New token error tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_token_no_perpetual_distribution_display() {
+        let err = TaskError::TokenNoPerpetualDistribution;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("perpetual distribution"),
+            "Expected perpetual distribution mention, got: {msg}"
+        );
+        assert!(
+            msg.contains("no rewards to claim"),
+            "Expected actionable info, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_recipient_identity_not_found_from_consensus_error() {
+        use dash_sdk::dpp::consensus::state::identity::RecipientIdentityDoesNotExistError;
+        let recipient_id = Identifier::random();
+        let expected_id_str = recipient_id.to_string(Encoding::Base58);
+        let consensus = ConsensusError::from(RecipientIdentityDoesNotExistError::new(recipient_id));
+        let broadcast_err = dash_sdk::error::StateTransitionBroadcastError {
+            code: 40216,
+            message: "recipient identity does not exist".to_string(),
+            cause: Some(consensus),
+        };
+        let sdk_err = SdkError::StateTransitionBroadcastError(broadcast_err);
+        let err = TaskError::from(sdk_err);
+        assert!(
+            matches!(
+                err,
+                TaskError::TokenRecipientIdentityNotFound {
+                    ref recipient_id,
+                    ..
+                } if *recipient_id == expected_id_str
+            ),
+            "Expected TokenRecipientIdentityNotFound with correct id, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&expected_id_str),
+            "Expected recipient id in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("does not exist"),
+            "Expected existence message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_identity_token_account_not_frozen_from_consensus_error() {
+        use dash_sdk::dpp::consensus::state::token::IdentityTokenAccountNotFrozenError;
+        let token_id = Identifier::random();
+        let identity_id = Identifier::random();
+        let action = "Unfreeze".to_string();
+        let expected_token_id_str = token_id.to_string(Encoding::Base58);
+        let expected_identity_id_str = identity_id.to_string(Encoding::Base58);
+        let consensus = ConsensusError::from(IdentityTokenAccountNotFrozenError::new(
+            token_id,
+            identity_id,
+            action.clone(),
+        ));
+        let broadcast_err = dash_sdk::error::StateTransitionBroadcastError {
+            code: 40220,
+            message: "identity token account is not frozen".to_string(),
+            cause: Some(consensus),
+        };
+        let sdk_err = SdkError::StateTransitionBroadcastError(broadcast_err);
+        let err = TaskError::from(sdk_err);
+        assert!(
+            matches!(
+                err,
+                TaskError::TokenAccountNotFrozen {
+                    ref identity_id,
+                    ref token_id,
+                    ref action,
+                    ..
+                } if *identity_id == expected_identity_id_str
+                    && *token_id == expected_token_id_str
+                    && *action == "Unfreeze"
+            ),
+            "Expected TokenAccountNotFrozen with correct fields, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&expected_identity_id_str),
+            "Expected identity id in message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&expected_token_id_str),
+            "Expected token id in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("Unfreeze"),
+            "Expected action in message, got: {msg}"
         );
     }
 }

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -2792,6 +2792,12 @@ mod tests {
             ),
             "Expected TokenRecipientIdentityNotFound with correct id, got: {err:?}"
         );
+        // Source chain must be preserved so the collapsible details panel / logs
+        // retain the full technical context.
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "Expected source chain to be preserved, got None"
+        );
         let msg = err.to_string();
         assert!(
             msg.contains(&expected_id_str),
@@ -2817,7 +2823,7 @@ mod tests {
             action.clone(),
         ));
         let broadcast_err = dash_sdk::error::StateTransitionBroadcastError {
-            code: 40220,
+            code: 40703,
             message: "identity token account is not frozen".to_string(),
             cause: Some(consensus),
         };
@@ -2836,6 +2842,12 @@ mod tests {
                     && *action == "Unfreeze"
             ),
             "Expected TokenAccountNotFrozen with correct fields, got: {err:?}"
+        );
+        // Source chain must be preserved so the collapsible details panel / logs
+        // retain the full technical context.
+        assert!(
+            std::error::Error::source(&err).is_some(),
+            "Expected source chain to be preserved, got None"
         );
         let msg = err.to_string();
         assert!(

--- a/src/backend_task/tokens/query_token_non_claimed_perpetual_distribution_rewards.rs
+++ b/src/backend_task/tokens/query_token_non_claimed_perpetual_distribution_rewards.rs
@@ -81,9 +81,7 @@ impl AppContext {
         let perpetual_distribution = token_config
             .distribution_rules()
             .perpetual_distribution()
-            .ok_or(TaskError::TokenQueryError {
-                detail: "Token does not have perpetual distribution".to_string(),
-            })?;
+            .ok_or(TaskError::TokenNoPerpetualDistribution)?;
         let data_contract = self
             .get_contract_by_token_id(&token_id)?
             .ok_or(TaskError::DataContractNotFound)?;


### PR DESCRIPTION
Closes #846.

## Summary

Replaces three confusing/raw-technical error messages in the token screen with dedicated typed `TaskError` variants and Everyday-User-voice messages.

## User Story

Imagine you are a token administrator trying to mint, unfreeze, or claim rewards. Previously, when something went wrong the banner would show raw SDK internals like `PlatformRejected { source_error: StateTransitionBroadcastError { code: 40216, ... RecipientIdentityDoesNotExistError { recipient_id: Identifier(IdentifierBytes32([...])) } }`. Now it says *"The recipient identity `<Base58 id>` does not exist on the platform. Check the ID and try again, or create the identity first."* — and you can actually do something about it.

## Changes

New `TaskError` variants (with `#[source]` preserving the full error chain for the collapsible details panel):

- `TokenNoPerpetualDistribution` — fieldless. Replaces the specific `TokenQueryError { detail: "Token does not have perpetual distribution" }` callsite in `query_token_non_claimed_perpetual_distribution_rewards.rs`.
- `TokenRecipientIdentityNotFound { recipient_id, source_error }` — mapped from `StateError::RecipientIdentityDoesNotExistError` (code `40216`). Triggered when minting to an identity that doesn't exist.
- `TokenAccountNotFrozen { identity_id, token_id, action, source_error }` — mapped from `StateError::IdentityTokenAccountNotFrozenError` (code `40703`). Triggered on Unfreeze / Destroy Frozen Funds against a non-frozen account.

Consensus-error mapping wired through the existing `ConsensusKind` match in `impl From<SdkError> for TaskError`.

Scope limited to the token screen per issue direction. `TokenQueryError` kept — still used by other callsites.

## Test Plan

- [x] `cargo test --all-features -p dash-evo-tool --lib -- backend_task::error` — 76/76 pass, including 3 new unit tests covering consensus-error → `TaskError` conversion and `Display` output shape.
- [x] `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [ ] Manual acceptance tests posted on the issue: https://github.com/dashpay/dash-evo-tool/issues/846#issuecomment-4311501505 — four scenarios (claim-without-distribution, mint-to-nonexistent, unfreeze-not-frozen, destroy-not-frozen).

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error clarity for token operations: added specific error messages for missing perpetual distribution, missing recipient identities, and unfrozen account states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->