### PR TITLE
chore(deps): upgrade egui to 0.35.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ What each verifies:
 
 - `dash-sdk` - Dash blockchain SDK (git dep from dashpay/platform)
 - `platform-wallet` / `platform-wallet-storage` - Upstream wallet backend (git dep from dashpay/platform): SPV chain sync, address derivation, asset-lock/identity handling, shielded coordinator
-- `egui/eframe 0.34` - Immediate mode GUI framework
+- `egui/eframe 0.35` - Immediate mode GUI framework
 - `tokio` - Async runtime (12 worker threads)
 - `rusqlite` - SQLite with bundled library
 - Rust edition 2024, minimum rust-version 1.92

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ What each verifies:
 
 - `dash-sdk` - Dash blockchain SDK (git dep from dashpay/platform)
 - `platform-wallet` / `platform-wallet-storage` - Upstream wallet backend (git dep from dashpay/platform): SPV chain sync, address derivation, asset-lock/identity handling, shielded coordinator
-- `egui/eframe 0.33` - Immediate mode GUI framework
+- `egui/eframe 0.34` - Immediate mode GUI framework
 - `tokio` - Async runtime (12 worker threads)
 - `rusqlite` - SQLite with bundled library
 - Rust edition 2024, minimum rust-version 1.92

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ User-facing error messages (shown in `MessageBanner` via `Display`) must follow 
 ### Key Dependencies
 
 - `dash-sdk` - Dash blockchain SDK (git dep from dashpay/platform)
-- `egui/eframe 0.33` - Immediate mode GUI framework
+- `egui/eframe 0.34` - Immediate mode GUI framework
 - `tokio` - Async runtime (12 worker threads)
 - `rusqlite` - SQLite with bundled library
 - Rust edition 2024, minimum rust-version 1.92

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ The UI and async backend communicate through the action/channel pattern describe
 ## Screen Pattern
 
 All screens implement the `ScreenLike` trait:
