### PR TITLE
refactor(ui): migrate Panel to show_inside(ui, …) and remove all egui 0.34 deprecation suppressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ Screen::ui() → AppAction::BackendTask(task)
 ## Screen Pattern
 
 All screens implement the `ScreenLike` trait:
-- `ui(&mut self, ctx: &Context) -> AppAction` - Render UI, return actions
+- `ui(&mut self, ui: &mut egui::Ui) -> AppAction` - Render UI, return actions
 - `display_task_result(&mut self, result: BackendTaskSuccessResult)` - Handle async results
 - `display_message(&mut self, msg: &str, type: MessageType)` - Show user feedback
 - `refresh(&mut self)` / `refresh_on_arrival(&mut self)` - Re-fetch data

--- a/src/app.rs
+++ b/src/app.rs
@@ -940,8 +940,8 @@ impl AppState {
 }
 
 impl App for AppState {
-    fn ui(&mut self, _ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
-        let ctx = _ui.ctx().clone();
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        let ctx = ui.ctx().clone();
         let ctx = &ctx;
         // ── Graceful shutdown: intercept window close so the UI stays responsive ──
         // When the user closes the window we cancel the native close, show a banner,
@@ -984,7 +984,7 @@ impl App for AppState {
             }
             // Render a minimal UI that shows the shutdown banner.
             self.theme.poll_and_apply(ctx);
-            crate::ui::components::styled::island_central_panel(ctx, |_ui| {});
+            crate::ui::components::styled::island_central_panel(ui, |_ui| {});
             return;
         }
 
@@ -1278,9 +1278,9 @@ impl App for AppState {
         if self.show_welcome_screen
             && let Some(welcome_screen) = &mut self.welcome_screen
         {
-            actions.push(welcome_screen.ui(ctx));
+            actions.push(welcome_screen.ui(ui));
         } else {
-            actions.push(self.visible_screen_mut().ui(ctx));
+            actions.push(self.visible_screen_mut().ui(ui));
         };
 
         // Schedule connection status refresh

--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -184,7 +184,7 @@ pub fn add_contract_chooser_panel(
     Panel::left("contract_chooser_panel")
         // Let the user resize this panel horizontally
         .resizable(true)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))

--- a/src/ui/components/contract_chooser_panel.rs
+++ b/src/ui/components/contract_chooser_panel.rs
@@ -15,7 +15,7 @@ use dash_sdk::dpp::data_contract::{
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformSerializableWithPlatformVersion;
-use egui::{Color32, Context as EguiContext, Frame, Margin, Panel, RichText};
+use egui::{Color32, Frame, Margin, Panel, RichText, Ui};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::error;
@@ -145,7 +145,7 @@ fn render_collapsing_header(
 
 #[allow(clippy::too_many_arguments)]
 pub fn add_contract_chooser_panel(
-    ctx: &EguiContext,
+    ui: &mut Ui,
     current_search_term: &mut String,
     app_context: &Arc<AppContext>,
     selected_data_contract: &mut QualifiedContract,
@@ -156,6 +156,8 @@ pub fn add_contract_chooser_panel(
     pending_fields_selection: &mut HashMap<String, bool>,
     chooser_state: &mut ContractChooserState,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Retrieve the list of known contracts
@@ -180,7 +182,6 @@ pub fn add_contract_chooser_panel(
 
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("contract_chooser_panel")
         // Let the user resize this panel horizontally
         .resizable(true)
@@ -190,7 +191,7 @@ pub fn add_contract_chooser_panel(
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Fill the entire available height
             let available_height = ui.available_height();
 

--- a/src/ui/components/dashpay_subscreen_chooser_panel.rs
+++ b/src/ui/components/dashpay_subscreen_chooser_panel.rs
@@ -28,7 +28,7 @@ pub fn add_dashpay_subscreen_chooser_panel(
 
     #[allow(deprecated)]
     Panel::left("dashpay_subscreen_chooser_panel")
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode)) // Light background instead of transparent

--- a/src/ui/components/dashpay_subscreen_chooser_panel.rs
+++ b/src/ui/components/dashpay_subscreen_chooser_panel.rs
@@ -4,16 +4,16 @@ use crate::model::feature_gate::FeatureGate;
 use crate::ui::RootScreenType;
 use crate::ui::dashpay::dashpay_screen::DashPaySubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 use std::sync::Arc;
 
 pub fn add_dashpay_subscreen_chooser_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     current_subscreen: DashPaySubscreen,
 ) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
 
     // Build subscreens list - Payment History is experimental (developer mode only)
     let mut subscreens = vec![DashPaySubscreen::Profile, DashPaySubscreen::Contacts];
@@ -26,7 +26,6 @@ pub fn add_dashpay_subscreen_chooser_panel(
 
     let active_screen = current_subscreen;
 
-    #[allow(deprecated)]
     Panel::left("dashpay_subscreen_chooser_panel")
         .default_size(270.0)
         .frame(
@@ -34,7 +33,7 @@ pub fn add_dashpay_subscreen_chooser_panel(
                 .fill(DashColors::background(dark_mode)) // Light background instead of transparent
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Fill the entire available height
             let available_height = ui.available_height();
 

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -30,7 +30,7 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
     #[allow(deprecated)]
     Panel::left("dpns_subscreen_chooser_panel")
         .resizable(true)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))

--- a/src/ui/components/dpns_subscreen_chooser_panel.rs
+++ b/src/ui/components/dpns_subscreen_chooser_panel.rs
@@ -3,11 +3,11 @@ use crate::ui::RootScreenType;
 use crate::ui::dpns::dpns_contested_names_screen::DPNSSubscreen;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 
-pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_dpns_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
 
     let subscreens = vec![
         DPNSSubscreen::Active,
@@ -27,7 +27,6 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
         _ => DPNSSubscreen::Active,
     };
 
-    #[allow(deprecated)]
     Panel::left("dpns_subscreen_chooser_panel")
         .resizable(true)
         .default_size(270.0)
@@ -36,7 +35,7 @@ pub fn add_dpns_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext)
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             let available_height = ui.available_height();
 
             Frame::new()

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -6,7 +6,7 @@ use crate::ui::components::styled::GradientButton;
 use crate::ui::theme::{DashColors, ResponseExt, Shadow, Shape, Spacing};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, Panel, RichText, TextureHandle};
+use egui::{Context, Frame, Image, Panel, RichText, TextureHandle, Ui};
 use egui_extras::{Size, StripBuilder};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
@@ -110,10 +110,12 @@ pub fn load_svg_icon(ctx: &Context, path: &str, width: u32, height: u32) -> Opti
 }
 
 pub fn add_left_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     selected_screen: RootScreenType,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Define the button details directly in this function.
@@ -166,7 +168,6 @@ pub fn add_left_panel(
 
     let dark_mode = ctx.global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("left_panel")
         .min_size(140.0)
         .max_size(140.0)
@@ -176,7 +177,7 @@ pub fn add_left_panel(
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Add margins for island effect
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Create an island panel with rounded edges
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/left_panel.rs
+++ b/src/ui/components/left_panel.rs
@@ -168,8 +168,8 @@ pub fn add_left_panel(
 
     #[allow(deprecated)]
     Panel::left("left_panel")
-        .min_width(140.0)
-        .max_width(140.0)
+        .min_size(140.0)
+        .max_size(140.0)
         .resizable(false)
         .frame(
             Frame::new()

--- a/src/ui/components/left_wallet_panel.rs
+++ b/src/ui/components/left_wallet_panel.rs
@@ -3,7 +3,7 @@ use crate::context::AppContext;
 use crate::ui::RootScreenType;
 use crate::ui::theme::DashColors;
 use eframe::epaint::Margin;
-use egui::{Context, Frame, Image, Panel, TextureHandle};
+use egui::{Context, Frame, Image, Panel, TextureHandle, Ui};
 use rust_embed::RustEmbed;
 use std::sync::Arc;
 use tracing::error;
@@ -40,10 +40,12 @@ fn load_icon(ctx: &Context, path: &str) -> Option<TextureHandle> {
 
 #[allow(dead_code)]
 pub fn add_left_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     _app_context: &Arc<AppContext>,
     selected_screen: RootScreenType,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
 
     // Define the button details directly in this function
@@ -65,7 +67,6 @@ pub fn add_left_panel(
 
     let panel_width = 50.0 + 20.0; // Button width (50) + 10px margin on each side (20 total)
 
-    #[allow(deprecated)]
     Panel::left("left_panel")
         .default_size(panel_width)
         .frame(
@@ -78,7 +79,7 @@ pub fn add_left_panel(
                     bottom: 0,
                 }),
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             ui.vertical_centered(|ui| {
                 for (label, screen_type, icon_path) in buttons.iter() {
                     if *screen_type == RootScreenType::RootScreenDocumentQuery {

--- a/src/ui/components/left_wallet_panel.rs
+++ b/src/ui/components/left_wallet_panel.rs
@@ -67,7 +67,7 @@ pub fn add_left_panel(
 
     #[allow(deprecated)]
     Panel::left("left_panel")
-        .default_width(panel_width)
+        .default_size(panel_width)
         .frame(
             Frame::new()
                 .fill(ctx.global_style().visuals.panel_fill)

--- a/src/ui/components/styled.rs
+++ b/src/ui/components/styled.rs
@@ -4,7 +4,9 @@ use crate::{
     context::AppContext,
     ui::theme::{DashColors, Shadow, Shape, Spacing, Typography},
 };
-use egui::{Button, CentralPanel, Color32, Frame, Margin, Response, RichText, Stroke, TextEdit, Ui, Vec2};
+use egui::{
+    Button, CentralPanel, Color32, Frame, Margin, Response, RichText, Stroke, TextEdit, Ui, Vec2,
+};
 
 // Re-export commonly used components
 pub use super::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};

--- a/src/ui/components/styled.rs
+++ b/src/ui/components/styled.rs
@@ -4,10 +4,7 @@ use crate::{
     context::AppContext,
     ui::theme::{DashColors, Shadow, Shape, Spacing, Typography},
 };
-use egui::{
-    Button, CentralPanel, Color32, Context, Frame, Margin, Response, RichText, Stroke, TextEdit,
-    Ui, Vec2,
-};
+use egui::{Button, CentralPanel, Color32, Frame, Margin, Response, RichText, Stroke, TextEdit, Ui, Vec2};
 
 // Re-export commonly used components
 pub use super::confirmation_dialog::{ConfirmationDialog, ConfirmationStatus};
@@ -536,25 +533,16 @@ pub fn styled_text_edit_multiline(text: &mut String, dark_mode: bool) -> TextEdi
 }
 
 /// Helper function to create an island-style central panel.
-///
-/// Wraps `CentralPanel::show(ctx, ...)`, which is deprecated in egui 0.34 in
-/// favor of `show_inside(ui, ...)`. The deprecation is silenced at this single
-/// boundary so the screen layer can keep its `&Context`-driven `ui()` shape.
-// TODO(egui-0.35): migrate to `Panel::central(...).show_inside(ui, ...)` and
-// thread `&mut Ui` from `App::ui` instead of `&Context`. Defers a 60+ call-site
-// refactor that exceeded the egui 0.34 upgrade scope. The current
-// `#[allow(deprecated)]` containment must be removed when this happens.
-pub fn island_central_panel<R>(ctx: &Context, content: impl FnOnce(&mut Ui) -> R) -> R {
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+pub fn island_central_panel<R>(ui: &mut Ui, content: impl FnOnce(&mut Ui) -> R) -> R {
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     CentralPanel::default()
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)), // Standard margins for all panels
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Calculate responsive margins based on available width, but ensure minimum spacing
             let available_width = ui.available_width();
             let inner_margin = if available_width > 1200.0 {

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -3,9 +3,9 @@ use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::ui::tokens::tokens_screen::TokensSubscreen;
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText};
+use egui::{Frame, Margin, Panel, RichText, Ui};
 
-pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_tokens_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
 
     let subscreens = vec![
@@ -24,9 +24,8 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
         _ => TokensSubscreen::MyTokens, // Fallback to Active screen if settings unavailable
     };
 
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
 
-    #[allow(deprecated)]
     Panel::left("tokens_subscreen_chooser_panel")
         .resizable(false)
         .default_size(270.0)
@@ -35,7 +34,7 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             let available_height = ui.available_height();
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/tokens_subscreen_chooser_panel.rs
+++ b/src/ui/components/tokens_subscreen_chooser_panel.rs
@@ -29,7 +29,7 @@ pub fn add_tokens_subscreen_chooser_panel(ctx: &Context, app_context: &AppContex
     #[allow(deprecated)]
     Panel::left("tokens_subscreen_chooser_panel")
         .resizable(false)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -96,7 +96,7 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
     #[allow(deprecated)]
     Panel::left("tools_subscreen_chooser_panel")
         .resizable(false)
-        .default_width(270.0)
+        .default_size(270.0)
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))

--- a/src/ui/components/tools_subscreen_chooser_panel.rs
+++ b/src/ui/components/tools_subscreen_chooser_panel.rs
@@ -3,7 +3,7 @@ use crate::spv::CoreBackendMode;
 use crate::ui::RootScreenType;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing, Typography};
 use crate::{app::AppAction, ui};
-use egui::{Context, Frame, Margin, Panel, RichText, ScrollArea};
+use egui::{Frame, Margin, Panel, RichText, ScrollArea, Ui};
 
 #[derive(PartialEq)]
 pub enum ToolsSubscreen {
@@ -45,9 +45,9 @@ impl ToolsSubscreen {
     }
 }
 
-pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext) -> AppAction {
+pub fn add_tools_subscreen_chooser_panel(ui: &mut Ui, app_context: &AppContext) -> AppAction {
     let mut action = AppAction::None;
-    let dark_mode = ctx.global_style().visuals.dark_mode;
+    let dark_mode = ui.ctx().global_style().visuals.dark_mode;
     let is_rpc_mode = app_context.core_backend_mode() == CoreBackendMode::Rpc;
 
     let subscreens = vec![
@@ -93,7 +93,6 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
         _ => ToolsSubscreen::PlatformInfo, // Fallback to Active screen if settings unavailable
     };
 
-    #[allow(deprecated)]
     Panel::left("tools_subscreen_chooser_panel")
         .resizable(false)
         .default_size(270.0)
@@ -102,7 +101,7 @@ pub fn add_tools_subscreen_chooser_panel(ctx: &Context, app_context: &AppContext
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::symmetric(10, 10)),
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             let available_height = ui.available_height();
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/components/top_panel.rs
+++ b/src/ui/components/top_panel.rs
@@ -201,23 +201,24 @@ fn add_connection_indicator(ui: &mut Ui, app_context: &Arc<AppContext>) -> AppAc
 }
 
 pub fn add_top_panel(
-    ctx: &Context,
+    ui: &mut Ui,
     app_context: &Arc<AppContext>,
     location: Vec<(&str, AppAction)>,
     right_buttons: Vec<(&str, DesiredAppAction)>,
 ) -> AppAction {
+    let ctx = ui.ctx().clone();
+    let ctx = &ctx;
     let mut action = AppAction::None;
     let dark_mode = ctx.global_style().visuals.dark_mode;
     let network_accent = DashColors::network_accent(app_context.network, dark_mode);
 
-    #[allow(deprecated)]
     Panel::top("top_panel")
         .frame(
             Frame::new()
                 .fill(DashColors::background(dark_mode))
                 .inner_margin(Margin::same(10)), // 10px margin on all sides
         )
-        .show(ctx, |ui| {
+        .show_inside(ui, |ui| {
             // Create an island panel with rounded edges
             Frame::new()
                 .fill(DashColors::surface(dark_mode))

--- a/src/ui/contracts_documents/add_contracts_screen.rs
+++ b/src/ui/contracts_documents/add_contracts_screen.rs
@@ -11,7 +11,7 @@ use crate::ui::{BackendTaskSuccessResult, MessageType, ScreenLike};
 use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::identifier::Identifier;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use std::sync::Arc;
 
 const MAX_CONTRACTS: usize = 10;
@@ -305,9 +305,9 @@ impl ScreenLike for AddContractsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -317,12 +317,12 @@ impl ScreenLike for AddContractsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             ui.heading("Add Contracts");
             ui.add_space(10.0);
 

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -692,7 +692,6 @@ impl ScreenLike for DocumentQueryScreen {
         let dark_mode = ctx.global_style().visuals.dark_mode;
 
         action |= {
-            #[allow(deprecated)]
             CentralPanel::default()
                 .frame(
                     Frame::new()
@@ -704,7 +703,7 @@ impl ScreenLike for DocumentQueryScreen {
                             bottom: 0, // Less space on the bottom
                         }),
                 )
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     // Create an island panel with rounded edges
                     Frame::new()
                         .fill(DashColors::surface(dark_mode))

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -23,7 +23,7 @@ use dash_sdk::dpp::data_contract::document_type::{DocumentType, Index};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
 use dash_sdk::platform::{Document, DocumentQuery, Identifier};
-use egui::{CentralPanel, Context, Frame, Margin, ScrollArea, Stroke, Ui};
+use egui::{CentralPanel, Frame, Margin, ScrollArea, Stroke, Ui};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -579,7 +579,9 @@ impl ScreenLike for DocumentQueryScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let load_contract_button = (
             "Load Contracts",
             DesiredAppAction::AddScreenType(Box::new(ScreenType::AddContracts)),
@@ -623,7 +625,7 @@ impl ScreenLike for DocumentQueryScreen {
         let mut action = AppAction::None;
         if self.app_context.network == Network::Mainnet {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Contracts", AppAction::None)],
                 vec![
@@ -640,7 +642,7 @@ impl ScreenLike for DocumentQueryScreen {
             );
         } else {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Contracts", AppAction::None)],
                 vec![
@@ -659,13 +661,13 @@ impl ScreenLike for DocumentQueryScreen {
         }
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenDocumentQuery,
         );
 
         action |= add_contract_chooser_panel(
-            ctx,
+            ui,
             &mut self.contract_search_term,
             &self.app_context,
             &mut self.selected_data_contract,

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -49,7 +49,7 @@ use dash_sdk::drive::query::WhereClause;
 use dash_sdk::platform::{DocumentQuery, Identifier, IdentityPublicKey};
 use dash_sdk::query_types::IndexMap;
 use eframe::epaint::Color32;
-use egui::{Context, Frame, Margin, RichText, Ui};
+use egui::{Frame, Margin, RichText, Ui};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
@@ -1564,9 +1564,11 @@ impl DocumentActionScreen {
 }
 
 impl ScreenLike for DocumentActionScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -1576,12 +1578,12 @@ impl ScreenLike for DocumentActionScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| match &self.broadcast_status {
+        action |= island_central_panel(ui, |ui| match &self.broadcast_status {
             BroadcastStatus::Broadcasted => {
                 let success_message = format!("{} successful!", self.action_type.display_name());
                 let back_button = ("Back to Contracts".to_string(), AppAction::GoToMainScreen);

--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -49,7 +49,7 @@ use dash_sdk::dpp::tokens::emergency_action::TokenEmergencyAction;
 use dash_sdk::dpp::tokens::token_event::TokenEvent;
 use dash_sdk::platform::Identifier;
 use dash_sdk::query_types::IndexMap;
-use eframe::egui::{self, Context, RichText};
+use eframe::egui::{self, RichText};
 use egui::{ScrollArea, TextStyle};
 use egui_extras::{Column, TableBuilder};
 use std::collections::BTreeMap;
@@ -474,9 +474,9 @@ impl ScreenLike for GroupActionsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -486,12 +486,12 @@ impl ScreenLike for GroupActionsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenDocumentQuery,
         );
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             ui.heading("Active Group Actions");
 
             ui.add_space(10.0);

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -24,7 +24,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::dpp::identity::{Purpose, SecurityLevel};
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, TextEdit};
+use eframe::egui::{self, Color32, Frame, Margin, TextEdit};
 use egui::{RichText, ScrollArea, Ui};
 use std::sync::{Arc, RwLock};
 
@@ -351,9 +351,11 @@ impl ScreenLike for RegisterDataContractScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -363,12 +365,12 @@ impl ScreenLike for RegisterDataContractScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             if self.broadcast_status == BroadcastStatus::Done {
                 return self.show_success(ui);
             }

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -26,7 +26,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{DataContract, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, TextEdit};
+use eframe::egui::{self, Color32, Frame, Margin, TextEdit};
 use egui::{RichText, ScrollArea, Ui};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -372,9 +372,11 @@ impl ScreenLike for UpdateDataContractScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Contracts", AppAction::GoToMainScreen),
@@ -384,12 +386,12 @@ impl ScreenLike for UpdateDataContractScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenDocumentQuery,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             if self.broadcast_status == BroadcastStatus::Done {
                 return self.show_success(ui);
             }

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -578,10 +578,9 @@ impl ScreenLike for AddContactScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("About Contact Requests", CONTACT_REQUEST_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -22,7 +22,7 @@ use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
 use dash_sdk::platform::IdentityPublicKey;
-use egui::{Context, RichText, ScrollArea, TextEdit, Ui};
+use egui::{RichText, ScrollArea, TextEdit, Ui};
 use std::sync::{Arc, RwLock};
 
 const CONTACT_REQUEST_INFO_TEXT: &str = "About Contact Requests:\n\n\
@@ -187,10 +187,12 @@ impl ScreenLike for AddContactScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Add top panel with navigation breadcrumbs
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -200,12 +202,12 @@ impl ScreenLike for AddContactScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content in island central panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show success screen if request was successful

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -521,8 +521,6 @@ impl ScreenLike for ContactDetailsScreen {
     }
 
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel with contact name if available
@@ -556,10 +554,9 @@ impl ScreenLike for ContactDetailsScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Private Contact Information", PRIVATE_CONTACT_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/contact_details.rs
+++ b/src/ui/dashpay/contact_details.rs
@@ -520,7 +520,9 @@ impl ScreenLike for ContactDetailsScreen {
         self.needs_backend_fetch = true;
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel with contact name if available
@@ -536,7 +538,7 @@ impl ScreenLike for ContactDetailsScreen {
             .unwrap_or_else(|| "Contact Details".to_string());
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -546,11 +548,11 @@ impl ScreenLike for ContactDetailsScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {

--- a/src/ui/dashpay/contact_info_editor.rs
+++ b/src/ui/dashpay/contact_info_editor.rs
@@ -343,10 +343,9 @@ impl ScreenLike for ContactInfoEditorScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Private Contact Information", PRIVATE_CONTACT_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/contact_info_editor.rs
+++ b/src/ui/dashpay/contact_info_editor.rs
@@ -311,7 +311,9 @@ impl ContactInfoEditorScreen {
 }
 
 impl ScreenLike for ContactInfoEditorScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel with back button
@@ -321,7 +323,7 @@ impl ScreenLike for ContactInfoEditorScreen {
         )];
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -332,12 +334,12 @@ impl ScreenLike for ContactInfoEditorScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -631,12 +631,14 @@ impl ContactProfileViewerScreen {
 }
 
 impl ScreenLike for ContactProfileViewerScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -646,11 +648,11 @@ impl ScreenLike for ContactProfileViewerScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if let Some((title, text)) = self.show_info_popup {

--- a/src/ui/dashpay/contact_profile_viewer.rs
+++ b/src/ui/dashpay/contact_profile_viewer.rs
@@ -632,8 +632,6 @@ impl ContactProfileViewerScreen {
 
 impl ScreenLike for ContactProfileViewerScreen {
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
@@ -656,10 +654,9 @@ impl ScreenLike for ContactProfileViewerScreen {
 
         // Show info popup if requested
         if let Some((title, text)) = self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new(title, text);
                     if popup.show(ui).inner {
                         self.show_info_popup = None;

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -1027,8 +1027,7 @@ impl ScreenLike for ContactRequests {
         let ctx = &ctx;
         // Create a simple central panel for rendering
         let mut action = AppAction::None;
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             action = self.render(ui);
         });
 

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -1022,7 +1022,9 @@ impl ScreenLike for ContactRequests {
         }
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Create a simple central panel for rendering
         let mut action = AppAction::None;
         #[allow(deprecated)]

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -1012,11 +1012,8 @@ impl ScreenLike for ContactsList {
     }
 
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
         let mut action = AppAction::None;
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             action = self.render(ui);
         });
         action

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -1011,7 +1011,9 @@ impl ScreenLike for ContactsList {
         }
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
         #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {

--- a/src/ui/dashpay/dashpay_screen.rs
+++ b/src/ui/dashpay/dashpay_screen.rs
@@ -6,7 +6,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
-use egui::{Context, Ui};
+use egui::{Ui};
 use std::sync::Arc;
 
 use super::contacts_list::ContactsList;
@@ -72,7 +72,7 @@ impl ScreenLike for DashPayScreen {
         self.refresh();
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel with action buttons based on current subscreen
@@ -107,21 +107,21 @@ impl ScreenLike for DashPayScreen {
         };
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("DashPay", AppAction::None)],
             right_buttons,
         );
 
         // Highlight Dashpay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // DashPay subscreen chooser panel on the left side of the content area
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, self.dashpay_subscreen);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, self.dashpay_subscreen);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render_subscreen(ui));
+        action |= island_central_panel(ui, |ui| self.render_subscreen(ui));
 
         // Handle custom actions from top panel buttons
         if let AppAction::Custom(command) = &action {

--- a/src/ui/dashpay/dashpay_screen.rs
+++ b/src/ui/dashpay/dashpay_screen.rs
@@ -6,7 +6,7 @@ use crate::ui::components::left_panel::add_left_panel;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
-use egui::{Ui};
+use egui::Ui;
 use std::sync::Arc;
 
 use super::contacts_list::ContactsList;

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -1278,10 +1278,9 @@ impl ProfileScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ui.ctx(), |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Profile Guidelines", PROFILE_GUIDELINES_INFO_TEXT);
                     if popup.show(ui).inner {
@@ -1292,10 +1291,9 @@ impl ProfileScreen {
 
         // Show avatar info popup if requested
         if self.show_avatar_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ui.ctx(), |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new("Avatar Image Guidelines", AVATAR_URL_INFO_TEXT);
                     if popup.show(ui).inner {
                         self.show_avatar_info_popup = false;

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -260,8 +260,6 @@ impl ProfileSearchScreen {
 
 impl ScreenLike for ProfileSearchScreen {
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel - consistent with other DashPay subscreens
@@ -303,10 +301,9 @@ impl ScreenLike for ProfileSearchScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("About Profile Search", PROFILE_SEARCH_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dashpay/profile_search.rs
+++ b/src/ui/dashpay/profile_search.rs
@@ -259,12 +259,14 @@ impl ProfileSearchScreen {
 }
 
 impl ScreenLike for ProfileSearchScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel - consistent with other DashPay subscreens
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -277,17 +279,17 @@ impl ScreenLike for ProfileSearchScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |= add_dashpay_subscreen_chooser_panel(
-            ctx,
+            ui,
             &self.app_context,
             DashPaySubscreen::ProfileSearch, // Use ProfileSearch as the active subscreen
         );
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Handle custom action from top panel button
         if let AppAction::Custom(command) = &action

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -400,8 +400,6 @@ impl QRCodeGeneratorScreen {
 
 impl ScreenLike for QRCodeGeneratorScreen {
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
@@ -430,10 +428,9 @@ impl ScreenLike for QRCodeGeneratorScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new("About Contact QR Codes", QR_CODE_INFO_TEXT);
                     if popup.show(ui).inner {
                         self.show_info_popup = false;

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -399,12 +399,14 @@ impl QRCodeGeneratorScreen {
 }
 
 impl ScreenLike for QRCodeGeneratorScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -414,17 +416,17 @@ impl ScreenLike for QRCodeGeneratorScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |= add_dashpay_subscreen_chooser_panel(
-            ctx,
+            ui,
             &self.app_context,
             DashPaySubscreen::Contacts, // Use Contacts as the active subscreen since QR Generator is launched from there
         );
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {

--- a/src/ui/dashpay/qr_scanner.rs
+++ b/src/ui/dashpay/qr_scanner.rs
@@ -331,12 +331,14 @@ impl QRScannerScreen {
 }
 
 impl ScreenLike for QRScannerScreen {
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -346,14 +348,14 @@ impl ScreenLike for QRScannerScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
 
         // Add DashPay subscreen chooser panel
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Contacts);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Contacts);
 
         // Main content area with island styling
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show wallet unlock popup if open
         if self.wallet_unlock_popup.is_open()

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -399,12 +399,14 @@ impl ScreenLike for SendPaymentScreen {
         self.refresh();
     }
 
-    fn ui(&mut self, ctx: &egui::Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Add top panel
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("DashPay", AppAction::None),
@@ -414,11 +416,11 @@ impl ScreenLike for SendPaymentScreen {
         );
 
         // Highlight DashPay in the main left panel
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenDashpay);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenDashpay);
         action |=
-            add_dashpay_subscreen_chooser_panel(ctx, &self.app_context, DashPaySubscreen::Payments);
+            add_dashpay_subscreen_chooser_panel(ui, &self.app_context, DashPaySubscreen::Payments);
 
-        action |= island_central_panel(ctx, |ui| self.render(ui));
+        action |= island_central_panel(ui, |ui| self.render(ui));
 
         // Show info popup if requested
         if self.show_info_popup {

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -424,10 +424,9 @@ impl ScreenLike for SendPaymentScreen {
 
         // Show info popup if requested
         if self.show_info_popup {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Payment Guidelines", PAYMENT_GUIDELINES_INFO_TEXT);
                     if popup.show(ui).inner {

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -7,7 +7,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Button, Color32, ComboBox, Context, Label, RichText, Ui};
+use eframe::egui::{self, Button, Color32, ComboBox, Label, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
 use itertools::Itertools;
 
@@ -1917,7 +1917,9 @@ impl ScreenLike for DPNSScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let has_identity_that_can_register = !self.user_identities.is_empty();
         let has_active_contests = {
             let guard = self.contested_names.lock().unwrap();
@@ -1999,7 +2001,7 @@ impl ScreenLike for DPNSScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("DPNS", AppAction::None)],
             right_buttons,
@@ -2014,19 +2016,19 @@ impl ScreenLike for DPNSScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsPlatformInfoScreen,
         );
 
         // Tools area chooser
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // DPNS subscreen chooser
-        action |= add_dpns_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_dpns_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Main panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             // Bulk-schedule ephemeral popup
             if self.show_bulk_schedule_popup {

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -1167,10 +1167,9 @@ impl ScreenLike for AddExistingIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup =
                         InfoPopup::new("Load Identity Information", &show_pop_up_info_text);
                     if popup.show(ui).inner {

--- a/src/ui/identities/add_existing_identity_screen.rs
+++ b/src/ui/identities/add_existing_identity_screen.rs
@@ -19,7 +19,6 @@ use bip39::rand::{prelude::IteratorRandom, thread_rng};
 use dash_sdk::dashcore_rpc::dashcore::Network;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::Identifier;
-use eframe::egui::Context;
 use egui::{Color32, ComboBox, RichText, Ui};
 use serde::Deserialize;
 use std::fs;
@@ -1073,9 +1072,11 @@ impl ScreenLike for AddExistingIdentityScreen {
         self.add_identity_status = AddIdentityStatus::Complete;
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -1085,12 +1086,12 @@ impl ScreenLike for AddExistingIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Error display is handled by the global MessageBanner

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -34,7 +34,6 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::prelude::AssetLockProof;
 use dash_sdk::platform::Identifier;
-use eframe::egui::Context;
 use egui::ahash::HashSet;
 use egui::{Align, Button, Color32, ComboBox, ScrollArea, Ui};
 use egui_extras::{Column, TableBuilder};
@@ -1097,9 +1096,11 @@ impl ScreenLike for AddNewIdentityScreen {
             WalletFundedScreenStep::Success => {}
         }
     }
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -1109,12 +1110,12 @@ impl ScreenLike for AddNewIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/add_new_identity_screen/mod.rs
+++ b/src/ui/identities/add_new_identity_screen/mod.rs
@@ -1315,10 +1315,9 @@ impl ScreenLike for AddNewIdentityScreen {
 
         // Show the info popup if requested
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new("Identity Information", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/identities_screen.rs
+++ b/src/ui/identities/identities_screen.rs
@@ -1080,7 +1080,9 @@ impl ScreenLike for IdentitiesScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut right_buttons = if !self.app_context.has_wallet.load(Ordering::Relaxed) {
             vec![
                 (
@@ -1121,20 +1123,20 @@ impl ScreenLike for IdentitiesScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Identities", AppAction::None)],
             right_buttons,
         );
 
-        action |= add_left_panel(ctx, &self.app_context, RootScreenType::RootScreenIdentities);
+        action |= add_left_panel(ui, &self.app_context, RootScreenType::RootScreenIdentities);
 
         let identities_vec = {
             let guard = self.identities.lock().unwrap();
             guard.values().cloned().collect::<Vec<_>>()
         };
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             if identities_vec.is_empty() {
                 self.render_no_identities_view(ui);

--- a/src/ui/identities/keys/add_key_screen.rs
+++ b/src/ui/identities/keys/add_key_screen.rs
@@ -26,7 +26,7 @@ use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::Identifier;
-use eframe::egui::{self, Context, Frame, Margin};
+use eframe::egui::{self, Frame, Margin};
 use egui::{Color32, RichText, Ui};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -385,9 +385,11 @@ impl ScreenLike for AddKeyScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -397,12 +399,12 @@ impl ScreenLike for AddKeyScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the key was added successfully

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -33,7 +33,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::identity_public_key::contract_bounds::ContractBounds;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::IdentityPublicKey;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText, ScrollArea};
 use std::sync::{Arc, RwLock};
 
@@ -71,9 +71,11 @@ pub struct KeyInfoScreen {
 impl ScreenLike for KeyInfoScreen {
     fn refresh(&mut self) {}
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -83,12 +85,12 @@ impl ScreenLike for KeyInfoScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/keys/key_info_screen.rs
+++ b/src/ui/identities/keys/key_info_screen.rs
@@ -579,10 +579,9 @@ impl ScreenLike for KeyInfoScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new("Sign Message Info", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/keys/keys_screen.rs
+++ b/src/ui/identities/keys/keys_screen.rs
@@ -16,10 +16,7 @@ impl ScreenLike for KeysScreen {
     fn refresh(&mut self) {}
 
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
-        let ctx = ui.ctx().clone();
-        let ctx = &ctx;
-        #[allow(deprecated)]
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.heading("Identity Keys");
 
             egui::ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/keys/keys_screen.rs
+++ b/src/ui/identities/keys/keys_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::ScreenLike;
 use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use std::sync::Arc;
 
 pub struct KeysScreen {
@@ -15,7 +15,9 @@ pub struct KeysScreen {
 impl ScreenLike for KeysScreen {
     fn refresh(&mut self) {}
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         #[allow(deprecated)]
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Identity Keys");

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -21,7 +21,7 @@ use dash_sdk::dpp::identity::Purpose;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{Context, Frame, Margin};
+use eframe::egui::{Frame, Margin};
 use egui::{Color32, RichText, Ui};
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -317,7 +317,9 @@ impl ScreenLike for RegisterDpnsNameScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Build breadcrumbs based on where we came from
         let breadcrumbs = match self.source {
             RegisterDpnsNameSource::Dpns => vec![
@@ -338,18 +340,18 @@ impl ScreenLike for RegisterDpnsNameScreen {
             ],
         };
 
-        let mut action = add_top_panel(ctx, &self.app_context, breadcrumbs, vec![]);
+        let mut action = add_top_panel(ui, &self.app_context, breadcrumbs, vec![]);
 
         // Use the appropriate left panel highlight based on source
         let root_screen = match self.source {
             RegisterDpnsNameSource::Dpns => crate::ui::RootScreenType::RootScreenDPNSActiveContests,
             RegisterDpnsNameSource::Identities => crate::ui::RootScreenType::RootScreenIdentities,
         };
-        action |= add_left_panel(ctx, &self.app_context, root_screen);
+        action |= add_left_panel(ui, &self.app_context, root_screen);
 
         // Don't show the tools/dpns subscreen chooser panels for this screen
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             egui::ScrollArea::vertical()

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -34,7 +34,6 @@ use dash_sdk::dpp::dashcore::{OutPoint, Transaction, TxOut};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::prelude::AssetLockProof;
-use eframe::egui::Context;
 use egui::{ComboBox, ScrollArea, Ui};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
@@ -507,9 +506,11 @@ impl ScreenLike for TopUpIdentityScreen {
             WalletFundedScreenStep::Success => {}
         }
     }
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -519,12 +520,12 @@ impl ScreenLike for TopUpIdentityScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             ScrollArea::vertical().show(ui, |ui| {

--- a/src/ui/identities/top_up_identity_screen/mod.rs
+++ b/src/ui/identities/top_up_identity_screen/mod.rs
@@ -676,10 +676,9 @@ impl ScreenLike for TopUpIdentityScreen {
 
         // Show the popup window if `show_popup` is true
         if let Some(show_pop_up_info_text) = self.show_pop_up_info.clone() {
-            #[allow(deprecated)]
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
-                .show(ctx, |ui| {
+                .show_inside(ui, |ui| {
                     let mut popup = InfoPopup::new("Wallet Selection Info", &show_pop_up_info_text);
                     if popup.show(ui).inner {
                         self.show_pop_up_info = None;

--- a/src/ui/identities/transfer_screen.rs
+++ b/src/ui/identities/transfer_screen.rs
@@ -25,7 +25,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::{Color32, RichText};
 use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
@@ -577,9 +577,11 @@ impl ScreenLike for TransferScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -589,12 +591,12 @@ impl ScreenLike for TransferScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the transfer was successful

--- a/src/ui/identities/withdraw_screen.rs
+++ b/src/ui/identities/withdraw_screen.rs
@@ -27,7 +27,7 @@ use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicK
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::IdentityPublicKey;
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::{Color32, RichText};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
@@ -368,9 +368,11 @@ impl ScreenLike for WithdrawalScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Identities", AppAction::GoToMainScreen),
@@ -380,12 +382,12 @@ impl ScreenLike for WithdrawalScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenIdentities,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show the success screen if the withdrawal was successful

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -55,7 +55,6 @@ use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::prelude::IdentityPublicKey;
 use dash_sdk::platform::Identifier;
 use dpns::dpns_contested_names_screen::DPNSSubscreen;
-use egui::Context;
 use identities::add_existing_identity_screen::AddExistingIdentityScreen;
 use identities::add_new_identity_screen::AddNewIdentityScreen;
 use identities::identities_screen::IdentitiesScreen;
@@ -961,7 +960,7 @@ pub trait ScreenLike {
     fn refresh_on_arrival(&mut self) {
         self.refresh()
     }
-    fn ui(&mut self, ctx: &Context) -> AppAction;
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction;
     /// Called by `AppState` **after** the global banner has already been set.
     ///
     /// Override **only for side-effects** such as clearing a progress banner
@@ -1311,73 +1310,73 @@ impl ScreenLike for Screen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         match self {
-            Screen::IdentitiesScreen(screen) => screen.ui(ctx),
-            Screen::DPNSScreen(screen) => screen.ui(ctx),
-            Screen::DocumentQueryScreen(screen) => screen.ui(ctx),
-            Screen::AddNewWalletScreen(screen) => screen.ui(ctx),
-            Screen::ImportMnemonicScreen(screen) => screen.ui(ctx),
-            Screen::AddNewIdentityScreen(screen) => screen.ui(ctx),
-            Screen::TopUpIdentityScreen(screen) => screen.ui(ctx),
-            Screen::AddExistingIdentityScreen(screen) => screen.ui(ctx),
-            Screen::KeyInfoScreen(screen) => screen.ui(ctx),
-            Screen::KeysScreen(screen) => screen.ui(ctx),
-            Screen::RegisterDpnsNameScreen(screen) => screen.ui(ctx),
-            Screen::RegisterDataContractScreen(screen) => screen.ui(ctx),
-            Screen::UpdateDataContractScreen(screen) => screen.ui(ctx),
-            Screen::DocumentActionScreen(screen) => screen.ui(ctx),
-            Screen::GroupActionsScreen(screen) => screen.ui(ctx),
-            Screen::WithdrawalScreen(screen) => screen.ui(ctx),
-            Screen::TransferScreen(screen) => screen.ui(ctx),
-            Screen::AddKeyScreen(screen) => screen.ui(ctx),
-            Screen::TransitionVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::NetworkChooserScreen(screen) => screen.ui(ctx),
-            Screen::WalletsBalancesScreen(screen) => screen.ui(ctx),
-            Screen::WalletSendScreen(screen) => screen.ui(ctx),
-            Screen::SingleKeyWalletSendScreen(screen) => screen.ui(ctx),
-            Screen::ProofLogScreen(screen) => screen.ui(ctx),
-            Screen::AddContractsScreen(screen) => screen.ui(ctx),
-            Screen::ProofVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::MasternodeListDiffScreen(screen) => screen.ui(ctx),
-            Screen::DocumentVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::ContractVisualizerScreen(screen) => screen.ui(ctx),
-            Screen::PlatformInfoScreen(screen) => screen.ui(ctx),
-            Screen::GroveSTARKScreen(screen) => screen.ui(ctx),
-            Screen::AddressBalanceScreen(screen) => screen.ui(ctx),
+            Screen::IdentitiesScreen(screen) => screen.ui(ui),
+            Screen::DPNSScreen(screen) => screen.ui(ui),
+            Screen::DocumentQueryScreen(screen) => screen.ui(ui),
+            Screen::AddNewWalletScreen(screen) => screen.ui(ui),
+            Screen::ImportMnemonicScreen(screen) => screen.ui(ui),
+            Screen::AddNewIdentityScreen(screen) => screen.ui(ui),
+            Screen::TopUpIdentityScreen(screen) => screen.ui(ui),
+            Screen::AddExistingIdentityScreen(screen) => screen.ui(ui),
+            Screen::KeyInfoScreen(screen) => screen.ui(ui),
+            Screen::KeysScreen(screen) => screen.ui(ui),
+            Screen::RegisterDpnsNameScreen(screen) => screen.ui(ui),
+            Screen::RegisterDataContractScreen(screen) => screen.ui(ui),
+            Screen::UpdateDataContractScreen(screen) => screen.ui(ui),
+            Screen::DocumentActionScreen(screen) => screen.ui(ui),
+            Screen::GroupActionsScreen(screen) => screen.ui(ui),
+            Screen::WithdrawalScreen(screen) => screen.ui(ui),
+            Screen::TransferScreen(screen) => screen.ui(ui),
+            Screen::AddKeyScreen(screen) => screen.ui(ui),
+            Screen::TransitionVisualizerScreen(screen) => screen.ui(ui),
+            Screen::NetworkChooserScreen(screen) => screen.ui(ui),
+            Screen::WalletsBalancesScreen(screen) => screen.ui(ui),
+            Screen::WalletSendScreen(screen) => screen.ui(ui),
+            Screen::SingleKeyWalletSendScreen(screen) => screen.ui(ui),
+            Screen::ProofLogScreen(screen) => screen.ui(ui),
+            Screen::AddContractsScreen(screen) => screen.ui(ui),
+            Screen::ProofVisualizerScreen(screen) => screen.ui(ui),
+            Screen::MasternodeListDiffScreen(screen) => screen.ui(ui),
+            Screen::DocumentVisualizerScreen(screen) => screen.ui(ui),
+            Screen::ContractVisualizerScreen(screen) => screen.ui(ui),
+            Screen::PlatformInfoScreen(screen) => screen.ui(ui),
+            Screen::GroveSTARKScreen(screen) => screen.ui(ui),
+            Screen::AddressBalanceScreen(screen) => screen.ui(ui),
 
             // Token Screens
-            Screen::TokensScreen(screen) => screen.ui(ctx),
-            Screen::TransferTokensScreen(screen) => screen.ui(ctx),
-            Screen::MintTokensScreen(screen) => screen.ui(ctx),
-            Screen::BurnTokensScreen(screen) => screen.ui(ctx),
-            Screen::DestroyFrozenFundsScreen(screen) => screen.ui(ctx),
-            Screen::FreezeTokensScreen(screen) => screen.ui(ctx),
-            Screen::UnfreezeTokensScreen(screen) => screen.ui(ctx),
-            Screen::PauseTokensScreen(screen) => screen.ui(ctx),
-            Screen::ResumeTokensScreen(screen) => screen.ui(ctx),
-            Screen::ClaimTokensScreen(screen) => screen.ui(ctx),
-            Screen::ViewTokenClaimsScreen(screen) => screen.ui(ctx),
-            Screen::UpdateTokenConfigScreen(screen) => screen.ui(ctx),
-            Screen::AddTokenById(screen) => screen.ui(ctx),
-            Screen::PurchaseTokenScreen(screen) => screen.ui(ctx),
-            Screen::SetTokenPriceScreen(screen) => screen.ui(ctx),
-            Screen::AssetLockDetailScreen(screen) => screen.ui(ctx),
-            Screen::CreateAssetLockScreen(screen) => screen.ui(ctx),
+            Screen::TokensScreen(screen) => screen.ui(ui),
+            Screen::TransferTokensScreen(screen) => screen.ui(ui),
+            Screen::MintTokensScreen(screen) => screen.ui(ui),
+            Screen::BurnTokensScreen(screen) => screen.ui(ui),
+            Screen::DestroyFrozenFundsScreen(screen) => screen.ui(ui),
+            Screen::FreezeTokensScreen(screen) => screen.ui(ui),
+            Screen::UnfreezeTokensScreen(screen) => screen.ui(ui),
+            Screen::PauseTokensScreen(screen) => screen.ui(ui),
+            Screen::ResumeTokensScreen(screen) => screen.ui(ui),
+            Screen::ClaimTokensScreen(screen) => screen.ui(ui),
+            Screen::ViewTokenClaimsScreen(screen) => screen.ui(ui),
+            Screen::UpdateTokenConfigScreen(screen) => screen.ui(ui),
+            Screen::AddTokenById(screen) => screen.ui(ui),
+            Screen::PurchaseTokenScreen(screen) => screen.ui(ui),
+            Screen::SetTokenPriceScreen(screen) => screen.ui(ui),
+            Screen::AssetLockDetailScreen(screen) => screen.ui(ui),
+            Screen::CreateAssetLockScreen(screen) => screen.ui(ui),
 
             // DashPay Screens
-            Screen::DashPayScreen(screen) => screen.ui(ctx),
-            Screen::DashPayAddContactScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactDetailsScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactProfileViewerScreen(screen) => screen.ui(ctx),
-            Screen::DashPaySendPaymentScreen(screen) => screen.ui(ctx),
-            Screen::DashPayContactInfoEditorScreen(screen) => screen.ui(ctx),
-            Screen::DashPayQRGeneratorScreen(screen) => screen.ui(ctx),
-            Screen::DashPayProfileSearchScreen(screen) => screen.ui(ctx),
+            Screen::DashPayScreen(screen) => screen.ui(ui),
+            Screen::DashPayAddContactScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactDetailsScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactProfileViewerScreen(screen) => screen.ui(ui),
+            Screen::DashPaySendPaymentScreen(screen) => screen.ui(ui),
+            Screen::DashPayContactInfoEditorScreen(screen) => screen.ui(ui),
+            Screen::DashPayQRGeneratorScreen(screen) => screen.ui(ui),
+            Screen::DashPayProfileSearchScreen(screen) => screen.ui(ui),
             // Shielded screens
-            Screen::ShieldScreen(screen) => screen.ui(ctx),
-            Screen::ShieldedSendScreen(screen) => screen.ui(ctx),
-            Screen::UnshieldCreditsScreen(screen) => screen.ui(ctx),
+            Screen::ShieldScreen(screen) => screen.ui(ui),
+            Screen::ShieldedSendScreen(screen) => screen.ui(ui),
+            Screen::UnshieldCreditsScreen(screen) => screen.ui(ui),
         }
     }
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -22,7 +22,7 @@ use crate::utils::path::format_path_for_display;
 use dash_sdk::dash_spv::sync::{ProgressPercentage, SyncProgress as SpvSyncProgress, SyncState};
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::identity::TimestampMillis;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -2038,21 +2038,21 @@ impl ScreenLike for NetworkChooserScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             self.current_app_context(),
             vec![("Networks", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             self.current_app_context(),
             RootScreenType::RootScreenNetworkChooser,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical()
                 .auto_shrink([true; 2])
                 .show(ui, |ui| self.render_network_table(ui))

--- a/src/ui/tokens/add_token_by_id_screen.rs
+++ b/src/ui/tokens/add_token_by_id_screen.rs
@@ -8,7 +8,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_configuration_conventi
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::DataContract;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 
 use crate::ui::theme::ComponentStyles;
 
@@ -307,9 +307,9 @@ impl ScreenLike for AddTokenByIdScreen {
         // nothing to refresh
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -320,15 +320,15 @@ impl ScreenLike for AddTokenByIdScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             // If we are in the "Complete" status, just show success screen
             if self.status == AddTokenStatus::Complete {
                 return self.show_success_screen(ui);

--- a/src/ui/tokens/burn_tokens_screen.rs
+++ b/src/ui/tokens/burn_tokens_screen.rs
@@ -22,7 +22,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -376,13 +376,15 @@ impl ScreenLike for BurnTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -393,7 +395,7 @@ impl ScreenLike for BurnTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -406,15 +408,15 @@ impl ScreenLike for BurnTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/claim_tokens_screen.rs
+++ b/src/ui/tokens/claim_tokens_screen.rs
@@ -21,7 +21,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_perpetual_distribution
 use dash_sdk::dpp::data_contract::TokenConfiguration;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use crate::app::{AppAction, BackendTasksExecutionMode};
 use crate::backend_task::BackendTask;
@@ -304,9 +304,11 @@ impl ScreenLike for ClaimTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -321,15 +323,15 @@ impl ScreenLike for ClaimTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == ClaimTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/destroy_frozen_funds_screen.rs
+++ b/src/ui/tokens/destroy_frozen_funds_screen.rs
@@ -35,7 +35,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -369,13 +369,15 @@ impl ScreenLike for DestroyFrozenFundsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -386,7 +388,7 @@ impl ScreenLike for DestroyFrozenFundsScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -399,15 +401,15 @@ impl ScreenLike for DestroyFrozenFundsScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             if self.status == DestroyFrozenFundsStatus::Complete {

--- a/src/ui/tokens/direct_token_purchase_screen.rs
+++ b/src/ui/tokens/direct_token_purchase_screen.rs
@@ -6,7 +6,7 @@ use dash_sdk::dpp::data_contract::associated_token::token_configuration::accesso
 use dash_sdk::dpp::data_contract::associated_token::token_configuration_convention::accessors::v0::TokenConfigurationConventionV0Getters;
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::RichText;
 
 use super::tokens_screen::IdentityTokenInfo;
@@ -397,10 +397,12 @@ impl ScreenLike for PurchaseTokenScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Build a top panel
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -412,15 +414,15 @@ impl ScreenLike for PurchaseTokenScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
             // If we are in the "Complete" status, just show success screen
             if self.status == PurchaseTokensStatus::Complete {

--- a/src/ui/tokens/freeze_tokens_screen.rs
+++ b/src/ui/tokens/freeze_tokens_screen.rs
@@ -35,7 +35,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -359,13 +359,15 @@ impl ScreenLike for FreezeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -376,7 +378,7 @@ impl ScreenLike for FreezeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -389,15 +391,15 @@ impl ScreenLike for FreezeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             if self.status == FreezeTokensStatus::Complete {
                 return self.show_success_screen(ui);
             }

--- a/src/ui/tokens/mint_tokens_screen.rs
+++ b/src/ui/tokens/mint_tokens_screen.rs
@@ -38,7 +38,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -393,13 +393,15 @@ impl ScreenLike for MintTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -410,7 +412,7 @@ impl ScreenLike for MintTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -423,15 +425,15 @@ impl ScreenLike for MintTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // If we are in the "Complete" status, just show success screen

--- a/src/ui/tokens/pause_tokens_screen.rs
+++ b/src/ui/tokens/pause_tokens_screen.rs
@@ -34,7 +34,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -307,13 +307,15 @@ impl ScreenLike for PauseTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -324,7 +326,7 @@ impl ScreenLike for PauseTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -337,15 +339,15 @@ impl ScreenLike for PauseTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             if self.status == PauseTokensStatus::Complete {
                 return self.show_success_screen(ui);
             }

--- a/src/ui/tokens/resume_tokens_screen.rs
+++ b/src/ui/tokens/resume_tokens_screen.rs
@@ -34,7 +34,7 @@ use dash_sdk::dpp::group::{GroupStateTransitionInfo, GroupStateTransitionInfoSta
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -307,13 +307,15 @@ impl ScreenLike for ResumeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -324,7 +326,7 @@ impl ScreenLike for ResumeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -337,15 +339,15 @@ impl ScreenLike for ResumeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == ResumeTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/set_token_price_screen.rs
+++ b/src/ui/tokens/set_token_price_screen.rs
@@ -40,7 +40,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use egui_extras::{Column, TableBuilder};
 use std::collections::HashSet;
@@ -855,13 +855,15 @@ impl ScreenLike for SetTokenPriceScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -872,7 +874,7 @@ impl ScreenLike for SetTokenPriceScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -885,15 +887,15 @@ impl ScreenLike for SetTokenPriceScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 // If we are in the "Complete" status, just show success screen
                 if self.status == SetTokenPriceStatus::Complete {

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -45,7 +45,7 @@ use dash_sdk::dpp::prelude::TimestampMillisInterval;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
 use dash_sdk::query_types::IndexMap;
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use crate::ui::theme::{DashColors, ResponseExt};
 use egui::{Checkbox, ColorImage, ComboBox, Response, RichText, TextEdit, TextureHandle};
 use enum_iterator::Sequence;
@@ -2817,7 +2817,9 @@ impl ScreenLike for TokensScreen {
         );
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
 
         // Build top-right buttons
@@ -2847,7 +2849,7 @@ impl ScreenLike for TokensScreen {
                 .unwrap_or_else(|| token_id.to_string(Encoding::Base58));
 
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::Custom("Back to tokens".to_string())),
@@ -2866,7 +2868,7 @@ impl ScreenLike for TokensScreen {
             );
 
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     (
@@ -2879,7 +2881,7 @@ impl ScreenLike for TokensScreen {
             );
         } else {
             action |= add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![("Tokens", AppAction::None)],
                 right_buttons.clone(),
@@ -2890,21 +2892,21 @@ impl ScreenLike for TokensScreen {
         match self.tokens_subscreen {
             TokensSubscreen::MyTokens => {
                 action |= add_left_panel(
-                    ctx,
+                    ui,
                     &self.app_context,
                     RootScreenType::RootScreenMyTokenBalances,
                 );
             }
             TokensSubscreen::SearchTokens => {
                 action |= add_left_panel(
-                    ctx,
+                    ui,
                     &self.app_context,
                     RootScreenType::RootScreenTokenSearch,
                 );
             }
             TokensSubscreen::TokenCreator => {
                 action |= add_left_panel(
-                    ctx,
+                    ui,
                     &self.app_context,
                     RootScreenType::RootScreenTokenCreator,
                 );
@@ -2912,10 +2914,10 @@ impl ScreenLike for TokensScreen {
         }
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tokens_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Main panel
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical()
                 .show(ui, |ui| {
                     let mut inner_action = AppAction::None;

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -2898,11 +2898,8 @@ impl ScreenLike for TokensScreen {
                 );
             }
             TokensSubscreen::SearchTokens => {
-                action |= add_left_panel(
-                    ui,
-                    &self.app_context,
-                    RootScreenType::RootScreenTokenSearch,
-                );
+                action |=
+                    add_left_panel(ui, &self.app_context, RootScreenType::RootScreenTokenSearch);
             }
             TokensSubscreen::TokenCreator => {
                 action |= add_left_panel(

--- a/src/ui/tokens/transfer_tokens_screen.rs
+++ b/src/ui/tokens/transfer_tokens_screen.rs
@@ -27,7 +27,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use eframe::egui::{Frame, Margin};
 use egui::RichText;
 use std::collections::HashSet;
@@ -378,9 +378,11 @@ impl ScreenLike for TransferTokensScreen {
     }
 
     /// Renders the UI components for the withdrawal screen
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -395,15 +397,15 @@ impl ScreenLike for TransferTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        let central_panel_action = island_central_panel(ctx, |ui| {
+        let central_panel_action = island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
 
             // Show the success screen if the transfer was successful

--- a/src/ui/tokens/unfreeze_tokens_screen.rs
+++ b/src/ui/tokens/unfreeze_tokens_screen.rs
@@ -36,7 +36,7 @@ use dash_sdk::dpp::group::GroupStateTransitionInfoStatus;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::platform::{Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Frame, Margin, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -361,13 +361,15 @@ impl ScreenLike for UnfreezeTokensScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -378,7 +380,7 @@ impl ScreenLike for UnfreezeTokensScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -391,15 +393,15 @@ impl ScreenLike for UnfreezeTokensScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             if self.status == UnfreezeTokensStatus::Complete {
                 action |= self.show_success_screen(ui);
                 return;

--- a/src/ui/tokens/update_token_config.rs
+++ b/src/ui/tokens/update_token_config.rs
@@ -36,7 +36,7 @@ use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::platform::{DataContract, Identifier, IdentityPublicKey};
-use eframe::egui::{self, Color32, Context, Ui};
+use eframe::egui::{self, Color32, Ui};
 use egui::RichText;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -946,13 +946,15 @@ impl ScreenLike for UpdateTokenConfigScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action;
 
         // Build a top panel
         if self.group_action_id.is_some() {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Contracts", AppAction::GoToMainScreen),
@@ -963,7 +965,7 @@ impl ScreenLike for UpdateTokenConfigScreen {
             );
         } else {
             action = add_top_panel(
-                ctx,
+                ui,
                 &self.app_context,
                 vec![
                     ("Tokens", AppAction::GoToMainScreen),
@@ -976,16 +978,16 @@ impl ScreenLike for UpdateTokenConfigScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
         // Central panel
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             egui::ScrollArea::vertical().show(ui, |ui| {
                 if self.update_status == UpdateTokenConfigStatus::Complete {
                     action |= self.show_success_screen(ui);

--- a/src/ui/tokens/view_token_claims_screen.rs
+++ b/src/ui/tokens/view_token_claims_screen.rs
@@ -14,7 +14,6 @@ use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::platform_value::Value;
 use dash_sdk::drive::query::{WhereClause, WhereOperator};
 use dash_sdk::platform::{Document, DocumentQuery};
-use egui::Context;
 use std::sync::Arc;
 
 use super::tokens_screen::IdentityTokenBasicInfo;
@@ -94,10 +93,10 @@ impl ScreenLike for ViewTokenClaimsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         // Top panel
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Tokens", AppAction::GoToMainScreen),
@@ -117,16 +116,16 @@ impl ScreenLike for ViewTokenClaimsScreen {
 
         // Left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenMyTokenBalances,
         );
 
         // Subscreen chooser
-        action |= add_tokens_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tokens_subscreen_chooser_panel(ui, &self.app_context);
 
         // Central panel
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("View Token Claims");
             ui.add_space(10.0);
 

--- a/src/ui/tools/address_balance_screen.rs
+++ b/src/ui/tools/address_balance_screen.rs
@@ -8,7 +8,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::tools_subscreen_chooser_panel::add_tools_subscreen_chooser_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, ScreenLike};
-use eframe::egui::{self, Context, ScrollArea, TextEdit, Ui};
+use eframe::egui::{self, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 
 pub struct AddressBalanceScreen {
@@ -153,22 +153,22 @@ impl ScreenLike for AddressBalanceScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsAddressBalanceScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, &self.app_context);
+        action |= add_tools_subscreen_chooser_panel(ui, &self.app_context);
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ScrollArea::vertical().show(ui, |ui| {
                 action |= self.render_input(ui);
                 self.render_result(ui);

--- a/src/ui/tools/contract_visualizer_screen.rs
+++ b/src/ui/tools/contract_visualizer_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::theme::DashColors;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::dpp::serialization::PlatformDeserializableWithPotentialValidationFromVersionedStructure;
 use dash_sdk::platform::DataContract;
-use eframe::egui::{Color32, Context, Frame, Margin, RichText, ScrollArea, TextEdit, Ui};
+use eframe::egui::{Color32, Frame, Margin, RichText, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 // ======================= 1.  Data & helpers =======================
 
@@ -178,22 +178,22 @@ impl crate::ui::ScreenLike for ContractVisualizerScreen {
         // Local parse errors are set directly via self.parse_status.
     }
     fn display_task_result(&mut self, _r: BackendTaskSuccessResult) {}
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsContractVisualizerScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         /* ---------- central panel ---------- */
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input(ui);
             self.show_output(ui);
             AppAction::None

--- a/src/ui/tools/document_visualizer_screen.rs
+++ b/src/ui/tools/document_visualizer_screen.rs
@@ -12,7 +12,7 @@ use crate::ui::theme::DashColors;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
 use dash_sdk::dpp::{data_contract::document_type::DocumentType, document::Document};
-use eframe::egui::{self, Color32, Context, Frame, Margin, RichText, TextEdit, Ui};
+use eframe::egui::{self, Color32, Frame, Margin, RichText, TextEdit, Ui};
 use std::sync::Arc;
 // ======================= 1.  Data & helpers =======================
 
@@ -200,22 +200,22 @@ impl crate::ui::ScreenLike for DocumentVisualizerScreen {
         // Local parse errors are set directly via self.parse_status.
     }
     fn display_task_result(&mut self, _r: BackendTaskSuccessResult) {}
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenToolsDocumentVisualizerScreen,
         );
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         /* ---------- central panel ---------- */
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             /* ---------- simple dual-combo chooser ---------- */
             //todo cache the contracts
             add_contract_doc_type_chooser_with_filtering(

--- a/src/ui/tools/grovestark_screen.rs
+++ b/src/ui/tools/grovestark_screen.rs
@@ -17,7 +17,7 @@ use dash_sdk::dpp::identity::{
     Identity, IdentityPublicKey, KeyType, Purpose, accessors::IdentityGettersV0,
 };
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use egui::{Button, ComboBox, Context, Frame, Grid, Margin, RichText, ScrollArea, TextEdit, Ui};
+use egui::{Button, ComboBox, Frame, Grid, Margin, RichText, ScrollArea, TextEdit, Ui};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1059,12 +1059,12 @@ impl ScreenLike for GroveSTARKScreen {
         // Pop on success if needed
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
         // Add top panel with breadcrumb
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
@@ -1072,16 +1072,16 @@ impl ScreenLike for GroveSTARKScreen {
 
         // Add left panel
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsGroveSTARKScreen,
         );
 
         // Add tools subscreen chooser panel
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Add central panel with the main UI
-        let panel_action = island_central_panel(ctx, |ui| {
+        let panel_action = island_central_panel(ui, |ui| {
             ui.label(
                 RichText::new("GroveSTARK Zero-Knowledge Proofs")
                     .size(Typography::SCALE_XL)

--- a/src/ui/tools/masternode_list_diff_screen.rs
+++ b/src/ui/tools/masternode_list_diff_screen.rs
@@ -39,7 +39,7 @@ use dash_sdk::dpp::dashcore::{
     BlockHash, ChainLock as ChainLock2, InstantLock as InstantLock2, Network, ProTxHash, QuorumHash,
 };
 use dash_sdk::dpp::prelude::CoreBlockHeight;
-use eframe::egui::{self, Context, ScrollArea, Ui};
+use eframe::egui::{self, ScrollArea, Ui};
 use egui::{Align, Frame, Layout, Margin, RichText, Stroke, TextEdit, Vec2};
 use itertools::Itertools;
 use rfd::FileDialog;
@@ -4413,24 +4413,24 @@ impl ScreenLike for MasternodeListDiffScreen {
         // Optionally refresh data when this screen is shown
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsMasternodeListDiffScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
         // Styled central panel consistent with other tool screens; scroll only below tab row
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             // Top: input area (base/end block height + Get DMLs button)
             let mut inner = AppAction::None;
             inner |= self.render_input_area(ui);

--- a/src/ui/tools/platform_info_screen.rs
+++ b/src/ui/tools/platform_info_screen.rs
@@ -10,7 +10,7 @@ use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::version::PlatformVersion;
-use eframe::egui::{self, Context, ScrollArea, Ui};
+use eframe::egui::{self, ScrollArea, Ui};
 use std::sync::Arc;
 
 pub struct PlatformInfoScreen {
@@ -158,23 +158,23 @@ impl ScreenLike for PlatformInfoScreen {
         // Don't auto-refresh - let user trigger actions manually
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsPlatformInfoScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        let panel_action = island_central_panel(ctx, |ui| {
+        let panel_action = island_central_panel(ui, |ui| {
             ui.heading("Platform Information Tool");
             ui.separator();
 

--- a/src/ui/tools/proof_log_screen.rs
+++ b/src/ui/tools/proof_log_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::theme::{DashColors, ResponseExt};
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::drive::grovedb::operations::proof::GroveDBProof;
 use dash_sdk::drive::query::PathQuery;
-use eframe::egui::{self, Context, Grid, ScrollArea, Ui};
+use eframe::egui::{self, Grid, ScrollArea, Ui};
 use egui::text::LayoutJob;
 use egui::{Color32, FontId, Frame, Stroke, TextFormat, TextStyle, Vec2};
 use regex::Regex;
@@ -372,23 +372,23 @@ impl ScreenLike for ProofLogScreen {
     }
 
     /// Renders the UI components for the proof viewer screen.
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsProofLogScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             // Fetch proof items if not already fetched
             if self.proof_items.is_empty() {
                 ui.vertical_centered(|ui| {

--- a/src/ui/tools/proof_visualizer_screen.rs
+++ b/src/ui/tools/proof_visualizer_screen.rs
@@ -9,7 +9,7 @@ use crate::ui::{MessageType, RootScreenType, ScreenLike};
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 use dash_sdk::drive::grovedb::operations::proof::GroveDBProof;
-use eframe::egui::{self, Context, ScrollArea, TextEdit, Ui};
+use eframe::egui::{self, ScrollArea, TextEdit, Ui};
 use egui::Color32;
 use std::sync::Arc;
 
@@ -145,23 +145,23 @@ impl ScreenLike for ProofVisualizerScreen {
         // Implement message display if needed
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsProofVisualizerScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input_field(ui);
             self.show_output(ui);
             AppAction::None

--- a/src/ui/tools/transition_visualizer_screen.rs
+++ b/src/ui/tools/transition_visualizer_screen.rs
@@ -16,7 +16,7 @@ use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 use dash_sdk::dpp::serialization::PlatformDeserializable;
 use dash_sdk::dpp::state_transition::StateTransition;
 use dash_sdk::platform::Identifier;
-use eframe::egui::{self, Color32, Context, ScrollArea, TextEdit, Ui, Window};
+use eframe::egui::{self, Color32, ScrollArea, TextEdit, Ui, Window};
 use egui::RichText;
 use serde_json::Value;
 use std::sync::Arc;
@@ -418,23 +418,25 @@ impl ScreenLike for TransitionVisualizerScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Tools", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenToolsTransitionVisualizerScreen,
         );
 
-        action |= add_tools_subscreen_chooser_panel(ctx, self.app_context.as_ref());
+        action |= add_tools_subscreen_chooser_panel(ui, self.app_context.as_ref());
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             self.show_input_field(ui);
             self.show_output(ui)
         });

--- a/src/ui/wallets/add_new_wallet_screen.rs
+++ b/src/ui/wallets/add_new_wallet_screen.rs
@@ -578,7 +578,9 @@ impl ScreenLike for AddNewWalletScreen {
         false
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut pending_action = AppAction::None;
         if self.core_wallets.is_none() && !self.core_wallets_loading {
             // SPV mode has no Dash Core RPC — skip listing Core wallets entirely.
@@ -592,7 +594,7 @@ impl ScreenLike for AddNewWalletScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::GoToMainScreen),
@@ -602,12 +604,12 @@ impl ScreenLike for AddNewWalletScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let ctx = ui.ctx().clone();
 

--- a/src/ui/wallets/asset_lock_detail_screen.rs
+++ b/src/ui/wallets/asset_lock_detail_screen.rs
@@ -13,7 +13,7 @@ use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::{Address, InstantLock, Transaction};
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::prelude::AssetLockProof;
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::{Color32, Frame, Margin, RichText};
 use std::sync::{Arc, RwLock};
 
@@ -275,9 +275,11 @@ impl ScreenWithWalletUnlock for AssetLockDetailScreen {
 }
 
 impl ScreenLike for AssetLockDetailScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 (
@@ -292,12 +294,12 @@ impl ScreenLike for AssetLockDetailScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -19,7 +19,7 @@ use crate::ui::identities::funding_common::{self, WalletFundedScreenStep, genera
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dashcore_rpc::dashcore::{Address, OutPoint, TxOut};
-use eframe::egui::{self, Context, Ui};
+use eframe::egui::{self, Ui};
 use egui::{Button, RichText, Vec2};
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
@@ -247,7 +247,7 @@ impl ScreenWithWalletUnlock for CreateAssetLockScreen {
 }
 
 impl ScreenLike for CreateAssetLockScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let wallet_name = self
             .wallet
             .read()
@@ -256,7 +256,7 @@ impl ScreenLike for CreateAssetLockScreen {
             .unwrap_or_else(|| "Unknown Wallet".to_string());
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 (
@@ -271,12 +271,12 @@ impl ScreenLike for CreateAssetLockScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/import_mnemonic_screen.rs
+++ b/src/ui/wallets/import_mnemonic_screen.rs
@@ -11,7 +11,6 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::identities::add_existing_identity_screen::AddExistingIdentityScreen;
 use crate::ui::identities::add_new_identity_screen::AddNewIdentityScreen;
 use crate::ui::{RootScreenType, Screen, ScreenLike};
-use eframe::egui::Context;
 
 use crate::database::is_unique_constraint_violation;
 use crate::model::wallet::Wallet;
@@ -481,7 +480,7 @@ impl ScreenLike for ImportMnemonicScreen {
         false
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut pending_action = AppAction::None;
         if self.core_wallets.is_none() && !self.core_wallets_loading {
             if self.app_context.core_backend_mode() == crate::spv::CoreBackendMode::Spv {
@@ -494,7 +493,7 @@ impl ScreenLike for ImportMnemonicScreen {
         }
 
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::GoToMainScreen),
@@ -504,12 +503,12 @@ impl ScreenLike for ImportMnemonicScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             crate::ui::RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
 
             // Show success screen if wallet was imported

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -3453,7 +3453,9 @@ impl WalletSendScreen {
 }
 
 impl ScreenLike for WalletSendScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = self
             .pending_refresh_task
             .take()
@@ -3461,19 +3463,19 @@ impl ScreenLike for WalletSendScreen {
             .unwrap_or(AppAction::None);
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::PopScreen), ("Send", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -654,9 +654,11 @@ impl ShieldScreen {
 }
 
 impl ScreenLike for ShieldScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -666,7 +668,7 @@ impl ScreenLike for ShieldScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
@@ -681,7 +683,7 @@ impl ScreenLike for ShieldScreen {
             action |= AppAction::BackendTask(task);
         }
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             let dark_mode = ui.style().visuals.dark_mode;
             ui.heading("Shield");
             ui.add_space(10.0);

--- a/src/ui/wallets/shielded_send_screen.rs
+++ b/src/ui/wallets/shielded_send_screen.rs
@@ -12,7 +12,7 @@ use crate::ui::components::styled::island_central_panel;
 use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText};
 use std::sync::Arc;
 
@@ -96,7 +96,7 @@ impl ScreenLike for ShieldedSendScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = self
             .pending_refresh_task
             .take()
@@ -104,7 +104,7 @@ impl ScreenLike for ShieldedSendScreen {
             .unwrap_or(AppAction::None);
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -114,12 +114,12 @@ impl ScreenLike for ShieldedSendScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("Send (Private)");
             ui.add_space(10.0);
             ui.label("Transfer credits privately within the shielded pool.");

--- a/src/ui/wallets/single_key_send_screen.rs
+++ b/src/ui/wallets/single_key_send_screen.rs
@@ -860,23 +860,25 @@ impl SingleKeyWalletSendScreen {
 }
 
 impl ScreenLike for SingleKeyWalletSendScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::PopScreen), ("Send", AppAction::None)],
             vec![],
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
         let is_rpc_mode = self.app_context.core_backend_mode() == CoreBackendMode::Rpc;
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/wallets/unshield_credits_screen.rs
+++ b/src/ui/wallets/unshield_credits_screen.rs
@@ -15,7 +15,7 @@ use crate::ui::components::top_panel::add_top_panel;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, ScreenLike};
 use dash_sdk::dpp::balances::credits::CREDITS_PER_DUFF;
-use eframe::egui::{self, Context};
+use eframe::egui::{self};
 use egui::{Color32, RichText};
 use std::sync::Arc;
 
@@ -84,7 +84,7 @@ impl ScreenLike for UnshieldCreditsScreen {
         }
     }
 
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = self
             .pending_refresh_task
             .take()
@@ -92,7 +92,7 @@ impl ScreenLike for UnshieldCreditsScreen {
             .unwrap_or(AppAction::None);
 
         action |= add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![
                 ("Wallets", AppAction::PopScreen),
@@ -102,12 +102,12 @@ impl ScreenLike for UnshieldCreditsScreen {
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ui.heading("Unshield Credits");
             ui.add_space(10.0);
             ui.label(

--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -2213,7 +2213,9 @@ impl WalletsBalancesScreen {
 }
 
 impl ScreenLike for WalletsBalancesScreen {
-    fn ui(&mut self, ctx: &Context) -> AppAction {
+    fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         // Check for pending platform balance refresh (triggered after transfers)
         let pending_refresh_action = if let Some(seed_hash) =
             self.pending_platform_balance_refresh.take()
@@ -2290,19 +2292,19 @@ impl ScreenLike for WalletsBalancesScreen {
             ));
         }
         let mut action = add_top_panel(
-            ctx,
+            ui,
             &self.app_context,
             vec![("Wallets", AppAction::None)],
             right_buttons,
         );
 
         action |= add_left_panel(
-            ctx,
+            ui,
             &self.app_context,
             RootScreenType::RootScreenWalletsBalances,
         );
 
-        action |= island_central_panel(ctx, |ui| {
+        action |= island_central_panel(ui, |ui| {
             let mut inner_action = AppAction::None;
             let dark_mode = ui.style().visuals.dark_mode;
 

--- a/src/ui/welcome_screen.rs
+++ b/src/ui/welcome_screen.rs
@@ -4,7 +4,7 @@ use crate::ui::components::left_panel::load_svg_icon;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing};
 use crate::ui::{RootScreenType, ScreenType};
-use egui::{Context, RichText, ScrollArea, Vec2};
+use egui::{RichText, ScrollArea, Vec2};
 use std::sync::Arc;
 
 /// The action the user wants to take after onboarding
@@ -25,12 +25,14 @@ impl WelcomeScreen {
         Self { app_context }
     }
 
-    pub fn ui(&mut self, ctx: &Context) -> AppAction {
+    pub fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {
+        let ctx = ui.ctx().clone();
+        let ctx = &ctx;
         let mut action = AppAction::None;
         let dark_mode = ctx.global_style().visuals.dark_mode;
 
         // Central panel with welcome content (using island style like other screens)
-        island_central_panel(ctx, |ui| {
+        island_central_panel(ui, |ui| {
             ScrollArea::vertical()
                 .auto_shrink([false, false])
                 .show(ui, |ui| {


### PR DESCRIPTION
## Summary

Follow-up to #857 (egui 0.33.3 → 0.34.2 upgrade). Removes the 27 `#[allow(deprecated)]` suppressions left by the upgrade PR's containment strategy by performing the structural migration deferred there:

- Flips the `ScreenLike::ui` trait signature from `&Context` to `&mut egui::Ui` (60+ screens, mechanical)
- Migrates the 9 panel helpers (`island_central_panel`, `add_top_panel`, `add_left_panel`, `add_left_wallet_panel`, plus the 5 chooser panels) from `Panel::show(ctx, …)` to `Panel::show_inside(ui, …)`
- Migrates the 17 direct `egui::CentralPanel::default().show(ctx, …)` sites in screens to `show_inside(ui, …)`
- Renames axis-non-agnostic Panel methods to their axis-agnostic forms (`default_width` → `default_size`, `min_width/max_width` → `min_size/max_size`)
- Removes the `TODO(egui-0.35)` breadcrumb planted by the upgrade PR
- Updates `CLAUDE.md` "Screen Pattern" section to document the new `&mut Ui` signature

After this PR, **zero egui-related `#[allow(deprecated)]` suppressions remain** anywhere in the codebase. The 6 AES-ECB / DIP-0015 suppressions in `src/model/wallet/` and `src/backend_task/dashpay/` are intentional cryptographic protocol choices (unrelated to egui) and remain untouched.

### Why "Option A" wasn't viable

The upgrade PR's optimistic plan was to leave the trait alone and only flip panel helpers to take `&mut Ui`. That doesn't work: panel helpers are invoked from inside `Screen::ui(ctx)` bodies (not from `App::ui` directly), so the only `&Context` available at the helper boundary is the screen's own. Wrapping each screen in a synthetic `CentralPanel::show(ctx, …)` adapter to obtain a `Ui` would re-introduce the same deprecated call we're trying to remove. The trait flip is the only clean path.

### Commit decomposition (4 refactor + 1 doc)

1. `refactor(ui): rename Panel axis-agnostic methods (default/min/max_size)` — trait-stable, removes one class of deprecation
2. `refactor(ui): flip ScreenLike::ui to &mut Ui and migrate panel helpers to show_inside` — semantically one refactor (squashed because the trait flip leaves the standalone commit with unused `Context` imports that the helper signature flip cleans up)
3. `refactor(ui): migrate screen central panels to show_inside(ui, …)` — last 17 deprecation sites
4. `refactor(ui): drop egui-0.35 TODO breadcrumb after panel migration`
5. `docs: update ScreenLike::ui signature in CLAUDE.md after trait flip`

Every commit compiles cleanly and passes `cargo clippy --all-features --all-targets -- -D warnings`.

## Stack

This PR targets `chore/upgrade-egui-0.34` (#857). It should be reviewed and merged after #857 lands; GitHub will auto-rebase the base.

## User-visible impact

None. Pure internal refactor — no UX changes, no functional changes, no string changes (no i18n surface touched).

## Test plan

- [x] `cargo build --all-features` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean — at every commit (verified by checking out each intermediate SHA, not just HEAD)
- [x] `cargo test --all-features --workspace` — 553 tests pass (468 unit + 10 e2e + 72 kittest + 3 doctests; ignored: 2 unit + 14 doctests + 59 backend-e2e)
- [x] `cargo test --test kittest --all-features` — 72/72 pass (matches PR #857 baseline)
- [ ] **Manual smoke** (out-of-band, before merge): launch `cargo run`, navigate the seven root screens (Identities, DPNS, Wallets, Tools, Contracts, Tokens, Settings), open at least one info popup per dashpay subscreen. Watch for unexpected double-frames, vanished margins, or banner placement drift. The migration is layout-equivalent in egui's own model, but verify visually.

## Notes for reviewers

- **Trait change is internal**: `ScreenLike::ui(&mut self, ui: &mut Ui)` is an internal API. No external callers.
- **`ctx.global_style()` not `ui.style()`**: where helpers needed global theme (e.g. outer-frame coloring), the substitution is `ui.ctx().global_style()` — preserving global semantics. `ui.style()` (local cumulative style) was deliberately not used in those positions; see PR #857 QA-002.
- **`Context::style()` itself deprecated**: in egui 0.34 — Bilby substituted `ui.ctx().global_style()` rather than `ui.ctx().style()` to avoid re-introducing a deprecation. Documented in commit 2.
- **IDE may flag pre-existing `tests/backend-e2e/` errors** (unresolved `wallets()`/`db()`/`sdk()` accessors). These are gated by `#[cfg(any(test, feature = "testing"))]` in `src/context/mod.rs:862`; rust-analyzer doesn't enable `--features testing` by default. `cargo build --all-features` and `cargo test --all-features --workspace` resolve them. Configure rust-analyzer with `"rust-analyzer.cargo.features": "all"` if the noise bothers you.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>