### PR TITLE
refactor(context): typed address-watch registration (ensure_address_watched)

### DIFF
--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -999,6 +999,23 @@ pub enum TaskError {
     /// Creating a network context failed during a network switch.
     #[error("Could not connect to {network}. Check your network configuration and retry.")]
     NetworkContextCreationFailed { network: Network, detail: String },
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Address-watch registration errors
+    // ──────────────────────────────────────────────────────────────────────────
+    /// An off-tree address (not covered by the standard BIP44 account watch)
+    /// could not be registered with the SPV subsystem. The running SPV loop
+    /// currently has no runtime registration API, so addresses outside the
+    /// wallet's BIP44 account may not receive their incoming transactions until
+    /// the wallet is reloaded.
+    ///
+    /// The associated Base58 address lets users identify which handle is
+    /// affected.
+    #[error(
+        "Could not start watching address {address}. Please reload the wallet and retry, \
+         or switch to Dash Core RPC mode in Expert settings if the problem persists."
+    )]
+    SpvOffTreeAddressRegistrationUnsupported { address: String },
 }
 
 /// Escapes control characters in a token name for safe display in error messages.

--- a/src/context/address_watch.rs
+++ b/src/context/address_watch.rs
@@ -1,0 +1,103 @@
+//! Typed address-watch registration for `AppContext`.
+//!
+//! The previous pair `ensure_address_imported` / `try_import_address` silently
+//! no-opped in SPV mode and relied on an undocumented precondition — that the
+//! address was already covered by the wallet's account-level watch. That was
+//! true for standard BIP44 receive addresses derived from the wallet xprv, but
+//! not for DashPay DIP-15 contact paths, imported single-key addresses, or
+//! P2SH multisig outputs.
+//!
+//! [`AddressCoverage`] forces callers to declare how SPV coverage is provided
+//! for an address so [`AppContext::ensure_address_watched`] can dispatch to
+//! the right subsystem and never silently drop coverage.
+//!
+//! [`AppContext::ensure_address_watched`]: crate::context::AppContext::ensure_address_watched
+
+use crate::model::wallet::DerivationPathReference;
+
+/// How SPV coverage is provided for an address being registered.
+///
+/// Callers must pick the variant that matches how the address was obtained.
+/// The wrong variant can cause incoming transactions to be missed (off-tree
+/// address classified as BIP44) or waste a runtime SPV registration slot
+/// (BIP44 address classified as off-tree).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressCoverage {
+    /// Address derived inside the wallet's standard BIP44 account
+    /// (`m/44'/coin'/0'/change/index`).
+    ///
+    /// SPV coverage is automatic via the account-level watch set up at wallet
+    /// load; no explicit SPV registration is required. In Core RPC mode the
+    /// address is imported into the wallet as watch-only.
+    StandardBip44Account,
+
+    /// Address derived outside the standard BIP44 account.
+    ///
+    /// Covers DashPay DIP-15 contact paths, imported single-key wallets,
+    /// Blockchain-Identities paths (`m/9'/…`), platform-payment addresses
+    /// (DIP-17), multisig outputs, and anything else that does not belong to
+    /// the wallet's BIP44 receive/change chains.
+    ///
+    /// In Core RPC mode the address is imported into the wallet as watch-only.
+    /// In SPV mode the running subsystem currently has no runtime registration
+    /// hook — see the `TODO(refactor)` note in
+    /// [`AppContext::ensure_address_watched`] and [`TaskError::SpvOffTreeAddressRegistrationUnsupported`].
+    ///
+    /// [`AppContext::ensure_address_watched`]: crate::context::AppContext::ensure_address_watched
+    /// [`TaskError::SpvOffTreeAddressRegistrationUnsupported`]: crate::backend_task::error::TaskError::SpvOffTreeAddressRegistrationUnsupported
+    OffTree,
+}
+
+impl AddressCoverage {
+    /// Map a [`DerivationPathReference`] to the appropriate coverage variant.
+    ///
+    /// Used by the wallet's internal address-registration helpers to pick the
+    /// correct variant without burdening every caller with the classification.
+    pub fn from_derivation_path_reference(reference: DerivationPathReference) -> Self {
+        match reference {
+            DerivationPathReference::BIP44 => Self::StandardBip44Account,
+            _ => Self::OffTree,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bip44_maps_to_standard_account() {
+        assert_eq!(
+            AddressCoverage::from_derivation_path_reference(DerivationPathReference::BIP44),
+            AddressCoverage::StandardBip44Account,
+        );
+    }
+
+    #[test]
+    fn non_bip44_references_map_to_off_tree() {
+        let off_tree_refs = [
+            DerivationPathReference::BIP32,
+            DerivationPathReference::BlockchainIdentities,
+            DerivationPathReference::ProviderFunds,
+            DerivationPathReference::ContactBasedFunds,
+            DerivationPathReference::ContactBasedFundsRoot,
+            DerivationPathReference::ContactBasedFundsExternal,
+            DerivationPathReference::BlockchainIdentityCreditRegistrationFunding,
+            DerivationPathReference::BlockchainIdentityCreditTopupFunding,
+            DerivationPathReference::BlockchainIdentityCreditInvitationFunding,
+            DerivationPathReference::ProviderPlatformNodeKeys,
+            DerivationPathReference::CoinJoin,
+            DerivationPathReference::PlatformPayment,
+            DerivationPathReference::Root,
+            DerivationPathReference::Unknown,
+        ];
+        for reference in off_tree_refs {
+            assert_eq!(
+                AddressCoverage::from_derivation_path_reference(reference),
+                AddressCoverage::OffTree,
+                "reference {:?} should map to OffTree",
+                reference,
+            );
+        }
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,3 +1,4 @@
+pub mod address_watch;
 pub mod connection_status;
 mod contract_token_db;
 mod identity_db;
@@ -5,6 +6,8 @@ mod settings_db;
 pub mod shielded;
 mod transaction_processing;
 mod wallet_lifecycle;
+
+pub use address_watch::AddressCoverage;
 
 pub(crate) use transaction_processing::get_transaction_info;
 
@@ -703,9 +706,84 @@ impl AppContext {
         Self::create_core_rpc_client(&url, self.network, &cfg.devnet_name, &cfg)
     }
 
+    /// Ensure SPV/Core is watching the given address, dispatching by
+    /// [`AddressCoverage`] and the active backend mode.
+    ///
+    /// # Dispatch matrix
+    ///
+    /// | Coverage                   | Core RPC mode                             | SPV mode                                                   |
+    /// |----------------------------|-------------------------------------------|------------------------------------------------------------|
+    /// | `StandardBip44Account`     | Import into the targeted Core wallet.     | No-op — wallet-level account watch already covers it.      |
+    /// | `OffTree`                  | Import into the targeted Core wallet.     | Returns [`TaskError::SpvOffTreeAddressRegistrationUnsupported`]. |
+    ///
+    /// Replaces the legacy `ensure_address_imported` / `try_import_address`
+    /// pair; see [`crate::context::address_watch`] for rationale.
+    ///
+    /// Fire-and-forget callers must use `let _` explicitly so the type system
+    /// makes the error-swallowing visible at the call site.
+    pub fn ensure_address_watched(
+        &self,
+        address: &Address,
+        coverage: AddressCoverage,
+        core_wallet_name: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<(), TaskError> {
+        match self.core_backend_mode() {
+            CoreBackendMode::Rpc => self.import_address_into_core(address, core_wallet_name, label),
+            CoreBackendMode::Spv => match coverage {
+                AddressCoverage::StandardBip44Account => Ok(()),
+                AddressCoverage::OffTree => {
+                    // TODO(refactor): SpvManager has no runtime API to register an
+                    // extra address outside the wallet's BIP44 account watch.
+                    // Until that upstream hook exists, surface a typed error so
+                    // callers can decide (warn-and-continue vs abort). The wallet
+                    // reload path covers these addresses once the user restarts
+                    // the SPV loop.
+                    tracing::warn!(
+                        address = %address,
+                        "Off-tree address registration requested in SPV mode; \
+                         running SPV loop has no runtime registration hook. \
+                         Incoming transactions to this address may be missed \
+                         until the wallet is reloaded."
+                    );
+                    Err(TaskError::SpvOffTreeAddressRegistrationUnsupported {
+                        address: address.to_string(),
+                    })
+                }
+            },
+        }
+    }
+
     /// Import an address into the correct Core wallet if it's not already known.
     /// Uses `core_wallet_name` to target the right wallet on multi-wallet nodes.
     /// No-op if the address is already watched/mine.
+    fn import_address_into_core(
+        &self,
+        address: &Address,
+        core_wallet_name: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<(), TaskError> {
+        let client = self.core_client_for_wallet(core_wallet_name)?;
+        let info = client
+            .get_address_info(address)
+            .map_err(|e| self.rpc_error_with_url(e))?;
+        if !(info.is_watchonly || info.is_mine) {
+            client
+                .import_address(address, label, Some(false))
+                .map_err(|e| self.rpc_error_with_url(e))?;
+        }
+        Ok(())
+    }
+
+    /// Legacy: retained only until all callers migrate to [`Self::ensure_address_watched`].
+    ///
+    /// Pre-existing behaviour: works in Core RPC mode, silently no-ops in SPV
+    /// mode. This is exactly the bug the typed API fixes — once every caller
+    /// has migrated, this method is removed.
+    #[deprecated(
+        note = "use `ensure_address_watched` with an explicit `AddressCoverage`; \
+                silent no-op in SPV mode hides off-tree coverage bugs"
+    )]
     pub fn ensure_address_imported(
         &self,
         address: &Address,
@@ -724,7 +802,11 @@ impl AppContext {
         Ok(())
     }
 
-    /// Import address into Core, ignoring errors. For best-effort registration.
+    /// Legacy: retained only until all callers migrate to [`Self::ensure_address_watched`].
+    #[deprecated(
+        note = "use `ensure_address_watched` with an explicit `AddressCoverage`; \
+                silent no-op in SPV mode hides off-tree coverage bugs"
+    )]
     pub fn try_import_address(
         &self,
         address: &Address,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -716,8 +716,9 @@ impl AppContext {
     /// | `StandardBip44Account`     | Import into the targeted Core wallet.     | No-op — wallet-level account watch already covers it.      |
     /// | `OffTree`                  | Import into the targeted Core wallet.     | Returns [`TaskError::SpvOffTreeAddressRegistrationUnsupported`]. |
     ///
-    /// Replaces the legacy `ensure_address_imported` / `try_import_address`
-    /// pair; see [`crate::context::address_watch`] for rationale.
+    /// See [`crate::context::address_watch`] for rationale and the history
+    /// of the legacy `ensure_address_imported` / `try_import_address` pair
+    /// this method replaced.
     ///
     /// Fire-and-forget callers must use `let _` explicitly so the type system
     /// makes the error-swallowing visible at the call site.
@@ -773,49 +774,6 @@ impl AppContext {
                 .map_err(|e| self.rpc_error_with_url(e))?;
         }
         Ok(())
-    }
-
-    /// Legacy: retained only until all callers migrate to [`Self::ensure_address_watched`].
-    ///
-    /// Pre-existing behaviour: works in Core RPC mode, silently no-ops in SPV
-    /// mode. This is exactly the bug the typed API fixes — once every caller
-    /// has migrated, this method is removed.
-    #[deprecated(
-        note = "use `ensure_address_watched` with an explicit `AddressCoverage`; \
-                silent no-op in SPV mode hides off-tree coverage bugs"
-    )]
-    pub fn ensure_address_imported(
-        &self,
-        address: &Address,
-        core_wallet_name: Option<&str>,
-        label: Option<&str>,
-    ) -> Result<(), TaskError> {
-        let client = self.core_client_for_wallet(core_wallet_name)?;
-        let info = client
-            .get_address_info(address)
-            .map_err(|e| self.rpc_error_with_url(e))?;
-        if !(info.is_watchonly || info.is_mine) {
-            client
-                .import_address(address, label, Some(false))
-                .map_err(|e| self.rpc_error_with_url(e))?;
-        }
-        Ok(())
-    }
-
-    /// Legacy: retained only until all callers migrate to [`Self::ensure_address_watched`].
-    #[deprecated(
-        note = "use `ensure_address_watched` with an explicit `AddressCoverage`; \
-                silent no-op in SPV mode hides off-tree coverage bugs"
-    )]
-    pub fn try_import_address(
-        &self,
-        address: &Address,
-        core_wallet_name: Option<&str>,
-        label: Option<&str>,
-    ) {
-        if let Ok(client) = self.core_client_for_wallet(core_wallet_name) {
-            let _ = client.import_address(address, label, Some(false));
-        }
     }
 
     /// Convert an RPC error to `TaskError`, enriching connection failures with

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -1000,16 +1000,8 @@ impl Wallet {
                 known_public_key = Some(public_key);
                 if let Some(app_context) = register {
                     let address = Address::p2pkh(&public_key, network);
-                    app_context.try_import_address(
-                        &address,
-                        self.core_wallet_name.as_deref(),
-                        Some(&format!(
-                            "Managed by Dash Evo Tool {} {}",
-                            self.alias.clone().unwrap_or_default(),
-                            derivation_path
-                        )),
-                    );
-
+                    // `register_address` handles address-watch registration internally
+                    // (dispatches by backend mode via `ensure_address_watched`).
                     self.register_address(
                         address,
                         &derivation_path,
@@ -1199,8 +1191,26 @@ impl Wallet {
             },
         );
 
-        if app_context.core_backend_mode() == crate::spv::CoreBackendMode::Rpc {
-            app_context.try_import_address(&address, self.core_wallet_name.as_deref(), None);
+        let coverage =
+            crate::context::AddressCoverage::from_derivation_path_reference(path_reference);
+        if let Err(e) = app_context.ensure_address_watched(
+            &address,
+            coverage,
+            self.core_wallet_name.as_deref(),
+            None,
+        ) {
+            // Best-effort: we've already persisted the address in the wallet
+            // maps and database, so downstream lookups still work. Only the
+            // external watch (Core RPC import or SPV registration) failed;
+            // log loudly and continue so the caller isn't blocked.
+            tracing::warn!(
+                address = %address,
+                error = %e,
+                ?coverage,
+                "Failed to register address for external watch; wallet-side \
+                 bookkeeping succeeded but incoming transactions may be missed \
+                 until the wallet is reloaded."
+            );
         }
 
         tracing::trace!(

--- a/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs
@@ -4,6 +4,7 @@ use crate::backend_task::error::TaskError;
 use crate::backend_task::identity::{
     IdentityRegistrationInfo, IdentityTask, RegisterIdentityFundingMethod,
 };
+use crate::context::AddressCoverage;
 use crate::ui::MessageType;
 use crate::ui::components::MessageBanner;
 use crate::ui::identities::add_new_identity_screen::{
@@ -31,16 +32,18 @@ impl AddNewIdentityScreen {
 
                     if let Some(has_address) = self.core_has_funding_address {
                         if !has_address {
-                            self.app_context.ensure_address_imported(
+                            self.app_context.ensure_address_watched(
                                 &receive_address,
+                                AddressCoverage::StandardBip44Account,
                                 core_wallet_name.as_deref(),
                                 Some("Managed by Dash Evo Tool"),
                             )?;
                         }
                         self.funding_address = Some(receive_address);
                     } else {
-                        self.app_context.ensure_address_imported(
+                        self.app_context.ensure_address_watched(
                             &receive_address,
+                            AddressCoverage::StandardBip44Account,
                             core_wallet_name.as_deref(),
                             Some("Managed by Dash Evo Tool"),
                         )?;

--- a/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
+++ b/src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs
@@ -2,6 +2,7 @@ use crate::app::AppAction;
 use crate::backend_task::BackendTask;
 use crate::backend_task::error::TaskError;
 use crate::backend_task::identity::{IdentityTask, IdentityTopUpInfo, TopUpIdentityFundingMethod};
+use crate::context::AddressCoverage;
 use crate::ui::MessageType;
 use crate::ui::components::MessageBanner;
 use crate::ui::identities::funding_common::{self, copy_to_clipboard, generate_qr_code_image};
@@ -23,8 +24,9 @@ impl TopUpIdentityScreen {
                     let core_wallet_name = wallet.core_wallet_name.clone();
                     drop(wallet);
 
-                    self.app_context.ensure_address_imported(
+                    self.app_context.ensure_address_watched(
                         &receive_address,
+                        AddressCoverage::StandardBip44Account,
                         core_wallet_name.as_deref(),
                         Some("Managed by Dash Evo Tool"),
                     )?;

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -2,7 +2,7 @@ use crate::app::AppAction;
 use crate::backend_task::core::{CoreItem, CoreTask};
 use crate::backend_task::error::TaskError;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult};
-use crate::context::AppContext;
+use crate::context::{AddressCoverage, AppContext};
 use crate::model::amount::Amount;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::wallet::Wallet;
@@ -106,19 +106,22 @@ impl CreateAssetLockScreen {
         let core_wallet_name = wallet.core_wallet_name.clone();
         drop(wallet);
 
-        // Import address to core if needed
+        // Ensure the funding address is watched (Core-RPC: imports into the
+        // targeted Core wallet; SPV: covered by the BIP44 account watch).
         if let Some(has_address) = self.core_has_funding_address {
             if !has_address {
-                self.app_context.ensure_address_imported(
+                self.app_context.ensure_address_watched(
                     &receive_address,
+                    AddressCoverage::StandardBip44Account,
                     core_wallet_name.as_deref(),
                     Some("Managed by Dash Evo Tool - Asset Lock"),
                 )?;
             }
             self.funding_address = Some(receive_address);
         } else {
-            self.app_context.ensure_address_imported(
+            self.app_context.ensure_address_watched(
                 &receive_address,
+                AddressCoverage::StandardBip44Account,
                 core_wallet_name.as_deref(),
                 Some("Managed by Dash Evo Tool - Asset Lock"),
             )?;


### PR DESCRIPTION
## Summary

Replaces the pair `AppContext::ensure_address_imported` /
`AppContext::try_import_address` with a single typed entry point
`ensure_address_watched(address, coverage, …)` that forces callers to
declare how SPV coverage is provided for the address and dispatches
accordingly. Eliminates the undocumented precondition that the old pair
silently relied on.

## Motivation

The legacy pair:

- Only made sense in Core RPC mode.
- No-opped silently in SPV mode (see
  [PR #839](https://github.com/dashpay/dash-evo-tool/pull/839)'s Copilot /
  CodeRabbit threads and the minimum SPV guard added there).
- Had an undocumented precondition that the address was already covered
  by SPV's account-level watch — true for standard BIP44 receive
  addresses derived from the wallet xprv; **not** true for DashPay
  DIP-15 contact paths, imported single-key wallets, Blockchain-Identities
  paths (`m/9'/…`), Platform-Payment paths (DIP-17), or multisig
  outputs.
- Ignored the precondition — an off-tree address passed in SPV mode
  would silently fail to be watched, and funds to that address would
  never be discovered.

PR #839 patches the specific SPV-mode QR-funding symptom; this PR
addresses the underlying API shape so the bug class cannot recur.

## Design

### `AddressCoverage` enum

```rust
pub enum AddressCoverage {
    /// Covered by the wallet's BIP44 account watch
    /// (`m/44'/coin'/0'/change/index`). SPV = no-op,
    /// Core RPC = import as watch-only.
    StandardBip44Account,
    /// DashPay contact paths, imported single-key wallets,
    /// Blockchain-Identities (m/9'/…), Platform-Payment (DIP-17),
    /// multisig. SPV = TODO hook (see below); Core RPC = import
    /// as watch-only.
    OffTree,
}
```

A convenience constructor
`AddressCoverage::from_derivation_path_reference(DerivationPathReference)`
maps `BIP44` → `StandardBip44Account` and every other variant →
`OffTree`, so the wallet's internal `register_address` helper picks the
right coverage without burdening every caller with the classification.

Started at the simpler two-variant shape — richer variants
(`DashPayContact { our_identity, contact, index }`, `RawImportedKey`,
…) can be added incrementally when they actually remove a string /
integer from downstream logic. None are needed today.

### `ensure_address_watched` dispatch matrix

| Coverage               | Core RPC mode                       | SPV mode                                                           |
|------------------------|-------------------------------------|--------------------------------------------------------------------|
| `StandardBip44Account` | Import into the targeted Core wallet. | No-op — wallet-level account watch already covers it.               |
| `OffTree`              | Import into the targeted Core wallet. | Returns `TaskError::SpvOffTreeAddressRegistrationUnsupported` with the Base58 address. |

Error propagation replaces silent `let _`: fire-and-forget call sites
must now use `let _ = …` or explicit matching, so the swallowing is
visible at the call site.

### New `TaskError` variant

```rust
TaskError::SpvOffTreeAddressRegistrationUnsupported { address: String }
```

i18n-ready, Everyday-User-friendly, actionable (reload wallet, or
switch to Expert-mode Core RPC), with the Base58 address as a
user-meaningful handle per CLAUDE.md rule 6.

## Migration

5 call sites migrated, all standard-account funding addresses:

- `src/ui/identities/add_new_identity_screen/by_wallet_qr_code.rs:34,43` — identity-creation QR funding
- `src/ui/identities/top_up_identity_screen/by_wallet_qr_code.rs:27` — identity-top-up QR funding
- `src/ui/wallets/create_asset_lock_screen.rs:113,122` — asset-lock funding
- `src/model/wallet/mod.rs:1196` — generic `register_address` helper (picks coverage from `DerivationPathReference`)
- `src/model/wallet/mod.rs:1001` — duplicate `try_import_address` removed; `register_address` already performs the registration via the typed API

Legacy methods `ensure_address_imported` and `try_import_address` are
removed in the final commit.

## Not in scope / deferred

- **`SpvManager` runtime registration hook.** The running SPV loop
  currently has no API to add a single off-tree address (account-level
  imports happen at wallet load). The typed API surfaces this as a
  `TaskError` variant and logs a `warn!`; a proper fix requires an
  upstream `SpvManager::register_addresses` method, which belongs in a
  separate PR. A `TODO(refactor)` comment marks the spot in
  `src/context/mod.rs`.
- **DashPay flow.** DashPay does not use the `try_import_address`
  pair — it maintains its own `wallet.known_addresses` /
  `wallet.watched_addresses` bookkeeping in
  `src/backend_task/dashpay/incoming_payments.rs`. So the suggested
  "commit 3" is a no-op; no DashPay code moves here. When the
  SpvManager hook above lands, that path can start calling
  `ensure_address_watched(addr, AddressCoverage::OffTree, …)` too.
- **UI or PasswordInput changes.** Those live in #839.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`
- [x] `cargo test --all-features --workspace` — 467 + 72 + 10 + 3 tests pass, including two new unit tests on `AddressCoverage::from_derivation_path_reference`.
- [x] `cargo test --doc --all-features --workspace`
- [ ] Manual: in SPV mode, repeat PR #839's test plan (QR funding, identity top-up, asset lock) — behaviour unchanged (BIP44 no-op is correct).
- [ ] Manual: in RPC mode, same flows — Core still watches imported addresses.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