-- `ui(&mut self, ctx: &Context) -> AppAction` - Render UI, return actions
+- `ui(&mut self, ui: &mut egui::Ui) -> AppAction` - Render UI, return actions
 - `display_task_result(&mut self, result: BackendTaskSuccessResult)` - Handle async results
 - `display_message(&mut self, msg: &str, type: MessageType)` - Show user feedback
 - `refresh(&mut self)` / `refresh_on_arrival(&mut self)` - Re-fetch data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,8 +115,8 @@ dependencies = [
  "accesskit_consumer 0.35.0",
  "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -210,7 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cc",
  "jni",
  "libc",
@@ -1000,9 +1000,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -1230,7 +1230,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "log",
  "polling",
  "rustix 0.38.44",
@@ -1244,7 +1244,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -1397,7 +1397,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2012,7 +2012,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
  "bip39",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cbc",
  "chrono",
  "chrono-humanize",
@@ -2488,7 +2488,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
@@ -2672,9 +2672,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
+checksum = "6758be723a3f298bbfda4db75748bc2ba0abafe096b6383c7c32da264764fbc3"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98fe83b2589105b69dd25ca1e0fa2135a6e864d502fd8e08978f937e128cfef"
+checksum = "8dc8234e2f681b2afd2b2e8c332fa614de2fddbdcb28d0acf5c420449682ea90"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2770,15 +2770,16 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
+checksum = "2796c98d50b79631281d516343a6f6e93c0666462ca36e2c93b39f25d7793325"
 dependencies = [
  "accesskit",
  "ahash",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "emath",
  "epaint",
+ "itertools 0.14.0",
  "log",
  "nohash-hasher",
  "profiling",
@@ -2790,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0c0559ac5598a1b887a6206dccbab7e3e6246c57cb00ae287262bd44776c9c"
+checksum = "d2e6cfac0725563555fa4f91e9f799b9d7c6c5dd831fca6abc8234afc64b7a34"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2810,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
+checksum = "9ea6bf3608db949588b95b8b341ee358d0c3f95cf4dc3f53d8d76717edee87db"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -2833,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55df531ff51161b3c6212e0ee2166b370f150254bf4448a8a15c3d26fec87958"
+checksum = "c833127228cc61cef806166adadc23572431fe2ea4cf753e60f654f82a2b3270"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
@@ -2845,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe04399ca5a2196965833a2918e50400449721fd9350e31ae7d84d6690859437"
+checksum = "5758a1110eb8259743c9b220241c30ff014b2dec53c1a2b861d464e41fa3483e"
 dependencies = [
  "egui",
  "egui_extras",
@@ -2856,14 +2857,15 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598d8675f6fd9088db8a93d8c7aacda936b2f3d0c2b0660ad1744a45b5caf922"
+checksum = "e2bd33be7338367bf21f54d62e069d58a5fb3ae033fa8bc6df7a77b9ef4cf957"
 dependencies = [
  "ahash",
  "egui",
  "enum-map",
  "image",
+ "itertools 0.14.0",
  "log",
  "mime_guess2",
  "profiling",
@@ -2871,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
+checksum = "52274b9bfb8d8e252cd0f00c9f6214f360d75a0962baa77a2d62ddb002fe99d4"
 dependencies = [
  "bytemuck",
  "egui",
@@ -2881,20 +2883,19 @@ dependencies = [
  "log",
  "memoffset",
  "profiling",
- "wasm-bindgen",
- "web-sys",
  "winit",
 ]
 
 [[package]]
 name = "egui_kittest"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb65436bc6f214ecc8ef4d9056a9344f92e70e22c162dbc3d515913df0fd3c5"
+checksum = "002c31e1f41461ce206333ffbd2e07563b79e87eb71c27e026151d12ee7b78e0"
 dependencies = [
  "eframe",
  "egui",
  "kittest",
+ "log",
  "serde",
  "toml 1.1.2+spec-1.1.0",
 ]
@@ -2942,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
+checksum = "cd4ec073c9898516584d8c6cfdcee95b530b3d941cd5031ef4050aa36812308b"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3089,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
+checksum = "4e60a8888b51da911df23918fd7301359b1d43a406a0ff3b8863af093dd7fc6c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -3099,6 +3100,7 @@ dependencies = [
  "emath",
  "epaint_default_fonts",
  "font-types",
+ "harfrust",
  "log",
  "nohash-hasher",
  "parking_lot",
@@ -3107,14 +3109,16 @@ dependencies = [
  "serde",
  "skrifa",
  "smallvec",
+ "unicode-general-category",
+ "unicode-segmentation",
  "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.34.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
+checksum = "13ee4e1f553a3584c301f3a56ff1a775f1384781396cea301c8d952e9b93f560"
 
 [[package]]
 name = "equivalent"
@@ -3231,12 +3235,9 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
-dependencies = [
- "bytemuck",
-]
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "ff"
@@ -3583,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3676,6 +3677,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3711,7 +3728,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cgl",
  "dispatch2",
@@ -3782,7 +3799,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3791,7 +3808,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -3802,7 +3819,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4126,6 +4143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4212,6 +4238,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431e8e389aa0f1e72bb9d1c2db8957a1a7a3580e8ed97db819c14837aac9b3e"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,6 +4298,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -4534,7 +4575,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4846,7 +4887,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4954,7 +4995,7 @@ dependencies = [
  "async-trait",
  "base58ck",
  "bip39",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dashcore",
  "dashcore-private",
  "dashcore_hashes",
@@ -5102,7 +5143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5117,7 +5158,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.0",
@@ -5175,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
 ]
@@ -5373,7 +5414,7 @@ checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -5438,7 +5479,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -5468,7 +5509,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5694,7 +5735,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -5710,7 +5751,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -5724,7 +5765,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -5748,7 +5789,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5760,7 +5801,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
 ]
@@ -5771,7 +5812,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -5814,7 +5855,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "dispatch",
  "libc",
@@ -5827,7 +5868,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -5839,7 +5880,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -5862,7 +5903,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5874,7 +5915,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
@@ -5886,7 +5927,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -5899,7 +5940,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -5922,7 +5963,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
@@ -5943,7 +5984,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -5966,7 +6007,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
@@ -6003,7 +6044,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -6164,7 +6205,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -6607,7 +6648,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6849,7 +6890,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -7074,7 +7115,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7117,9 +7158,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.37.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -7159,7 +7200,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7168,7 +7209,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7497,7 +7538,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "once_cell",
  "serde",
  "serde_derive",
@@ -7592,7 +7633,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -7662,7 +7703,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -7675,7 +7716,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -7771,7 +7812,7 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "core_maths",
  "log",
@@ -7899,7 +7940,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8132,7 +8173,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "359e552886ae54d1642091645980d83f7db465fd9b5b0248e3680713c1773388"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -8213,9 +8254,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skrifa"
-version = "0.40.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -8251,7 +8292,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.13.0",
  "calloop-wayland-source 0.3.0",
  "cursor-icon",
@@ -8276,7 +8317,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "calloop 0.14.4",
  "calloop-wayland-source 0.4.1",
  "cursor-icon",
@@ -8348,7 +8389,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8534,7 +8575,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -9113,7 +9154,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -9320,6 +9361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9523,27 +9570,29 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vello_common"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
 dependencies = [
  "bytemuck",
  "fearless_simd",
- "hashbrown 0.16.1",
+ "guillotiere",
+ "hashbrown 0.17.1",
  "log",
  "peniko",
- "skrifa",
  "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.6"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
 dependencies = [
  "bytemuck",
- "hashbrown 0.16.1",
+ "glifo",
+ "hashbrown 0.17.1",
  "vello_common",
 ]
 
@@ -9765,7 +9814,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -9791,7 +9840,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -9803,7 +9852,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -9825,7 +9874,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -9837,7 +9886,7 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9850,7 +9899,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9863,7 +9912,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9876,7 +9925,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -9983,7 +10032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -10015,7 +10064,7 @@ dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -10086,7 +10135,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.9.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
  "cfg-if",
@@ -10125,9 +10174,9 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
- "windows-result 0.4.1",
+ "windows",
+ "windows-core",
+ "windows-result",
 ]
 
 [[package]]
@@ -10146,7 +10195,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -10220,36 +10269,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -10258,20 +10285,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -10282,20 +10296,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -10304,9 +10307,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -10333,12 +10336,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -10358,22 +10355,12 @@ dependencies = [
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -10382,18 +10369,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -10402,16 +10380,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -10420,7 +10389,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10465,7 +10434,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10505,7 +10474,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -10518,20 +10487,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -10681,7 +10641,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
@@ -10940,7 +10900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -11043,7 +11003,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,57 +20,48 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
 dependencies = [
  "enumn",
  "serde",
+ "uuid",
 ]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.14.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
+checksum = "842fd8203e6dfcf531d24f5bac792088edfba7d6b35844fead191603fb32a260"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
+ "accesskit_consumer",
  "atspi-common",
+ "phf 0.13.1",
  "serde",
- "thiserror 1.0.69",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd06f5fea9819250fffd4debf926709f3593ac22f8c1541a2573e5ee0ca01cd"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
-dependencies = [
- "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+checksum = "534bc3fdc89a64a1db3c46b33c198fde2b7c3c7d094e5809c8c8bf2970c18243"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
- "hashbrown 0.15.5",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -78,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.17.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
+checksum = "90e549dd7c6562b6a2ea807b44726e6241707db054a817dc4c7e2b8d3b39bfac"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -96,23 +87,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
- "hashbrown 0.15.5",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -664,20 +655,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
 dependencies = [
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
 dependencies = [
  "enumflags2",
  "serde",
@@ -690,22 +680,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-connection"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
 name = "atspi-proxies"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
@@ -940,11 +918,11 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -955,9 +933,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitcoin-internals"
@@ -1041,12 +1019,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.2.17",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -1422,7 +1394,7 @@ checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1432,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -1554,13 +1526,22 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1649,7 +1630,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -1662,17 +1643,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -2638,9 +2608,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
+checksum = "55f6cc0cb3b84a21232c468db972ebcddd34decbf1ff02cdebffd807c13bbd81"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2697,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
+checksum = "fea3080bfd001aee2223dcb2228d9de7d31f41d7cfb99e8cd70df3ae8083a42f"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2708,16 +2678,15 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
  "glutin",
  "glutin-winit",
  "home",
  "image",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "pollster",
@@ -2737,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
+checksum = "3cbe28ac1a9c0761319aafb9ad37737720cc49d99c13a4a6b990768fa01ffe67"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2757,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
+checksum = "2f311c0b9cdd8a38821ae6f245fbe6e1a3d7d157c77b7d22344f205b317232c8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2777,18 +2746,18 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
+checksum = "e8e97625c2fe0fadc8b92ec690fbf515e15e2efd67ca50e063ad3302ec8ee626"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "bytemuck",
  "egui",
  "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "profiling",
  "raw-window-handle",
  "serde",
@@ -2800,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5246a4e9b83c345ec8230933bd0dca16d1c3c11db0edd4fd9c1a90683240b49"
+checksum = "55df531ff51161b3c6212e0ee2166b370f150254bf4448a8a15c3d26fec87958"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
@@ -2812,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3cff846279556f57af8ea606f2e4ceaf83e60b81db014c126dfb926fa06c75b"
+checksum = "fe04399ca5a2196965833a2918e50400449721fd9350e31ae7d84d6690859437"
 dependencies = [
  "egui",
  "egui_extras",
@@ -2823,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
+checksum = "8c609fc87f6c70ffd3afd679cbb294985096d2fc0be33e762ad5614bde4925bc"
 dependencies = [
  "ahash",
  "egui",
@@ -2838,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
+checksum = "6caa4eca47cc2358e2c5ae60843a94118e338f87099c6af4170e6e968e8d77cb"
 dependencies = [
  "bytemuck",
  "egui",
@@ -2855,13 +2824,15 @@ dependencies = [
 
 [[package]]
 name = "egui_kittest"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43afb5f968dfa9e6c8f5e609ab9039e11a2c4af79a326f4cb1b99cf6875cb6a0"
+checksum = "48bca6ff2e8a8929519287d5fe8eb99f579b7d45b6ced9e9dc21824965896b57"
 dependencies = [
  "eframe",
  "egui",
  "kittest",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2907,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
+checksum = "a74fbbf7501c430b89df62d102b6bfa02162faaf3e155512c677c9d20f5708d1"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3054,28 +3025,32 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
+checksum = "92b452e348c2758115288802ca25f86ee286ce2cfae6643711ce116662311310"
 dependencies = [
- "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "font-types",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
+ "self_cell",
  "serde",
+ "skrifa",
+ "smallvec",
+ "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.33.3"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
+checksum = "1644e25dbe3d663fd9c2a4181772c64b23361e377e550c10422ecc3a7de1c3c2"
 
 [[package]]
 name = "equivalent"
@@ -3194,6 +3169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3256,6 +3240,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
 
 [[package]]
 name = "fontconfig-parser"
@@ -3600,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3677,34 +3671,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4481,7 +4458,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4991,13 +4968,12 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kittest"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd6dd2cce251a360101038acb9334e3a50cd38cd02fefddbf28aa975f043c8"
+checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.30.1",
- "parking_lot",
+ "accesskit_consumer",
 ]
 
 [[package]]
@@ -5093,6 +5069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5154,15 +5136,6 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -5246,21 +5219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5273,8 +5231,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
 dependencies = [
  "mime",
- "phf",
- "phf_shared",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
  "unicase",
 ]
 
@@ -5360,12 +5318,12 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
+ "bit-set 0.9.1",
  "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
@@ -5657,15 +5615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5703,7 +5652,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -5789,7 +5738,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5830,6 +5779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -5870,6 +5820,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5879,7 +5841,20 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -5907,10 +5882,22 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -6174,6 +6161,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "peniko"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6196,8 +6196,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -6206,8 +6217,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -6216,8 +6227,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6226,12 +6247,25 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
  "unicase",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6242,6 +6276,15 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6584,7 +6627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6605,7 +6648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6870,6 +6913,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6887,6 +6942,16 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -7221,14 +7286,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "base64 0.22.1",
  "bitflags 2.11.0",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
  "unicode-ident",
 ]
 
@@ -7644,6 +7710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7942,6 +8014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7961,6 +8043,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -8058,9 +8143,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -8655,6 +8740,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.0",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8674,9 +8772,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -8712,16 +8810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -8985,6 +9083,12 @@ name = "typed-path"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -9255,6 +9359,32 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_common",
+]
 
 [[package]]
 name = "version-compare"
@@ -9710,12 +9840,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -9739,13 +9870,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.11.0",
  "bytemuck",
  "cfg_aliases",
@@ -9764,57 +9895,66 @@ dependencies = [
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.8.0",
+ "bit-set 0.9.1",
  "bitflags 2.11.0",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -9823,10 +9963,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
  "ndk-sys",
- "objc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -9835,27 +9978,41 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -9920,7 +10077,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9931,25 +10088,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -9962,16 +10121,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9980,11 +10135,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -9995,18 +10163,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -10014,17 +10182,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10065,6 +10222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10073,15 +10240,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10100,16 +10258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10254,6 +10402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10462,7 +10619,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,57 +20,68 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.21.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf203f9d3bd8f29f98833d1fbef628df18f759248a547e7e01cfbf63cda36a99"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
 dependencies = [
  "enumn",
  "serde",
+ "uuid",
 ]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.14.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
+checksum = "1e8c61bee90b42a772d39d06a740207dc71a4e780004ace1db8d99fb1baaa954"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
+ "accesskit_consumer 0.36.0",
  "atspi-common",
+ "phf 0.13.1",
  "serde",
- "thiserror 1.0.69",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.30.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd06f5fea9819250fffd4debf926709f3593ac22f8c1541a2573e5ee0ca01cd"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.31.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
+checksum = "25e0d7e25d06f4dc21d1774d67146e9e80d6789216cbd4d1e88185b0095dba60"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.22.2"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
+checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.37.0",
+ "hashbrown 0.16.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -78,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.17.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
+checksum = "b016ca8db0ea0ea2ceff29a9d6240391492d960716aa471967c00e8cc8cb197c"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -96,23 +107,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.29.2"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.31.0",
- "hashbrown 0.15.5",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
  "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.29.2"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -678,20 +689,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
 dependencies = [
  "atspi-common",
- "atspi-connection",
  "atspi-proxies",
 ]
 
 [[package]]
 name = "atspi-common"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
 dependencies = [
  "enumflags2",
  "serde",
@@ -704,22 +714,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atspi-connection"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
 name = "atspi-proxies"
-version = "0.9.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
 dependencies = [
  "atspi-common",
  "serde",
@@ -954,7 +952,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -962,6 +969,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitcoin-io"
@@ -1039,12 +1052,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
 ]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -1410,7 +1417,7 @@ checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1420,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -1551,13 +1558,22 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1652,7 +1668,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -1665,17 +1681,6 @@ checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -2667,9 +2672,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecolor"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddb8ac7643d1dba1bb02110e804406dd459a838efcb14011ced10556711a8e"
+checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -2726,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "eframe"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457481173e6db5ca9fa2be93a58df8f4c7be639587aeb4853b526c6cf87db4e6"
+checksum = "f98fe83b2589105b69dd25ca1e0fa2135a6e864d502fd8e08978f937e128cfef"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2737,16 +2742,15 @@ dependencies = [
  "egui-wgpu",
  "egui-winit",
  "egui_glow",
- "glow",
  "glutin",
  "glutin-winit",
  "home",
  "image",
  "js-sys",
  "log",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "pollster",
@@ -2766,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9b567d356674e9a5121ed3fedfb0a7c31e059fe71f6972b691bcd0bfc284e3"
+checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2786,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "egui-wgpu"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4d209971c84b2352a06174abdba701af1e552ce56b144d96f2bd50a3c91236"
+checksum = "9f0c0559ac5598a1b887a6206dccbab7e3e6246c57cb00ae287262bd44776c9c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2806,18 +2810,18 @@ dependencies = [
 
 [[package]]
 name = "egui-winit"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
+checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
 dependencies = [
  "accesskit_winit",
  "arboard",
  "bytemuck",
  "egui",
  "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "profiling",
  "raw-window-handle",
  "serde",
@@ -2829,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5246a4e9b83c345ec8230933bd0dca16d1c3c11db0edd4fd9c1a90683240b49"
+checksum = "55df531ff51161b3c6212e0ee2166b370f150254bf4448a8a15c3d26fec87958"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
@@ -2841,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "egui_commonmark_backend"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3cff846279556f57af8ea606f2e4ceaf83e60b81db014c126dfb926fa06c75b"
+checksum = "fe04399ca5a2196965833a2918e50400449721fd9350e31ae7d84d6690859437"
 dependencies = [
  "egui",
  "egui_extras",
@@ -2852,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01d34e845f01c62e3fded726961092e70417d66570c499b9817ab24674ca4ed"
+checksum = "598d8675f6fd9088db8a93d8c7aacda936b2f3d0c2b0660ad1744a45b5caf922"
 dependencies = [
  "ahash",
  "egui",
@@ -2867,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6420863ea1d90e750f75075231a260030ad8a9f30a7cef82cdc966492dc4c4eb"
+checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
 dependencies = [
  "bytemuck",
  "egui",
@@ -2884,13 +2888,15 @@ dependencies = [
 
 [[package]]
 name = "egui_kittest"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43afb5f968dfa9e6c8f5e609ab9039e11a2c4af79a326f4cb1b99cf6875cb6a0"
+checksum = "5cb65436bc6f214ecc8ef4d9056a9344f92e70e22c162dbc3d515913df0fd3c5"
 dependencies = [
  "eframe",
  "egui",
  "kittest",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -2936,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "emath"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491bdf728bf25ddd9ad60d4cf1c48588fa82c013a2440b91aa7fc43e34a07c32"
+checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
 dependencies = [
  "bytemuck",
  "serde",
@@ -3083,28 +3089,32 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009d0dd3c2163823a0abdb899451ecbc78798dec545ee91b43aff1fa790bab62"
+checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
 dependencies = [
- "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
  "epaint_default_fonts",
+ "font-types",
  "log",
  "nohash-hasher",
  "parking_lot",
  "profiling",
+ "self_cell",
  "serde",
+ "skrifa",
+ "smallvec",
+ "vello_cpu",
 ]
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.33.3"
+version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fbe202b6578d3d56428fa185cdf114a05e49da05f477b3c7f0fbb221f1862"
+checksum = "f8970033a4282a7bcf899b38b5ed3a58b732fe093d03785d58648515d8d309da"
 
 [[package]]
 name = "equivalent"
@@ -3182,7 +3192,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -3217,6 +3227,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3282,6 +3301,16 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+ "serde",
+]
 
 [[package]]
 name = "fontconfig-parser"
@@ -3666,9 +3695,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -3743,34 +3772,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.1",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4522,7 +4534,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5011,13 +5023,12 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kittest"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd6dd2cce251a360101038acb9334e3a50cd38cd02fefddbf28aa975f043c8"
+checksum = "90ceaa75eb0036a32b6b9833962eb18137449e9817e2e586006471925b727fd5"
 dependencies = [
  "accesskit",
- "accesskit_consumer 0.30.1",
- "parking_lot",
+ "accesskit_consumer 0.35.0",
 ]
 
 [[package]]
@@ -5124,6 +5135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5185,15 +5202,6 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
@@ -5277,21 +5285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.1",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5304,8 +5297,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
 dependencies = [
  "mime",
- "phf",
- "phf_shared",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
  "unicase",
 ]
 
@@ -5374,12 +5367,12 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
@@ -5671,15 +5664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5717,7 +5701,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -5803,7 +5787,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5844,6 +5828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -5884,6 +5869,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,7 +5890,20 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -5921,10 +5931,22 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -6199,6 +6221,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6221,8 +6256,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -6231,8 +6277,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -6241,8 +6287,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -6251,12 +6307,25 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
  "unicase",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6267,6 +6336,15 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "unicase",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6729,7 +6807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6750,7 +6828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7006,6 +7084,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7023,6 +7113,16 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]
@@ -7393,14 +7493,15 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
 dependencies = [
- "base64 0.22.1",
  "bitflags 2.11.1",
+ "once_cell",
  "serde",
  "serde_derive",
+ "typeid",
  "unicode-ident",
 ]
 
@@ -7816,6 +7917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8105,6 +8212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8124,6 +8241,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -8224,9 +8344,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
+version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -8799,6 +8919,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9116,6 +9249,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9381,6 +9520,32 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vello_common"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_common",
+]
 
 [[package]]
 name = "version_check"
@@ -9813,12 +9978,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -9842,13 +10008,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.11.1",
  "bytemuck",
  "cfg_aliases",
@@ -9867,57 +10033,66 @@ dependencies = [
  "thiserror 2.0.18",
  "wgpu-core-deps-apple",
  "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
+ "wgpu-naga-bridge",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.1",
- "block",
+ "block2 0.6.2",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -9926,10 +10101,13 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "metal",
  "naga",
  "ndk-sys",
- "objc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "once_cell",
  "ordered-float",
  "parking_lot",
@@ -9938,27 +10116,41 @@ dependencies = [
  "profiling",
  "range-alloc",
  "raw-window-handle",
+ "raw-window-metal",
  "renderdoc-sys",
  "smallvec",
  "thiserror 2.0.18",
  "wasm-bindgen",
+ "wayland-sys",
  "web-sys",
+ "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
+ "raw-window-handle",
  "web-sys",
 ]
 
@@ -10017,7 +10209,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10028,25 +10220,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -10059,16 +10253,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.58.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -10077,11 +10267,24 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -10092,18 +10295,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-future"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -10111,17 +10314,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10175,6 +10367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10183,15 +10385,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10210,16 +10403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10340,6 +10523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10506,7 +10698,7 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-ui-kit",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ rust-version = "1.92"
 tokio-util = { version = "0.7.15" }
 bip39 = { version = "2.2.0", features = ["all-languages", "rand", "zeroize"] }
 derive_more = "2.1.1"
-egui = "0.33.3"
-egui_extras = "0.33.3"
-egui_commonmark = "0.22.0"
+egui = "0.34.2"
+egui_extras = "0.34.2"
+egui_commonmark = "0.23.0"
 rfd = "0.17.2"
 qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
-eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
+eframe = { version = "0.34.2", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 dash-sdk = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-secret-protection", features = [
     "core_key_wallet",
@@ -110,7 +110,7 @@ cli = ["dep:rmcp", "rmcp/server", "rmcp/macros", "rmcp/client", "rmcp/transport-
 headless = ["cli", "mcp"]
 
 [dev-dependencies]
-egui_kittest = { version = "0.33.3", features = ["eframe"] }
+egui_kittest = { version = "0.34.2", features = ["eframe"] }
 tokio-shared-rt = "=0.1.0"
 criterion = "0.5.1"
 # Used only by error-mapping unit tests to construct a genuine divergent-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ rust-version = "1.92"
 tokio-util = { version = "0.7.15" }
 bip39 = { version = "2.2.0", features = ["all-languages", "rand", "zeroize"] }
 derive_more = "2.1.1"
-egui = "0.34.2"
-egui_extras = "0.34.2"
-egui_commonmark = "0.23.0"
+egui = "0.35.0"
+egui_extras = "0.35.0"
+egui_commonmark = "0.24.0"
 rfd = "0.17.2"
 qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
-eframe = { version = "0.34.2", features = ["persistence", "wgpu"] }
+eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 dash-sdk = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-secret-protection", features = [
     "core_key_wallet",
@@ -110,7 +110,7 @@ cli = ["dep:rmcp", "rmcp/server", "rmcp/macros", "rmcp/client", "rmcp/transport-
 headless = ["cli", "mcp"]
 
 [dev-dependencies]
-egui_kittest = { version = "0.34.2", features = ["eframe"] }
+egui_kittest = { version = "0.35.0", features = ["eframe"] }
 tokio-shared-rt = "=0.1.0"
 criterion = "0.5.1"
 # Used only by error-mapping unit tests to construct a genuine divergent-version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ rust-version = "1.92"
 tokio-util = { version = "0.7.15" }
 bip39 = { version = "2.2.0", features = ["all-languages", "rand"] }
 derive_more = "2.1.1"
-egui = "0.33.3"
-egui_extras = "0.33.3"
-egui_commonmark = "0.22.0"
+egui = "0.34.2"
+egui_extras = "0.34.2"
+egui_commonmark = "0.23.0"
 rfd = "0.17.2"
 qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
-eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
+eframe = { version = "0.34.2", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 dash-sdk = { git = "https://github.com/dashpay/platform", rev = "54048b9352c5c8361f4cbfaa6a188dd3244e00c4", features = [
     "core_key_wallet",
@@ -105,7 +105,7 @@ cli = ["dep:rmcp", "rmcp/server", "rmcp/macros", "rmcp/client", "rmcp/transport-
 headless = ["cli", "mcp"]
 
 [dev-dependencies]
-egui_kittest = { version = "0.33.3", features = ["eframe"] }
+egui_kittest = { version = "0.34.2", features = ["eframe"] }
 tokio-shared-rt = "=0.1.0"
 
 [[bin]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1509,8 +1509,8 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn ui(&mut self, _ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = _ui.ctx().clone();
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
         let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,
@@ -1553,7 +1553,7 @@ impl App for AppState {
             }
             // Render a minimal UI that shows the shutdown banner.
             self.theme.poll_and_apply(ctx);
-            crate::ui::components::styled::island_central_panel(ctx, |_ui| {});
+            crate::ui::components::styled::island_central_panel(ui, |_ui| {});
             return;
         }
 
@@ -1852,9 +1852,9 @@ impl App for AppState {
         if self.show_welcome_screen
             && let Some(welcome_screen) = &mut self.welcome_screen
         {
-            actions.push(welcome_screen.ui(ctx));
+            actions.push(welcome_screen.ui(ui));
         } else {
-            actions.push(self.visible_screen_mut().ui(ctx));
+            actions.push(self.visible_screen_mut().ui(ui));
         };
 
         // Blocking progress overlay: above banners, below the secret prompt.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1509,7 +1509,9 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,
         // and start an async shutdown. Once all tasks have finished (or timed out)
@@ -1990,7 +1992,7 @@ impl App for AppState {
         }
     }
 
-    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+    fn on_exit(&mut self) {
         // On macOS, order windows out before winit tears down the event
         // handler. This lets AppKit properly clean up display-related KVO
         // observers (TouchBar, etc.) while views are still alive.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1509,8 +1509,8 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = ui.ctx().clone();
+    fn ui(&mut self, _ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = _ui.ctx().clone();
         let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,

--- a/src/app.rs
+++ b/src/app.rs
@@ -940,7 +940,9 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,
         // and start an async shutdown. Once all tasks have finished (or timed out)
@@ -1358,7 +1360,7 @@ impl App for AppState {
         }
     }
 
-    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+    fn on_exit(&mut self) {
         // On macOS, order windows out before winit tears down the event
         // handler. This lets AppKit properly clean up display-related KVO
         // observers (TouchBar, etc.) while views are still alive.

--- a/src/app.rs
+++ b/src/app.rs
@@ -940,8 +940,8 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = ui.ctx().clone();
+    fn ui(&mut self, _ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = _ui.ctx().clone();
         let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,

--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -29,8 +29,8 @@ use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::drive::query::{SelectProjection, WhereClause, WhereOperator};
 use dash_sdk::platform::{Document, DocumentQuery, Fetch, FetchMany, Identifier, Identity};
-use egui::ahash::HashMap;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
 

--- a/src/model/secret.rs
+++ b/src/model/secret.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::ops::Range;
 
 use egui::TextBuffer;
+use egui::text::CharIndex;
 use zeroize::{Zeroize, Zeroizing};
 
 /// Default pre-allocation capacity for `Secret` buffers.
@@ -183,13 +184,13 @@ impl TextBuffer for Secret {
         self.inner.as_str()
     }
 
-    fn insert_text(&mut self, text: &str, char_index: usize) -> usize {
+    fn insert_text(&mut self, text: &str, char_index: CharIndex) -> usize {
         let n = <String as TextBuffer>::insert_text(&mut *self.inner, text, char_index);
         self.relock_if_moved();
         n
     }
 
-    fn delete_char_range(&mut self, char_range: Range<usize>) {
+    fn delete_char_range(&mut self, char_range: Range<CharIndex>) {
         <String as TextBuffer>::delete_char_range(&mut *self.inner, char_range);
         // Zero deleted bytes in trailing capacity [len..capacity)
         let ptr = self.inner.as_mut_ptr();
@@ -344,12 +345,12 @@ mod tests {
         let mut secret = Secret::new("hello");
 
         // insert_text appends " world"
-        let inserted = secret.insert_text(" world", 5);
+        let inserted = secret.insert_text(" world", CharIndex(5));
         assert_eq!(inserted, 6);
         assert_eq!(secret.expose_secret(), "hello world");
 
         // delete_char_range removes " world"
-        secret.delete_char_range(5..11);
+        secret.delete_char_range(CharIndex(5)..CharIndex(11));
         assert_eq!(secret.expose_secret(), "hello");
     }
 
@@ -450,7 +451,7 @@ mod tests {
     #[test]
     fn test_delete_char_range_zeroes_trailing() {
         let mut secret = Secret::new("abcdef");
-        secret.delete_char_range(3..6);
+        secret.delete_char_range(CharIndex(3)..CharIndex(6));
         assert_eq!(secret.expose_secret(), "abc");
         // Trailing capacity bytes (after len) should be zeroed
         let len = secret.inner.len();

--- a/src/ui/components/confirmation_dialog.rs
+++ b/src/ui/components/confirmation_dialog.rs
@@ -178,7 +178,7 @@ impl ConfirmationDialog {
                 // Set minimum width for the dialog
                 ui.set_min_width(300.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Message content with bold text and proper color
                 ui.add_space(10.0);

--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -15,7 +15,7 @@ use dash_sdk::dpp::data_contract::{
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformSerializableWithPlatformVersion;
-use egui::{Color32, Context as EguiContext, Frame, Margin, Panel, RichText};
+use egui::{Color32, Frame, Margin, Panel, RichText, Ui};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
@@ -145,7 +145,7 @@ fn render_collapsing_header(
 
 #[allow(clippy::too_many_arguments)]
 pub fn add_contract_chooser_panel(
-    ctx: &EguiContext,
+    ui: &mut Ui,
     current_search_term: &mut String,
     app_context: &Arc<AppContext>,
     selected_data_contract: &mut QualifiedContract,
@@ -156,6 +156,8 @@ pub fn add_contract_chooser_panel(
     pending_fields_selection: &mut HashMap<String, bool>,
     chooser_state: &mut ContractChooserState,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Retrieve the list of known contracts
@@ -180,17 +182,16 @@ pub fn add_contract_chooser_panel(
 
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("contract_chooser_panel")
         // Let the user resize this panel horizontally
         .resizable(true)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             // Fill the entire available height
             let available_height = ui.available_height();
 

--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -15,7 +15,7 @@ use dash_sdk::dpp::data_contract::{
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformSerializableWithPlatformVersion;
-use egui::{Color32, Context as EguiContext, Frame, Margin, RichText, Panel};
+use egui::{Color32, Context as EguiContext, Frame, Margin, Panel, RichText};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;

--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -15,7 +15,7 @@ use dash_sdk::dpp::data_contract::{
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformSerializableWithPlatformVersion;
-use egui::{Color32, Context as EguiContext, Frame, Margin, RichText, SidePanel};
+use egui::{Color32, Context as EguiContext, Frame, Margin, RichText, Panel};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
@@ -55,7 +55,7 @@ fn render_collapsing_header(
     indent_level: usize,
 ) -> bool {
     let text = text.into();
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
     let indent = indent_level as f32 * 16.0;
 
     let mut clicked = false;
@@ -178,9 +178,10 @@ pub fn add_contract_chooser_panel(
         })
         .collect();
 
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    SidePanel::left("contract_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("contract_chooser_panel")
         // Let the user resize this panel horizontally
         .resizable(true)
         .default_width(270.0)

--- a/src/ui/components/dashpay_subscreen_chooser_panel.rs
+++ b/src/ui/components/dashpay_subscreen_chooser_panel.rs
@@ -4,14 +4,16 @@ use crate::model::feature_gate::FeatureGate;
 use crate::ui::RootScreenType;
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 use std::sync::Arc;
 
 pub fn add_dashpay_subscreen_chooser_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     current_subscreen: DashPaySubscreen,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
@@ -26,15 +28,14 @@ pub fn add_dashpay_subscreen_chooser_panel(
 
     let active_screen = current_subscreen;
 
-    #[allow(deprecated)]
     Panel::left("dashpay_subscreen_chooser_panel")
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode)) // Light background instead of transparent
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             // Fill the entire available height
             let available_height = ui.available_height();
 

--- a/src/ui/components/dashpay_subscreen_chooser_panel.rs
+++ b/src/ui/components/dashpay_subscreen_chooser_panel.rs
@@ -4,7 +4,7 @@ use crate::model::feature_gate::FeatureGate;
 use crate::ui::RootScreenType;
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
-use egui::{Context, Frame, Margin, RichText, SidePanel};
+use egui::{Context, Frame, Margin, RichText, Panel};
 use std::sync::Arc;
 
 pub fn add_dashpay_subscreen_chooser_panel(
@@ -13,7 +13,7 @@ pub fn add_dashpay_subscreen_chooser_panel(
     current_subscreen: DashPaySubscreen,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
     // Build subscreens list - Payment History is experimental (developer mode only)
     let mut subscreens = vec![DashPaySubscreen::Profile, DashPaySubscreen::Contacts];
@@ -26,7 +26,8 @@ pub fn add_dashpay_subscreen_chooser_panel(
 
     let active_screen = current_subscreen;
 
-    SidePanel::left("dashpay_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("dashpay_subscreen_chooser_panel")
         .default_width(270.0)
         .frame(
             Frame::new()

--- a/src/ui/components/dashpay_subscreen_chooser_panel.rs
+++ b/src/ui/components/dashpay_subscreen_chooser_panel.rs
@@ -4,7 +4,7 @@ use crate::model::feature_gate::FeatureGate;
 use crate::ui::RootScreenType;
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
-use egui::{Context, Frame, Margin, RichText, Panel};
+use egui::{Context, Frame, Margin, Panel, RichText};
 use std::sync::Arc;
 
 pub fn add_dashpay_subscreen_chooser_panel(

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::ui::RootScreenType;
 use crate::ui::dpns::dpns_contested_names_screen::DPNSSubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, Panel};
+use egui::{Context, Frame, Margin, Panel, RichText};
 
 pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -3,9 +3,11 @@ use crate::ui::RootScreenType;
 use crate::ui::dpns::dpns_contested_names_screen::DPNSSubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 
-pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_dpns_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
@@ -24,16 +26,15 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
         _ => DPNSSubscreen::Active,
     };
 
-    #[allow(deprecated)]
     Panel::left("dpns_subscreen_chooser_panel")
         .resizable(true)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             let available_height = ui.available_height();
 
             Frame::new()

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -3,11 +3,11 @@ use crate::ui::RootScreenType;
 use crate::ui::dpns::dpns_contested_names_screen::DPNSSubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, SidePanel};
+use egui::{Context, Frame, Margin, RichText, Panel};
 
 pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
     let subscreens = vec![
         DPNSSubscreen::Active,
@@ -27,7 +27,8 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
         _ => DPNSSubscreen::Active,
     };
 
-    SidePanel::left("dpns_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("dpns_subscreen_chooser_panel")
         .resizable(true)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -3,11 +3,11 @@ use crate::ui::RootScreenType;
 use crate::ui::dpns::dpns_contested_names_screen::DPNSSubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, SidePanel};
+use egui::{Context, Frame, Margin, RichText, Panel};
 
 pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
     let subscreens = vec![
         DPNSSubscreen::Active,
@@ -24,7 +24,8 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
         _ => DPNSSubscreen::Active,
     };
 
-    SidePanel::left("dpns_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("dpns_subscreen_chooser_panel")
         .resizable(true)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/entropy_grid.rs
+++ b/src/ui/components/entropy_grid.rs
@@ -62,7 +62,7 @@ impl U256EntropyGrid {
                             // Determine the bit value and colors based on theme
                             let bit_value =
                                 (self.random_number[byte_index] >> bit_in_byte) & 1 == 1;
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             let color = if bit_value {
                                 // On squares: Deep Blue in light mode, muted Dash Blue in dark mode
                                 if dark_mode {

--- a/src/ui/components/info_popup.rs
+++ b/src/ui/components/info_popup.rs
@@ -95,7 +95,7 @@ impl InfoPopup {
                     ui.set_max_width(500.0);
                 }
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Message content
                 ui.add_space(10.0);

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -6,7 +6,7 @@ use crate::ui::components::styled::GradientButton;
 use crate::ui::theme::{DashColors, ResponseExt, Shadow, Shape, Spacing};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, Panel, RichText, TextureHandle};
+use egui::{Context, Frame, Image, Panel, RichText, TextureHandle, Ui};
 use egui_extras::{Size, StripBuilder};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
@@ -110,10 +110,12 @@ pub fn load_svg_icon(ctx: &Context, path: &str, width: u32, height: u32) -> Opti
 }
 
 pub fn add_left_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     selected_screen: RootScreenType,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Define the button details directly in this function.
@@ -166,17 +168,16 @@ pub fn add_left_panel(
 
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("left_panel")
-        .min_width(140.0)
-        .max_width(140.0)
+        .min_size(140.0)
+        .max_size(140.0)
         .resizable(false)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             // Create an island panel with rounded edges
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -6,7 +6,7 @@ use crate::ui::components::styled::GradientButton;
 use crate::ui::theme::{DashColors, ResponseExt, Shadow, Shape, Spacing};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, RichText, Panel, TextureHandle};
+use egui::{Context, Frame, Image, Panel, RichText, TextureHandle};
 use egui_extras::{Size, StripBuilder};
 use rust_embed::RustEmbed;
 use std::sync::Arc;

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -6,7 +6,7 @@ use crate::ui::components::styled::GradientButton;
 use crate::ui::theme::{DashColors, ResponseExt, Shadow, Shape, Spacing};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, RichText, SidePanel, TextureHandle};
+use egui::{Context, Frame, Image, RichText, Panel, TextureHandle};
 use egui_extras::{Size, StripBuilder};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
@@ -164,9 +164,10 @@ pub fn add_left_panel(
         ),
     ];
 
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    SidePanel::left("left_panel")
+    #[allow(deprecated)]
+    Panel::left("left_panel")
         .min_width(140.0)
         .max_width(140.0)
         .resizable(false)

--- a/src/ui/components/left_wallet_panel.rs
+++ b/src/ui/components/left_wallet_panel.rs
@@ -3,7 +3,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::DashColors;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, Panel, TextureHandle};
+use egui::{Context, Frame, Image, Panel, TextureHandle, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;
@@ -40,10 +40,12 @@ fn load_icon(ctx: &Context, path: &str) -> Option<TextureHandle> {
 
 #[allow(dead_code)]
 pub fn add_left_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     _app_context: &Arc<AppContext>,
     selected_screen: RootScreenType,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Define the button details directly in this function
@@ -65,9 +67,8 @@ pub fn add_left_panel(
 
     let panel_width = 50.0 + 20.0; // Button width (50) + 10px margin on each side (20 total)
 
-    #[allow(deprecated)]
     Panel::left("left_panel")
-        .default_width(panel_width)
+        .default_size(panel_width)
         .frame(
             Frame::new()
                 .fill(ctx.global_style().visuals.panel_fill)
@@ -78,7 +79,7 @@ pub fn add_left_panel(
                     bottom: 0,
                 }),
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             ui.vertical_centered(|ui| {
                 for (label, screen_type, icon_path) in buttons.iter() {
                     if *screen_type == RootScreenType::RootScreenDocumentQuery {

--- a/src/ui/components/left_wallet_panel.rs
+++ b/src/ui/components/left_wallet_panel.rs
@@ -3,7 +3,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::DashColors;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, SidePanel, TextureHandle};
+use egui::{Context, Frame, Image, Panel, TextureHandle};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;
@@ -65,11 +65,12 @@ pub fn add_left_panel(
 
     let panel_width = 50.0 + 20.0; // Button width (50) + 10px margin on each side (20 total)
 
-    SidePanel::left("left_panel")
+    #[allow(deprecated)]
+    Panel::left("left_panel")
         .default_width(panel_width)
         .frame(
             Frame::new()
-                .fill(ctx.style().visuals.panel_fill)
+                .fill(ctx.global_style().visuals.panel_fill)
                 .inner_margin(Margin {
                     left: 10,
                     right: 10,

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -596,7 +596,7 @@ fn render_banner(
     details_expanded: &mut bool,
     banner_key: u64,
 ) -> bool {
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
     let fg_color = DashColors::message_color(message_type, dark_mode);
     let bg_color = DashColors::message_background_color(message_type, dark_mode);
     let secondary_color = DashColors::text_secondary(dark_mode);

--- a/src/ui/components/message_banner.rs
+++ b/src/ui/components/message_banner.rs
@@ -656,7 +656,7 @@ fn render_banner(
     details_expanded: &mut bool,
     banner_key: u64,
 ) -> bool {
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
     let fg_color = DashColors::message_color(message_type, dark_mode);
     let bg_color = DashColors::message_background_color(message_type, dark_mode);
     let secondary_color = DashColors::text_secondary(dark_mode);

--- a/src/ui/components/passphrase_modal.rs
+++ b/src/ui/components/passphrase_modal.rs
@@ -161,14 +161,14 @@ pub fn passphrase_modal(
                 spread: 0,
                 color: DashColors::popup_shadow(),
             },
-            fill: ctx.style().visuals.window_fill,
+            fill: ctx.global_style().visuals.window_fill,
             stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
         })
         .show(ctx, |ui| {
             ui.set_min_width(350.0);
             ui.set_max_width(400.0);
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             ui.label(egui::RichText::new(config.body).color(DashColors::text_primary(dark_mode)));
 

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -141,7 +141,7 @@ impl PasswordInput {
 
     /// Render the password input. Returns a [`PasswordInputResponse`].
     pub fn show(&mut self, ui: &mut Ui) -> PasswordInputResponse {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // -- TextEdit --------------------------------------------------------
         // INTENTIONAL(SEC-005): Egui TextEdit may cache plaintext in layout galleys and

--- a/src/ui/components/password_input.rs
+++ b/src/ui/components/password_input.rs
@@ -135,7 +135,7 @@ impl PasswordInput {
 
     /// Render the password input. Returns a [`PasswordInputResponse`].
     pub fn show(&mut self, ui: &mut Ui) -> PasswordInputResponse {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // -- TextEdit --------------------------------------------------------
         // INTENTIONAL(SEC-005): Egui TextEdit may cache plaintext in layout galleys and

--- a/src/ui/components/progress_overlay.rs
+++ b/src/ui/components/progress_overlay.rs
@@ -844,7 +844,7 @@ impl ProgressOverlay {
             // cancel directive.
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
         let rect = ctx.content_rect();
 
         // SEC-002: the dim + pointer sink + card render on Order::Foreground so
@@ -916,7 +916,7 @@ impl Component for ProgressOverlay {
         let Some(state) = &mut self.state else {
             return empty_overlay_response(ui);
         };
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let elapsed = state.created_at.elapsed();
         let stuck = stuck_reveal(elapsed);
         let show_elapsed = state.show_elapsed || stuck;
@@ -1051,7 +1051,7 @@ fn render_card(
 ) -> Option<String> {
     let mut clicked = None;
     egui::Frame::new()
-        .fill(ui.ctx().style().visuals.window_fill)
+        .fill(ui.style().visuals.window_fill)
         .inner_margin(egui::Margin::same(Spacing::MD as i8))
         .corner_radius(Shape::RADIUS_LG as f32)
         .shadow(Shadow::elevated())
@@ -1323,6 +1323,7 @@ mod tests {
     /// Drives one render pass over a bare context so `ctx.data`-level effects
     /// (log-once, focus) can be inspected without a kittest harness.
     fn render_once(ctx: &egui::Context) {
+        #[allow(deprecated)]
         let _ = ctx.run(egui::RawInput::default(), |ctx| {
             ProgressOverlay::render_global(ctx, false);
         });
@@ -1541,6 +1542,7 @@ mod tests {
             ],
             ..Default::default()
         };
+        #[allow(deprecated)]
         let _ = ctx.run(raw, |ctx| {
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
@@ -1618,6 +1620,7 @@ mod tests {
             events: vec![key_down(egui::Key::Enter), key_down(egui::Key::Space)],
             ..Default::default()
         };
+        #[allow(deprecated)]
         let _ = ctx.run(raw, |ctx| {
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
@@ -1654,6 +1657,7 @@ mod tests {
             events: vec![egui::Event::Text("hi".to_string())],
             ..Default::default()
         };
+        #[allow(deprecated)]
         let _ = ctx.run(raw, |ctx| {
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
@@ -1746,6 +1750,7 @@ mod tests {
         // No interaction has happened yet.
         assert!(overlay.current_value().is_none());
 
+        #[allow(deprecated)]
         let _ = ctx.run(egui::RawInput::default(), |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 let response = overlay.show(ui).inner;
@@ -1889,6 +1894,7 @@ mod tests {
         let ctx = egui::Context::default();
         let mut overlay = ProgressOverlay::new().with_description("Working.");
         overlay.clear();
+        #[allow(deprecated)]
         let _ = ctx.run(egui::RawInput::default(), |ctx| {
             egui::CentralPanel::default().show(ctx, |ui| {
                 let response = overlay.show(ui).inner;

--- a/src/ui/components/progress_overlay.rs
+++ b/src/ui/components/progress_overlay.rs
@@ -1323,8 +1323,8 @@ mod tests {
     /// Drives one render pass over a bare context so `ctx.data`-level effects
     /// (log-once, focus) can be inspected without a kittest harness.
     fn render_once(ctx: &egui::Context) {
-        #[allow(deprecated)]
-        let _ = ctx.run(egui::RawInput::default(), |ctx| {
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            let ctx = ui.ctx();
             ProgressOverlay::render_global(ctx, false);
         });
     }
@@ -1542,8 +1542,8 @@ mod tests {
             ],
             ..Default::default()
         };
-        #[allow(deprecated)]
-        let _ = ctx.run(raw, |ctx| {
+        let _ = ctx.run_ui(raw, |ui| {
+            let ctx = ui.ctx();
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
                 leaked.set(i.events.iter().any(|e| {
@@ -1620,8 +1620,8 @@ mod tests {
             events: vec![key_down(egui::Key::Enter), key_down(egui::Key::Space)],
             ..Default::default()
         };
-        #[allow(deprecated)]
-        let _ = ctx.run(raw, |ctx| {
+        let _ = ctx.run_ui(raw, |ui| {
+            let ctx = ui.ctx();
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
                 leaked.set(i.events.iter().any(|e| {
@@ -1657,8 +1657,8 @@ mod tests {
             events: vec![egui::Event::Text("hi".to_string())],
             ..Default::default()
         };
-        #[allow(deprecated)]
-        let _ = ctx.run(raw, |ctx| {
+        let _ = ctx.run_ui(raw, |ui| {
+            let ctx = ui.ctx();
             ProgressOverlay::claim_input(ctx);
             ctx.input(|i| {
                 kept.set(i.events.iter().any(|e| matches!(e, egui::Event::Text(_))));
@@ -1750,9 +1750,8 @@ mod tests {
         // No interaction has happened yet.
         assert!(overlay.current_value().is_none());
 
-        #[allow(deprecated)]
-        let _ = ctx.run(egui::RawInput::default(), |ctx| {
-            egui::CentralPanel::default().show(ctx, |ui| {
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
                 let response = overlay.show(ui).inner;
                 // A frame with no click is unchanged, valid, and value-free.
                 assert!(!response.has_changed());
@@ -1894,9 +1893,8 @@ mod tests {
         let ctx = egui::Context::default();
         let mut overlay = ProgressOverlay::new().with_description("Working.");
         overlay.clear();
-        #[allow(deprecated)]
-        let _ = ctx.run(egui::RawInput::default(), |ctx| {
-            egui::CentralPanel::default().show(ctx, |ui| {
+        let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
+            egui::CentralPanel::default().show(ui, |ui| {
                 let response = overlay.show(ui).inner;
                 assert!(!response.has_changed());
                 assert!(response.changed_value().is_none());

--- a/src/ui/components/selection_dialog.rs
+++ b/src/ui/components/selection_dialog.rs
@@ -208,7 +208,7 @@ impl SelectionDialog {
             .show(ui.ctx(), |ui| {
                 ui.set_min_width(300.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Message
                 ui.add_space(10.0);
@@ -259,7 +259,7 @@ impl SelectionDialog {
 
                         // Cancel button
                         if let Some(cancel_text) = &self.cancel_text {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             if ComponentStyles::add_secondary_button(
                                 ui,
                                 cancel_text.clone(),

--- a/src/ui/components/styled.rs
+++ b/src/ui/components/styled.rs
@@ -5,8 +5,7 @@ use crate::{
     ui::theme::{DashColors, Shadow, Shape, Spacing, Typography},
 };
 use egui::{
-    Button, CentralPanel, Color32, Context, Frame, Margin, Response, RichText, Stroke, TextEdit,
-    Ui, Vec2,
+    Button, CentralPanel, Color32, Frame, Margin, Response, RichText, Stroke, TextEdit, Ui, Vec2,
 };
 
 // Re-export commonly used components
@@ -536,25 +535,16 @@ pub fn styled_text_edit_multiline(text: &mut String, dark_mode: bool) -> TextEdi
 }
 
 /// Helper function to create an island-style central panel.
-///
-/// Wraps `CentralPanel::show(ctx, ...)`, which is deprecated in egui 0.34 in
-/// favor of `show_inside(ui, ...)`. The deprecation is silenced at this single
-/// boundary so the screen layer can keep its `&Context`-driven `ui()` shape.
-// TODO(egui-0.35): migrate to `Panel::central(...).show_inside(ui, ...)` and
-// thread `&mut Ui` from `App::ui` instead of `&Context`. Defers a 60+ call-site
-// refactor that exceeded the egui 0.34 upgrade scope. The current
-// `#[allow(deprecated)]` containment must be removed when this happens.
-pub fn island_central_panel<R>(ctx: &Context, content: impl FnOnce(&mut Ui) -> R) -> R {
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+pub fn island_central_panel<R>(ui: &mut Ui, content: impl FnOnce(&mut Ui) -> R) -> R {
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     CentralPanel::default()
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Standard margins for all panels
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             // Calculate responsive margins based on available width, but ensure minimum spacing
             let available_width = ui.available_width();
             let inner_margin = if available_width > 1200.0 {

--- a/src/ui/components/styled.rs
+++ b/src/ui/components/styled.rs
@@ -54,7 +54,7 @@ impl StyledButton {
     }
 
     pub fn show(self, ui: &mut Ui) -> Response {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         let (text_color, bg_color, _hover_color, stroke) = match self.variant {
             ButtonVariant::Primary => (
@@ -163,7 +163,7 @@ impl StyledCard {
     // }
 
     pub fn show<R>(self, ui: &mut Ui, content: impl FnOnce(&mut Ui) -> R) -> R {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         let stroke = if self.show_border {
             Stroke::new(1.0, DashColors::border(dark_mode))
@@ -301,7 +301,7 @@ impl GlassCard {
     }
 
     pub fn show<R>(self, ui: &mut Ui, content: impl FnOnce(&mut Ui) -> R) -> R {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         egui::Frame::new()
             .fill(DashColors::glass_white(dark_mode))
@@ -361,7 +361,7 @@ impl HeroSection {
             .shadow(Shadow::glow())
             .show(ui, |ui| {
                 ui.vertical_centered(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new(self.title)
                             .font(Typography::heading_large())
@@ -535,10 +535,15 @@ pub fn styled_text_edit_multiline(text: &mut String, dark_mode: bool) -> TextEdi
         .background_color(DashColors::input_background(dark_mode))
 }
 
-/// Helper function to create an island-style central panel
+/// Helper function to create an island-style central panel.
+///
+/// Wraps `CentralPanel::show(ctx, ...)`, which is deprecated in egui 0.34 in
+/// favor of `show_inside(ui, ...)`. The deprecation is silenced at this single
+/// boundary so the screen layer can keep its `&Context`-driven `ui()` shape.
 pub fn island_central_panel<R>(ctx: &Context, content: impl FnOnce(&mut Ui) -> R) -> R {
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
+    #[allow(deprecated)]
     CentralPanel::default()
         .frame(
             Frame::new()

--- a/src/ui/components/styled.rs
+++ b/src/ui/components/styled.rs
@@ -540,6 +540,10 @@ pub fn styled_text_edit_multiline(text: &mut String, dark_mode: bool) -> TextEdi
 /// Wraps `CentralPanel::show(ctx, ...)`, which is deprecated in egui 0.34 in
 /// favor of `show_inside(ui, ...)`. The deprecation is silenced at this single
 /// boundary so the screen layer can keep its `&Context`-driven `ui()` shape.
+// TODO(egui-0.35): migrate to `Panel::central(...).show_inside(ui, ...)` and
+// thread `&mut Ui` from `App::ui` instead of `&Context`. Defers a 60+ call-site
+// refactor that exceeded the egui 0.34 upgrade scope. The current
+// `#[allow(deprecated)]` containment must be removed when this happens.
 pub fn island_central_panel<R>(ctx: &Context, content: impl FnOnce(&mut Ui) -> R) -> R {
     let dark_mode = ctx.global_style().visuals.dark_mode;
 

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::ui::tokens::tokens_screen::TokensSubscreen;
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, SidePanel};
+use egui::{Context, Frame, Margin, RichText, Panel};
 
 pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
@@ -21,9 +21,10 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
         _ => TokensSubscreen::MyTokens,
     };
 
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    SidePanel::left("tokens_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("tokens_subscreen_chooser_panel")
         .resizable(false)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -3,9 +3,11 @@ use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::ui::tokens::tokens_screen::TokensSubscreen;
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 
-pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_tokens_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     let subscreens = vec![
@@ -23,16 +25,15 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
 
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("tokens_subscreen_chooser_panel")
         .resizable(false)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             let available_height = ui.available_height();
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::ui::tokens::tokens_screen::TokensSubscreen;
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, Panel};
+use egui::{Context, Frame, Margin, Panel, RichText};
 
 pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::ui::tokens::tokens_screen::TokensSubscreen;
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, SidePanel};
+use egui::{Context, Frame, Margin, RichText, Panel};
 
 pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
@@ -24,9 +24,10 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
         _ => TokensSubscreen::MyTokens, // Fallback to Active screen if settings unavailable
     };
 
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    SidePanel::left("tokens_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("tokens_subscreen_chooser_panel")
         .resizable(false)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::spv::CoreBackendMode;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, ScrollArea, Panel};
+use egui::{Context, Frame, Margin, Panel, RichText, ScrollArea};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -2,7 +2,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, ScrollArea, SidePanel};
+use egui::{Context, Frame, Margin, RichText, ScrollArea, Panel};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {
@@ -33,7 +33,7 @@ impl ToolsSubscreen {
 
 pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
 
     let subscreens = vec![
         ToolsSubscreen::PlatformInfo,
@@ -67,7 +67,8 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
         _ => ToolsSubscreen::PlatformInfo,
     };
 
-    SidePanel::left("tools_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("tools_subscreen_chooser_panel")
         .resizable(false)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::spv::CoreBackendMode;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, ScrollArea, SidePanel};
+use egui::{Context, Frame, Margin, RichText, ScrollArea, Panel};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {
@@ -47,7 +47,7 @@ impl ToolsSubscreen {
 
 pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
     let is_rpc_mode = app_context.core_backend_mode() == CoreBackendMode::Rpc;
 
     let subscreens = vec![
@@ -93,7 +93,8 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
         _ => ToolsSubscreen::PlatformInfo, // Fallback to Active screen if settings unavailable
     };
 
-    SidePanel::left("tools_subscreen_chooser_panel")
+    #[allow(deprecated)]
+    Panel::left("tools_subscreen_chooser_panel")
         .resizable(false)
         .default_width(270.0)
         .frame(

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -2,7 +2,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, RichText, ScrollArea, Panel};
+use egui::{Context, Frame, Margin, Panel, RichText, ScrollArea};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -2,7 +2,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText, ScrollArea};
+use egui::{Frame, Margin, Panel, RichText, ScrollArea, Ui};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {
@@ -31,7 +31,9 @@ impl ToolsSubscreen {
     }
 }
 
-pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_tools_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
@@ -67,16 +69,15 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
         _ => ToolsSubscreen::PlatformInfo,
     };
 
-    #[allow(deprecated)]
     Panel::left("tools_subscreen_chooser_panel")
         .resizable(false)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             let available_height = ui.available_height();
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -173,23 +173,24 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
 }
 
 pub fn add_top_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     location: Vec<(&str, AppAction)>,
     right_buttons: Vec<(&str, DesiredAppAction)>,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
     let dark_mode = ctx.global_style().visuals.dark_mode;
     let network_accent = DashColors::network_accent(app_context.network, dark_mode);
 
-    #[allow(deprecated)]
     Panel::top("top_panel")
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::same(10)), // 10px margin on all sides
         )
-        .show(ctx, |ui| {
+        .show(ui, |ui| {
             // Create an island panel with rounded edges
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -6,7 +6,7 @@ use crate::context::connection_status::OverallConnectionState;
 use crate::spv::CoreBackendMode;
 use crate::ui::ScreenType;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt, Shadow, Shape};
-use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, Panel, Ui};
+use egui::{Align2, Context, FontId, Frame, Margin, Panel, RichText, TextureHandle, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -6,7 +6,7 @@ use crate::context::connection_status::OverallConnectionState;
 use crate::spv::CoreBackendMode;
 use crate::ui::ScreenType;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt, Shadow, Shape};
-use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, TopBottomPanel, Ui};
+use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, Panel, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;
@@ -101,7 +101,7 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
     let backend_mode = status.backend_mode();
     let overall = status.overall_state();
 
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
     let circle_size = 14.0;
 
     // Five-state color: green (synced), orange (syncing/connecting), magenta (error), red (disconnected)
@@ -207,10 +207,11 @@ pub fn add_top_panel(
     right_buttons: Vec<(&str, DesiredAppAction)>,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
     let network_accent = DashColors::network_accent(app_context.network, dark_mode);
 
-    TopBottomPanel::top("top_panel")
+    #[allow(deprecated)]
+    Panel::top("top_panel")
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
@@ -289,7 +290,7 @@ pub fn add_top_panel(
                                     );
                                     let popup_id = ui.make_persistent_id("docs_popup");
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     egui::Popup::new(
                                         popup_id,
                                         ui.ctx().clone(),
@@ -328,7 +329,7 @@ pub fn add_top_panel(
                                         network_accent,
                                     );
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     egui::Popup::new(
                                         popup_id,
                                         ui.ctx().clone(),

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -3,7 +3,7 @@ use crate::context::AppContext;
 use crate::context::connection_status::OverallConnectionState;
 use crate::ui::ScreenType;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt, Shadow, Shape};
-use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, TopBottomPanel, Ui};
+use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, Panel, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;
@@ -97,7 +97,7 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
     let status = app_context.connection_status();
     let overall = status.overall_state();
 
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
     let circle_size = 14.0;
 
     // Five-state color: green (synced), orange (syncing/connecting), magenta (error), red (disconnected)
@@ -179,10 +179,11 @@ pub fn add_top_panel(
     right_buttons: Vec<(&str, DesiredAppAction)>,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.style().visuals.dark_mode;
+    let dark_mode = ctx.global_style().visuals.dark_mode;
     let network_accent = DashColors::network_accent(app_context.network, dark_mode);
 
-    TopBottomPanel::top("top_panel")
+    #[allow(deprecated)]
+    Panel::top("top_panel")
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
@@ -261,7 +262,7 @@ pub fn add_top_panel(
                                     );
                                     let popup_id = ui.make_persistent_id("docs_popup");
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     egui::Popup::new(
                                         popup_id,
                                         ui.ctx().clone(),
@@ -300,7 +301,7 @@ pub fn add_top_panel(
                                         network_accent,
                                     );
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     egui::Popup::new(
                                         popup_id,
                                         ui.ctx().clone(),

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -3,7 +3,7 @@ use crate::context::AppContext;
 use crate::context::connection_status::OverallConnectionState;
 use crate::ui::ScreenType;
 use crate::ui::theme::{ComponentStyles, DashColors, ResponseExt, Shadow, Shape};
-use egui::{Align2, Context, FontId, Frame, Margin, RichText, TextureHandle, Panel, Ui};
+use egui::{Align2, Context, FontId, Frame, Margin, Panel, RichText, TextureHandle, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;

--- a/src/ui/components/wallet_unlock_popup.rs
+++ b/src/ui/components/wallet_unlock_popup.rs
@@ -109,14 +109,14 @@ impl WalletUnlockPopup {
                     spread: 0,
                     color: DashColors::popup_shadow(),
                 },
-                fill: ctx.style().visuals.window_fill,
+                fill: ctx.global_style().visuals.window_fill,
                 stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
             })
             .show(ctx, |ui| {
                 ui.set_min_width(350.0);
                 ui.set_max_width(400.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Title/description
                 ui.label(

--- a/src/ui/contracts_documents/add_contracts_screen.rs
+++ b/src/ui/contracts_documents/add_contracts_screen.rs
@@ -11,7 +11,7 @@ use crate::ui::{BackendTaskSuccessResult, MessageType, ScreenLike};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::identifier::Identifier;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use std::sync::Arc;
 
 const MAX_CONTRACTS: usize = 10;
@@ -305,9 +305,9 @@ impl ScreenLike for AddContractsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -317,12 +317,12 @@ impl ScreenLike for AddContractsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             ui.heading("Add Contracts");
             ui.add_space(10.0);
 

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -692,50 +692,50 @@ impl ScreenLike for DocumentQueryScreen {
         action |= {
             #[allow(deprecated)]
             CentralPanel::default()
-            .frame(
-                Frame::new()
-                    .fill(DashColors::background(dark_mode))
-                    .inner_margin(Margin {
-                        left: 10,
-                        right: 19, // More space on the right
-                        top: 10,
-                        bottom: 0, // Less space on the bottom
-                    }),
-            )
-            .show(ctx, |ui| {
-                // Create an island panel with rounded edges
-                Frame::new()
-                    .fill(DashColors::surface(dark_mode))
-                    .stroke(Stroke::new(1.0, DashColors::border_light(dark_mode)))
-                    .inner_margin(Margin::same(20))
-                    .corner_radius(egui::CornerRadius::same(Shape::RADIUS_LG))
-                    .shadow(Shadow::elevated())
-                    .show(ui, |ui| {
-                        MessageBanner::show_global(ui);
-                        let mut inner_action = AppAction::None;
+                .frame(
+                    Frame::new()
+                        .fill(DashColors::background(dark_mode))
+                        .inner_margin(Margin {
+                            left: 10,
+                            right: 19, // More space on the right
+                            top: 10,
+                            bottom: 0, // Less space on the bottom
+                        }),
+                )
+                .show(ctx, |ui| {
+                    // Create an island panel with rounded edges
+                    Frame::new()
+                        .fill(DashColors::surface(dark_mode))
+                        .stroke(Stroke::new(1.0, DashColors::border_light(dark_mode)))
+                        .inner_margin(Margin::same(20))
+                        .corner_radius(egui::CornerRadius::same(Shape::RADIUS_LG))
+                        .shadow(Shadow::elevated())
+                        .show(ui, |ui| {
+                            MessageBanner::show_global(ui);
+                            let mut inner_action = AppAction::None;
 
-                        // Use a vertical layout that allocates space properly
-                        ui.vertical(|ui| {
-                            // Input field at the top
-                            inner_action |= self.show_input_field(ui);
+                            // Use a vertical layout that allocates space properly
+                            ui.vertical(|ui| {
+                                // Input field at the top
+                                inner_action |= self.show_input_field(ui);
 
-                            // Document display area that expands to fill available space
-                            ui.with_layout(
-                                egui::Layout::top_down_justified(egui::Align::LEFT),
-                                |ui| {
-                                    inner_action |= self.show_output(ui);
-                                },
-                            );
-                        });
+                                // Document display area that expands to fill available space
+                                ui.with_layout(
+                                    egui::Layout::top_down_justified(egui::Align::LEFT),
+                                    |ui| {
+                                        inner_action |= self.show_output(ui);
+                                    },
+                                );
+                            });
 
-                        if self.contract_to_remove.is_some() {
-                            inner_action |= self.show_remove_contract_popup(ui);
-                        }
-                        inner_action
-                    })
-                    .inner
-            })
-            .inner
+                            if self.contract_to_remove.is_some() {
+                                inner_action |= self.show_remove_contract_popup(ui);
+                            }
+                            inner_action
+                        })
+                        .inner
+                })
+                .inner
         };
 
         action

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -166,7 +166,7 @@ impl DocumentQueryScreen {
             let available = ui.available_width();
             let text_width = (available - button_width - spacing).max(100.0); // Ensure minimum width
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(
                 egui::TextEdit::singleline(&mut self.document_query)
                     .desired_width(text_width)
@@ -294,7 +294,7 @@ impl DocumentQueryScreen {
                         });
 
                         ui.separator();
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                             self.show_fields_dropdown = false;
                         }
@@ -453,7 +453,7 @@ impl DocumentQueryScreen {
         let mut combined_string = doc_strings.join("\n\n");
 
         // 3) Display in multiline text
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.add(
             egui::TextEdit::multiline(&mut combined_string)
                 .desired_rows(10)
@@ -687,9 +687,11 @@ impl ScreenLike for DocumentQueryScreen {
         }
 
         // Custom central panel with adjusted margins for Document Query screen
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
-        action |= CentralPanel::default()
+        action |= {
+            #[allow(deprecated)]
+            CentralPanel::default()
             .frame(
                 Frame::new()
                     .fill(DashColors::background(dark_mode))
@@ -733,7 +735,8 @@ impl ScreenLike for DocumentQueryScreen {
                     })
                     .inner
             })
-            .inner;
+            .inner
+        };
 
         action
     }

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -23,7 +23,7 @@ use dash_sdk::dpp::data_contract::document_type::{DocumentType, Index};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
 use dash_sdk::platform::{Document, DocumentQuery, Identifier};
-use egui::{CentralPanel, Context, Frame, Margin, ScrollArea, Stroke, Ui};
+use egui::{CentralPanel, Frame, Margin, ScrollArea, Stroke, Ui};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -579,7 +579,9 @@ impl ScreenLike for DocumentQueryScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let load_contract_button = (
             "Load Contracts",
             DesiredAppAction::AddScreenType(Box::new(ScreenType::AddContracts)),
@@ -623,7 +625,7 @@ impl ScreenLike for DocumentQueryScreen {
         let mut action = AppAction::None;
         if self.app_context.network == Network::Mainnet {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Contracts", AppAction::None)],
                 vec![
@@ -640,7 +642,7 @@ impl ScreenLike for DocumentQueryScreen {
             );
         } else {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Contracts", AppAction::None)],
                 vec![
@@ -659,13 +661,13 @@ impl ScreenLike for DocumentQueryScreen {
         }
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenDocumentQuery,
         );
 
         action |= add_contract_chooser_panel(
-            ctx,
+            ui,
             &mut self.contract_search_term,
             &self.app_context,
             &mut self.selected_data_contract,
@@ -690,7 +692,6 @@ impl ScreenLike for DocumentQueryScreen {
         let dark_mode = ctx.global_style().visuals.dark_mode;
 
         action |= {
-            #[allow(deprecated)]
             CentralPanel::default()
                 .frame(
                     Frame::new()
@@ -702,7 +703,7 @@ impl ScreenLike for DocumentQueryScreen {
                             bottom: 0, // Less space on the bottom
                         }),
                 )
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     // Create an island panel with rounded edges
                     Frame::new()
                         .fill(DashColors::surface(dark_mode))

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -49,7 +49,7 @@ use dash_sdk::drive::query::WhereClause;
 use dash_sdk::platform::{DocumentQuery, Identifier, IdentityPublicKey};
 use dash_sdk::query_types::IndexMap;
 use eframe::epaint::Color32;
-use egui::{Context, Frame, Margin, RichText, Ui};
+use egui::{Frame, Margin, RichText, Ui};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
@@ -1561,9 +1561,11 @@ impl DocumentActionScreen {
 }
 
 impl ScreenLike for DocumentActionScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -1573,12 +1575,12 @@ impl ScreenLike for DocumentActionScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| match &self.broadcast_status {
+        action |= island_central_panel(ui, |ui| match &self.broadcast_status {
             BroadcastStatus::Broadcasted => {
                 let success_message = format!("{} successful!", self.action_type.display_name());
                 let back_button = ("Back to Contracts".to_string(), AppAction::GoToMainScreen);

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -373,7 +373,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -510,7 +510,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -570,7 +570,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -653,7 +653,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -662,7 +662,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Price (credits):");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.price_input,
                 dark_mode,
@@ -682,7 +682,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -691,7 +691,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Recipient Identity:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.recipient_id_input,
                 dark_mode,
@@ -735,7 +735,7 @@ impl DocumentActionScreen {
                         | DocumentPropertyType::I16
                         | DocumentPropertyType::U8
                         | DocumentPropertyType::I8 => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("integer")
@@ -744,7 +744,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::F64 => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("floating-point")
@@ -753,7 +753,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::String(size) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add({
                                 let text_edit = egui::TextEdit::singleline(val)
                                     .text_color(DashColors::text_primary(dark_mode))
@@ -766,7 +766,7 @@ impl DocumentActionScreen {
                             });
                         }
                         DocumentPropertyType::ByteArray(_size) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("hex or base64")
@@ -775,7 +775,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::Identifier => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("base58 identifier")
@@ -793,7 +793,7 @@ impl DocumentActionScreen {
                             }
                         }
                         DocumentPropertyType::Date => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("unix-ms")
@@ -804,7 +804,7 @@ impl DocumentActionScreen {
                         DocumentPropertyType::Object(_)
                         | DocumentPropertyType::Array(_)
                         | DocumentPropertyType::VariableTypeArray(_) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::multiline(val)
                                     .hint_text("JSON value")
@@ -896,7 +896,7 @@ impl DocumentActionScreen {
         };
 
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -370,7 +370,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -507,7 +507,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -567,7 +567,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -650,7 +650,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -659,7 +659,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Price (credits):");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.price_input,
                 dark_mode,
@@ -679,7 +679,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Document ID:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.document_id_input,
                 dark_mode,
@@ -688,7 +688,7 @@ impl DocumentActionScreen {
 
         ui.horizontal(|ui| {
             ui.label("Recipient Identity:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add(styled_text_edit_singleline(
                 &mut self.recipient_id_input,
                 dark_mode,
@@ -732,7 +732,7 @@ impl DocumentActionScreen {
                         | DocumentPropertyType::I16
                         | DocumentPropertyType::U8
                         | DocumentPropertyType::I8 => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("integer")
@@ -741,7 +741,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::F64 => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("floating-point")
@@ -750,7 +750,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::String(size) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add({
                                 let text_edit = egui::TextEdit::singleline(val)
                                     .text_color(DashColors::text_primary(dark_mode))
@@ -763,7 +763,7 @@ impl DocumentActionScreen {
                             });
                         }
                         DocumentPropertyType::ByteArray(_size) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("hex or base64")
@@ -772,7 +772,7 @@ impl DocumentActionScreen {
                             );
                         }
                         DocumentPropertyType::Identifier => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("base58 identifier")
@@ -790,7 +790,7 @@ impl DocumentActionScreen {
                             }
                         }
                         DocumentPropertyType::Date => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
                                     .hint_text("unix-ms")
@@ -801,7 +801,7 @@ impl DocumentActionScreen {
                         DocumentPropertyType::Object(_)
                         | DocumentPropertyType::Array(_)
                         | DocumentPropertyType::VariableTypeArray(_) => {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::multiline(val)
                                     .hint_text("JSON value")
@@ -893,7 +893,7 @@ impl DocumentActionScreen {
         };
 
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -49,7 +49,7 @@ use dash_sdk::dpp::tokens::emergency_action::TokenEmergencyAction;
 use dash_sdk::dpp::tokens::token_event::TokenEvent;
 use dash_sdk::platform::Identifier;
 use dash_sdk::query_types::IndexMap;
-use eframe::egui::{self, Context, RichText};
+use eframe::egui::{self, RichText};
 use egui::{ScrollArea, TextStyle};
 use egui_extras::{Column, TableBuilder};
 use std::collections::BTreeMap;
@@ -474,9 +474,9 @@ impl ScreenLike for GroupActionsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -486,12 +486,12 @@ impl ScreenLike for GroupActionsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenDocumentQuery,
         );
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             ui.heading("Active Group Actions");
 
             ui.add_space(10.0);

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -24,7 +24,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{Purpose, SecurityLevel};
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, TextEdit};
+use eframe::egui::{self, Color32, Frame, Margin, TextEdit};
 use egui::{RichText, ScrollArea, Ui};
 use std::sync::{Arc, RwLock};
 
@@ -351,9 +351,11 @@ impl ScreenLike for RegisterDataContractScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -363,12 +365,12 @@ impl ScreenLike for RegisterDataContractScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             if self.broadcast_status == BroadcastStatus::Done {
                 return self.show_success(ui);
             }

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -156,7 +156,7 @@ impl RegisterDataContractScreen {
     }
 
     fn ui_input_field(&mut self, ui: &mut egui::Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let response = ui.add(
             TextEdit::multiline(&mut self.contract_json_input)
                 .desired_rows(12)
@@ -179,7 +179,7 @@ impl RegisterDataContractScreen {
         };
 
         if let Some(msg) = error_msg {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             let error_color = DashColors::error_color(dark_mode);
             Frame::new()
                 .fill(error_color.gamma_multiply(0.1))
@@ -224,7 +224,7 @@ impl RegisterDataContractScreen {
                     .estimate_storage_based_fee(contract_size, 20); // ~20 seeks for tree operations
                 let estimated_fee = registration_fee.saturating_add(storage_fee);
                 ui.add_space(10.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -171,7 +171,7 @@ impl UpdateDataContractScreen {
         ScrollArea::vertical()
             .max_height(ui.available_height() - 100.0)
             .show(ui, |ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let response = ui.add(
                     TextEdit::multiline(&mut self.contract_json_input)
                         .desired_rows(6)
@@ -235,7 +235,7 @@ impl UpdateDataContractScreen {
                     .contract_update;
                 let estimated_fee = base_fee.saturating_add(registration_fee);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -26,7 +26,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, TextEdit};
+use eframe::egui::{self, Color32, Frame, Margin, TextEdit};
 use egui::{RichText, ScrollArea, Ui};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -372,9 +372,11 @@ impl ScreenLike for UpdateDataContractScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -384,12 +386,12 @@ impl ScreenLike for UpdateDataContractScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             if self.broadcast_status == BroadcastStatus::Done {
                 return self.show_success(ui);
             }

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -241,7 +241,7 @@ impl ScreenLike for AddContactScreen {
             }
 
             ui.group(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("From (Sender)")
                         .strong()
@@ -323,7 +323,7 @@ impl ScreenLike for AddContactScreen {
             // Loading indicator
             if matches!(self.status, ContactRequestStatus::Sending) {
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add(egui::widgets::Spinner::default().color(DashColors::DASH_BLUE));
                     ui.label(
                         RichText::new("Sending contact request...")
@@ -335,7 +335,7 @@ impl ScreenLike for AddContactScreen {
 
             // Show error if any
             if let ContactRequestStatus::Error(ref err) = self.status {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let error_color = if dark_mode {
                     DashColors::ERROR
                 } else {
@@ -400,7 +400,7 @@ impl ScreenLike for AddContactScreen {
             // Contact request form
             ScrollArea::vertical().show(ui, |ui| {
                 ui.group(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("To (Recipient)")
                             .strong()
@@ -443,7 +443,7 @@ impl ScreenLike for AddContactScreen {
                 // Show summary if all required fields are filled
                 if self.selected_identity.is_some() && !self.username_or_id.is_empty() {
                     ui.group(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Request Summary")
                                 .strong()
@@ -494,7 +494,7 @@ impl ScreenLike for AddContactScreen {
                 }
 
                 ui.group(|ui| {
-                    let _dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let _dark_mode = ui.style().visuals.dark_mode;
 
                     // Check wallet lock status before showing send button
                     let wallet_locked = if let Some(wallet) = &self.selected_wallet {
@@ -576,6 +576,7 @@ impl ScreenLike for AddContactScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -23,7 +23,7 @@ use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 use dash_sdk::platform::IdentityPublicKey;
-use egui::{Context, RichText, ScrollArea, TextEdit, Ui};
+use egui::{RichText, ScrollArea, TextEdit, Ui};
 use std::sync::{Arc, RwLock};
 
 const CONTACT_REQUEST_INFO_TEXT: &str = "About Contact Requests:\n\n\
@@ -188,10 +188,12 @@ impl ScreenLike for AddContactScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Add top panel with navigation breadcrumbs
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -201,12 +203,12 @@ impl ScreenLike for AddContactScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content in island central panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show success screen if request was successful
@@ -577,10 +579,9 @@ impl ScreenLike for AddContactScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("About Contact Requests", CONTACT_REQUEST_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -242,7 +242,7 @@ impl ScreenLike for AddContactScreen {
             }
 
             ui.group(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("From (Sender)")
                         .strong()
@@ -324,7 +324,7 @@ impl ScreenLike for AddContactScreen {
             // Loading indicator
             if matches!(self.status, ContactRequestStatus::Sending) {
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add(egui::widgets::Spinner::default().color(DashColors::DASH_BLUE));
                     ui.label(
                         RichText::new("Sending contact request...")
@@ -336,7 +336,7 @@ impl ScreenLike for AddContactScreen {
 
             // Show error if any
             if let ContactRequestStatus::Error(ref err) = self.status {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let error_color = if dark_mode {
                     DashColors::ERROR
                 } else {
@@ -401,7 +401,7 @@ impl ScreenLike for AddContactScreen {
             // Contact request form
             ScrollArea::vertical().show(ui, |ui| {
                 ui.group(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("To (Recipient)")
                             .strong()
@@ -444,7 +444,7 @@ impl ScreenLike for AddContactScreen {
                 // Show summary if all required fields are filled
                 if self.selected_identity.is_some() && !self.username_or_id.is_empty() {
                     ui.group(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Request Summary")
                                 .strong()
@@ -495,7 +495,7 @@ impl ScreenLike for AddContactScreen {
                 }
 
                 ui.group(|ui| {
-                    let _dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let _dark_mode = ui.style().visuals.dark_mode;
 
                     // Check wallet lock status before showing send button
                     let wallet_locked = if let Some(wallet) = &self.selected_wallet {
@@ -577,6 +577,7 @@ impl ScreenLike for AddContactScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -424,7 +424,7 @@ impl ContactDetailsScreen {
                         ui.label("No payment history with this contact");
                     } else {
                         for payment in &self.payment_history {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.horizontal(|ui| {
                                 // Direction indicator
                                 if payment.is_incoming {
@@ -554,6 +554,7 @@ impl ScreenLike for ContactDetailsScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -413,7 +413,7 @@ impl ContactDetailsScreen {
                         ui.label("No payment history with this contact");
                     } else {
                         for payment in &self.payment_history {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.horizontal(|ui| {
                                 // Direction indicator
                                 if payment.is_incoming {
@@ -543,6 +543,7 @@ impl ScreenLike for ContactDetailsScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -509,7 +509,7 @@ impl ScreenLike for ContactDetailsScreen {
         self.needs_backend_fetch = true;
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel with contact name if available
@@ -525,7 +525,7 @@ impl ScreenLike for ContactDetailsScreen {
             .unwrap_or_else(|| "Contact Details".to_string());
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -535,18 +535,17 @@ impl ScreenLike for ContactDetailsScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Private Contact Information", PRIVATE_CONTACT_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/contact_info_editor.rs
+++ b/src/ui/dashpay/contact_info_editor.rs
@@ -120,7 +120,7 @@ impl ContactInfoEditorScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Header with Back button and title
         ui.horizontal(|ui| {
@@ -265,7 +265,7 @@ impl ContactInfoEditorScreen {
                 } else {
                     // Action buttons
                     ui.horizontal(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
 
                         if self.saving {
                             ui.spinner();
@@ -341,6 +341,7 @@ impl ScreenLike for ContactInfoEditorScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_info_editor.rs
+++ b/src/ui/dashpay/contact_info_editor.rs
@@ -311,7 +311,9 @@ impl ContactInfoEditorScreen {
 }
 
 impl ScreenLike for ContactInfoEditorScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel with back button
@@ -321,7 +323,7 @@ impl ScreenLike for ContactInfoEditorScreen {
         )];
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -332,19 +334,18 @@ impl ScreenLike for ContactInfoEditorScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Private Contact Information", PRIVATE_CONTACT_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -215,7 +215,7 @@ impl ContactProfileViewerScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Fetch profile on first render if not already done
         if !self.initial_fetch_done && !self.loading {
@@ -654,6 +654,7 @@ impl ScreenLike for ContactProfileViewerScreen {
 
         // Show info popup if requested
         if let Some((title, text)) = self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -213,7 +213,7 @@ impl ContactProfileViewerScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Fetch profile on first render if not already done
         if !self.initial_fetch_done && !self.loading {
@@ -651,6 +651,7 @@ impl ScreenLike for ContactProfileViewerScreen {
 
         // Show info popup if requested
         if let Some((title, text)) = self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -628,12 +628,12 @@ impl ContactProfileViewerScreen {
 }
 
 impl ScreenLike for ContactProfileViewerScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -643,18 +643,17 @@ impl ScreenLike for ContactProfileViewerScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if let Some((title, text)) = self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new(title, text);
                     if popup.show(ui).inner {
                         self.show_info_popup = None;

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -606,7 +606,7 @@ impl ContactRequests {
         // Show structured error with action buttons if any
         let mut dismiss_error = false;
         if let Some(err) = &self.error {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             let error_color = if dark_mode {
                 DashColors::ERROR
             } else {
@@ -648,7 +648,7 @@ impl ContactRequests {
         }
 
         // Tabs
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.horizontal(|ui| {
             let incoming_tab = egui::Button::new(RichText::new("Incoming").color(
                 if self.active_tab == RequestTab::Incoming {
@@ -715,7 +715,7 @@ impl ContactRequests {
                 } else {
                     ScrollArea::vertical().id_salt("incoming_requests_scroll").show(ui, |ui| {
                     if self.incoming_requests.is_empty() {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -748,7 +748,7 @@ impl ContactRequests {
 
                                     ui.vertical(|ui| {
                                         use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
 
                                         // Display name or username or identity ID
                                         let name = request
@@ -897,7 +897,7 @@ impl ContactRequests {
                 } else {
                     ScrollArea::vertical().id_salt("outgoing_requests_scroll").show(ui, |ui| {
                     if self.outgoing_requests.is_empty() {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -940,7 +940,7 @@ impl ContactRequests {
 
                                     ui.vertical(|ui| {
                                         use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
 
                                         // For outgoing requests, show display name or username or truncated ID
                                         let id_str = request.to_identity.to_string(Encoding::Base58);
@@ -991,7 +991,7 @@ impl ContactRequests {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
-                                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                            let dark_mode = ui.style().visuals.dark_mode;
                                             ui.label(
                                                 RichText::new("Cannot be cancelled once sent")
                                                     .small()
@@ -1025,6 +1025,7 @@ impl ScreenLike for ContactRequests {
     fn ui(&mut self, ctx: &egui::Context) -> AppAction {
         // Create a simple central panel for rendering
         let mut action = AppAction::None;
+        #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             action = self.render(ui);
         });

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -822,11 +822,12 @@ impl ScreenLike for ContactRequests {
         }
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Create a simple central panel for rendering
         let mut action = AppAction::None;
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             action = self.render(ui);
         });
 

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -406,7 +406,7 @@ impl ContactRequests {
         // Show structured error with action buttons if any
         let mut dismiss_error = false;
         if let Some(err) = &self.error {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             let error_color = if dark_mode {
                 DashColors::ERROR
             } else {
@@ -448,7 +448,7 @@ impl ContactRequests {
         }
 
         // Tabs
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.horizontal(|ui| {
             let incoming_tab = egui::Button::new(RichText::new("Incoming").color(
                 if self.active_tab == RequestTab::Incoming {
@@ -515,7 +515,7 @@ impl ContactRequests {
                 } else {
                     ScrollArea::vertical().id_salt("incoming_requests_scroll").show(ui, |ui| {
                     if self.incoming_requests.is_empty() {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -548,7 +548,7 @@ impl ContactRequests {
 
                                     ui.vertical(|ui| {
                                         use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
 
                                         // Display name or username or identity ID
                                         let name = request
@@ -697,7 +697,7 @@ impl ContactRequests {
                 } else {
                     ScrollArea::vertical().id_salt("outgoing_requests_scroll").show(ui, |ui| {
                     if self.outgoing_requests.is_empty() {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -740,7 +740,7 @@ impl ContactRequests {
 
                                     ui.vertical(|ui| {
                                         use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
 
                                         // For outgoing requests, show display name or username or truncated ID
                                         let id_str = request.to_identity.to_string(Encoding::Base58);
@@ -791,7 +791,7 @@ impl ContactRequests {
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
-                                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                            let dark_mode = ui.style().visuals.dark_mode;
                                             ui.label(
                                                 RichText::new("Cannot be cancelled once sent")
                                                     .small()
@@ -825,6 +825,7 @@ impl ScreenLike for ContactRequests {
     fn ui(&mut self, ctx: &egui::Context) -> AppAction {
         // Create a simple central panel for rendering
         let mut action = AppAction::None;
+        #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             action = self.render(ui);
         });

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -292,7 +292,7 @@ impl ContactsList {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Identity selector
         let identities = self
@@ -703,7 +703,7 @@ impl ContactsList {
             .id_salt("contacts_list_scroll")
             .show(ui, |ui| {
                 if self.contacts.is_empty() {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     Frame::group(ui.style())
                         .fill(ui.visuals().extreme_bg_color)
                         .corner_radius(5.0)
@@ -738,7 +738,7 @@ impl ContactsList {
                             });
                         });
                 } else if filtered_contacts.is_empty() {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     Frame::group(ui.style())
                         .fill(ui.visuals().extreme_bg_color)
                         .corner_radius(5.0)
@@ -878,7 +878,7 @@ impl ContactsList {
                                         .cloned()
                                         .unwrap_or_else(|| "Unknown".to_string());
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
 
                                     // Add hidden indicator to name if contact is hidden
                                     let display_name = if contact.is_hidden {
@@ -1013,6 +1013,7 @@ impl ScreenLike for ContactsList {
 
     fn ui(&mut self, ctx: &egui::Context) -> AppAction {
         let mut action = AppAction::None;
+        #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             action = self.render(ui);
         });

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -1054,10 +1054,9 @@ impl ScreenLike for ContactsList {
         }
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show(ui, |ui| {
             action = self.render(ui);
         });
         action

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -301,7 +301,7 @@ impl ContactsList {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Auto-fetch contacts on first render or after identity change.
         if !self.has_loaded && !self.loading && self.selected_identity.is_some() {
@@ -731,7 +731,7 @@ impl ContactsList {
             .id_salt("contacts_list_scroll")
             .show(ui, |ui| {
                 if self.contacts.is_empty() {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     Frame::group(ui.style())
                         .fill(ui.visuals().extreme_bg_color)
                         .corner_radius(5.0)
@@ -766,7 +766,7 @@ impl ContactsList {
                             });
                         });
                 } else if filtered_contacts.is_empty() {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     Frame::group(ui.style())
                         .fill(ui.visuals().extreme_bg_color)
                         .corner_radius(5.0)
@@ -906,7 +906,7 @@ impl ContactsList {
                                         .cloned()
                                         .unwrap_or_else(|| "Unknown".to_string());
 
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
 
                                     // Add hidden indicator to name if contact is hidden
                                     let display_name = if contact.is_hidden {
@@ -1056,6 +1056,7 @@ impl ScreenLike for ContactsList {
 
     fn ui(&mut self, ctx: &egui::Context) -> AppAction {
         let mut action = AppAction::None;
+        #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             action = self.render(ui);
         });

--- a/src/ui/dashpay/dashpay_screen.rs
+++ b/src/ui/dashpay/dashpay_screen.rs
@@ -7,7 +7,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
-use egui::{Context, Ui};
+use egui::Ui;
 use std::sync::Arc;
 
 use super::contacts_list::ContactsList;
@@ -73,7 +73,7 @@ impl ScreenLike for DashPayScreen {
         self.refresh();
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel with action buttons based on current subscreen
@@ -108,21 +108,21 @@ impl ScreenLike for DashPayScreen {
         };
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("DashPay", AppAction::None)],
             right_buttons,
         );
 
         // Highlight Dashpay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // DashPay subscreen chooser panel on the left side of the content area
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, self.dashpay_subscreen);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, self.dashpay_subscreen);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render_subscreen(ui));
+        action |= island_central_panel(ui, |ui| self.render_subscreen(ui));
 
         // Handle custom actions from top panel buttons
         if let AppAction::Custom(command) = &action {

--- a/src/ui/dashpay/mod.rs
+++ b/src/ui/dashpay/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Arc;
 /// Renders a styled "No Identities Loaded" card for DashPay screens.
 /// Returns an AppAction if the user clicks the "Load Identity" button.
 pub fn render_no_identities_card(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAction {
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
 
     Frame::group(ui.style())
         .fill(ui.visuals().extreme_bg_color)

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -1166,10 +1166,9 @@ impl ProfileScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ui.ctx(), |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Profile Guidelines", PROFILE_GUIDELINES_INFO_TEXT);
                     if popup.show(ui).inner {
@@ -1180,10 +1179,9 @@ impl ProfileScreen {
 
         // Show avatar info popup if requested
         if self.show_avatar_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ui.ctx(), |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new("Avatar Image Guidelines", AVATAR_URL_INFO_TEXT);
                     if popup.show(ui).inner {
                         self.show_avatar_info_popup = false;

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -562,7 +562,7 @@ impl ProfileScreen {
 
         // Profile loading status - styled card when no profile loaded
         if !self.profile_load_attempted && !self.loading {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             Frame::group(ui.style())
                 .fill(ui.visuals().extreme_bg_color)
                 .corner_radius(5.0)
@@ -592,7 +592,7 @@ impl ProfileScreen {
         // Loading or saving indicator
         if self.loading || self.saving {
             ui.horizontal(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.add(egui::widgets::Spinner::default().color(DashColors::DASH_BLUE));
                 let status_text = if self.saving {
                     "Saving profile..."
@@ -610,7 +610,7 @@ impl ProfileScreen {
                         // Main editing panel (left side)
                         ui.vertical(|ui| {
                             ui.group(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.horizontal(|ui| {
                                     ui.label(
                                         RichText::new("Edit Profile")
@@ -1061,7 +1061,7 @@ impl ProfileScreen {
                                     if let Some(identity) = &self.selected_identity
                                         && !identity.dpns_names.is_empty()
                                     {
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
                                         ui.label(
                                             RichText::new(format!(
                                                 "@{}",
@@ -1103,7 +1103,7 @@ impl ProfileScreen {
                             ui.separator();
 
                             // Bio
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new("Bio:")
                                     .strong()
@@ -1125,7 +1125,7 @@ impl ProfileScreen {
                         });
                     } else if self.profile_load_attempted {
                         // No profile exists (only show after we've tried to load)
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -1166,6 +1166,7 @@ impl ProfileScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ui.ctx(), |ui| {
@@ -1179,6 +1180,7 @@ impl ProfileScreen {
 
         // Show avatar info popup if requested
         if self.show_avatar_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ui.ctx(), |ui| {
@@ -1223,7 +1225,7 @@ impl ProfileScreen {
                             ui.add_space(10.0);
 
                             // Show URL in smaller, secondary text
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new(&avatar_url)
                                     .small()

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -662,7 +662,7 @@ impl ProfileScreen {
 
         // Profile loading status - styled card when no profile loaded
         if !self.profile_load_attempted && !self.loading {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             Frame::group(ui.style())
                 .fill(ui.visuals().extreme_bg_color)
                 .corner_radius(5.0)
@@ -692,7 +692,7 @@ impl ProfileScreen {
         // Loading or saving indicator
         if self.loading || self.saving {
             ui.horizontal(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.add(egui::widgets::Spinner::default().color(DashColors::DASH_BLUE));
                 let status_text = if self.saving {
                     "Saving profile..."
@@ -710,7 +710,7 @@ impl ProfileScreen {
                         // Main editing panel (left side)
                         ui.vertical(|ui| {
                             ui.group(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.horizontal(|ui| {
                                     ui.label(
                                         RichText::new("Edit Profile")
@@ -1173,7 +1173,7 @@ impl ProfileScreen {
                                     if let Some(identity) = &self.selected_identity
                                         && !identity.dpns_names.is_empty()
                                     {
-                                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                        let dark_mode = ui.style().visuals.dark_mode;
                                         ui.label(
                                             RichText::new(format!(
                                                 "@{}",
@@ -1215,7 +1215,7 @@ impl ProfileScreen {
                             ui.separator();
 
                             // Bio
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new("Bio:")
                                     .strong()
@@ -1237,7 +1237,7 @@ impl ProfileScreen {
                         });
                     } else if self.profile_load_attempted {
                         // No profile exists (only show after we've tried to load)
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         Frame::group(ui.style())
                             .fill(ui.visuals().extreme_bg_color)
                             .corner_radius(5.0)
@@ -1278,6 +1278,7 @@ impl ProfileScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ui.ctx(), |ui| {
@@ -1291,6 +1292,7 @@ impl ProfileScreen {
 
         // Show avatar info popup if requested
         if self.show_avatar_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ui.ctx(), |ui| {
@@ -1335,7 +1337,7 @@ impl ProfileScreen {
                             ui.add_space(10.0);
 
                             // Show URL in smaller, secondary text
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new(&avatar_url)
                                     .small()

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -259,12 +259,12 @@ impl ProfileSearchScreen {
 }
 
 impl ScreenLike for ProfileSearchScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel - consistent with other DashPay subscreens
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -277,17 +277,17 @@ impl ScreenLike for ProfileSearchScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |= add_dashpay_subscreen_chooser_panel(
-            ctx,
+            ui,
             &self.app_context,
             DashPaySubscreen::ProfileSearch, // Use ProfileSearch as the active subscreen
         );
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Handle custom action from top panel button
         if let AppAction::Custom(command) = &action
@@ -301,10 +301,9 @@ impl ScreenLike for ProfileSearchScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("About Profile Search", PROFILE_SEARCH_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -109,7 +109,7 @@ impl ProfileSearchScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Header
         ui.horizontal(|ui| {
@@ -301,6 +301,7 @@ impl ScreenLike for ProfileSearchScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -392,12 +392,12 @@ impl QRCodeGeneratorScreen {
 }
 
 impl ScreenLike for QRCodeGeneratorScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -407,24 +407,23 @@ impl ScreenLike for QRCodeGeneratorScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |= add_dashpay_subscreen_chooser_panel(
-            ctx,
+            ui,
             &self.app_context,
             DashPaySubscreen::Contacts, // Use Contacts as the active subscreen since QR Generator is launched from there
         );
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new("About Contact QR Codes", QR_CODE_INFO_TEXT);
                     if popup.show(ui).inner {
                         self.show_info_popup = false;

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -135,7 +135,7 @@ impl QRCodeGeneratorScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Header with info icon
         ui.horizontal(|ui| {
@@ -421,6 +421,7 @@ impl ScreenLike for QRCodeGeneratorScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -142,7 +142,7 @@ impl QRCodeGeneratorScreen {
 
     pub fn render(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Header with info icon
         ui.horizontal(|ui| {
@@ -428,6 +428,7 @@ impl ScreenLike for QRCodeGeneratorScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/dashpay/qr_scanner.rs
+++ b/src/ui/dashpay/qr_scanner.rs
@@ -331,12 +331,14 @@ impl QRScannerScreen {
 }
 
 impl ScreenLike for QRScannerScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -346,14 +348,14 @@ impl ScreenLike for QRScannerScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show wallet unlock popup if open
         if self.wallet_unlock_popup.is_open()

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -235,13 +235,13 @@ impl SendPaymentScreen {
             ui.group(|ui| {
                 // From identity
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("From:")
                             .strong()
                             .color(DashColors::text_primary(dark_mode)),
                     );
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new(self.from_identity.to_string())
                             .color(DashColors::text_primary(dark_mode)),
@@ -250,7 +250,7 @@ impl SendPaymentScreen {
 
                 // Wallet Balance (from wallet, not identity)
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("Wallet Balance:")
                             .strong()
@@ -275,17 +275,17 @@ impl SendPaymentScreen {
 
                 // To contact
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("To:")
                             .strong()
                             .color(DashColors::text_primary(dark_mode)),
                     );
                     if let Some(name) = &self.to_contact_name {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(RichText::new(name).color(DashColors::text_primary(dark_mode)));
                     } else {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new(format!("{}", self.to_contact_id))
                                 .color(DashColors::text_primary(dark_mode)),
@@ -325,7 +325,7 @@ impl SendPaymentScreen {
                 ui.add_space(10.0);
 
                 // Memo field
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("Memo (optional):")
                         .strong()
@@ -337,7 +337,7 @@ impl SendPaymentScreen {
                         .desired_rows(3)
                         .desired_width(f32::INFINITY),
                 );
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new(format!("{}/100 characters", self.memo.len()))
                         .small()
@@ -422,6 +422,7 @@ impl ScreenLike for SendPaymentScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {
@@ -650,7 +651,7 @@ impl PaymentHistory {
         }
 
         if self.selected_identity.is_none() {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(
                 RichText::new("Please select an identity to view payment history")
                     .color(DashColors::text_primary(dark_mode)),
@@ -670,7 +671,7 @@ impl PaymentHistory {
         // Payment list
         ScrollArea::vertical().show(ui, |ui| {
             if self.payments.is_empty() {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::group(ui.style())
                     .fill(ui.visuals().extreme_bg_color)
                     .corner_radius(5.0)
@@ -696,7 +697,7 @@ impl PaymentHistory {
             } else {
                 for payment in &self.payments {
                     ui.group(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.horizontal(|ui| {
                             // Avatar placeholder
                             ui.vertical(|ui| {

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -391,12 +391,14 @@ impl ScreenLike for SendPaymentScreen {
         self.refresh();
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -406,18 +408,17 @@ impl ScreenLike for SendPaymentScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Payments);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Payments);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Payment Guidelines", PAYMENT_GUIDELINES_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -220,13 +220,13 @@ impl SendPaymentScreen {
             ui.group(|ui| {
                 // From identity
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("From:")
                             .strong()
                             .color(DashColors::text_primary(dark_mode)),
                     );
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new(self.from_identity.to_string())
                             .color(DashColors::text_primary(dark_mode)),
@@ -235,7 +235,7 @@ impl SendPaymentScreen {
 
                 // Wallet Balance (from wallet, not identity)
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("Wallet Balance:")
                             .strong()
@@ -263,17 +263,17 @@ impl SendPaymentScreen {
 
                 // To contact
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("To:")
                             .strong()
                             .color(DashColors::text_primary(dark_mode)),
                     );
                     if let Some(name) = &self.to_contact_name {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(RichText::new(name).color(DashColors::text_primary(dark_mode)));
                     } else {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new(format!("{}", self.to_contact_id))
                                 .color(DashColors::text_primary(dark_mode)),
@@ -317,7 +317,7 @@ impl SendPaymentScreen {
                 ui.add_space(10.0);
 
                 // Memo field
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("Memo (optional):")
                         .strong()
@@ -329,7 +329,7 @@ impl SendPaymentScreen {
                         .desired_rows(3)
                         .desired_width(f32::INFINITY),
                 );
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new(format!("{}/100 characters", self.memo.len()))
                         .small()
@@ -414,6 +414,7 @@ impl ScreenLike for SendPaymentScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {
@@ -587,7 +588,7 @@ impl PaymentHistory {
         }
 
         if self.selected_identity.is_none() {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(
                 RichText::new("Please select an identity to view payment history")
                     .color(DashColors::text_primary(dark_mode)),
@@ -607,7 +608,7 @@ impl PaymentHistory {
         // Payment list
         ScrollArea::vertical().show(ui, |ui| {
             if self.payments.is_empty() {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::group(ui.style())
                     .fill(ui.visuals().extreme_bg_color)
                     .corner_radius(5.0)
@@ -633,7 +634,7 @@ impl PaymentHistory {
             } else {
                 for payment in &self.payments {
                     ui.group(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.horizontal(|ui| {
                             // Avatar placeholder
                             ui.vertical(|ui| {

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -289,7 +289,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
 
             if self.dpns_subscreen != DPNSSubscreen::ScheduledVotes {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(RichText::new("Please check back later or try refreshing the list.").color(DashColors::text_primary(dark_mode)));
                 ui.add_space(20.0);
                 if StyledButton::primary("Refresh").show(ui).clicked() {
@@ -315,7 +315,7 @@ impl DPNSScreen {
                     }
                 }
             } else {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let text_color = DashColors::text_primary(dark_mode);
                 ui.label(
                     RichText::new("To schedule votes, go to the Active Contests subscreen, click your choices, and then click the 'Vote' button in the top-right.").color(text_color)
@@ -333,7 +333,7 @@ impl DPNSScreen {
     /// Show the Active Contests table
     fn render_table_active_contests(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.active_filter_term);
         });
@@ -402,7 +402,7 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Contestants").color(DashColors::text_primary(dark_mode)),
                         );
@@ -464,7 +464,7 @@ impl DPNSScreen {
                                         (contested_name.normalized_contested_name.clone(), None)
                                     };
 
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 let label_response = ui.label(
                                     RichText::new(used_name)
                                         .color(DashColors::text_primary(dark_mode)),
@@ -478,7 +478,7 @@ impl DPNSScreen {
                             row.col(|ui| {
                                 let label_text = format!("{}", locked_votes);
                                 let dark_green = Color32::from_rgb(0, 100, 0);
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 let normal_color = DashColors::text_primary(dark_mode);
                                 let text_widget = if is_locked_votes_bold {
                                     RichText::new(label_text).strong().color(dark_green)
@@ -580,7 +580,7 @@ impl DPNSScreen {
 
                             // Ending Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(ending_time) = contested_name.end_time {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_millis_opt(ending_time as i64)
@@ -608,7 +608,7 @@ impl DPNSScreen {
 
                             // Last Updated
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(last_updated) = contested_name.last_updated {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_opt(last_updated as i64, 0)
@@ -657,7 +657,7 @@ impl DPNSScreen {
     /// Show a Past Contests table
     fn render_table_past_contests(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.past_filter_term);
         });
@@ -728,7 +728,7 @@ impl DPNSScreen {
                         body.row(25.0, |mut row| {
                             // Name
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(&contested_name.normalized_contested_name)
                                         .color(DashColors::text_primary(dark_mode)),
@@ -736,7 +736,7 @@ impl DPNSScreen {
                             });
                             // Ended Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(ended_time) = contested_name.end_time {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_millis_opt(ended_time as i64)
@@ -762,7 +762,7 @@ impl DPNSScreen {
                             });
                             // Last Updated
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(last_updated) = contested_name.last_updated {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_opt(last_updated as i64, 0)
@@ -794,7 +794,7 @@ impl DPNSScreen {
                             });
                             // Awarded To
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 match contested_name.state {
                                     ContestState::Unknown => {
                                         ui.label(
@@ -834,7 +834,7 @@ impl DPNSScreen {
     /// Show the Owned DPNS names table
     fn render_table_local_dpns_names(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.owned_filter_term);
         });
@@ -905,7 +905,7 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Actions").color(DashColors::text_primary(dark_mode)),
                         );
@@ -922,14 +922,14 @@ impl DPNSScreen {
                         };
                         body.row(25.0, |mut row| {
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(&display_name)
                                         .color(DashColors::text_primary(dark_mode)),
                                 );
                             });
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(identifier.to_string(Encoding::Base58))
                                         .color(DashColors::text_primary(dark_mode)),
@@ -942,7 +942,7 @@ impl DPNSScreen {
                             .map(|dt| dt.to_string())
                             .unwrap_or_else(|| "Invalid timestamp".to_string());
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(dt).color(DashColors::text_primary(dark_mode)),
                                 );
@@ -1018,13 +1018,13 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Voter").color(DashColors::text_primary(dark_mode)),
                         );
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Vote Choice").color(DashColors::text_primary(dark_mode)),
                         );
@@ -1035,13 +1035,13 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Status").color(DashColors::text_primary(dark_mode)),
                         );
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Actions").color(DashColors::text_primary(dark_mode)),
                         );
@@ -1072,7 +1072,7 @@ impl DPNSScreen {
                             });
                             // Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let LocalResult::Single(dt) =
                                     Utc.timestamp_millis_opt(vote.0.unix_timestamp as i64)
                                 {
@@ -1097,7 +1097,7 @@ impl DPNSScreen {
                             });
                             // Status
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 match vote.1 {
                                     ScheduledVoteCastingStatus::NotStarted => {
                                         ui.label(
@@ -1264,7 +1264,7 @@ impl DPNSScreen {
     fn show_bulk_schedule_popup_window(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.heading(
             RichText::new("Cast or Schedule Votes").color(DashColors::text_primary(dark_mode)),
         );
@@ -1281,7 +1281,7 @@ impl DPNSScreen {
             ui.add_space(5.0);
             ui.colored_label(Color32::DARK_RED, "No masternode identities loaded. Please go to the Identities screen to load your masternodes.");
             ui.add_space(10.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                 self.show_bulk_schedule_popup = false;
             }
@@ -1293,7 +1293,7 @@ impl DPNSScreen {
             ui.add_space(5.0);
             ui.colored_label(Color32::DARK_RED, "No votes selected. Please click the votes you want to cast or schedule in the Active Contests screen.");
             ui.add_space(10.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                 self.show_bulk_schedule_popup = false;
             }
@@ -1303,7 +1303,7 @@ impl DPNSScreen {
         egui::ScrollArea::vertical().show(ui, |ui| {
             // Show which votes were clicked
             ui.group(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.heading(
                     RichText::new("Selected Votes:").color(DashColors::text_primary(dark_mode)),
                 );
@@ -1325,7 +1325,7 @@ impl DPNSScreen {
                         ResourceVoteChoice::TowardsIdentity(id) => id.to_string(Encoding::Base58),
                         other => other.to_string(),
                     };
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new(format!(
                             "{}   =>   {}   |   Contest ends at {}",
@@ -1339,7 +1339,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
 
             // Show each identity + let user pick None / Immediate / Scheduled
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.heading(
                 RichText::new("Select cast method for each node:")
                     .color(DashColors::text_primary(dark_mode)),
@@ -1347,7 +1347,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
             ui.group(|ui| {
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(RichText::new("Set all:").color(DashColors::text_primary(dark_mode)));
 
                     // A ComboBox to pick No Vote / Cast Now / Schedule
@@ -1408,7 +1408,7 @@ impl DPNSScreen {
                         ref mut minutes,
                     } = self.set_all_option
                     {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Schedule In:")
                                 .color(DashColors::text_primary(dark_mode)),
@@ -1434,7 +1434,7 @@ impl DPNSScreen {
                             .alias
                             .clone()
                             .unwrap_or_else(|| identity.identity.id().to_string(Encoding::Base58));
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new(format!("Identity: {}", label))
                                 .color(DashColors::text_primary(dark_mode)),
@@ -1509,7 +1509,7 @@ impl DPNSScreen {
                             minutes,
                         } = current_option
                         {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new("Schedule In:")
                                     .color(DashColors::text_primary(dark_mode)),
@@ -1547,7 +1547,7 @@ impl DPNSScreen {
         }
 
         ui.add_space(5.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode).clicked() {
             self.selected_votes.clear();
             self.show_bulk_schedule_popup = false;
@@ -1564,7 +1564,7 @@ impl DPNSScreen {
                 // Elapsed time is shown in the global banner
             }
             VoteHandlingStatus::SchedulingVotes => {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("Scheduling votes...").color(DashColors::text_primary(dark_mode)),
                 );
@@ -1680,36 +1680,36 @@ impl DPNSScreen {
                     if let Some(message) = &self.bulk_schedule_message {
                         match message.0 {
                             MessageType::Error => {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("❌").color(DashColors::text_primary(dark_mode)),
                                 );
                                 if message.1.contains("Successes") {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.heading(
                                         RichText::new("Only some votes succeeded")
                                             .color(DashColors::text_primary(dark_mode)),
                                     );
                                 } else {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.heading(
                                         RichText::new("No votes succeeded")
                                             .color(DashColors::text_primary(dark_mode)),
                                     );
                                 }
                                 ui.add_space(10.0);
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(message.1.clone())
                                         .color(DashColors::text_primary(dark_mode)),
                                 );
                             }
                             MessageType::Success => {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("🎉").color(DashColors::text_primary(dark_mode)),
                                 );
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("Successfully casted and scheduled all votes")
                                         .color(DashColors::text_primary(dark_mode)),
@@ -1721,7 +1721,7 @@ impl DPNSScreen {
                 }
                 VoteHandlingStatus::Failed(message) => {
                     // This means there was a DET-side error, not Platform-side
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.heading(RichText::new("❌").color(DashColors::text_primary(dark_mode)));
                     ui.heading(
                         RichText::new("Error casting and scheduling votes (DET-side)")
@@ -1736,7 +1736,7 @@ impl DPNSScreen {
             }
 
             ui.add_space(20.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_primary_button(ui, "Go back to Active Contests").clicked() {
                 self.bulk_vote_handling_status = VoteHandlingStatus::NotStarted;
                 self.show_bulk_schedule_popup = false;

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -7,7 +7,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Button, Color32, ComboBox, Context, Label, RichText, Ui};
+use eframe::egui::{self, Button, Color32, ComboBox, Label, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
 use itertools::Itertools;
 
@@ -1913,7 +1913,9 @@ impl ScreenLike for DPNSScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let has_identity_that_can_register = !self.user_identities.is_empty();
         let has_active_contests = {
             let guard = self.contested_names.lock().unwrap();
@@ -1995,7 +1997,7 @@ impl ScreenLike for DPNSScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("DPNS", AppAction::None)],
             right_buttons,
@@ -2010,19 +2012,19 @@ impl ScreenLike for DPNSScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsPlatformInfoScreen,
         );
 
         // Tools area chooser
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // DPNS subscreen chooser
-        action |= add_dpns_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_dpns_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Main panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             // Bulk-schedule ephemeral popup
             if self.show_bulk_schedule_popup {

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -290,7 +290,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
 
             if self.dpns_subscreen != DPNSSubscreen::ScheduledVotes {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(RichText::new("Please check back later or try refreshing the list.").color(DashColors::text_primary(dark_mode)));
                 ui.add_space(20.0);
                 if StyledButton::primary("Refresh").show(ui).clicked() {
@@ -316,7 +316,7 @@ impl DPNSScreen {
                     }
                 }
             } else {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let text_color = DashColors::text_primary(dark_mode);
                 ui.label(
                     RichText::new("To schedule votes, go to the Active Contests subscreen, click your choices, and then click the 'Vote' button in the top-right.").color(text_color)
@@ -334,7 +334,7 @@ impl DPNSScreen {
     /// Show the Active Contests table
     fn render_table_active_contests(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.active_filter_term);
         });
@@ -403,7 +403,7 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Contestants").color(DashColors::text_primary(dark_mode)),
                         );
@@ -465,7 +465,7 @@ impl DPNSScreen {
                                         (contested_name.normalized_contested_name.clone(), None)
                                     };
 
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 let label_response = ui.label(
                                     RichText::new(used_name)
                                         .color(DashColors::text_primary(dark_mode)),
@@ -479,7 +479,7 @@ impl DPNSScreen {
                             row.col(|ui| {
                                 let label_text = format!("{}", locked_votes);
                                 let dark_green = Color32::from_rgb(0, 100, 0);
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 let normal_color = DashColors::text_primary(dark_mode);
                                 let text_widget = if is_locked_votes_bold {
                                     RichText::new(label_text).strong().color(dark_green)
@@ -581,7 +581,7 @@ impl DPNSScreen {
 
                             // Ending Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(ending_time) = contested_name.end_time {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_millis_opt(ending_time as i64)
@@ -609,7 +609,7 @@ impl DPNSScreen {
 
                             // Last Updated
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(last_updated) = contested_name.last_updated {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_opt(last_updated as i64, 0)
@@ -658,7 +658,7 @@ impl DPNSScreen {
     /// Show a Past Contests table
     fn render_table_past_contests(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.past_filter_term);
         });
@@ -729,7 +729,7 @@ impl DPNSScreen {
                         body.row(25.0, |mut row| {
                             // Name
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(&contested_name.normalized_contested_name)
                                         .color(DashColors::text_primary(dark_mode)),
@@ -737,7 +737,7 @@ impl DPNSScreen {
                             });
                             // Ended Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(ended_time) = contested_name.end_time {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_millis_opt(ended_time as i64)
@@ -763,7 +763,7 @@ impl DPNSScreen {
                             });
                             // Last Updated
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let Some(last_updated) = contested_name.last_updated {
                                     if let LocalResult::Single(dt) =
                                         Utc.timestamp_opt(last_updated as i64, 0)
@@ -795,7 +795,7 @@ impl DPNSScreen {
                             });
                             // Awarded To
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 match contested_name.state {
                                     ContestState::Unknown => {
                                         ui.label(
@@ -835,7 +835,7 @@ impl DPNSScreen {
     /// Show the Owned DPNS names table
     fn render_table_local_dpns_names(&mut self, ui: &mut Ui) {
         ui.horizontal(|ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.label(RichText::new("Filter by name:").color(DashColors::text_primary(dark_mode)));
             ui.text_edit_singleline(&mut self.owned_filter_term);
         });
@@ -906,7 +906,7 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Actions").color(DashColors::text_primary(dark_mode)),
                         );
@@ -923,14 +923,14 @@ impl DPNSScreen {
                         };
                         body.row(25.0, |mut row| {
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(&display_name)
                                         .color(DashColors::text_primary(dark_mode)),
                                 );
                             });
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(identifier.to_string(Encoding::Base58))
                                         .color(DashColors::text_primary(dark_mode)),
@@ -943,7 +943,7 @@ impl DPNSScreen {
                             .map(|dt| dt.to_string())
                             .unwrap_or_else(|| "Invalid timestamp".to_string());
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(dt).color(DashColors::text_primary(dark_mode)),
                                 );
@@ -1020,13 +1020,13 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Voter").color(DashColors::text_primary(dark_mode)),
                         );
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Vote Choice").color(DashColors::text_primary(dark_mode)),
                         );
@@ -1037,13 +1037,13 @@ impl DPNSScreen {
                         }
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Status").color(DashColors::text_primary(dark_mode)),
                         );
                     });
                     header.col(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.heading(
                             RichText::new("Actions").color(DashColors::text_primary(dark_mode)),
                         );
@@ -1074,7 +1074,7 @@ impl DPNSScreen {
                             });
                             // Time
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 if let LocalResult::Single(dt) =
                                     Utc.timestamp_millis_opt(vote.0.unix_timestamp as i64)
                                 {
@@ -1099,7 +1099,7 @@ impl DPNSScreen {
                             });
                             // Status
                             row.col(|ui| {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 match vote.1 {
                                     ScheduledVoteCastingStatus::NotStarted => {
                                         ui.label(
@@ -1266,7 +1266,7 @@ impl DPNSScreen {
     fn show_bulk_schedule_popup_window(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.heading(
             RichText::new("Cast or Schedule Votes").color(DashColors::text_primary(dark_mode)),
         );
@@ -1283,7 +1283,7 @@ impl DPNSScreen {
             ui.add_space(5.0);
             ui.colored_label(Color32::DARK_RED, "No masternode identities loaded. Please go to the Identities screen to load your masternodes.");
             ui.add_space(10.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                 self.show_bulk_schedule_popup = false;
             }
@@ -1295,7 +1295,7 @@ impl DPNSScreen {
             ui.add_space(5.0);
             ui.colored_label(Color32::DARK_RED, "No votes selected. Please click the votes you want to cast or schedule in the Active Contests screen.");
             ui.add_space(10.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                 self.show_bulk_schedule_popup = false;
             }
@@ -1305,7 +1305,7 @@ impl DPNSScreen {
         egui::ScrollArea::vertical().show(ui, |ui| {
             // Show which votes were clicked
             ui.group(|ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.heading(
                     RichText::new("Selected Votes:").color(DashColors::text_primary(dark_mode)),
                 );
@@ -1327,7 +1327,7 @@ impl DPNSScreen {
                         ResourceVoteChoice::TowardsIdentity(id) => id.to_string(Encoding::Base58),
                         other => other.to_string(),
                     };
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new(format!(
                             "{}   =>   {}   |   Contest ends at {}",
@@ -1341,7 +1341,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
 
             // Show each identity + let user pick None / Immediate / Scheduled
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.heading(
                 RichText::new("Select cast method for each node:")
                     .color(DashColors::text_primary(dark_mode)),
@@ -1349,7 +1349,7 @@ impl DPNSScreen {
             ui.add_space(10.0);
             ui.group(|ui| {
                 ui.horizontal(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(RichText::new("Set all:").color(DashColors::text_primary(dark_mode)));
 
                     // A ComboBox to pick No Vote / Cast Now / Schedule
@@ -1410,7 +1410,7 @@ impl DPNSScreen {
                         ref mut minutes,
                     } = self.set_all_option
                     {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new("Schedule In:")
                                 .color(DashColors::text_primary(dark_mode)),
@@ -1436,7 +1436,7 @@ impl DPNSScreen {
                             .alias
                             .clone()
                             .unwrap_or_else(|| identity.identity.id().to_string(Encoding::Base58));
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.label(
                             RichText::new(format!("Identity: {}", label))
                                 .color(DashColors::text_primary(dark_mode)),
@@ -1512,7 +1512,7 @@ impl DPNSScreen {
                             minutes,
                         } = current_option
                         {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.label(
                                 RichText::new("Schedule In:")
                                     .color(DashColors::text_primary(dark_mode)),
@@ -1550,7 +1550,7 @@ impl DPNSScreen {
         }
 
         ui.add_space(5.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode).clicked() {
             self.selected_votes.clear();
             self.show_bulk_schedule_popup = false;
@@ -1567,7 +1567,7 @@ impl DPNSScreen {
                 // Elapsed time is shown in the global banner
             }
             VoteHandlingStatus::SchedulingVotes => {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     RichText::new("Scheduling votes...").color(DashColors::text_primary(dark_mode)),
                 );
@@ -1683,36 +1683,36 @@ impl DPNSScreen {
                     if let Some(message) = &self.bulk_schedule_message {
                         match message.0 {
                             MessageType::Error => {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("❌").color(DashColors::text_primary(dark_mode)),
                                 );
                                 if message.1.contains("Successes") {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.heading(
                                         RichText::new("Only some votes succeeded")
                                             .color(DashColors::text_primary(dark_mode)),
                                     );
                                 } else {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.heading(
                                         RichText::new("No votes succeeded")
                                             .color(DashColors::text_primary(dark_mode)),
                                     );
                                 }
                                 ui.add_space(10.0);
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.label(
                                     RichText::new(message.1.clone())
                                         .color(DashColors::text_primary(dark_mode)),
                                 );
                             }
                             MessageType::Success => {
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("🎉").color(DashColors::text_primary(dark_mode)),
                                 );
-                                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                let dark_mode = ui.style().visuals.dark_mode;
                                 ui.heading(
                                     RichText::new("Successfully casted and scheduled all votes")
                                         .color(DashColors::text_primary(dark_mode)),
@@ -1724,7 +1724,7 @@ impl DPNSScreen {
                 }
                 VoteHandlingStatus::Failed(message) => {
                     // This means there was a DET-side error, not Platform-side
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.heading(RichText::new("❌").color(DashColors::text_primary(dark_mode)));
                     ui.heading(
                         RichText::new("Error casting and scheduling votes (DET-side)")
@@ -1739,7 +1739,7 @@ impl DPNSScreen {
             }
 
             ui.add_space(20.0);
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             if ComponentStyles::add_primary_button(ui, "Go back to Active Contests").clicked() {
                 self.bulk_vote_handling_status = VoteHandlingStatus::NotStarted;
                 self.show_bulk_schedule_popup = false;

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -958,7 +958,7 @@ pub fn show_success_screen_with_info(
     info_section: Option<(&str, &str)>,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
 
     ui.vertical_centered(|ui| {
         ui.add_space(if info_section.is_some() { 60.0 } else { 100.0 });
@@ -1041,7 +1041,7 @@ pub fn show_group_token_success_screen_with_fee(
     fee_info: Option<(&str, &str)>,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ui.ctx().style().visuals.dark_mode;
+    let dark_mode = ui.style().visuals.dark_mode;
 
     ui.vertical_centered(|ui| {
         ui.add_space(if fee_info.is_some() { 60.0 } else { 100.0 });

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -474,7 +474,7 @@ impl AddExistingIdentityScreen {
             .fill(if is_valid_id {
                 DashColors::DASH_BLUE
             } else {
-                ComponentStyles::button_disabled_fill(ui.ctx().style().visuals.dark_mode)
+                ComponentStyles::button_disabled_fill(ui.style().visuals.dark_mode)
             })
             .frame(true)
             .corner_radius(3.0);
@@ -859,7 +859,7 @@ impl AddExistingIdentityScreen {
             .fill(if is_valid {
                 DashColors::DASH_BLUE
             } else {
-                ComponentStyles::button_disabled_fill(ui.ctx().style().visuals.dark_mode)
+                ComponentStyles::button_disabled_fill(ui.style().visuals.dark_mode)
             })
             .frame(true)
             .corner_radius(3.0);
@@ -1182,6 +1182,7 @@ impl ScreenLike for AddExistingIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -473,7 +473,7 @@ impl AddExistingIdentityScreen {
             .fill(if is_valid_id {
                 DashColors::DASH_BLUE
             } else {
-                ComponentStyles::button_disabled_fill(ui.ctx().style().visuals.dark_mode)
+                ComponentStyles::button_disabled_fill(ui.style().visuals.dark_mode)
             })
             .frame(true)
             .corner_radius(3.0);
@@ -843,7 +843,7 @@ impl AddExistingIdentityScreen {
             .fill(if is_valid {
                 DashColors::DASH_BLUE
             } else {
-                ComponentStyles::button_disabled_fill(ui.ctx().style().visuals.dark_mode)
+                ComponentStyles::button_disabled_fill(ui.style().visuals.dark_mode)
             })
             .frame(true)
             .corner_radius(3.0);
@@ -1166,6 +1166,7 @@ impl ScreenLike for AddExistingIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -20,7 +20,6 @@ use bip39::rand::{prelude::IteratorRandom, thread_rng};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::Identifier;
-use eframe::egui::Context;
 use egui::{Color32, ComboBox, RichText, Ui};
 use serde::Deserialize;
 use std::fs;
@@ -1089,9 +1088,11 @@ impl ScreenLike for AddExistingIdentityScreen {
         self.add_identity_status = AddIdentityStatus::Complete;
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -1101,12 +1102,12 @@ impl ScreenLike for AddExistingIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Error display is handled by the global MessageBanner
@@ -1182,10 +1183,9 @@ impl ScreenLike for AddExistingIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Load Identity Information", &show_pop_up_info_text);
                     if popup.show(ui).inner {

--- a/src/ui/identities/add_new_identity_screen/by_platform_address.rs
+++ b/src/ui/identities/add_new_identity_screen/by_platform_address.rs
@@ -212,7 +212,7 @@ impl AddNewIdentityScreen {
         let step = *self.step.read().unwrap();
 
         // Display estimated fee before action button (reuse already calculated value)
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         egui::Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
@@ -114,7 +114,7 @@ impl AddNewIdentityScreen {
             .fee_estimator()
             .estimate_identity_create(key_count);
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         egui::Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/add_new_identity_screen/by_using_unused_asset_lock.rs
@@ -126,7 +126,7 @@ impl AddNewIdentityScreen {
             .fee_estimator()
             .estimate_identity_create(key_count);
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         egui::Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/identities/add_new_identity_screen/by_using_unused_balance.rs
+++ b/src/ui/identities/add_new_identity_screen/by_using_unused_balance.rs
@@ -63,7 +63,7 @@ impl AddNewIdentityScreen {
             .fee_estimator()
             .estimate_identity_create(key_count);
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         egui::Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -581,7 +581,7 @@ impl AddNewIdentityScreen {
 
             // Use a lighter stripe color that doesn't clash with comboboxes
             let original_stripe_color = ui.visuals().faint_bg_color;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.visuals_mut().faint_bg_color = DashColors::stripe(dark_mode);
 
             TableBuilder::new(ui)
@@ -1257,7 +1257,7 @@ impl ScreenLike for AddNewIdentityScreen {
 
                 ui.horizontal(|ui| {
                     ui.label("Alias:");
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add(
                         egui::TextEdit::singleline(&mut self.alias_input)
                             .hint_text(egui::RichText::new("e.g., My Main Identity").color(DashColors::text_secondary(dark_mode)))
@@ -1265,7 +1265,7 @@ impl ScreenLike for AddNewIdentityScreen {
                     );
                 });
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     egui::RichText::new("Note: This is a Dash Evo Tool nickname, not a DPNS username.")
                         .small()
@@ -1314,6 +1314,7 @@ impl ScreenLike for AddNewIdentityScreen {
 
         // Show the info popup if requested
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -621,7 +621,7 @@ impl AddNewIdentityScreen {
 
             // Use a lighter stripe color that doesn't clash with comboboxes
             let original_stripe_color = ui.visuals().faint_bg_color;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.visuals_mut().faint_bg_color = DashColors::stripe(dark_mode);
 
             let revealed_wifs = &self.revealed_wifs;
@@ -1334,7 +1334,7 @@ impl ScreenLike for AddNewIdentityScreen {
 
                 ui.horizontal(|ui| {
                     ui.label("Alias:");
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add(
                         egui::TextEdit::singleline(&mut self.alias_input)
                             .hint_text(egui::RichText::new("e.g., My Main Identity").color(DashColors::text_secondary(dark_mode)))
@@ -1342,7 +1342,7 @@ impl ScreenLike for AddNewIdentityScreen {
                     );
                 });
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.label(
                     egui::RichText::new("Note: This is a Dash Evo Tool nickname, not a DPNS username.")
                         .small()
@@ -1388,6 +1388,7 @@ impl ScreenLike for AddNewIdentityScreen {
 
         // Show the info popup if requested
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -35,11 +35,10 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use dash_sdk::platform::Identifier;
-use eframe::egui::Context;
-use egui::ahash::HashSet;
 use egui::{Align, Button, Color32, ComboBox, ScrollArea, Ui};
 use egui_extras::{Column, TableBuilder};
 use std::collections::HashMap;
+use std::collections::HashSet;
 
 use crate::model::amount::Amount;
 use crate::ui::components::amount_input::AmountInput;
@@ -1174,9 +1173,11 @@ impl ScreenLike for AddNewIdentityScreen {
         false
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -1186,12 +1187,12 @@ impl ScreenLike for AddNewIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
@@ -1388,10 +1389,9 @@ impl ScreenLike for AddNewIdentityScreen {
 
         // Show the info popup if requested
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new("Identity Information", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -219,7 +219,7 @@ impl IdentitiesScreen {
     }
 
     fn show_alias(&mut self, ui: &mut Ui, qualified_identity: &QualifiedIdentity) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(alias) = &qualified_identity.alias {
             ui.label(RichText::new(alias).color(DashColors::text_primary(dark_mode)));
@@ -380,7 +380,7 @@ impl IdentitiesScreen {
     }
 
     fn render_no_identities_view(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Optionally put everything in a framed "card"-like container
         Frame::group(ui.style())
@@ -615,7 +615,7 @@ impl IdentitiesScreen {
                                                     let actions_popup_id = ui.make_persistent_id(format!("actions_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                         egui::Popup::from_toggle_button_response(&actions_response).id(actions_popup_id)
                                                         .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
-                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.ctx().style().visuals.dark_mode)))
+                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.style().visuals.dark_mode)))
                                                         .show(|ui| {
                                                         ui.set_min_width(150.0);
 
@@ -725,12 +725,12 @@ impl IdentitiesScreen {
                                                     let popup_id = ui.make_persistent_id(format!("keys_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                     egui::Popup::from_toggle_button_response(&button_response).id(popup_id)
                                                         .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
-                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.ctx().style().visuals.dark_mode)))
+                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.style().visuals.dark_mode)))
                                                         .show(|ui| {
                                                             // Wrap in a scroll area so popups with many keys are accessible
                                                             let max_popup_height = ui.ctx().content_rect().height() * 0.6;
                                                             egui::ScrollArea::vertical().max_height(max_popup_height).show(ui, |ui| {
-                                                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                                            let dark_mode = ui.style().visuals.dark_mode;
 
                                                             // Main Identity Keys
                                                             if !public_keys.is_empty() {
@@ -946,13 +946,13 @@ impl IdentitiesScreen {
                     spread: 0,
                     color: DashColors::popup_shadow(),
                 },
-                fill: ctx.style().visuals.window_fill,
+                fill: ctx.global_style().visuals.window_fill,
                 stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
             })
             .show(ctx, |ui| {
                 ui.set_min_width(300.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 ui.label(
                     RichText::new("Enter a new alias for this identity:")

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -1079,7 +1079,9 @@ impl ScreenLike for IdentitiesScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut right_buttons = if !self.app_context.has_wallet.load(Ordering::Relaxed) {
             vec![
                 (
@@ -1120,20 +1122,20 @@ impl ScreenLike for IdentitiesScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Identities", AppAction::None)],
             right_buttons,
         );
 
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenIdentities);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenIdentities);
 
         let identities_vec = {
             let guard = self.identities.lock().unwrap();
             guard.values().cloned().collect::<Vec<_>>()
         };
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             if identities_vec.is_empty() {
                 self.render_no_identities_view(ui);

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -219,7 +219,7 @@ impl IdentitiesScreen {
     }
 
     fn show_alias(&mut self, ui: &mut Ui, qualified_identity: &QualifiedIdentity) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(alias) = &qualified_identity.alias {
             ui.label(RichText::new(alias).color(DashColors::text_primary(dark_mode)));
@@ -380,7 +380,7 @@ impl IdentitiesScreen {
     }
 
     fn render_no_identities_view(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Optionally put everything in a framed "card"-like container
         Frame::group(ui.style())
@@ -615,7 +615,7 @@ impl IdentitiesScreen {
                                                     let actions_popup_id = ui.make_persistent_id(format!("actions_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                         egui::Popup::from_toggle_button_response(&actions_response).id(actions_popup_id)
                                                         .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
-                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.ctx().style().visuals.dark_mode)))
+                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.style().visuals.dark_mode)))
                                                         .show(|ui| {
                                                         ui.set_min_width(150.0);
 
@@ -725,12 +725,12 @@ impl IdentitiesScreen {
                                                     let popup_id = ui.make_persistent_id(format!("keys_popup_{}", qualified_identity.identity.id().to_string(Encoding::Base58)));
                                                     egui::Popup::from_toggle_button_response(&button_response).id(popup_id)
                                                         .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
-                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.ctx().style().visuals.dark_mode)))
+                                                        .frame(egui::Frame::popup(ui.style()).fill(DashColors::popup_fill(ui.style().visuals.dark_mode)))
                                                         .show(|ui| {
                                                             // Wrap in a scroll area so popups with many keys are accessible
                                                             let max_popup_height = ui.ctx().content_rect().height() * 0.6;
                                                             egui::ScrollArea::vertical().max_height(max_popup_height).show(ui, |ui| {
-                                                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                                            let dark_mode = ui.style().visuals.dark_mode;
 
                                                             // Main Identity Keys
                                                             if !public_keys.is_empty() {
@@ -947,13 +947,13 @@ impl IdentitiesScreen {
                     spread: 0,
                     color: DashColors::popup_shadow(),
                 },
-                fill: ctx.style().visuals.window_fill,
+                fill: ctx.global_style().visuals.window_fill,
                 stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
             })
             .show(ctx, |ui| {
                 ui.set_min_width(300.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 ui.label(
                     RichText::new("Enter a new alias for this identity:")

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -650,7 +650,7 @@ impl ScreenLike for AddKeyScreen {
             let fee_estimator = self.app_context.fee_estimator();
             let estimated_fee = fee_estimator.estimate_identity_update();
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             Frame::new()
                 .fill(DashColors::surface(dark_mode))
                 .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -26,7 +26,7 @@ use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::Identifier;
-use eframe::egui::{self, Context, Frame, Margin};
+use eframe::egui::{self, Frame, Margin};
 use egui::{Color32, RichText, Ui};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -385,9 +385,11 @@ impl ScreenLike for AddKeyScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -397,12 +399,12 @@ impl ScreenLike for AddKeyScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the key was added successfully

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -229,7 +229,7 @@ impl ScreenLike for KeyInfoScreen {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
-                let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+                let text_primary = DashColors::text_primary(ui.style().visuals.dark_mode);
                 ui.heading(RichText::new("Key Information").color(text_primary));
                 ui.add_space(10.0);
 
@@ -633,6 +633,7 @@ impl ScreenLike for KeyInfoScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {
@@ -843,7 +844,7 @@ impl KeyInfoScreen {
     }
 
     fn render_sign_input(&mut self, ui: &mut egui::Ui) {
-        let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+        let text_primary = DashColors::text_primary(ui.style().visuals.dark_mode);
         ui.add_space(10.0);
         ui.separator();
         ui.add_space(10.0);

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -39,7 +39,7 @@ use dash_sdk::dpp::identity::identity_public_key::contract_bounds::ContractBound
 use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::IdentityPublicKey;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText, ScrollArea};
 use std::sync::{Arc, RwLock};
 use zxcvbn::zxcvbn;
@@ -208,9 +208,11 @@ impl ScreenLike for KeyInfoScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -220,12 +222,12 @@ impl ScreenLike for KeyInfoScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
@@ -633,10 +635,9 @@ impl ScreenLike for KeyInfoScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new("Sign Message Info", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -1081,7 +1081,7 @@ impl KeyInfoScreen {
         if status == IdentityProtectionStatus::NoVaultKeys {
             return;
         }
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         egui::CollapsingHeader::new("Key Protection")
             .default_open(false)
@@ -1134,9 +1134,10 @@ impl KeyInfoScreen {
         }
         if self.protection_in_flight {
             ui.add_space(4.0);
-            ui.label(RichText::new("Working…").color(DashColors::text_secondary(
-                ui.ctx().style().visuals.dark_mode,
-            )));
+            ui.label(
+                RichText::new("Working…")
+                    .color(DashColors::text_secondary(ui.style().visuals.dark_mode)),
+            );
         }
     }
 
@@ -1203,7 +1204,7 @@ impl KeyInfoScreen {
 
     /// The opt-in password form: new password + confirmation + strength + hint.
     fn render_new_password_form(&mut self, ui: &mut egui::Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.label(
             RichText::new(format!(
                 "This password protects the signing keys for {}.",
@@ -1247,7 +1248,7 @@ impl KeyInfoScreen {
 
     /// The opt-out password form: verify the current password.
     fn render_verify_password_form(&mut self, ui: &mut egui::Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.label(
             RichText::new(format!(
                 "Enter the current password for the signing keys for {}.",

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -92,7 +92,7 @@ impl ScreenLike for KeyInfoScreen {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
-                let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+                let text_primary = DashColors::text_primary(ui.style().visuals.dark_mode);
                 ui.heading(RichText::new("Key Information").color(text_primary));
                 ui.add_space(10.0);
 
@@ -577,6 +577,7 @@ impl ScreenLike for KeyInfoScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {
@@ -692,7 +693,7 @@ impl KeyInfoScreen {
     }
 
     fn render_sign_input(&mut self, ui: &mut egui::Ui) {
-        let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+        let text_primary = DashColors::text_primary(ui.style().visuals.dark_mode);
         ui.add_space(10.0);
         ui.separator();
         ui.add_space(10.0);

--- a/src/ui/identities/keys/keys_screen.rs
+++ b/src/ui/identities/keys/keys_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::ScreenLike;
 use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use std::sync::Arc;
 
 pub struct KeysScreen {
@@ -15,9 +15,8 @@ pub struct KeysScreen {
 impl ScreenLike for KeysScreen {
     fn refresh(&mut self) {}
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        egui::CentralPanel::default().show(ui, |ui| {
             ui.heading("Identity Keys");
 
             egui::ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/keys/keys_screen.rs
+++ b/src/ui/identities/keys/keys_screen.rs
@@ -16,6 +16,7 @@ impl ScreenLike for KeysScreen {
     fn refresh(&mut self) {}
 
     fn ui(&mut self, ctx: &Context) -> AppAction {
+        #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Identity Keys");
 

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -357,7 +357,9 @@ impl ScreenLike for RegisterDpnsNameScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Build breadcrumbs based on where we came from
         let breadcrumbs = match self.source {
             RegisterDpnsNameSource::Dpns => vec![
@@ -378,18 +380,18 @@ impl ScreenLike for RegisterDpnsNameScreen {
             ],
         };
 
-        let mut action = add_top_panel(ctx, &self.app_context, breadcrumbs, vec![]);
+        let mut action = add_top_panel(ui, &self.app_context, breadcrumbs, vec![]);
 
         // Use the appropriate left panel highlight based on source
         let root_screen = match self.source {
             RegisterDpnsNameSource::Dpns => crate::ui::RootScreenType::RootScreenDPNSActiveContests,
             RegisterDpnsNameSource::Identities => crate::ui::RootScreenType::RootScreenIdentities,
         };
-        action |= add_left_panel(ctx, &self.app_context, root_screen);
+        action |= add_left_panel(ui, &self.app_context, root_screen);
 
         // Don't show the tools/dpns subscreen chooser panels for this screen
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             egui::ScrollArea::vertical()

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -525,7 +525,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
             // Fee estimation
             let fee_estimator = self.app_context.fee_estimator();
             let estimated_fee = fee_estimator.estimate_document_create();
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -485,7 +485,7 @@ impl ScreenLike for RegisterDpnsNameScreen {
             // Fee estimation
             let fee_estimator = self.app_context.fee_estimator();
             let estimated_fee = fee_estimator.estimate_document_create();
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/identities/top_up_identity_screen/by_platform_address.rs
+++ b/src/ui/identities/top_up_identity_screen/by_platform_address.rs
@@ -26,7 +26,7 @@ impl TopUpIdentityScreen {
         step_number: u32,
     ) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.heading(format!(
             "{}. Select a Platform address to use for top-up.",

--- a/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
@@ -112,7 +112,7 @@ impl TopUpIdentityScreen {
         let fee_estimator = self.app_context.fee_estimator();
         let estimated_fee = fee_estimator.estimate_identity_topup();
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
+++ b/src/ui/identities/top_up_identity_screen/by_using_unused_asset_lock.rs
@@ -102,7 +102,7 @@ impl TopUpIdentityScreen {
         let fee_estimator = self.app_context.fee_estimator();
         let estimated_fee = fee_estimator.estimate_identity_topup();
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/top_up_identity_screen/by_using_unused_balance.rs
+++ b/src/ui/identities/top_up_identity_screen/by_using_unused_balance.rs
@@ -51,7 +51,7 @@ impl TopUpIdentityScreen {
         let fee_estimator = self.app_context.fee_estimator();
         let estimated_fee = fee_estimator.estimate_identity_topup();
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -682,6 +682,7 @@ impl ScreenLike for TopUpIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -675,6 +675,7 @@ impl ScreenLike for TopUpIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
+            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show(ctx, |ui| {

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -34,7 +34,6 @@ use dash_sdk::dpp::balances::credits::{Credits, Duffs};
 use dash_sdk::dpp::dashcore::OutPoint;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::Context;
 use egui::{ComboBox, ScrollArea, Ui};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
@@ -518,9 +517,11 @@ impl ScreenLike for TopUpIdentityScreen {
         false
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -530,12 +531,12 @@ impl ScreenLike for TopUpIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {
@@ -682,10 +683,9 @@ impl ScreenLike for TopUpIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show(ui, |ui| {
                     let mut popup = InfoPopup::new("Wallet Selection Info", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -25,7 +25,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::{Color32, RichText};
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
@@ -577,9 +577,11 @@ impl ScreenLike for TransferScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -589,12 +591,12 @@ impl ScreenLike for TransferScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the transfer was successful

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -181,7 +181,7 @@ impl TransferScreen {
     }
 
     fn render_destination_type_selector(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Colors for selected/unselected states
         let selected_fill = DashColors::DASH_BLUE;
@@ -745,7 +745,7 @@ impl ScreenLike for TransferScreen {
                 };
 
                 // Display estimated fee
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::group(ui.style())
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -574,7 +574,7 @@ impl ScreenLike for WithdrawalScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_credit_withdrawal();
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -576,7 +576,7 @@ impl ScreenLike for WithdrawalScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_credit_withdrawal();
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -27,7 +27,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::IdentityPublicKey;
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::{Color32, RichText};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -368,9 +368,11 @@ impl ScreenLike for WithdrawalScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -380,12 +382,12 @@ impl ScreenLike for WithdrawalScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the withdrawal was successful

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -53,7 +53,6 @@ use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::prelude::IdentityPublicKey;
 use dash_sdk::platform::Identifier;
 use dpns::dpns_contested_names_screen::DPNSSubscreen;
-use egui::Context;
 use identities::add_existing_identity_screen::AddExistingIdentityScreen;
 use identities::add_new_identity_screen::AddNewIdentityScreen;
 use identities::identities_screen::IdentitiesScreen;
@@ -931,7 +930,7 @@ pub trait ScreenLike {
     fn refresh_on_arrival(&mut self) {
         self.refresh()
     }
-    fn ui(&mut self, ctx: &Context) -> AppAction;
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction;
     /// Called by `AppState` **after** the global banner has already been set.
     ///
     /// Override **only for side-effects** such as clearing a progress banner
@@ -1275,71 +1274,71 @@ impl ScreenLike for Screen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         match self {
-            Screen::IdentitiesScreen(screen) => screen.ui(ctx),
-            Screen::DPNSScreen(screen) => screen.ui(ctx),
-            Screen::DocumentQueryScreen(screen) => screen.ui(ctx),
-            Screen::AddNewWalletScreen(screen) => screen.ui(ctx),
-            Screen::ImportMnemonicScreen(screen) => screen.ui(ctx),
-            Screen::AddNewIdentityScreen(screen) => screen.ui(ctx),
-            Screen::TopUpIdentityScreen(screen) => screen.ui(ctx),
-            Screen::AddExistingIdentityScreen(screen) => screen.ui(ctx),
-            Screen::KeyInfoScreen(screen) => screen.ui(ctx),
-            Screen::KeysScreen(screen) => screen.ui(ctx),
-            Screen::RegisterDpnsNameScreen(screen) => screen.ui(ctx),
-            Screen::RegisterDataContractScreen(screen) => screen.ui(ctx),
-            Screen::UpdateDataContractScreen(screen) => screen.ui(ctx),
-            Screen::DocumentActionScreen(screen) => screen.ui(ctx),
-            Screen::GroupActionsScreen(screen) => screen.ui(ctx),
-            Screen::WithdrawalScreen(screen) => screen.ui(ctx),
-            Screen::TransferScreen(screen) => screen.ui(ctx),
-            Screen::AddKeyScreen(screen) => screen.ui(ctx),
-            Screen::TransitionVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::NetworkChooserScreen(screen) => screen.ui(ctx),
-            Screen::WalletsBalancesScreen(screen) => screen.ui(ctx),
-            Screen::WalletSendScreen(screen) => screen.ui(ctx),
-            Screen::SingleKeyWalletSendScreen(screen) => screen.ui(ctx),
-            Screen::AddContractsScreen(screen) => screen.ui(ctx),
-            Screen::ProofVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::DocumentVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::ContractVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::PlatformInfoScreen(screen) => screen.ui(ctx),
-            Screen::GroveSTARKScreen(screen) => screen.ui(ctx),
-            Screen::AddressBalanceScreen(screen) => screen.ui(ctx),
+            Screen::IdentitiesScreen(screen) => screen.ui(ui),
+            Screen::DPNSScreen(screen) => screen.ui(ui),
+            Screen::DocumentQueryScreen(screen) => screen.ui(ui),
+            Screen::AddNewWalletScreen(screen) => screen.ui(ui),
+            Screen::ImportMnemonicScreen(screen) => screen.ui(ui),
+            Screen::AddNewIdentityScreen(screen) => screen.ui(ui),
+            Screen::TopUpIdentityScreen(screen) => screen.ui(ui),
+            Screen::AddExistingIdentityScreen(screen) => screen.ui(ui),
+            Screen::KeyInfoScreen(screen) => screen.ui(ui),
+            Screen::KeysScreen(screen) => screen.ui(ui),
+            Screen::RegisterDpnsNameScreen(screen) => screen.ui(ui),
+            Screen::RegisterDataContractScreen(screen) => screen.ui(ui),
+            Screen::UpdateDataContractScreen(screen) => screen.ui(ui),
+            Screen::DocumentActionScreen(screen) => screen.ui(ui),
+            Screen::GroupActionsScreen(screen) => screen.ui(ui),
+            Screen::WithdrawalScreen(screen) => screen.ui(ui),
+            Screen::TransferScreen(screen) => screen.ui(ui),
+            Screen::AddKeyScreen(screen) => screen.ui(ui),
+            Screen::TransitionVisualizerScreen(screen) => screen.ui(ui),
+            Screen::NetworkChooserScreen(screen) => screen.ui(ui),
+            Screen::WalletsBalancesScreen(screen) => screen.ui(ui),
+            Screen::WalletSendScreen(screen) => screen.ui(ui),
+            Screen::SingleKeyWalletSendScreen(screen) => screen.ui(ui),
+            Screen::AddContractsScreen(screen) => screen.ui(ui),
+            Screen::ProofVisualizerScreen(screen) => screen.ui(ui),
+            Screen::DocumentVisualizerScreen(screen) => screen.ui(ui),
+            Screen::ContractVisualizerScreen(screen) => screen.ui(ui),
+            Screen::PlatformInfoScreen(screen) => screen.ui(ui),
+            Screen::GroveSTARKScreen(screen) => screen.ui(ui),
+            Screen::AddressBalanceScreen(screen) => screen.ui(ui),
 
             // Token Screens
-            Screen::TokensScreen(screen) => screen.ui(ctx),
-            Screen::TransferTokensScreen(screen) => screen.ui(ctx),
-            Screen::MintTokensScreen(screen) => screen.ui(ctx),
-            Screen::BurnTokensScreen(screen) => screen.ui(ctx),
-            Screen::DestroyFrozenFundsScreen(screen) => screen.ui(ctx),
-            Screen::FreezeTokensScreen(screen) => screen.ui(ctx),
-            Screen::UnfreezeTokensScreen(screen) => screen.ui(ctx),
-            Screen::PauseTokensScreen(screen) => screen.ui(ctx),
-            Screen::ResumeTokensScreen(screen) => screen.ui(ctx),
-            Screen::ClaimTokensScreen(screen) => screen.ui(ctx),
-            Screen::ViewTokenClaimsScreen(screen) => screen.ui(ctx),
-            Screen::UpdateTokenConfigScreen(screen) => screen.ui(ctx),
-            Screen::AddTokenById(screen) => screen.ui(ctx),
-            Screen::PurchaseTokenScreen(screen) => screen.ui(ctx),
-            Screen::SetTokenPriceScreen(screen) => screen.ui(ctx),
-            Screen::AssetLockDetailScreen(screen) => screen.ui(ctx),
-            Screen::CreateAssetLockScreen(screen) => screen.ui(ctx),
+            Screen::TokensScreen(screen) => screen.ui(ui),
+            Screen::TransferTokensScreen(screen) => screen.ui(ui),
+            Screen::MintTokensScreen(screen) => screen.ui(ui),
+            Screen::BurnTokensScreen(screen) => screen.ui(ui),
+            Screen::DestroyFrozenFundsScreen(screen) => screen.ui(ui),
+            Screen::FreezeTokensScreen(screen) => screen.ui(ui),
+            Screen::UnfreezeTokensScreen(screen) => screen.ui(ui),
+            Screen::PauseTokensScreen(screen) => screen.ui(ui),
+            Screen::ResumeTokensScreen(screen) => screen.ui(ui),
+            Screen::ClaimTokensScreen(screen) => screen.ui(ui),
+            Screen::ViewTokenClaimsScreen(screen) => screen.ui(ui),
+            Screen::UpdateTokenConfigScreen(screen) => screen.ui(ui),
+            Screen::AddTokenById(screen) => screen.ui(ui),
+            Screen::PurchaseTokenScreen(screen) => screen.ui(ui),
+            Screen::SetTokenPriceScreen(screen) => screen.ui(ui),
+            Screen::AssetLockDetailScreen(screen) => screen.ui(ui),
+            Screen::CreateAssetLockScreen(screen) => screen.ui(ui),
 
             // DashPay Screens
-            Screen::DashPayScreen(screen) => screen.ui(ctx),
-            Screen::DashPayAddContactScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactDetailsScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactProfileViewerScreen(screen) => screen.ui(ctx),
-            Screen::DashPaySendPaymentScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactInfoEditorScreen(screen) => screen.ui(ctx),
-            Screen::DashPayQRGeneratorScreen(screen) => screen.ui(ctx),
-            Screen::DashPayProfileSearchScreen(screen) => screen.ui(ctx),
+            Screen::DashPayScreen(screen) => screen.ui(ui),
+            Screen::DashPayAddContactScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactDetailsScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactProfileViewerScreen(screen) => screen.ui(ui),
+            Screen::DashPaySendPaymentScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactInfoEditorScreen(screen) => screen.ui(ui),
+            Screen::DashPayQRGeneratorScreen(screen) => screen.ui(ui),
+            Screen::DashPayProfileSearchScreen(screen) => screen.ui(ui),
             // Shielded screens
-            Screen::ShieldScreen(screen) => screen.ui(ctx),
-            Screen::ShieldedSendScreen(screen) => screen.ui(ctx),
-            Screen::UnshieldCreditsScreen(screen) => screen.ui(ctx),
+            Screen::ShieldScreen(screen) => screen.ui(ui),
+            Screen::ShieldedSendScreen(screen) => screen.ui(ui),
+            Screen::UnshieldCreditsScreen(screen) => screen.ui(ui),
         }
     }
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -21,7 +21,7 @@ use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dash_spv::sync::{ProgressPercentage, SyncProgress as SpvSyncProgress, SyncState};
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::identity::TimestampMillis;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -1465,21 +1465,21 @@ impl ScreenLike for NetworkChooserScreen {
         self.theme_preference = settings.theme_mode;
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             self.current_app_context(),
             vec![("Networks", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             self.current_app_context(),
             RootScreenType::RootScreenNetworkChooser,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical()
                 .auto_shrink([true; 2])
                 .show(ui, |ui| self.render_network_table(ui))

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -241,7 +241,7 @@ impl NetworkChooserScreen {
     /// Render the simplified settings interface
     fn render_network_table(&mut self, ui: &mut Ui) -> AppAction {
         let mut app_action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Connection Settings Card
         StyledCard::new().padding(24.0).show(ui, |ui| {
@@ -1501,7 +1501,7 @@ impl NetworkChooserScreen {
             }
         }
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         egui::Frame::new()
             .fill(DashColors::glass_white(dark_mode))
@@ -1605,7 +1605,7 @@ impl NetworkChooserScreen {
         snapshot: &SpvStatusSnapshot,
     ) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.label(
             egui::RichText::new("SPV Maintenance")

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -156,7 +156,7 @@ impl NetworkChooserScreen {
     /// Render the simplified settings interface
     fn render_network_table(&mut self, ui: &mut Ui) -> AppAction {
         let mut app_action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Connection Settings Card
         StyledCard::new().padding(24.0).show(ui, |ui| {
@@ -941,7 +941,7 @@ impl NetworkChooserScreen {
             }
         }
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         egui::Frame::new()
             .fill(DashColors::glass_white(dark_mode))
@@ -1045,7 +1045,7 @@ impl NetworkChooserScreen {
         snapshot: &SpvStatusSnapshot,
     ) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.label(
             egui::RichText::new("SPV Maintenance")

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -890,7 +890,7 @@ impl ComponentStyles {
             ui.add(Self::primary_button(label))
                 .on_hover_cursor(CursorIcon::PointingHand)
         } else {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             let text = match label.into() {
                 WidgetText::RichText(rt) => rt
                     .as_ref()
@@ -1087,7 +1087,7 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     // Apply the custom visuals first
     ctx.set_visuals(visuals);
 
-    let mut style = (*ctx.style()).clone();
+    let mut style = (*ctx.global_style()).clone();
 
     // Configure modern visuals with gradients and glass effects
     // Override all background colors again to ensure they stick
@@ -1175,5 +1175,5 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     // Don't override extreme_bg_color here - it should remain as input_background for TextEdit widgets
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
-    ctx.set_style(style);
+    ctx.set_global_style(style);
 }

--- a/src/ui/tokens/add_token_by_id_screen.rs
+++ b/src/ui/tokens/add_token_by_id_screen.rs
@@ -8,7 +8,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_configuration_conventi
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::DataContract;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 
 use crate::ui::theme::ComponentStyles;
 
@@ -307,9 +307,9 @@ impl ScreenLike for AddTokenByIdScreen {
         // nothing to refresh
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -320,15 +320,15 @@ impl ScreenLike for AddTokenByIdScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             // If we are in the "Complete" status, just show success screen
             if self.status == AddTokenStatus::Complete {
                 return self.show_success_screen(ui);

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -22,7 +22,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -376,13 +376,15 @@ impl ScreenLike for BurnTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -393,7 +395,7 @@ impl ScreenLike for BurnTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -406,15 +408,15 @@ impl ScreenLike for BurnTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -415,7 +415,7 @@ impl ScreenLike for BurnTokensScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         let central_panel_action = island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen
             if self.status == BurnTokensStatus::Complete {
@@ -613,7 +613,7 @@ impl ScreenLike for BurnTokensScreen {
                 // Display estimated fee before action button
                 let estimated_fee = fee_estimator.estimate_token_transition();
                 ui.add_space(10.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 egui::Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -563,7 +563,7 @@ impl ScreenLike for ClaimTokensScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -21,7 +21,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_perpetual_distribution
 use dash_sdk::dpp::data_contract::TokenConfiguration;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::BackendTask;
@@ -304,9 +304,11 @@ impl ScreenLike for ClaimTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -321,15 +323,15 @@ impl ScreenLike for ClaimTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == ClaimTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -408,7 +408,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             if self.status == DestroyFrozenFundsStatus::Complete {
                 action |= self.show_success_screen(ui);

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -35,7 +35,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -369,13 +369,15 @@ impl ScreenLike for DestroyFrozenFundsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -386,7 +388,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -399,15 +401,15 @@ impl ScreenLike for DestroyFrozenFundsScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             if self.status == DestroyFrozenFundsStatus::Complete {

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -176,7 +176,7 @@ impl PurchaseTokenScreen {
         if let Some(pricing_schedule) = &self.fetched_pricing_schedule {
             ui.add_space(5.0);
             ui.label("Current pricing:");
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             match pricing_schedule {
                 TokenPricingSchedule::SinglePrice(price_per_unit) => {
@@ -421,7 +421,7 @@ impl ScreenLike for PurchaseTokenScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             // If we are in the "Complete" status, just show success screen
             if self.status == PurchaseTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
@@ -570,7 +570,7 @@ impl ScreenLike for PurchaseTokenScreen {
 
                 // Display estimated fee before action button
                 let estimated_fee = self.app_context.fee_estimator().estimate_token_transition();
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 egui::Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -6,7 +6,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_configuration::accesso
 use dash_sdk::dpp::data_contract::associated_token::token_configuration_convention::accessors::v0::TokenConfigurationConventionV0Getters;
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::RichText;
 
 use super::tokens_screen::IdentityTokenInfo;
@@ -397,10 +397,12 @@ impl ScreenLike for PurchaseTokenScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Build a top panel
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -412,15 +414,15 @@ impl ScreenLike for PurchaseTokenScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
             // If we are in the "Complete" status, just show success screen
             if self.status == PurchaseTokensStatus::Complete {

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -35,7 +35,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -359,13 +359,15 @@ impl ScreenLike for FreezeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -376,7 +378,7 @@ impl ScreenLike for FreezeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -389,15 +391,15 @@ impl ScreenLike for FreezeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             if self.status == FreezeTokensStatus::Complete {
                 return self.show_success_screen(ui);
             }

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -547,7 +547,7 @@ impl ScreenLike for FreezeTokensScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))
@@ -578,7 +578,7 @@ impl ScreenLike for FreezeTokensScreen {
                 // Display estimated fee before action button
                 let estimated_fee = fee_estimator.estimate_token_transition();
                 ui.add_space(10.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 egui::Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -432,7 +432,7 @@ impl ScreenLike for MintTokensScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         let central_panel_action = island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen
             if self.status == MintTokensStatus::Complete {
@@ -658,7 +658,7 @@ impl ScreenLike for MintTokensScreen {
                 // Display estimated fee before action button
                 let estimated_fee = fee_estimator.estimate_token_transition();
                 ui.add_space(10.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 egui::Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(egui::Margin::symmetric(10, 8))

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -38,7 +38,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -393,13 +393,15 @@ impl ScreenLike for MintTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -410,7 +412,7 @@ impl ScreenLike for MintTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -423,15 +425,15 @@ impl ScreenLike for MintTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -34,7 +34,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -307,13 +307,15 @@ impl ScreenLike for PauseTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -324,7 +326,7 @@ impl ScreenLike for PauseTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -337,15 +339,15 @@ impl ScreenLike for PauseTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             if self.status == PauseTokensStatus::Complete {
                 return self.show_success_screen(ui);
             }

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -480,7 +480,7 @@ impl ScreenLike for PauseTokensScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -481,7 +481,7 @@ impl ScreenLike for ResumeTokensScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -34,7 +34,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -307,13 +307,15 @@ impl ScreenLike for ResumeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -324,7 +326,7 @@ impl ScreenLike for ResumeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -337,15 +339,15 @@ impl ScreenLike for ResumeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == ResumeTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -409,7 +409,7 @@ impl SetTokenPriceScreen {
                 }
             }
             PricingType::TieredPricing => {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let text_primary = DashColors::text_primary(dark_mode);
                 ui.label("Add pricing tiers to offer volume discounts");
                 ui.add_space(10.0);
@@ -1099,7 +1099,7 @@ impl ScreenLike for SetTokenPriceScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -40,7 +40,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use egui_extras::{Column, TableBuilder};
 use std::collections::HashSet;
@@ -855,13 +855,15 @@ impl ScreenLike for SetTokenPriceScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -872,7 +874,7 @@ impl ScreenLike for SetTokenPriceScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -885,15 +887,15 @@ impl ScreenLike for SetTokenPriceScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 // If we are in the "Complete" status, just show success screen
                 if self.status == SetTokenPriceStatus::Complete {

--- a/src/ui/tokens/tokens_screen/data_contract_json_pop_up.rs
+++ b/src/ui/tokens/tokens_screen/data_contract_json_pop_up.rs
@@ -40,7 +40,7 @@ impl TokensScreen {
                 })
                 .show(ui.ctx(), |ui| {
                     // Display the JSON in a multiline text box
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add_space(10.0);
                     ui.label(
                         egui::RichText::new("Below is the data contract JSON:")
@@ -66,7 +66,7 @@ impl TokensScreen {
 
                     // Close button — right-aligned to match ConfirmationDialog pattern
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                             self.show_json_popup = false;
                         }

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -45,7 +45,7 @@ use dash_sdk::dpp::prelude::TimestampMillisInterval;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use dash_sdk::query_types::IndexMap;
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use crate::ui::theme::{DashColors, ResponseExt};
 use egui::{Checkbox, ColorImage, ComboBox, Response, RichText, TextEdit, TextureHandle};
 use enum_iterator::Sequence;
@@ -2798,7 +2798,9 @@ impl ScreenLike for TokensScreen {
         );
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Build top-right buttons
@@ -2828,7 +2830,7 @@ impl ScreenLike for TokensScreen {
                 .unwrap_or_else(|| token_id.to_string(Encoding::Base58));
 
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::Custom("Back to tokens".to_string())),
@@ -2847,7 +2849,7 @@ impl ScreenLike for TokensScreen {
             );
 
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     (
@@ -2860,7 +2862,7 @@ impl ScreenLike for TokensScreen {
             );
         } else {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Tokens", AppAction::None)],
                 right_buttons.clone(),
@@ -2871,21 +2873,18 @@ impl ScreenLike for TokensScreen {
         match self.tokens_subscreen {
             TokensSubscreen::MyTokens => {
                 action |= add_left_panel(
-                    ctx,
+                    ui,
                     &self.app_context,
                     RootScreenType::RootScreenMyTokenBalances,
                 );
             }
             TokensSubscreen::SearchTokens => {
-                action |= add_left_panel(
-                    ctx,
-                    &self.app_context,
-                    RootScreenType::RootScreenTokenSearch,
-                );
+                action |=
+                    add_left_panel(ui, &self.app_context, RootScreenType::RootScreenTokenSearch);
             }
             TokensSubscreen::TokenCreator => {
                 action |= add_left_panel(
-                    ctx,
+                    ui,
                     &self.app_context,
                     RootScreenType::RootScreenTokenCreator,
                 );
@@ -2893,10 +2892,10 @@ impl ScreenLike for TokensScreen {
         }
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tokens_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Main panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical()
                 .show(ui, |ui| {
                     let mut inner_action = AppAction::None;

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -331,7 +331,7 @@ impl ChangeControlRulesUI {
                             self.authorized_identity.get_or_insert_with(String::new);
                             if let Some(ref mut id_str) = self.authorized_identity {
                                 ui.horizontal(|ui| {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.add_sized(
                                         [300.0, 22.0],
                                         TextEdit::singleline(id_str)
@@ -414,7 +414,7 @@ impl ChangeControlRulesUI {
                             self.admin_identity.get_or_insert_with(String::new);
                             if let Some(ref mut id_str) = self.admin_identity {
                                 ui.horizontal(|ui| {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.add_sized(
                                         [300.0, 22.0],
                                         TextEdit::singleline(id_str)
@@ -580,7 +580,7 @@ impl ChangeControlRulesUI {
                             self.authorized_identity.get_or_insert_with(String::new);
                             if let Some(ref mut id_str) = self.authorized_identity {
                                 ui.horizontal(|ui| {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.add_sized(
                                         [300.0, 22.0],
                                         TextEdit::singleline(id_str)
@@ -663,7 +663,7 @@ impl ChangeControlRulesUI {
                             self.admin_identity.get_or_insert_with(String::new);
                             if let Some(ref mut id_str) = self.admin_identity {
                                 ui.horizontal(|ui| {
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.add_sized(
                                         [300.0, 22.0],
                                         TextEdit::singleline(id_str)

--- a/src/ui/tokens/tokens_screen/my_tokens.rs
+++ b/src/ui/tokens/tokens_screen/my_tokens.rs
@@ -177,7 +177,7 @@ impl TokensScreen {
             if let Some(token_info) = self.all_known_tokens.get(&token_id).cloned() {
                 let mut is_open = true;
                 let mut close_popup = false;
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 let window_response = egui::Window::new("Token Configuration Details")
                     .resizable(true)
@@ -195,7 +195,7 @@ impl TokensScreen {
                                     self.render_token_info_popup_content(ui, &token_info);
 
                                     ui.separator();
-                                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                                    let dark_mode = ui.style().visuals.dark_mode;
                                     ui.with_layout(
                                         egui::Layout::right_to_left(egui::Align::Center),
                                         |ui| {
@@ -230,7 +230,7 @@ impl TokensScreen {
     }
     fn render_no_owned_tokens(&mut self, ui: &mut Ui) -> AppAction {
         let mut app_action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         Frame::group(ui.style())
             .fill(ui.visuals().extreme_bg_color)
@@ -623,7 +623,7 @@ impl TokensScreen {
                             }
 
                             ui.separator();
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             ui.with_layout(
                                 egui::Layout::right_to_left(egui::Align::Center),
                                 |ui| {
@@ -673,7 +673,7 @@ impl TokensScreen {
         let mut pos = 0;
         let mut action = AppAction::None;
         ui.spacing_mut().item_spacing.x = 5.0;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if range.contains(&pos) {
             if itb.available_actions.can_transfer {

--- a/src/ui/tokens/tokens_screen/token_creator.rs
+++ b/src/ui/tokens/tokens_screen/token_creator.rs
@@ -77,7 +77,7 @@ impl TokensScreen {
                             }
                         };
                         if all_identities.is_empty() {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             Frame::group(ui.style())
                                 .fill(ui.visuals().extreme_bg_color)
                                 .corner_radius(5.0)
@@ -1579,7 +1579,7 @@ impl TokensScreen {
 
                 ui.add_space(5.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let schemas_response = ui.add_sized(
                     [ui.available_width(), 120.0],
                     TextEdit::multiline(&mut self.document_schemas_input)

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -404,7 +404,7 @@ impl ScreenLike for TransferTokensScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         let central_panel_action = island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Show the success screen if the transfer was successful
             if self.transfer_tokens_status == TransferTokensStatus::Complete {

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -400,7 +400,7 @@ impl ScreenLike for TransferTokensScreen {
         action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
 
         let central_panel_action = island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Show the success screen if the transfer was successful
             if self.transfer_tokens_status == TransferTokensStatus::Complete {

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -27,7 +27,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -374,9 +374,11 @@ impl ScreenLike for TransferTokensScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -391,15 +393,15 @@ impl ScreenLike for TransferTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // Show the success screen if the transfer was successful

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -550,7 +550,7 @@ impl ScreenLike for UnfreezeTokensScreen {
                 let fee_estimator = self.app_context.fee_estimator();
                 let estimated_fee = fee_estimator.estimate_document_batch(1); // Token operations are document batch transitions
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 Frame::new()
                     .fill(DashColors::surface(dark_mode))
                     .inner_margin(Margin::symmetric(10, 8))

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -36,7 +36,7 @@ use dash_sdk::dpp::group::GroupStateTransitionInfoStatus;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -361,13 +361,15 @@ impl ScreenLike for UnfreezeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -378,7 +380,7 @@ impl ScreenLike for UnfreezeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -391,15 +393,15 @@ impl ScreenLike for UnfreezeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == UnfreezeTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -719,7 +719,7 @@ impl UpdateTokenConfigScreen {
         // Display estimated fee before action button
         let estimated_fee = self.app_context.fee_estimator().estimate_token_transition();
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         egui::Frame::new()
             .fill(DashColors::surface(dark_mode))
             .inner_margin(egui::Margin::symmetric(10, 8))
@@ -865,7 +865,7 @@ impl UpdateTokenConfigScreen {
                 authorized_identity_input.get_or_insert_with(String::new);
                 if let Some(id_str) = authorized_identity_input {
                     ui.horizontal(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         ui.add_sized(
                             [300.0, 22.0],
                             egui::TextEdit::singleline(id_str)

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -36,7 +36,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{DataContract, Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -946,13 +946,15 @@ impl ScreenLike for UpdateTokenConfigScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -963,7 +965,7 @@ impl ScreenLike for UpdateTokenConfigScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -976,16 +978,16 @@ impl ScreenLike for UpdateTokenConfigScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
         // Central panel
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 if self.update_status == UpdateTokenConfigStatus::Complete {
                     action |= self.show_success_screen(ui);

--- a/src/ui/tokens/view_token_claims_screen.rs
+++ b/src/ui/tokens/view_token_claims_screen.rs
@@ -14,7 +14,6 @@ use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::drive::query::{SelectProjection, WhereClause, WhereOperator};
 use dash_sdk::platform::{Document, DocumentQuery};
-use egui::Context;
 use std::sync::Arc;
 
 use super::tokens_screen::IdentityTokenBasicInfo;
@@ -97,10 +96,10 @@ impl ScreenLike for ViewTokenClaimsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         // Top panel
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -120,16 +119,16 @@ impl ScreenLike for ViewTokenClaimsScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
         // Central panel
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("View Token Claims");
             ui.add_space(10.0);
 

--- a/src/ui/tools/address_balance_screen.rs
+++ b/src/ui/tools/address_balance_screen.rs
@@ -8,7 +8,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, ScreenLike};
-use eframe::egui::{self, Context, ScrollArea, TextEdit, Ui};
+use eframe::egui::{self, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 
 pub struct AddressBalanceScreen {
@@ -153,22 +153,22 @@ impl ScreenLike for AddressBalanceScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsAddressBalanceScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tools_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ScrollArea::vertical().show(ui, |ui| {
                 action |= self.render_input(ui);
                 self.render_result(ui);

--- a/src/ui/tools/contract_visualizer_screen.rs
+++ b/src/ui/tools/contract_visualizer_screen.rs
@@ -121,7 +121,7 @@ impl ContractVisualizerScreen {
 
     fn show_input(&mut self, ui: &mut Ui) {
         ui.label("Enter hex, base64, or comma-separated integers for Contract:");
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let resp = ui.add(
             TextEdit::multiline(&mut self.input_data_hex)
                 .desired_rows(4)

--- a/src/ui/tools/contract_visualizer_screen.rs
+++ b/src/ui/tools/contract_visualizer_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::theme::DashColors;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::dpp::serialization::PlatformDeserializableWithPotentialValidationFromVersionedStructure;
 use dash_sdk::platform::DataContract;
-use eframe::egui::{Color32, Context, Frame, Margin, RichText, ScrollArea, TextEdit, Ui};
+use eframe::egui::{Color32, Frame, Margin, RichText, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 // ======================= 1.  Data & helpers =======================
 
@@ -178,22 +178,22 @@ impl crate::ui::ScreenLike for ContractVisualizerScreen {
         // Local parse errors are set directly via self.parse_status.
     }
     fn display_task_result(&mut self, _r: BackendTaskSuccessResult) {}
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsContractVisualizerScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         /* ---------- central panel ---------- */
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input(ui);
             self.show_output(ui);
             AppAction::None

--- a/src/ui/tools/document_visualizer_screen.rs
+++ b/src/ui/tools/document_visualizer_screen.rs
@@ -12,7 +12,7 @@ use crate::ui::theme::DashColors;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
 use dash_sdk::dpp::{data_contract::document_type::DocumentType, document::Document};
-use eframe::egui::{self, Color32, Context, Frame, Margin, RichText, TextEdit, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, RichText, TextEdit, Ui};
 use std::sync::Arc;
 // ======================= 1.  Data & helpers =======================
 
@@ -200,22 +200,22 @@ impl crate::ui::ScreenLike for DocumentVisualizerScreen {
         // Local parse errors are set directly via self.parse_status.
     }
     fn display_task_result(&mut self, _r: BackendTaskSuccessResult) {}
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsDocumentVisualizerScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         /* ---------- central panel ---------- */
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             /* ---------- simple dual-combo chooser ---------- */
             //todo cache the contracts
             add_contract_doc_type_chooser_with_filtering(

--- a/src/ui/tools/document_visualizer_screen.rs
+++ b/src/ui/tools/document_visualizer_screen.rs
@@ -140,7 +140,7 @@ impl DocumentVisualizerScreen {
 
     fn show_input(&mut self, ui: &mut Ui) {
         ui.label("Enter hex, base64, or comma-separated integers for Document:");
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let resp = ui.add(
             TextEdit::multiline(&mut self.input_data_hex)
                 .desired_rows(4)

--- a/src/ui/tools/grovestark_screen.rs
+++ b/src/ui/tools/grovestark_screen.rs
@@ -17,7 +17,7 @@ use dash_sdk::dpp::identity::{
     Identity, IdentityPublicKey, KeyType, Purpose, accessors::IdentityGettersV0,
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use egui::{Button, ComboBox, Context, Frame, Grid, Margin, RichText, ScrollArea, TextEdit, Ui};
+use egui::{Button, ComboBox, Frame, Grid, Margin, RichText, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1012,12 +1012,12 @@ impl ScreenLike for GroveSTARKScreen {
         // Pop on success if needed
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel with breadcrumb
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
@@ -1025,16 +1025,16 @@ impl ScreenLike for GroveSTARKScreen {
 
         // Add left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsGroveSTARKScreen,
         );
 
         // Add tools subscreen chooser panel
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Add central panel with the main UI
-        let panel_action = island_central_panel(ctx, |ui| {
+        let panel_action = island_central_panel(ui, |ui| {
             ui.label(
                 RichText::new("GroveSTARK Zero-Knowledge Proofs")
                     .size(Typography::SCALE_XL)

--- a/src/ui/tools/grovestark_screen.rs
+++ b/src/ui/tools/grovestark_screen.rs
@@ -475,7 +475,7 @@ impl GroveSTARKScreen {
     }
 
     fn render_generation_ui(&mut self, ui: &mut Ui, app_context: &AppContext) -> Option<AppAction> {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let debug_build = cfg!(debug_assertions);
 
         ui.label(
@@ -817,7 +817,7 @@ impl GroveSTARKScreen {
         ui: &mut Ui,
         app_context: &AppContext,
     ) -> Option<AppAction> {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let debug_build = cfg!(debug_assertions);
 
         ui.label(
@@ -1039,7 +1039,7 @@ impl ScreenLike for GroveSTARKScreen {
                 RichText::new("GroveSTARK Zero-Knowledge Proofs")
                     .size(Typography::SCALE_XL)
                     .strong()
-                    .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode)),
+                    .color(DashColors::text_primary(ui.style().visuals.dark_mode)),
             );
             ui.add_space(5.0);
 
@@ -1047,7 +1047,7 @@ impl ScreenLike for GroveSTARKScreen {
             ui.label(
                 RichText::new("WARNING: GroveSTARK is a research project. It has not been audited and may contain bugs and security flaws. This feature is NOT ready for production usage.")
                     .size(Typography::SCALE_XS)
-                    .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode))
+                    .color(DashColors::text_primary(ui.style().visuals.dark_mode))
             );
             ui.add_space(Spacing::SM);
             ui.separator();
@@ -1061,11 +1061,11 @@ impl ScreenLike for GroveSTARKScreen {
                     RichText::new("Mode:")
                         .size(Typography::SCALE_LG)
                         .strong()
-                        .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode)),
+                        .color(DashColors::text_primary(ui.style().visuals.dark_mode)),
                 );
                 ui.add_space(10.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Generate button
                 let generate_selected = self.mode == ProofMode::Generate;

--- a/src/ui/tools/grovestark_screen.rs
+++ b/src/ui/tools/grovestark_screen.rs
@@ -522,7 +522,7 @@ impl GroveSTARKScreen {
     }
 
     fn render_generation_ui(&mut self, ui: &mut Ui, app_context: &AppContext) -> Option<AppAction> {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let debug_build = cfg!(debug_assertions);
 
         ui.label(
@@ -864,7 +864,7 @@ impl GroveSTARKScreen {
         ui: &mut Ui,
         app_context: &AppContext,
     ) -> Option<AppAction> {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let debug_build = cfg!(debug_assertions);
 
         ui.label(
@@ -1086,7 +1086,7 @@ impl ScreenLike for GroveSTARKScreen {
                 RichText::new("GroveSTARK Zero-Knowledge Proofs")
                     .size(Typography::SCALE_XL)
                     .strong()
-                    .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode)),
+                    .color(DashColors::text_primary(ui.style().visuals.dark_mode)),
             );
             ui.add_space(5.0);
 
@@ -1094,7 +1094,7 @@ impl ScreenLike for GroveSTARKScreen {
             ui.label(
                 RichText::new("WARNING: GroveSTARK is a research project. It has not been audited and may contain bugs and security flaws. This feature is NOT ready for production usage.")
                     .size(Typography::SCALE_XS)
-                    .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode))
+                    .color(DashColors::text_primary(ui.style().visuals.dark_mode))
             );
             ui.add_space(Spacing::SM);
             ui.separator();
@@ -1108,11 +1108,11 @@ impl ScreenLike for GroveSTARKScreen {
                     RichText::new("Mode:")
                         .size(Typography::SCALE_LG)
                         .strong()
-                        .color(DashColors::text_primary(ui.ctx().style().visuals.dark_mode)),
+                        .color(DashColors::text_primary(ui.style().visuals.dark_mode)),
                 );
                 ui.add_space(10.0);
 
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
 
                 // Generate button
                 let generate_selected = self.mode == ProofMode::Generate;

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -1659,7 +1659,7 @@ impl MasternodeListDiffScreen {
                 PendingTask::QrInfoWithDmls => "Fetching QR info + DMLs…",
                 PendingTask::ChainLocks => "Fetching chain locks…",
             };
-            let text_primary = DashColors::text_primary(ui.ctx().style().visuals.dark_mode);
+            let text_primary = DashColors::text_primary(ui.style().visuals.dark_mode);
             ui.colored_label(text_primary, label);
         });
         ui.add_space(6.0);
@@ -2553,7 +2553,7 @@ impl MasternodeListDiffScreen {
 
     /// Render the details for the selected quorum
     fn render_quorum_details(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let border = DashColors::border(dark_mode);
         ui.heading("Quorum Details");
         if let Some(dml_key) = self.selection.selected_dml_diff_key {
@@ -2764,7 +2764,7 @@ impl MasternodeListDiffScreen {
 
     /// Render the details for the selected Masternode
     fn render_mn_details(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let border = DashColors::border(dark_mode);
         ui.heading("Masternode Details");
 

--- a/src/ui/tools/platform_info_screen.rs
+++ b/src/ui/tools/platform_info_screen.rs
@@ -10,7 +10,7 @@ use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::version::PlatformVersion;
-use eframe::egui::{self, Context, ScrollArea, Ui};
+use eframe::egui::{self, ScrollArea, Ui};
 use std::sync::Arc;
 
 pub struct PlatformInfoScreen {
@@ -158,23 +158,23 @@ impl ScreenLike for PlatformInfoScreen {
         // Don't auto-refresh - let user trigger actions manually
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsPlatformInfoScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        let panel_action = island_central_panel(ctx, |ui| {
+        let panel_action = island_central_panel(ui, |ui| {
             ui.heading("Platform Information Tool");
             ui.separator();
 

--- a/src/ui/tools/proof_log_screen.rs
+++ b/src/ui/tools/proof_log_screen.rs
@@ -335,7 +335,7 @@ impl ProofLogScreen {
 
                 // Create the layout job with highlighted hashes
                 let font_id = TextStyle::Monospace.resolve(ui.style());
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 let text_primary = DashColors::text_primary(dark_mode);
                 let border = DashColors::border(dark_mode);
                 let layout_job =

--- a/src/ui/tools/proof_visualizer_screen.rs
+++ b/src/ui/tools/proof_visualizer_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::{MessageType, RootScreenType, ScreenLike};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::drive::grovedb::operations::proof::GroveDBProof;
-use eframe::egui::{self, Context, ScrollArea, TextEdit, Ui};
+use eframe::egui::{self, ScrollArea, TextEdit, Ui};
 use egui::Color32;
 use std::sync::Arc;
 
@@ -145,23 +145,23 @@ impl ScreenLike for ProofVisualizerScreen {
         // Implement message display if needed
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsProofVisualizerScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input_field(ui);
             self.show_output(ui);
             AppAction::None

--- a/src/ui/tools/proof_visualizer_screen.rs
+++ b/src/ui/tools/proof_visualizer_screen.rs
@@ -79,7 +79,7 @@ impl ProofVisualizerScreen {
     fn show_input_field(&mut self, ui: &mut Ui) {
         ui.label("Enter hex, base64, or comma-separated integers for GroveDB proof:");
         ui.add_space(5.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let response = ui.add(
             TextEdit::multiline(&mut self.input_data)
                 .desired_rows(6)
@@ -106,7 +106,7 @@ impl ProofVisualizerScreen {
         ScrollArea::vertical().show(ui, |ui| {
             if let Some(ref json) = self.proof_string {
                 ui.add_space(5.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.add(
                     TextEdit::multiline(&mut json.clone())
                         .desired_rows(10)
@@ -119,7 +119,7 @@ impl ProofVisualizerScreen {
                 ui.add_space(10.0);
             } else if let Some(ref error) = self.error {
                 ui.add_space(5.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.add(
                     TextEdit::multiline(&mut error.clone())
                         .desired_rows(10)

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -153,7 +153,7 @@ impl TransitionVisualizerScreen {
     fn show_input_field(&mut self, ui: &mut Ui) {
         ui.label("Enter hex, base64, or comma-separated integers for state transition:");
         ui.add_space(5.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let response = ui.add(
             TextEdit::multiline(&mut self.input_data)
                 .desired_rows(6)
@@ -207,7 +207,7 @@ impl TransitionVisualizerScreen {
         ScrollArea::vertical().show(ui, |ui| {
             if let Some(ref json) = self.parsed_json {
                 ui.add_space(5.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.add(
                     TextEdit::multiline(&mut json.clone())
                         .desired_rows(10)

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -16,7 +16,7 @@ use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformDeserializable;
 use dash_sdk::dpp::state_transition::StateTransition;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, ScrollArea, TextEdit, Ui, Window};
+use eframe::egui::{self, Color32, ScrollArea, TextEdit, Ui, Window};
 use egui::RichText;
 use serde_json::Value;
 use std::sync::Arc;
@@ -418,23 +418,25 @@ impl ScreenLike for TransitionVisualizerScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsTransitionVisualizerScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input_field(ui);
             self.show_output(ui)
         });

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -528,11 +528,13 @@ impl AddNewWalletScreen {
 }
 
 impl ScreenLike for AddNewWalletScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let pending_action = AppAction::None;
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::GoToMainScreen),
@@ -542,12 +544,12 @@ impl ScreenLike for AddNewWalletScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let ctx = ui.ctx().clone();
 

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -198,7 +198,7 @@ impl AddNewWalletScreen {
 
     fn show_success(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Check for incoming funds by looking at wallet balance
         // Use total_balance_duffs() which falls back to max_balance() (from UTXOs) if SPV balance not set
@@ -402,7 +402,7 @@ impl AddNewWalletScreen {
     }
 
     fn render_seed_phrase_input(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let surface = DashColors::surface(dark_mode);
         let border = DashColors::border(dark_mode);
         let text_primary = DashColors::text_primary(dark_mode);
@@ -810,7 +810,7 @@ impl ScreenLike for AddNewWalletScreen {
                 .show(ctx, |ui| {
                     ui.label(error_message);
                     ui.add_space(10.0);
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                         self.error = None;
                     }

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -167,7 +167,7 @@ impl AddNewWalletScreen {
 
     fn show_success(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Check for incoming funds via the display-only WalletBackend snapshot.
         if !self.funds_received {
@@ -367,7 +367,7 @@ impl AddNewWalletScreen {
     }
 
     fn render_seed_phrase_input(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let surface = DashColors::surface(dark_mode);
         let border = DashColors::border(dark_mode);
         let text_primary = DashColors::text_primary(dark_mode);
@@ -714,7 +714,7 @@ impl ScreenLike for AddNewWalletScreen {
                 .show(ctx, |ui| {
                     ui.label(error_message);
                     ui.add_space(10.0);
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     if ComponentStyles::add_secondary_button(ui, "Close", dark_mode).clicked() {
                         self.error = None;
                     }

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -11,7 +11,7 @@ use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::dashcore::OutPoint;
 use dash_sdk::dpp::prelude::AssetLockProof;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::{Color32, Frame, Margin, RichText};
 use platform_wallet::wallet::asset_lock::tracked::TrackedAssetLock;
 use std::sync::Arc;
@@ -273,9 +273,9 @@ impl AssetLockDetailScreen {
 }
 
 impl ScreenLike for AssetLockDetailScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 (
@@ -290,7 +290,7 @@ impl ScreenLike for AssetLockDetailScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
@@ -304,7 +304,7 @@ impl ScreenLike for AssetLockDetailScreen {
             action |= AppAction::BackendTask(task);
         }
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -46,7 +46,7 @@ impl AssetLockDetailScreen {
     }
 
     fn render_asset_lock_info(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         let Some(lock) = self.load_tracked_lock() else {
             if self.asset_lock_cache.is_failed(&self.wallet_seed_hash) {
@@ -306,7 +306,7 @@ impl ScreenLike for AssetLockDetailScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             ui.horizontal(|ui| {
                 ui.heading(

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -73,7 +73,7 @@ impl AssetLockDetailScreen {
     }
 
     fn render_asset_lock_info(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some((tx, address, amount, _islock, proof)) = self.get_asset_lock_data() {
             Frame::new()
@@ -299,7 +299,7 @@ impl ScreenLike for AssetLockDetailScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Header with Back button (outside ScrollArea to avoid scrollbar overlap)
             ui.horizontal(|ui| {
@@ -362,7 +362,7 @@ impl ScreenLike for AssetLockDetailScreen {
 
                     let mut close_popup = false;
                     ui.horizontal(|ui| {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         if ComponentStyles::add_primary_button(ui, "Copy").clicked()
                             && let Some(ref wif) = self.private_key_wif
                         {

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -278,7 +278,7 @@ impl ScreenLike for CreateAssetLockScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Header with Back button and Advanced Options checkbox (outside ScrollArea)
             ui.horizontal(|ui| {

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -18,7 +18,7 @@ use crate::ui::identities::funding_common::{WalletFundedScreenStep, generate_qr_
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::Address;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::{Button, RichText, Vec2};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -217,7 +217,9 @@ impl CreateAssetLockScreen {
 }
 
 impl ScreenLike for CreateAssetLockScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let wallet_name = self
             .wallet
             .read()
@@ -226,7 +228,7 @@ impl ScreenLike for CreateAssetLockScreen {
             .unwrap_or_else(|| "Unknown Wallet".to_string());
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 (
@@ -241,12 +243,12 @@ impl ScreenLike for CreateAssetLockScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -248,7 +248,7 @@ impl ScreenLike for CreateAssetLockScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Header with Back button and Advanced Options checkbox (outside ScrollArea)
             ui.horizontal(|ui| {

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -7,7 +7,6 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::identities::add_existing_identity_screen::AddExistingIdentityScreen;
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::{RootScreenType, Screen, ScreenLike};
-use eframe::egui::Context;
 
 use crate::model::wallet::Wallet;
 use crate::ui::components::password_input::PasswordInput;
@@ -440,11 +439,11 @@ impl Drop for ImportMnemonicScreen {
 }
 
 impl ScreenLike for ImportMnemonicScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let pending_action = AppAction::None;
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::GoToMainScreen),
@@ -454,12 +453,12 @@ impl ScreenLike for ImportMnemonicScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show success screen if wallet was imported

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -366,7 +366,7 @@ impl ImportMnemonicScreen {
 
                             let mut word = self.seed_phrase_words[i].clone();
 
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             let response = ui.add_sized(
                                 Vec2::new(input_width, 20.0),
                                 egui::TextEdit::singleline(&mut word)

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -340,7 +340,7 @@ impl ImportMnemonicScreen {
 
                             let mut word = self.seed_phrase_words[i].clone();
 
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             let response = ui.add_sized(
                                 Vec2::new(input_width, 20.0),
                                 egui::TextEdit::singleline(&mut word)

--- a/src/ui/wallets/import_single_key.rs
+++ b/src/ui/wallets/import_single_key.rs
@@ -204,7 +204,7 @@ impl ImportSingleKeyDialog {
     }
 
     fn body(&mut self, ui: &mut Ui, response: &mut ImportSingleKeyResponse) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let text_color = DashColors::text_primary(dark_mode);
 
         ui.label(

--- a/src/ui/wallets/restore_single_key.rs
+++ b/src/ui/wallets/restore_single_key.rs
@@ -166,7 +166,7 @@ impl RestoreSingleKeyDialog {
     }
 
     fn body(&mut self, ui: &mut Ui, response: &mut RestoreSingleKeyResponse) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let text_color = DashColors::text_primary(dark_mode);
 
         let Some(target) = self.target.clone() else {

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -3412,23 +3412,25 @@ impl WalletSendScreen {
 }
 
 impl ScreenLike for WalletSendScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::PopScreen), ("Send", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -1206,7 +1206,7 @@ impl WalletSendScreen {
             self.wallet_open_attempted = true;
         }
         if wallet_needs_unlock(wallet) {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add_space(10.0);
             ui.colored_label(
                 DashColors::warning_color(dark_mode),
@@ -1311,7 +1311,7 @@ impl WalletSendScreen {
     }
 
     fn render_wallet_info(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(wallet_arc) = &self.selected_wallet
             && let Ok(wallet) = wallet_arc.read()
@@ -1754,7 +1754,7 @@ impl WalletSendScreen {
     }
 
     fn render_source_selection(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.label(
             RichText::new("Send from")
@@ -2163,7 +2163,7 @@ impl WalletSendScreen {
     }
 
     fn render_amount_input(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let fee_estimator = self.app_context.fee_estimator();
 
         // Get max amount and hint based on source selection
@@ -2365,7 +2365,7 @@ impl WalletSendScreen {
     /// Renders a breakdown of which platform addresses will be used and how much from each.
     /// Uses the same allocation algorithm as the actual send logic.
     fn render_platform_source_breakdown(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let network = self.app_context.network;
         let fee_estimator = self.app_context.fee_estimator();
 
@@ -2527,7 +2527,7 @@ impl WalletSendScreen {
     /// Render the advanced send UI with multiple inputs/outputs
     fn render_advanced_send(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Wallet info
         self.render_wallet_info(ui);
@@ -2696,7 +2696,7 @@ impl WalletSendScreen {
 
     /// Render Core address inputs for advanced mode
     fn render_core_inputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut inputs_to_remove = Vec::new();
 
         ui.label(
@@ -2820,7 +2820,7 @@ impl WalletSendScreen {
 
     /// Render Platform address inputs for advanced mode
     fn render_platform_inputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut inputs_to_remove = Vec::new();
 
         ui.label(
@@ -2949,7 +2949,7 @@ impl WalletSendScreen {
 
     /// Render the outputs section for advanced mode
     fn render_advanced_outputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut outputs_to_remove = Vec::new();
         let num_outputs = self.advanced_outputs.len();
 
@@ -3430,7 +3430,7 @@ impl ScreenLike for WalletSendScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             if let Some(status_action) = self.render_send_status(ui) {
                 return status_action;

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -1214,7 +1214,7 @@ impl WalletSendScreen {
             self.wallet_open_attempted = true;
         }
         if wallet_needs_unlock(wallet) {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.add_space(10.0);
             ui.colored_label(
                 DashColors::warning_color(dark_mode),
@@ -1319,7 +1319,7 @@ impl WalletSendScreen {
     }
 
     fn render_wallet_info(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(wallet_arc) = &self.selected_wallet
             && let Ok(wallet) = wallet_arc.read()
@@ -1813,7 +1813,7 @@ impl WalletSendScreen {
     }
 
     fn render_source_selection(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.label(
             RichText::new("Send from")
@@ -2218,7 +2218,7 @@ impl WalletSendScreen {
     }
 
     fn render_amount_input(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let fee_estimator = self.app_context.fee_estimator();
 
         // Get max amount and hint based on source selection
@@ -2404,7 +2404,7 @@ impl WalletSendScreen {
     /// Renders a breakdown of which platform addresses will be used and how much from each.
     /// Uses the same allocation algorithm as the actual send logic.
     fn render_platform_source_breakdown(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let network = self.app_context.network;
         let fee_estimator = self.app_context.fee_estimator();
 
@@ -2566,7 +2566,7 @@ impl WalletSendScreen {
     /// Render the advanced send UI with multiple inputs/outputs
     fn render_advanced_send(&mut self, ui: &mut Ui) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         // Wallet info
         self.render_wallet_info(ui);
@@ -2735,7 +2735,7 @@ impl WalletSendScreen {
 
     /// Render Core address inputs for advanced mode
     fn render_core_inputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut inputs_to_remove = Vec::new();
 
         ui.label(
@@ -2859,7 +2859,7 @@ impl WalletSendScreen {
 
     /// Render Platform address inputs for advanced mode
     fn render_platform_inputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut inputs_to_remove = Vec::new();
 
         ui.label(
@@ -2988,7 +2988,7 @@ impl WalletSendScreen {
 
     /// Render the outputs section for advanced mode
     fn render_advanced_outputs(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut outputs_to_remove = Vec::new();
         let num_outputs = self.advanced_outputs.len();
 
@@ -3475,7 +3475,7 @@ impl ScreenLike for WalletSendScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             if let Some(status_action) = self.render_send_status(ui) {
                 return status_action;

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -218,7 +218,7 @@ impl ScreenLike for ShieldScreen {
         );
 
         island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.heading("Shield");
             ui.add_space(10.0);
             ui.label("Move funds from a platform or core address into the shielded pool.");

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -19,7 +19,7 @@ use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
 use dash_sdk::dpp::version::PlatformVersion;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::RichText;
 use std::sync::Arc;
 
@@ -200,9 +200,11 @@ impl ShieldScreen {
 }
 
 impl ScreenLike for ShieldScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -212,12 +214,12 @@ impl ScreenLike for ShieldScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
             ui.heading("Shield");
             ui.add_space(10.0);

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -507,7 +507,7 @@ impl ShieldScreen {
 
     /// Render the batch progress UI (used for Platform batch mode).
     fn render_batch_progress(&mut self, ui: &mut egui::Ui, ctx: &Context, action: &mut AppAction) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let stages_snapshot = self.batch_stages.clone();
         if let Some(stages) = stages_snapshot {
             let lock_stage = |s: &Arc<Mutex<ShieldStage>>| -> ShieldStage {
@@ -682,7 +682,7 @@ impl ScreenLike for ShieldScreen {
         }
 
         island_central_panel(ctx, |ui| {
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             ui.heading("Shield");
             ui.add_space(10.0);
             ui.label("Move funds from a platform or core address into the shielded pool.");

--- a/src/ui/wallets/shielded_send_screen.rs
+++ b/src/ui/wallets/shielded_send_screen.rs
@@ -12,7 +12,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText};
 use std::sync::Arc;
 
@@ -84,11 +84,11 @@ impl ScreenLike for ShieldedSendScreen {
         self.max_balance = self.app_context.shielded_balance_credits(&self.seed_hash);
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -98,12 +98,12 @@ impl ScreenLike for ShieldedSendScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("Send (Private)");
             ui.add_space(10.0);
             ui.label("Transfer credits privately within the shielded pool.");

--- a/src/ui/wallets/shielded_tab.rs
+++ b/src/ui/wallets/shielded_tab.rs
@@ -317,7 +317,7 @@ impl ShieldedTabView {
 
     /// Render the shielded tab content.
     pub fn ui(&mut self, ui: &mut Ui) -> AppAction {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut action = self.tick();
 
         // Messages

--- a/src/ui/wallets/shielded_tab.rs
+++ b/src/ui/wallets/shielded_tab.rs
@@ -325,7 +325,7 @@ impl ShieldedTabView {
 
     /// Render the shielded tab content.
     pub fn ui(&mut self, ui: &mut Ui) -> AppAction {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let mut action = self.tick();
         let indicator = self.current_indicator();
 

--- a/src/ui/wallets/single_key_send_screen.rs
+++ b/src/ui/wallets/single_key_send_screen.rs
@@ -293,7 +293,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_recipients(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -395,7 +395,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_options(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -489,7 +489,7 @@ impl SingleKeyWalletSendScreen {
 
     /// Render the simple (beginner) send UI - single recipient, minimal options
     fn render_simple_send(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -561,7 +561,7 @@ impl SingleKeyWalletSendScreen {
             return action;
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         egui::Window::new("Fee Confirmation Required")
             .collapsible(false)
@@ -677,7 +677,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_wallet_info(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(wallet_arc) = &self.selected_wallet
             && let Ok(wallet) = wallet_arc.read()
@@ -739,7 +739,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_wallet_unlock(&mut self, ui: &mut Ui) -> AppAction {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         Frame::group(ui.style())
             .fill(DashColors::surface(dark_mode))
@@ -878,7 +878,7 @@ impl ScreenLike for SingleKeyWalletSendScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Message display is handled by the global MessageBanner.
 

--- a/src/ui/wallets/single_key_send_screen.rs
+++ b/src/ui/wallets/single_key_send_screen.rs
@@ -280,7 +280,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_recipients(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -382,7 +382,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_options(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -452,7 +452,7 @@ impl SingleKeyWalletSendScreen {
 
     /// Render the simple (beginner) send UI - single recipient, minimal options
     fn render_simple_send(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(15.0);
 
@@ -524,7 +524,7 @@ impl SingleKeyWalletSendScreen {
             return action;
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         egui::Window::new("Fee Confirmation Required")
             .collapsible(false)
@@ -640,7 +640,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_wallet_info(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(wallet_arc) = &self.selected_wallet
             && let Ok(wallet) = wallet_arc.read()
@@ -702,7 +702,7 @@ impl SingleKeyWalletSendScreen {
     }
 
     fn render_wallet_unlock(&mut self, ui: &mut Ui) -> AppAction {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         Frame::group(ui.style())
             .fill(DashColors::surface(dark_mode))
@@ -848,7 +848,7 @@ impl ScreenLike for SingleKeyWalletSendScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Message display is handled by the global MessageBanner.
 

--- a/src/ui/wallets/single_key_send_screen.rs
+++ b/src/ui/wallets/single_key_send_screen.rs
@@ -829,16 +829,18 @@ impl SingleKeyWalletSendScreen {
 }
 
 impl ScreenLike for SingleKeyWalletSendScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::PopScreen), ("Send", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
@@ -846,7 +848,7 @@ impl ScreenLike for SingleKeyWalletSendScreen {
         // Single-key wallets are unsupported in this version.
         let is_rpc_mode = false;
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/unshield_credits_screen.rs
+++ b/src/ui/wallets/unshield_credits_screen.rs
@@ -15,7 +15,7 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText};
 use std::sync::Arc;
 
@@ -72,11 +72,11 @@ impl ScreenLike for UnshieldCreditsScreen {
         self.max_balance = self.app_context.shielded_balance_credits(&self.seed_hash);
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -86,12 +86,12 @@ impl ScreenLike for UnshieldCreditsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("Unshield Credits");
             ui.add_space(10.0);
             ui.label(

--- a/src/ui/wallets/unshield_credits_screen.rs
+++ b/src/ui/wallets/unshield_credits_screen.rs
@@ -122,7 +122,7 @@ impl ScreenLike for UnshieldCreditsScreen {
             ));
             ui.add_space(15.0);
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Error/success messages
             if let Some(err) = &self.error_message {

--- a/src/ui/wallets/unshield_credits_screen.rs
+++ b/src/ui/wallets/unshield_credits_screen.rs
@@ -106,7 +106,7 @@ impl ScreenLike for UnshieldCreditsScreen {
             ));
             ui.add_space(15.0);
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Error/success messages
             if let Some(err) = &self.error_message {

--- a/src/ui/wallets/wallets_screen/asset_locks.rs
+++ b/src/ui/wallets/wallets_screen/asset_locks.rs
@@ -53,14 +53,14 @@ impl WalletsBalancesScreen {
         let load_failed = self.asset_lock_cache.is_failed(&seed_hash);
         let mut retry_clicked = false;
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         Frame::new()
             .fill(DashColors::surface(dark_mode))
             .corner_radius(5.0)
             .inner_margin(Margin::same(15))
             .stroke(egui::Stroke::new(1.0, DashColors::border_light(dark_mode)))
             .show(ui, |ui| {
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.horizontal(|ui| {
                     ui.heading(
                         RichText::new("Asset Locks").color(DashColors::text_primary(dark_mode)),

--- a/src/ui/wallets/wallets_screen/asset_locks.rs
+++ b/src/ui/wallets/wallets_screen/asset_locks.rs
@@ -17,14 +17,14 @@ impl WalletsBalancesScreen {
         if let Some(arc_wallet) = &self.selected_wallet {
             let wallet = arc_wallet.read().unwrap();
 
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
             Frame::new()
                 .fill(DashColors::surface(dark_mode))
                 .corner_radius(5.0)
                 .inner_margin(Margin::same(15))
                 .stroke(egui::Stroke::new(1.0, DashColors::border_light(dark_mode)))
                 .show(ui, |ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.horizontal(|ui| {
                         ui.heading(RichText::new("Asset Locks").color(DashColors::text_primary(dark_mode)));
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -149,7 +149,7 @@ impl WalletsBalancesScreen {
                 spread: 0,
                 color: DashColors::popup_shadow(),
             },
-            fill: ctx.style().visuals.window_fill,
+            fill: ctx.global_style().visuals.window_fill,
             stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
         }
     }
@@ -241,7 +241,7 @@ impl WalletsBalancesScreen {
                 }
 
                 ui.add_space(8.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.horizontal(|ui| {
                     let has_address_error = self.send_dialog.address_error.is_some();
                     if ComponentStyles::add_primary_button_enabled(ui, !has_address_error, "Send")
@@ -288,7 +288,7 @@ impl WalletsBalancesScreen {
             }
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Determine current address based on selected type
         let current_address = match self.receive_dialog.address_type {
@@ -690,7 +690,7 @@ impl WalletsBalancesScreen {
 
         let mut action = AppAction::None;
         let mut open = self.fund_platform_dialog.is_open;
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Draw dark overlay behind the popup
         Self::draw_modal_overlay(ctx, "fund_platform_dialog_overlay");
@@ -863,7 +863,7 @@ impl WalletsBalancesScreen {
             return;
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
         let mut open = self.private_key_dialog.is_open;
 
         // Draw dark overlay behind the dialog
@@ -1290,7 +1290,7 @@ impl WalletsBalancesScreen {
 
         let mut action = AppAction::None;
         let mut open = self.mine_dialog.is_open;
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         Self::draw_modal_overlay(ctx, "mine_dialog_overlay");
 

--- a/src/ui/wallets/wallets_screen/dialogs.rs
+++ b/src/ui/wallets/wallets_screen/dialogs.rs
@@ -133,7 +133,7 @@ impl WalletsBalancesScreen {
                 spread: 0,
                 color: DashColors::popup_shadow(),
             },
-            fill: ctx.style().visuals.window_fill,
+            fill: ctx.global_style().visuals.window_fill,
             stroke: egui::Stroke::new(1.0, DashColors::popup_border_glow()),
         }
     }
@@ -233,7 +233,7 @@ impl WalletsBalancesScreen {
                 }
 
                 ui.add_space(8.0);
-                let dark_mode = ui.ctx().style().visuals.dark_mode;
+                let dark_mode = ui.style().visuals.dark_mode;
                 ui.horizontal(|ui| {
                     let has_address_error = self.send_dialog.address_error.is_some();
                     if ComponentStyles::add_primary_button_enabled(ui, !has_address_error, "Send")
@@ -280,7 +280,7 @@ impl WalletsBalancesScreen {
             }
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Determine current address based on selected type
         let current_address = match self.receive_dialog.address_type {
@@ -699,7 +699,7 @@ impl WalletsBalancesScreen {
 
         let mut action = AppAction::None;
         let mut open = self.fund_platform_dialog.is_open;
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Draw dark overlay behind the popup
         Self::draw_modal_overlay(ctx, "fund_platform_dialog_overlay");
@@ -872,7 +872,7 @@ impl WalletsBalancesScreen {
             return;
         }
 
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
         let mut open = self.private_key_dialog.is_open;
 
         // Draw dark overlay behind the dialog
@@ -1308,7 +1308,7 @@ impl WalletsBalancesScreen {
 
         let mut action = AppAction::None;
         let mut open = self.mine_dialog.is_open;
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         Self::draw_modal_overlay(ctx, "mine_dialog_overlay");
 

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2240,7 +2240,9 @@ impl WalletsBalancesScreen {
 }
 
 impl ScreenLike for WalletsBalancesScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Check for pending platform balance refresh (triggered after transfers)
         let pending_refresh_action = if let Some(seed_hash) =
             self.pending_platform_balance_refresh.take()
@@ -2315,19 +2317,19 @@ impl ScreenLike for WalletsBalancesScreen {
             ));
         }
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::None)],
             right_buttons,
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -575,7 +575,7 @@ impl WalletsBalancesScreen {
                         });
 
                     ui.colored_label(
-                        DashColors::text_primary(ui.ctx().style().visuals.dark_mode),
+                        DashColors::text_primary(ui.style().visuals.dark_mode),
                         format!(" Balance: {}", Self::format_dash(current_balance)),
                     );
                 });
@@ -621,7 +621,7 @@ impl WalletsBalancesScreen {
 
                     // Buttons for single key wallet
                     if let Some(wallet_arc) = single_key_wallet_opt {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         let (key_hash, alias) = wallet_arc
                             .read()
                             .ok()
@@ -733,7 +733,7 @@ impl WalletsBalancesScreen {
     }
 
     fn render_remove_wallet_button(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(selected_wallet) = &self.selected_wallet {
             let remove_button =
@@ -848,7 +848,7 @@ impl WalletsBalancesScreen {
             .shadow(ui.visuals().window_shadow) // drop shadow
             .show(ui, |ui| {
                 ui.vertical_centered(|ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.add_space(5.0);
 
                     if migration_running {
@@ -1028,7 +1028,7 @@ impl WalletsBalancesScreen {
     fn render_action_buttons(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
         let mut action = AppAction::None;
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.horizontal(|ui| {
             if ui
                 .button(
@@ -1251,7 +1251,7 @@ impl WalletsBalancesScreen {
     /// Render the Accounts & Addresses tab bar and content.
     fn render_account_tabs(&mut self, ui: &mut Ui, summaries: &[AccountSummary]) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(14.0);
 
@@ -1448,7 +1448,7 @@ impl WalletsBalancesScreen {
         summaries: &[AccountSummary],
     ) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let sections = self.system_tab_sections(summaries);
 
         ui.horizontal(|ui| {
@@ -1559,7 +1559,7 @@ impl WalletsBalancesScreen {
             return;
         }
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let show_fee = self.app_context.is_developer_mode();
         let mut order: Vec<usize> = relevant_indices.clone();
         order.sort_by(|&a, &b| {
@@ -1699,7 +1699,7 @@ impl WalletsBalancesScreen {
 
     /// Render a compact sync status panel showing Core, Platform, and Shielded sync progress.
     fn render_sync_status(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let secondary = DashColors::text_secondary(dark_mode);
         let syncing_color = DashColors::DASH_BLUE;
         let sz = 12.0;
@@ -1831,7 +1831,7 @@ impl WalletsBalancesScreen {
 
     /// Render the total balance label only (used in the left column of the header).
     fn render_balance_total(&self, ui: &mut Ui, wallet: &Wallet) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let seed_hash = wallet.seed_hash();
         let core_balance = self.core_balance_duffs(&seed_hash);
         let platform_balance = self.platform_balance_duffs(&seed_hash);
@@ -1848,7 +1848,7 @@ impl WalletsBalancesScreen {
 
     /// Render the collapsible breakdown detail (used in the right column of the header).
     fn render_balance_breakdown_detail(&mut self, ui: &mut Ui, wallet: &Wallet) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let seed_hash = wallet.seed_hash();
         let core_balance = self.core_balance_duffs(&seed_hash);
         let platform_balance = self.platform_balance_duffs(&seed_hash);
@@ -1891,7 +1891,7 @@ impl WalletsBalancesScreen {
             )
         };
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         let detail_width = ui.available_width();
         ui.horizontal(|row| {
@@ -2175,7 +2175,7 @@ impl WalletsBalancesScreen {
             return;
         };
         let count = self.pending_protected_restores.len();
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         egui::Frame::group(ui.style())
             .fill(DashColors::input_background(dark_mode))
@@ -2329,7 +2329,7 @@ impl ScreenLike for WalletsBalancesScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Message display is handled by the global MessageBanner
 
@@ -2424,7 +2424,7 @@ impl ScreenLike for WalletsBalancesScreen {
                 .resizable(false)
                 .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
                 .show(ctx, |ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.vertical(|ui| {
                         ui.label("Enter new wallet name:");
                         ui.add_space(5.0);
@@ -2634,7 +2634,7 @@ impl ScreenLike for WalletsBalancesScreen {
                         ui.add_space(10.0);
 
                         ui.horizontal(|ui| {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode)
                                 .clicked()
                             {

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -659,7 +659,7 @@ impl WalletsBalancesScreen {
                         });
 
                     ui.colored_label(
-                        DashColors::text_primary(ui.ctx().style().visuals.dark_mode),
+                        DashColors::text_primary(ui.style().visuals.dark_mode),
                         format!(" Balance: {}", Self::format_dash(current_balance)),
                     );
                 });
@@ -705,7 +705,7 @@ impl WalletsBalancesScreen {
 
                     // Buttons for single key wallet
                     if let Some(wallet_arc) = single_key_wallet_opt {
-                        let dark_mode = ui.ctx().style().visuals.dark_mode;
+                        let dark_mode = ui.style().visuals.dark_mode;
                         let (key_hash, alias) = wallet_arc
                             .read()
                             .ok()
@@ -814,7 +814,7 @@ impl WalletsBalancesScreen {
     }
 
     fn render_remove_wallet_button(&mut self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         if let Some(selected_wallet) = &self.selected_wallet {
             let remove_button =
@@ -920,7 +920,7 @@ impl WalletsBalancesScreen {
                 ui.vertical_centered(|ui| {
                     // Heading
                     ui.add_space(5.0);
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.label(
                         RichText::new("No Wallets Loaded")
                             .strong()
@@ -1070,7 +1070,7 @@ impl WalletsBalancesScreen {
     fn render_action_buttons(&mut self, ui: &mut Ui, ctx: &Context) -> AppAction {
         let mut action = AppAction::None;
         ui.add_space(10.0);
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         ui.horizontal(|ui| {
             if ui
                 .button(
@@ -1294,7 +1294,7 @@ impl WalletsBalancesScreen {
     /// Render the Accounts & Addresses tab bar and content.
     fn render_account_tabs(&mut self, ui: &mut Ui, summaries: &[AccountSummary]) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         ui.add_space(14.0);
 
@@ -1491,7 +1491,7 @@ impl WalletsBalancesScreen {
         summaries: &[AccountSummary],
     ) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let sections = self.system_tab_sections(summaries);
 
         ui.horizontal(|ui| {
@@ -1607,7 +1607,7 @@ impl WalletsBalancesScreen {
             return;
         }
 
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let show_fee = self.app_context.is_developer_mode();
         let mut order: Vec<usize> = relevant_indices.clone();
         order.sort_by(|&a, &b| {
@@ -1751,7 +1751,7 @@ impl WalletsBalancesScreen {
 
     /// Render a compact sync status panel showing Core, Platform, and Shielded sync progress.
     fn render_sync_status(&self, ui: &mut Ui) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let secondary = DashColors::text_secondary(dark_mode);
         let syncing_color = DashColors::DASH_BLUE;
         let sz = 12.0;
@@ -1956,7 +1956,7 @@ impl WalletsBalancesScreen {
 
     /// Render the total balance label only (used in the left column of the header).
     fn render_balance_total(&self, ui: &mut Ui, wallet: &Wallet) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let core_balance = wallet.total_balance_duffs();
         let platform_balance = Self::platform_balance_duffs(wallet);
         let shielded_balance = self.shielded_balance_duffs(&wallet.seed_hash());
@@ -1972,7 +1972,7 @@ impl WalletsBalancesScreen {
 
     /// Render the collapsible breakdown detail (used in the right column of the header).
     fn render_balance_breakdown_detail(&mut self, ui: &mut Ui, wallet: &Wallet) {
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
         let core_balance = wallet.total_balance_duffs();
         let platform_balance = Self::platform_balance_duffs(wallet);
         let shielded_balance = self.shielded_balance_duffs(&wallet.seed_hash());
@@ -2014,7 +2014,7 @@ impl WalletsBalancesScreen {
             )
         };
         let mut action = AppAction::None;
-        let dark_mode = ui.ctx().style().visuals.dark_mode;
+        let dark_mode = ui.style().visuals.dark_mode;
 
         let detail_width = ui.available_width();
         ui.horizontal(|row| {
@@ -2304,7 +2304,7 @@ impl ScreenLike for WalletsBalancesScreen {
 
         action |= island_central_panel(ctx, |ui| {
             let mut inner_action = AppAction::None;
-            let dark_mode = ui.ctx().style().visuals.dark_mode;
+            let dark_mode = ui.style().visuals.dark_mode;
 
             // Message display is handled by the global MessageBanner
 
@@ -2358,7 +2358,7 @@ impl ScreenLike for WalletsBalancesScreen {
                 .resizable(false)
                 .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
                 .show(ctx, |ui| {
-                    let dark_mode = ui.ctx().style().visuals.dark_mode;
+                    let dark_mode = ui.style().visuals.dark_mode;
                     ui.vertical(|ui| {
                         ui.label("Enter new wallet name:");
                         ui.add_space(5.0);
@@ -2547,7 +2547,7 @@ impl ScreenLike for WalletsBalancesScreen {
                         ui.add_space(10.0);
 
                         ui.horizontal(|ui| {
-                            let dark_mode = ui.ctx().style().visuals.dark_mode;
+                            let dark_mode = ui.style().visuals.dark_mode;
                             if ComponentStyles::add_secondary_button(ui, "Cancel", dark_mode)
                                 .clicked()
                             {

--- a/src/ui/welcome_screen.rs
+++ b/src/ui/welcome_screen.rs
@@ -27,7 +27,7 @@ impl WelcomeScreen {
 
     pub fn ui(&mut self, ctx: &Context) -> AppAction {
         let mut action = AppAction::None;
-        let dark_mode = ctx.style().visuals.dark_mode;
+        let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Central panel with welcome content (using island style like other screens)
         island_central_panel(ctx, |ui| {

--- a/src/ui/welcome_screen.rs
+++ b/src/ui/welcome_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::components::left_panel::load_svg_icon;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing};
 use crate::ui::{RootScreenType, ScreenType};
-use egui::{Context, RichText, ScrollArea, Vec2};
+use egui::{RichText, ScrollArea, Vec2};
 use std::sync::Arc;
 
 /// The action the user wants to take after onboarding
@@ -25,12 +25,14 @@ impl WelcomeScreen {
         Self { app_context }
     }
 
-    pub fn ui(&mut self, ctx: &Context) -> AppAction {
+    pub fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
         let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Central panel with welcome content (using island style like other screens)
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {


### PR DESCRIPTION
## Why this PR exists
- **Problem**: DET was pinned to egui 0.33. egui 0.35 hard-removes the panel/style/`App` APIs DET relied on, and the upstream platform-wallet rewrite (#860) changed much of the UI this upgrade touches — so the two must land in order.
- **Blocking relationship**: Stacked on **#860** (platform-wallet backend rewrite); base is `docs/platform-wallet-migration-design`, merge after #860. **Supersedes #858** — the deferred `ScreenLike::ui` → `&mut Ui` refactor is folded in here because egui 0.35 makes it mandatory (#858 has been closed).

## What was done
Upgrades the egui family **0.33 → 0.35.0** on top of #860, and performs the structural migration egui 0.35 forces:
- Pins: `egui` / `eframe` / `egui_extras` / `egui_kittest` = `0.35.0`, `egui_commonmark` = `0.24.0`.
- `eframe::App::update(ctx)` → `App::ui(&mut Ui)` (with a `let ctx = ui.ctx().clone()` shim keeping ~250 ctx call sites stable); `on_exit` drops the glow arg (wgpu-only).
- **`ScreenLike::ui(&Context)` → `ui(&mut egui::Ui)`** across ~60 screens — mandatory because 0.35 removed `Panel::show(ctx,…)` / `CentralPanel::show(ctx,…)`. `App::ui` threads the root `ui` into screens; the 9 panel helpers + `island_central_panel` + 17 direct `CentralPanel` sites now use `.show(ui,…)`.
- `SidePanel` / `TopBottomPanel` → `Panel::{left,right,top,bottom}`; axis-agnostic renames (`default_width`→`default_size`, `min`/`max_width`→`min`/`max_size`).
- `Context::style()` / `set_style()` → `global_style()` / `set_global_style()`; `Context::run` → `run_ui`.
- Non-UI 0.35 fixes: `egui::ahash` re-export dropped (→ `std::collections`); `TextBuffer` now uses the `CharIndex` newtype (egui#8245) → updated `Secret`.
- **Zero egui `#[allow(deprecated)]` remain** (this was #858's acceptance bar; the 6 remaining allows are pre-existing non-egui crypto choices in `model/wallet/` and `backend_task/dashpay/`).
- `CLAUDE.md` "Screen Pattern" + Key Dependencies updated to the new signature/version.

## Testing
- `cargo build --all-features` — clean
- `cargo clippy --all-features --all-targets -- -D warnings` — clean (0/0)
- `cargo +nightly fmt --all -- --check` — clean
- `cargo test --all-features --workspace` — 1234 passed / 0 failed (81 ignored: network backend-e2e)
- `cargo test --test kittest --all-features` — 149 passed / 0 failed
- No egui image-snapshot baselines exist in this repo (kittest asserts on domain state), so the harfrust text-engine change required no snapshot regeneration.

## Breaking changes
- None user-facing. Internal: `ScreenLike::ui` signature is now `&mut egui::Ui`.
- Subtle text rendering changes (harfrust) and minor egui 0.35 behavioral shifts (windows move by title-bar drag only; drag-to-scroll is touch-only).

## Notes
- Rebased onto #860; history kept as the incremental 0.33→0.34→0.35 steps (no squash, per request).
- The branch is named `chore/upgrade-egui-0.34` but the content targets **0.35.0** — a PR's head branch can't be renamed, so the title reflects the real version.

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app to the latest GUI stack, improving compatibility with the newest interface APIs.

* **Bug Fixes**
  * Refined panel rendering and theme handling across many screens for more consistent light/dark appearance.
  * Improved text, button, and popup styling in several dialogs and forms.

* **Refactor**
  * Modernized screen rendering flow across the app to better align with the current UI framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->