### PR TITLE
fix: stop recommending dashpay.io contracts

### DIFF
--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -532,16 +532,9 @@ impl ScreenLike for RegisterDataContractScreen {
                 ui.heading("3. Paste the contract JSON below");
                 ui.add_space(5.0);
 
-                // Add link to dashpay.io
-                ui.horizontal(|ui| {
-                    ui.label("Easily create a contract JSON here:");
-                    ui.add(egui::Hyperlink::from_label_and_url(
-                        RichText::new("dashpay.io")
-                            .underline()
-                            .color(DashColors::ACTION_BUTTON_BLUE),
-                        "https://dashpay.io",
-                    ));
-                });
+                ui.label(
+                    "Paste a data contract JSON compatible with the current Dash Platform protocol.",
+                );
                 ui.add_space(5.0);
 
                 self.ui_input_field(ui);

--- a/src/ui/tokens/tokens_screen/token_creator.rs
+++ b/src/ui/tokens/tokens_screen/token_creator.rs
@@ -1573,48 +1573,41 @@ impl TokensScreen {
             ui.add_space(3.0);
 
             ui.indent("document_schemas_section", |ui| {
-                // Add link to dashpay.io
-            ui.horizontal(|ui| {
-                    ui.label("Paste JSON document schemas to include in the contract. Easily create document schemas here:");
-                    ui.add(egui::Hyperlink::from_label_and_url(
-                        RichText::new("dashpay.io")
-                            .underline()
-                            .color(DashColors::ACTION_BUTTON_BLUE),
-                        "https://dashpay.io",
-                    ));
-                });
-
-            ui.add_space(5.0);
-
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
-            let schemas_response = ui.add_sized(
-                [ui.available_width(), 120.0],
-                TextEdit::multiline(&mut self.document_schemas_input)
-                    .text_color(DashColors::text_primary(dark_mode))
-                    .background_color(DashColors::input_background(dark_mode)),
-            );
-
-            if schemas_response.changed() {
-                self.parse_document_schemas();
-            }
-
-            ui.add_space(5.0);
-
-            // Show validation result
-            if let Some(ref error) = self.document_schemas_error {
-                ui.colored_label(
-                    Color32::DARK_RED,
-                    format!("Schema validation error: {}", error),
+                ui.label(
+                    "Paste the document-schemas JSON object for this contract, with one schema entry per document type.",
                 );
-            } else if self.parsed_document_schemas.is_some() {
-                let schema_count = self.parsed_document_schemas.as_ref().unwrap().len();
-                if schema_count > 0 {
-                    ui.colored_label(
-                        Color32::DARK_GREEN,
-                        format!("✓ {} valid document schema(s) parsed", schema_count),
-                    );
+
+                ui.add_space(5.0);
+
+                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let schemas_response = ui.add_sized(
+                    [ui.available_width(), 120.0],
+                    TextEdit::multiline(&mut self.document_schemas_input)
+                        .text_color(DashColors::text_primary(dark_mode))
+                        .background_color(DashColors::input_background(dark_mode)),
+                );
+
+                if schemas_response.changed() {
+                    self.parse_document_schemas();
                 }
-            }
+
+                ui.add_space(5.0);
+
+                // Show validation result
+                if let Some(ref error) = self.document_schemas_error {
+                    ui.colored_label(
+                        Color32::DARK_RED,
+                        format!("Schema validation error: {}", error),
+                    );
+                } else if self.parsed_document_schemas.is_some() {
+                    let schema_count = self.parsed_document_schemas.as_ref().unwrap().len();
+                    if schema_count > 0 {
+                        ui.colored_label(
+                            Color32::DARK_GREEN,
+                            format!("✓ {} valid document schema(s) parsed", schema_count),
+                        );
+                    }
+                }
             });
         }
     }


### PR DESCRIPTION
# Fix stale contract guidance

## Summary

- Remove stale `dashpay.io` recommendations from contract registration and
  token document-schema entry points.
- Replace the links with neutral guidance to paste JSON compatible with the
  current Dash Platform protocol.

Fixes #840.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- pre-commit hook: `cargo check`
- pre-PR code review gate: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified instructional text for the contract JSON input to emphasize compatibility with the current protocol.
  * Simplified guidance for document-schemas input with a clearer, more direct label.
  * Preserved the multiline JSON editor behavior with live parsing and conditional validation feedback (error messages or success count).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->