### PR TITLE
chore(deps): bump platform to v3.1.0-dev.8 (9e00c8b894)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,15 +1678,6 @@ dependencies = [
 
 [[package]]
 name = "core2"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239fa3ae9b63c2dc74bd3fa852d4792b8b305ae64eeede946265b6af62f1fff3"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "core2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
@@ -1702,6 +1693,12 @@ checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
 ]
+
+[[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
 
 [[package]]
 name = "cpufeatures"
@@ -1729,12 +1726,6 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -1866,8 +1857,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1968,8 +1959,8 @@ dependencies = [
 
 [[package]]
 name = "dash-async"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1978,8 +1969,8 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2068,8 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "dash-network"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -2079,16 +2070,16 @@ dependencies = [
 
 [[package]]
 name = "dash-network-seeds"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dash-network",
 ]
 
 [[package]]
 name = "dash-platform-macros"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "heck",
  "quote",
@@ -2097,8 +2088,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2108,6 +2099,7 @@ dependencies = [
  "dapi-grpc",
  "dash-async",
  "dash-context-provider",
+ "dash-network-seeds",
  "dash-platform-macros",
  "derive_more 1.0.0",
  "dotenvy",
@@ -2134,8 +2126,8 @@ dependencies = [
 
 [[package]]
 name = "dash-spv"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2144,8 +2136,8 @@ dependencies = [
  "dashcore",
  "dashcore_hashes",
  "futures",
+ "git-state",
  "hex",
- "hickory-resolver",
  "key-wallet",
  "key-wallet-manager",
  "rand 0.8.5",
@@ -2163,8 +2155,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -2189,13 +2181,13 @@ dependencies = [
 
 [[package]]
 name = "dashcore-private"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 
 [[package]]
 name = "dashcore-rpc"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2207,8 +2199,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore-rpc-json"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2222,8 +2214,8 @@ dependencies = [
 
 [[package]]
 name = "dashcore_hashes"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2246,8 +2238,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2257,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -2272,12 +2264,6 @@ dependencies = [
  "wallet-utils-contract",
  "withdrawals-contract",
 ]
-
-[[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "data-url"
@@ -2509,8 +2495,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2520,8 +2506,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2570,8 +2556,8 @@ dependencies = [
 
 [[package]]
 name = "dpp-json-convertible-derive"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2580,18 +2566,18 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
  "derive_more 1.0.0",
  "dpp",
- "grovedb 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-epoch-based-storage-flags",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -2605,8 +2591,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -2929,18 +2915,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enum-iterator"
@@ -3570,6 +3544,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-state"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,20 +3745,20 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-dense-fixed-sized-merkle-tree",
- "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-merk 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-merk 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-merkle-mountain-range",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-query",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "hex",
  "hex-literal",
  "indexmap 2.13.0",
@@ -3792,11 +3771,11 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-merkle-mountain-range",
  "grovedb-query",
@@ -3807,11 +3786,11 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "incrementalmerkletree",
  "orchard",
  "rusqlite",
@@ -3832,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3842,11 +3821,11 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-query",
  "thiserror 2.0.18",
 ]
@@ -3868,12 +3847,12 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "hex",
  "integer-encoding",
  "thiserror 2.0.18",
@@ -3882,9 +3861,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "hex",
  "integer-encoding",
  "intmap",
@@ -3915,19 +3894,19 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
  "blake3",
  "byteorder",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-element 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-path 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "grovedb-query",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
- "grovedb-visualize 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
+ "grovedb-visualize 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -3937,11 +3916,11 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
 ]
 
 [[package]]
@@ -3955,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "hex",
 ]
@@ -3963,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -3986,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4004,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b#8f25b20d04bfc0e8bdfb3870676d647a0d74918b"
+source = "git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9#60f29685172653f6007e63d0916bce4633bc23b9"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -4242,52 +4221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.9.2",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "moka",
- "once_cell",
- "parking_lot",
- "rand 0.9.2",
- "resolv-conf",
- "smallvec",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,7 +4414,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4694,19 +4627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e611826a1868311677fdcdfbec9e8621d104c732d080f546a854530232f0ee"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4928,8 +4848,8 @@ dependencies = [
 
 [[package]]
 name = "key-wallet"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -4950,21 +4870,22 @@ dependencies = [
 
 [[package]]
 name = "key-wallet-manager"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=18b4f2a44997114c953fc36b0918866980724da1#18b4f2a44997114c953fc36b0918866980724da1"
+version = "0.43.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "dashcore",
  "key-wallet",
  "rayon",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "keyword-search-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5169,8 +5090,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5303,23 +5224,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "moka"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "equivalent",
- "parking_lot",
- "portable-atomic",
- "smallvec",
- "tagptr",
- "uuid",
 ]
 
 [[package]]
@@ -5942,10 +5846,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6021,13 +5921,13 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.12.0"
-source = "git+https://github.com/dashpay/orchard.git?rev=41c8f7169f2683c99cf0e0c63e8d25ec12c47a79#41c8f7169f2683c99cf0e0c63e8d25ec12c47a79"
+version = "0.13.1"
+source = "git+https://github.com/dashpay/orchard.git?rev=898258d76aab2822249492aede59a02d49278fff#898258d76aab2822249492aede59a02d49278fff"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2 0.3.3",
+ "corez",
  "ff",
  "fpe",
  "getset",
@@ -6317,8 +6217,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-encryption"
-version = "2.1.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "aes",
  "cbc",
@@ -6328,8 +6228,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6337,8 +6237,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6348,8 +6248,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6368,19 +6268,19 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "bincode 2.0.1",
- "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=8f25b20d04bfc0e8bdfb3870676d647a0d74918b)",
+ "grovedb-version 4.0.0 (git+https://github.com/dashpay/grovedb?rev=60f29685172653f6007e63d0916bce4633bc23b9)",
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]
 
 [[package]]
 name = "platform-versioning"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6584,7 +6484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6605,7 +6505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7098,15 +6998,9 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "resvg"
@@ -7249,8 +7143,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "backon",
  "chrono",
@@ -7275,8 +7169,8 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8271,12 +8165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tagptr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8303,8 +8191,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-abci"
-version = "1.5.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
+version = "1.5.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.1#fae47294618125fa9d69150e8a7a5b607af6867c"
 dependencies = [
  "bytes",
  "hex",
@@ -8318,8 +8206,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto"
-version = "1.5.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
+version = "1.5.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.1#fae47294618125fa9d69150e8a7a5b607af6867c"
 dependencies = [
  "bytes",
  "chrono",
@@ -8336,8 +8224,8 @@ dependencies = [
 
 [[package]]
 name = "tenderdash-proto-compiler"
-version = "1.5.0"
-source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.0#7a6b7433f780938c244e4d201bf8e66aa02cd9c2"
+version = "1.5.1"
+source = "git+https://github.com/dashpay/rs-tenderdash-abci?tag=v1.5.1#fae47294618125fa9d69150e8a7a5b607af6867c"
 dependencies = [
  "fs_extra",
  "prost-build",
@@ -8513,8 +8401,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -8804,9 +8692,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+checksum = "3c0469c353de5f665c95f898074b5b004b500c6722214c3249f1dc79c0a2a3f6"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8823,7 +8711,7 @@ dependencies = [
  "tower-service",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -9027,7 +8915,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abbf77aed65cb885a8ba07138c365879be3d9a93dce82bf6cc50feca9138ec15"
 dependencies = [
- "core2 0.4.0",
+ "core2",
 ]
 
 [[package]]
@@ -9342,8 +9230,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9463,19 +9351,6 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -9893,12 +9768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9920,7 +9789,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10733,8 +10602,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "3.1.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=54048b9352c5c8361f4cbfaa6a188dd3244e00c4#54048b9352c5c8361f4cbfaa6a188dd3244e00c4"
+version = "3.1.0-dev.8"
+source = "git+https://github.com/dashpay/platform?rev=9e00c8b894c45ee25df35ae694570c61ff007788#9e00c8b894c45ee25df35ae694570c61ff007788"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",
@@ -11104,9 +10973,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.33.3", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "54048b9352c5c8361f4cbfaa6a188dd3244e00c4", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "9e00c8b894c45ee25df35ae694570c61ff007788", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -28,7 +28,7 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "54048b9352c5c83
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "54048b9352c5c8361f4cbfaa6a188dd3244e00c4" }
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "9e00c8b894c45ee25df35ae694570c61ff007788" }
 zip32 = "0.2.0"
 grovestark = { git = "https://www.github.com/dashpay/grovestark", rev = "5b9e289cca54c79b1305d5f4f40bf1148f1eb0e3" }
 rayon = "1.8"

--- a/src/backend_task/contract.rs
+++ b/src/backend_task/contract.rs
@@ -79,6 +79,9 @@ impl AppContext {
                                 // Fetch the contract description from the Search Contract
                                 let search_contract = &self.keyword_search_contract;
                                 let document_query = DocumentQuery {
+                                    select: Default::default(),
+                                    group_by: vec![],
+                                    having: vec![],
                                     data_contract: search_contract.clone(),
                                     document_type_name: "fullDescription".to_string(),
                                     limit: 1,

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -708,11 +708,11 @@ impl AppContext {
         // change address (key-wallet 0.43 derives addresses directly rather than
         // exposing a bare next-change index).
         let account_xpub = {
-            let wallet = wm
-                .get_wallet(wallet_id)
-                .ok_or_else(|| TaskError::WalletPaymentFailed {
-                    detail: "Wallet object not found".to_string(),
-                })?;
+            let wallet =
+                wm.get_wallet(wallet_id)
+                    .ok_or_else(|| TaskError::WalletPaymentFailed {
+                        detail: "Wallet object not found".to_string(),
+                    })?;
             let wallet_account = wallet
                 .accounts
                 .standard_bip44_accounts
@@ -741,12 +741,11 @@ impl AppContext {
                 })?;
 
             let utxos: Vec<_> = account.utxos.values().cloned().collect();
-            let change_addr =
-                account
-                    .next_change_address(Some(&account_xpub), false)
-                    .map_err(|e| TaskError::WalletPaymentFailed {
-                        detail: format!("Failed to derive change address: {e}"),
-                    })?;
+            let change_addr = account
+                .next_change_address(Some(&account_xpub), false)
+                .map_err(|e| TaskError::WalletPaymentFailed {
+                    detail: format!("Failed to derive change address: {e}"),
+                })?;
             (utxos, change_addr)
         };
 
@@ -756,7 +755,7 @@ impl AppContext {
                 .map(|(addr, amt)| (addr.clone(), (*amt as f64 * scale_factor) as u64))
                 .collect();
 
-            let build_result = (|| -> Result<Transaction, BuilderError> {
+            let build_result: Result<Transaction, BuilderError> = {
                 let mut builder = TransactionBuilder::new()
                     .set_fee_rate(FeeRate::normal())
                     .set_change_address(change_addr.clone())
@@ -769,7 +768,7 @@ impl AppContext {
                 }
 
                 builder.build_unsigned().map(|(tx, _fee)| tx)
-            })();
+            };
 
             match build_result {
                 Ok(tx) => return Ok(tx),

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -25,7 +25,7 @@ use dash_sdk::dpp::dashcore::{
 };
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::key_wallet::Network as WalletNetwork;
-use dash_sdk::dpp::key_wallet::account::ECDSAAddressDerivation;
+use dash_sdk::dpp::key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::fee::FeeRate;
@@ -704,43 +704,51 @@ impl AppContext {
         let mut scale_factor = 1.0f64;
         let mut attempted_fallback = false;
 
-        // Get UTXOs and change address from the wallet account
-        let (utxos, change_index) = {
-            let managed_info =
-                wm.get_wallet_info(wallet_id)
-                    .ok_or_else(|| TaskError::WalletPaymentFailed {
-                        detail: "Wallet info unavailable".to_string(),
-                    })?;
-            let account = managed_info
-                .accounts()
+        // The account xpub is needed by the managed account to derive the next
+        // change address (key-wallet 0.43 derives addresses directly rather than
+        // exposing a bare next-change index).
+        let account_xpub = {
+            let wallet = wm
+                .get_wallet(wallet_id)
+                .ok_or_else(|| TaskError::WalletPaymentFailed {
+                    detail: "Wallet object not found".to_string(),
+                })?;
+            let wallet_account = wallet
+                .accounts
                 .standard_bip44_accounts
                 .get(&DEFAULT_BIP44_ACCOUNT_INDEX)
+                .ok_or_else(|| TaskError::WalletPaymentFailed {
+                    detail: "BIP44 wallet account missing".to_string(),
+                })?;
+            wallet_account.account_xpub
+        };
+
+        // Get UTXOs and the next (unused) change address from the managed account.
+        // `add_to_state = false` peeks the next change address without advancing
+        // the pool, preserving the prior "derive at next change index" behaviour.
+        let (utxos, change_addr) = {
+            let managed_info = wm.get_wallet_info_mut(wallet_id).ok_or_else(|| {
+                TaskError::WalletPaymentFailed {
+                    detail: "Wallet info unavailable".to_string(),
+                }
+            })?;
+            let account = managed_info
+                .accounts_mut()
+                .standard_bip44_accounts
+                .get_mut(&DEFAULT_BIP44_ACCOUNT_INDEX)
                 .ok_or_else(|| TaskError::WalletPaymentFailed {
                     detail: "BIP44 account missing".to_string(),
                 })?;
 
             let utxos: Vec<_> = account.utxos.values().cloned().collect();
-            let change_index = account.get_next_change_address_index().unwrap_or(0);
-            (utxos, change_index)
+            let change_addr =
+                account
+                    .next_change_address(Some(&account_xpub), false)
+                    .map_err(|e| TaskError::WalletPaymentFailed {
+                        detail: format!("Failed to derive change address: {e}"),
+                    })?;
+            (utxos, change_addr)
         };
-
-        let wallet = wm
-            .get_wallet(wallet_id)
-            .ok_or_else(|| TaskError::WalletPaymentFailed {
-                detail: "Wallet object not found".to_string(),
-            })?;
-        let wallet_account = wallet
-            .accounts
-            .standard_bip44_accounts
-            .get(&DEFAULT_BIP44_ACCOUNT_INDEX)
-            .ok_or_else(|| TaskError::WalletPaymentFailed {
-                detail: "BIP44 wallet account missing".to_string(),
-            })?;
-        let change_addr = wallet_account
-            .derive_change_address(change_index)
-            .map_err(|e| TaskError::WalletPaymentFailed {
-                detail: format!("Failed to derive change address: {e}"),
-            })?;
 
         loop {
             let scaled_recipients: Vec<(Address, u64)> = recipients
@@ -751,20 +759,16 @@ impl AppContext {
             let build_result = (|| -> Result<Transaction, BuilderError> {
                 let mut builder = TransactionBuilder::new()
                     .set_fee_rate(FeeRate::normal())
-                    .set_change_address(change_addr.clone());
+                    .set_change_address(change_addr.clone())
+                    .set_selection_strategy(SelectionStrategy::LargestFirst)
+                    .set_current_height(current_height)
+                    .add_inputs(utxos.iter().cloned());
 
                 for (addr, amt) in &scaled_recipients {
-                    builder = builder.add_output(addr, *amt)?;
+                    builder = builder.add_output(addr, *amt);
                 }
 
-                builder = builder.select_inputs(
-                    &utxos,
-                    SelectionStrategy::LargestFirst,
-                    current_height,
-                    |_| None, // No private keys for unsigned tx
-                )?;
-
-                builder.build()
+                builder.build_unsigned().map(|(tx, _fee)| tx)
             })();
 
             match build_result {
@@ -871,30 +875,22 @@ impl AppContext {
         // Build the transaction using TransactionBuilder
         let mut builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::normal())
-            .set_change_address(change_address.clone());
+            .set_change_address(change_address.clone())
+            .set_selection_strategy(SelectionStrategy::OptimalConsolidation)
+            .set_current_height(current_height)
+            .add_inputs(all_utxos);
 
         for (address, amount) in recipients {
-            builder = builder
-                .add_output(&address, amount)
-                .map_err(|e: BuilderError| WalletError::TransactionBuild(e.to_string()))?;
+            builder = builder.add_output(&address, amount);
         }
 
-        builder = builder
-            .select_inputs(
-                &all_utxos,
-                SelectionStrategy::OptimalConsolidation,
-                current_height,
-                |_| None, // No private keys for unsigned transaction
-            )
-            // TODO(RUST-002): String-based error classification — see #660
-            .map_err(|e: BuilderError| match e.to_string() {
-                msg if msg.contains("Insufficient") => WalletError::InsufficientFunds,
-                msg => WalletError::TransactionBuild(msg),
-            })?;
-
         builder
-            .build()
-            .map_err(|e: BuilderError| WalletError::TransactionBuild(e.to_string()))
+            .build_unsigned()
+            .map(|(tx, _fee)| tx)
+            .map_err(|e: BuilderError| match e {
+                BuilderError::InsufficientFunds { .. } => WalletError::InsufficientFunds,
+                other => WalletError::TransactionBuild(other.to_string()),
+            })
     }
 
     fn sign_spv_transaction(

--- a/src/backend_task/core/mod.rs
+++ b/src/backend_task/core/mod.rs
@@ -724,8 +724,14 @@ impl AppContext {
         };
 
         // Get UTXOs and the next (unused) change address from the managed account.
-        // `add_to_state = false` peeks the next change address without advancing
-        // the pool, preserving the prior "derive at next change index" behaviour.
+        // `add_to_state = false` does not advance the address pool, but key-wallet
+        // 0.43's `next_change_address` still bumps the managed account's monitor
+        // revision unconditionally. There is no read-only "peek next change address"
+        // on ManagedCoreFundsAccount, so this fee-estimation peek takes a write lock
+        // and nudges the monitor revision. That only signals the mempool bloom filter
+        // it may be stale (a one-time rebuild), so it is acceptable here.
+        // TODO(v3.1-bump): switch to a non-mutating change-address peek if key-wallet
+        // exposes one upstream.
         let (utxos, change_addr) = {
             let managed_info = wm.get_wallet_info_mut(wallet_id).ok_or_else(|| {
                 TaskError::WalletPaymentFailed {
@@ -755,6 +761,10 @@ impl AppContext {
                 .map(|(addr, amt)| (addr.clone(), (*amt as f64 * scale_factor) as u64))
                 .collect();
 
+            // build_unsigned requires input >= output + fee and returns
+            // InsufficientFunds otherwise; the old build() let change shrink and
+            // could return a tx that underpaid the fee. The fallback loop below
+            // now drives off that earlier (correct) InsufficientFunds.
             let build_result: Result<Transaction, BuilderError> = {
                 let mut builder = TransactionBuilder::new()
                     .set_fee_rate(FeeRate::normal())

--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -538,6 +538,9 @@ async fn resolve_username_to_identity(
 
     // Use the cached DPNS contract from AppContext instead of fetching from network
     let domain_query = DocumentQuery {
+        select: Default::default(),
+        group_by: vec![],
+        having: vec![],
         data_contract: app_context.dpns_contract.clone(),
         document_type_name: "domain".to_string(),
         where_clauses: vec![

--- a/src/backend_task/document.rs
+++ b/src/backend_task/document.rs
@@ -268,6 +268,9 @@ impl AppContext {
             ) => {
                 // First fetch the document to transfer
                 let document_query = DocumentQuery {
+                    select: Default::default(),
+                    group_by: vec![],
+                    having: vec![],
                     data_contract: data_contract.clone(),
                     document_type_name: document_type.name().to_string(),
                     where_clauses: vec![],
@@ -325,6 +328,9 @@ impl AppContext {
             ) => {
                 // First fetch the document to purchase
                 let document_query = DocumentQuery {
+                    select: Default::default(),
+                    group_by: vec![],
+                    having: vec![],
                     data_contract: data_contract.clone(),
                     document_type_name: document_type.name().to_string(),
                     where_clauses: vec![],
@@ -383,6 +389,9 @@ impl AppContext {
             ) => {
                 // First fetch the document to set price on
                 let document_query = DocumentQuery {
+                    select: Default::default(),
+                    group_by: vec![],
+                    having: vec![],
                     data_contract: data_contract.clone(),
                     document_type_name: document_type.name().to_string(),
                     where_clauses: vec![],

--- a/src/backend_task/identity/add_key_to_identity.rs
+++ b/src/backend_task/identity/add_key_to_identity.rs
@@ -64,6 +64,7 @@ impl AppContext {
             sdk.version(),
             None,
         )
+        .await
         .map_err(|e| TaskError::IdentityUpdateTransitionError {
             source_error: Box::new(SdkError::Protocol(e)),
         })?;

--- a/src/backend_task/identity/discover_identities.rs
+++ b/src/backend_task/identity/discover_identities.rs
@@ -252,6 +252,9 @@ impl AppContext {
             use dash_sdk::platform::{Document, DocumentQuery, FetchMany};
 
             let query = DocumentQuery {
+                select: Default::default(),
+                group_by: vec![],
+                having: vec![],
                 data_contract: self.dpns_contract.clone(),
                 document_type_name: "domain".to_string(),
                 where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -316,6 +316,9 @@ impl AppContext {
 
         // Fetch DPNS names using SDK
         let dpns_names_document_query = DocumentQuery {
+            select: Default::default(),
+            group_by: vec![],
+            having: vec![],
             data_contract: self.dpns_contract.clone(),
             document_type_name: "domain".to_string(),
             where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/load_identity_by_dpns_name.rs
+++ b/src/backend_task/identity/load_identity_by_dpns_name.rs
@@ -23,6 +23,9 @@ impl AppContext {
 
         // Query the DPNS contract for the domain document
         let domain_query = DocumentQuery {
+            select: Default::default(),
+            group_by: vec![],
+            having: vec![],
             data_contract: self.dpns_contract.clone(),
             document_type_name: "domain".to_string(),
             where_clauses: vec![
@@ -73,6 +76,9 @@ impl AppContext {
 
         // Fetch all DPNS names owned by this identity
         let dpns_names_document_query = DocumentQuery {
+            select: Default::default(),
+            group_by: vec![],
+            having: vec![],
             data_contract: self.dpns_contract.clone(),
             document_type_name: "domain".to_string(),
             where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -101,6 +101,9 @@ impl AppContext {
         let identity_id = identity.id();
 
         let dpns_names_document_query = DocumentQuery {
+            select: Default::default(),
+            group_by: vec![],
+            having: vec![],
             data_contract: self.dpns_contract.clone(),
             document_type_name: "domain".to_string(),
             where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
+++ b/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
@@ -22,6 +22,9 @@ impl AppContext {
             let identity_id = qualified_identity.identity.id();
 
             let dpns_names_document_query = DocumentQuery {
+                select: Default::default(),
+                group_by: vec![],
+                having: vec![],
                 data_contract: self.dpns_contract.clone(),
                 document_type_name: "domain".to_string(),
                 where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/register_dpns_name.rs
+++ b/src/backend_task/identity/register_dpns_name.rs
@@ -158,6 +158,9 @@ impl AppContext {
             .await?;
 
         let dpns_names_document_query = DocumentQuery {
+            select: Default::default(),
+            group_by: vec![],
+            having: vec![],
             data_contract: self.dpns_contract.clone(),
             document_type_name: "domain".to_string(),
             where_clauses: vec![WhereClause {

--- a/src/backend_task/identity/register_identity.rs
+++ b/src/backend_task/identity/register_identity.rs
@@ -463,7 +463,7 @@ impl AppContext {
         qualified_identity: QualifiedIdentity,
     ) -> Result<Identity, TaskError> {
         match identity
-            .put_to_platform_and_wait_for_response(
+            .put_to_platform_and_wait_for_response_with_private_key(
                 sdk,
                 asset_lock_proof.clone(),
                 asset_lock_proof_private_key,
@@ -475,38 +475,46 @@ impl AppContext {
             Ok(updated_identity) => Ok(updated_identity),
             Err(e) => {
                 if matches!(e, Error::Protocol(ProtocolError::UnknownVersionError(_))) {
-                    identity
-                        .put_to_platform_and_wait_for_response(
+                    let retry_result = identity
+                        .put_to_platform_and_wait_for_response_with_private_key(
                             sdk,
                             asset_lock_proof.clone(),
                             asset_lock_proof_private_key,
                             &qualified_identity,
                             None,
                         )
-                        .await
-                        .map_err(|retry_err| {
-                            let logged = self.log_drive_proof_error(retry_err, RequestType::BroadcastStateTransition);
+                        .await;
+
+                    match retry_result {
+                        Ok(updated_identity) => Ok(updated_identity),
+                        Err(retry_err) => {
+                            let logged = self.log_drive_proof_error(
+                                retry_err,
+                                RequestType::BroadcastStateTransition,
+                            );
                             // If the logged variant is ProofError, return it directly;
                             // otherwise log the reconstructed transition for debugging.
-                            if matches!(logged, TaskError::ProofError { .. }) {
-                                return logged;
-                            }
-                            if let Ok(transition) = IdentityCreateTransition::try_from_identity_with_signer(
-                                identity,
-                                asset_lock_proof,
-                                asset_lock_proof_private_key.inner.as_ref(),
-                                &qualified_identity,
-                                &NativeBlsModule,
-                                0,
-                                self.platform_version(),
-                            ) {
+                            if !matches!(logged, TaskError::ProofError { .. })
+                                && let Ok(transition) =
+                                    IdentityCreateTransition::try_from_identity_with_signer_and_private_key(
+                                        identity,
+                                        asset_lock_proof,
+                                        asset_lock_proof_private_key.inner.as_ref(),
+                                        &qualified_identity,
+                                        &NativeBlsModule,
+                                        0,
+                                        self.platform_version(),
+                                    )
+                                    .await
+                            {
                                 tracing::debug!(
                                     "Register identity retry failed; reconstructed transition: {:?}",
                                     transition
                                 );
                             }
-                            logged
-                        })
+                            Err(logged)
+                        }
+                    }
                 } else {
                     Err(self.log_drive_proof_error(e, RequestType::BroadcastStateTransition))
                 }

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -228,11 +228,10 @@ impl AppContext {
 
         let updated_identity_balance = match qualified_identity
             .identity
-            .top_up_identity(
+            .top_up_identity_with_private_key(
                 &sdk,
                 asset_lock_proof.clone(),
                 &asset_lock_proof_private_key,
-                None,
                 None,
             )
             .await
@@ -257,11 +256,10 @@ impl AppContext {
                             // Retry with chain asset lock proof
                             qualified_identity
                                 .identity
-                                .top_up_identity(
+                                .top_up_identity_with_private_key(
                                     &sdk,
                                     chain_asset_lock_proof,
                                     &asset_lock_proof_private_key,
-                                    None,
                                     None,
                                 )
                                 .await
@@ -283,11 +281,10 @@ impl AppContext {
                 } else if matches!(e, Error::Protocol(ProtocolError::UnknownVersionError(_))) {
                     qualified_identity
                         .identity
-                        .top_up_identity(
+                        .top_up_identity_with_private_key(
                             &sdk,
                             asset_lock_proof.clone(),
                             &asset_lock_proof_private_key,
-                            None,
                             None,
                         )
                         .await
@@ -300,14 +297,16 @@ impl AppContext {
                                 return logged;
                             }
                             // Log the reconstructed transition for debugging before returning the error.
-                            if let Ok(transition) = IdentityTopUpTransition::try_from_identity(
-                                &qualified_identity.identity,
-                                asset_lock_proof,
-                                asset_lock_proof_private_key.inner.as_ref(),
-                                0,
-                                self.platform_version(),
-                                None,
-                            ) {
+                            if let Ok(transition) =
+                                IdentityTopUpTransition::try_from_identity_with_private_key(
+                                    &qualified_identity.identity,
+                                    asset_lock_proof,
+                                    asset_lock_proof_private_key.inner.as_ref(),
+                                    0,
+                                    self.platform_version(),
+                                    None,
+                                )
+                            {
                                 tracing::debug!(
                                     "Top-up retry failed; reconstructed transition: {:?}",
                                     transition

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -490,6 +490,9 @@ impl AppContext {
                 .map_err(|e| TaskError::from(SdkError::Protocol(e)))?;
 
                 let queued_document_query = DocumentQuery {
+                    select: Default::default(),
+                    group_by: vec![],
+                    having: vec![],
                     data_contract: Arc::new(withdrawal_contract),
                     document_type_name: "withdrawal".to_string(),
                     where_clauses: vec![],
@@ -535,6 +538,9 @@ impl AppContext {
                 .map_err(|e| TaskError::from(SdkError::Protocol(e)))?;
 
                 let completed_document_query = DocumentQuery {
+                    select: Default::default(),
+                    group_by: vec![],
+                    having: vec![],
                     data_contract: Arc::new(withdrawal_contract),
                     document_type_name: "withdrawal".to_string(),
                     where_clauses: vec![WhereClause {

--- a/src/backend_task/shielded/bundle.rs
+++ b/src/backend_task/shielded/bundle.rs
@@ -114,23 +114,59 @@ pub async fn build_shield_credit(
     let fee_strategy: AddressFundsFeeStrategy =
         vec![AddressFundsFeeStrategyStep::DeductFromInput(0)];
 
-    // Clone the wallet so the signer is owned across the async build (the
-    // std RwLock guard is not held across an await point).
+    // Clone the wallet so the signer is owned by the offloaded build.
     let wallet = { wallet_arc.read()?.clone() };
+    let platform_version = sdk.version();
     // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
-    build_shield_transition(
-        &recipient_addr,
+    build_shield_transition_offloaded(
+        recipient_addr,
         amount,
         inputs,
         fee_strategy,
-        &wallet,
-        0,
-        &prover,
-        [0u8; 36],
-        sdk.version(),
+        wallet,
+        prover,
+        platform_version,
     )
     .await
-    .map_err(|e| shielded_build_error(e.to_string()))
+}
+
+/// Run the (CPU-heavy, Halo2-proving) shield build on the blocking pool.
+///
+/// `build_shield_transition` is async but its proving step runs synchronously
+/// inline before the first await, so awaiting it directly would block a tokio
+/// worker for seconds. We drive the whole future on a `spawn_blocking` thread
+/// (where `block_on` is permitted) so the proof generation stays off the async
+/// worker pool.
+async fn build_shield_transition_offloaded(
+    recipient_addr: OrchardAddress,
+    amount: u64,
+    inputs: BTreeMap<PlatformAddress, (u32, u64)>,
+    fee_strategy: AddressFundsFeeStrategy,
+    wallet: crate::model::wallet::Wallet,
+    prover: CachedProver,
+    platform_version: &'static PlatformVersion,
+) -> Result<dash_sdk::dpp::state_transition::StateTransition, TaskError> {
+    let handle = tokio::runtime::Handle::current();
+    tokio::task::spawn_blocking(move || {
+        handle.block_on(async {
+            // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
+            build_shield_transition(
+                &recipient_addr,
+                amount,
+                inputs,
+                fee_strategy,
+                &wallet,
+                0,
+                &prover,
+                [0u8; 36],
+                platform_version,
+            )
+            .await
+            .map_err(|e| shielded_build_error(e.to_string()))
+        })
+    })
+    .await
+    .map_err(|e| shielded_build_error(format!("shield proof task panicked: {e}")))?
 }
 
 /// Build and broadcast a Shield transition (transparent -> shielded pool).
@@ -198,23 +234,19 @@ pub async fn shield_credits(
     }
 
     let state_transition = {
-        // Clone the wallet so the signer is owned across the async build (the
-        // std RwLock guard is not held across an await point).
+        // Clone the wallet so the signer is owned by the offloaded build.
         let wallet = { wallet_arc.read()?.clone() };
-        // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
-        build_shield_transition(
-            &recipient_addr,
+        let platform_version = sdk.version();
+        build_shield_transition_offloaded(
+            recipient_addr,
             amount,
             inputs,
             fee_strategy,
-            &wallet,
-            0,
-            &prover,
-            [0u8; 36],
-            sdk.version(),
+            wallet,
+            prover,
+            platform_version,
         )
-        .await
-        .map_err(|e| shielded_build_error(e.to_string()))?
+        .await?
     };
 
     if let Some(s) = &stage {

--- a/src/backend_task/shielded/bundle.rs
+++ b/src/backend_task/shielded/bundle.rs
@@ -21,7 +21,7 @@ use dash_sdk::grovedb_commitment_tree::{
 };
 use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 
 /// Wrapper around a cached `ProvingKey` that implements `OrchardProver`.
 struct CachedProver {
@@ -114,8 +114,6 @@ pub async fn build_shield_credit(
     let fee_strategy: AddressFundsFeeStrategy =
         vec![AddressFundsFeeStrategyStep::DeductFromInput(0)];
 
-    // Clone the wallet so the signer is owned by the offloaded build.
-    let wallet = { wallet_arc.read()?.clone() };
     let platform_version = sdk.version();
     // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
     build_shield_transition_offloaded(
@@ -123,7 +121,7 @@ pub async fn build_shield_credit(
         amount,
         inputs,
         fee_strategy,
-        wallet,
+        wallet_arc,
         prover,
         platform_version,
     )
@@ -136,18 +134,23 @@ pub async fn build_shield_credit(
 /// inline before the first await, so awaiting it directly would block a tokio
 /// worker for seconds. We drive the whole future on a `spawn_blocking` thread
 /// (where `block_on` is permitted) so the proof generation stays off the async
-/// worker pool.
+/// worker pool. The wallet read guard is taken inside that dedicated thread and
+/// never crosses a thread boundary, so we pass the cheap `Arc` rather than
+/// deep-cloning the wallet (and its seed material).
 async fn build_shield_transition_offloaded(
     recipient_addr: OrchardAddress,
     amount: u64,
     inputs: BTreeMap<PlatformAddress, (u32, u64)>,
     fee_strategy: AddressFundsFeeStrategy,
-    wallet: crate::model::wallet::Wallet,
+    wallet_arc: Arc<RwLock<crate::model::wallet::Wallet>>,
     prover: CachedProver,
     platform_version: &'static PlatformVersion,
 ) -> Result<dash_sdk::dpp::state_transition::StateTransition, TaskError> {
     let handle = tokio::runtime::Handle::current();
     tokio::task::spawn_blocking(move || {
+        let wallet = wallet_arc
+            .read()
+            .map_err(|_| shielded_build_error("wallet lock poisoned".to_string()))?;
         handle.block_on(async {
             // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
             build_shield_transition(
@@ -155,7 +158,7 @@ async fn build_shield_transition_offloaded(
                 amount,
                 inputs,
                 fee_strategy,
-                &wallet,
+                &*wallet,
                 0,
                 &prover,
                 [0u8; 36],
@@ -166,7 +169,13 @@ async fn build_shield_transition_offloaded(
         })
     })
     .await
-    .map_err(|e| shielded_build_error(format!("shield proof task panicked: {e}")))?
+    .map_err(|e| {
+        if e.is_cancelled() {
+            shielded_build_error("shield proof task was cancelled".to_string())
+        } else {
+            shielded_build_error(format!("shield proof task panicked: {e}"))
+        }
+    })?
 }
 
 /// Build and broadcast a Shield transition (transparent -> shielded pool).
@@ -234,15 +243,13 @@ pub async fn shield_credits(
     }
 
     let state_transition = {
-        // Clone the wallet so the signer is owned by the offloaded build.
-        let wallet = { wallet_arc.read()?.clone() };
         let platform_version = sdk.version();
         build_shield_transition_offloaded(
             recipient_addr,
             amount,
             inputs,
             fee_strategy,
-            wallet,
+            wallet_arc,
             prover,
             platform_version,
         )

--- a/src/backend_task/shielded/bundle.rs
+++ b/src/backend_task/shielded/bundle.rs
@@ -85,7 +85,7 @@ impl ShieldStage {
 /// Build a Shield transition without broadcasting (for batch parallel mode).
 ///
 /// Returns the built `StateTransition` so the caller can broadcast in nonce order.
-pub fn build_shield_credit(
+pub async fn build_shield_credit(
     app_context: &Arc<AppContext>,
     seed_hash: &WalletSeedHash,
     recipient_payment_address: &PaymentAddress,
@@ -114,19 +114,22 @@ pub fn build_shield_credit(
     let fee_strategy: AddressFundsFeeStrategy =
         vec![AddressFundsFeeStrategyStep::DeductFromInput(0)];
 
-    let wallet = wallet_arc.read()?;
+    // Clone the wallet so the signer is owned across the async build (the
+    // std RwLock guard is not held across an await point).
+    let wallet = { wallet_arc.read()?.clone() };
     // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
     build_shield_transition(
         &recipient_addr,
         amount,
         inputs,
         fee_strategy,
-        &*wallet,
+        &wallet,
         0,
         &prover,
         [0u8; 36],
         sdk.version(),
     )
+    .await
     .map_err(|e| shielded_build_error(e.to_string()))
 }
 
@@ -195,19 +198,22 @@ pub async fn shield_credits(
     }
 
     let state_transition = {
-        let wallet = wallet_arc.read()?;
+        // Clone the wallet so the signer is owned across the async build (the
+        // std RwLock guard is not held across an await point).
+        let wallet = { wallet_arc.read()?.clone() };
         // memo: 36-byte structured memo (4-byte type tag + 32-byte payload); all zeros = empty memo
         build_shield_transition(
             &recipient_addr,
             amount,
             inputs,
             fee_strategy,
-            &*wallet,
+            &wallet,
             0,
             &prover,
             [0u8; 36],
             sdk.version(),
         )
+        .await
         .map_err(|e| shielded_build_error(e.to_string()))?
     };
 

--- a/src/backend_task/update_data_contract.rs
+++ b/src/backend_task/update_data_contract.rs
@@ -104,6 +104,7 @@ impl AppContext {
                     allow_signing_with_any_purpose: false,
                 },
             )
+            .await
             .map_err(|e| TaskError::from(dash_sdk::Error::Protocol(e)))?;
 
         match state_transition.broadcast_and_wait(sdk, None).await {

--- a/src/backend_task/wallet/fetch_platform_address_balances.rs
+++ b/src/backend_task/wallet/fetch_platform_address_balances.rs
@@ -9,6 +9,7 @@ use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
 use dash_sdk::platform::address_sync::AddressSyncConfig;
+use dash_sdk::platform::address_sync::AddressIndex;
 use dash_sdk::platform::address_sync::AddressSyncResult;
 use std::sync::Arc;
 
@@ -82,17 +83,18 @@ impl AppContext {
                 tracing::debug!(
                     "Platform address balance tree is empty. Returning empty sync result."
                 );
-                AddressSyncResult::default()
+                AddressSyncResult::<AddressIndex, PlatformAddress>::default()
             }
             Err(e) => return Err(crate::backend_task::error::TaskError::from(e)),
         };
 
+        let highest_found_index = result.found.keys().map(|(tag, _)| *tag).max();
         tracing::info!(
             "Sync complete: duration={:?}, found={}, absent={}, highest_index={:?}, checkpoint={}, new_sync_height={}, new_sync_timestamp={}",
             start_time.elapsed(),
             result.found.len(),
             result.absent.len(),
-            result.highest_found_index,
+            highest_found_index,
             result.checkpoint_height,
             result.new_sync_height,
             result.new_sync_timestamp,

--- a/src/backend_task/wallet/fetch_platform_address_balances.rs
+++ b/src/backend_task/wallet/fetch_platform_address_balances.rs
@@ -8,8 +8,8 @@ use dash_sdk::RequestSettings;
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::key_wallet::bip32::DerivationPath;
-use dash_sdk::platform::address_sync::AddressSyncConfig;
 use dash_sdk::platform::address_sync::AddressIndex;
+use dash_sdk::platform::address_sync::AddressSyncConfig;
 use dash_sdk::platform::address_sync::AddressSyncResult;
 use std::sync::Arc;
 

--- a/src/context/wallet_lifecycle.rs
+++ b/src/context/wallet_lifecycle.rs
@@ -509,13 +509,13 @@ impl AppContext {
 
         let mut inserted = 0u32;
         for account in collection.all_accounts() {
-            let account_type = account.account_type.to_account_type();
+            let account_type = account.managed_account_type().to_account_type();
             let Some((path_reference, path_type)) = Self::spv_account_metadata(&account_type)
             else {
                 continue;
             };
 
-            for address in account.account_type.all_addresses() {
+            for address in account.all_addresses() {
                 if let Some(info) = account.get_address_info(&address)
                     && let Ok(true) = self.register_spv_address(
                         wallet_arc,
@@ -852,7 +852,7 @@ impl AppContext {
                     let mut registered = false;
                     for acc in collection.all_accounts() {
                         if let Some(ai) = acc.get_address_info(&address) {
-                            let account_type = acc.account_type.to_account_type();
+                            let account_type = acc.managed_account_type().to_account_type();
                             let (path_reference, path_type) =
                                 Self::spv_account_metadata(&account_type).unwrap_or_else(|| {
                                     let default_ref = if ai.path.is_bip44(self.network) {

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -17,6 +17,7 @@ use dash_sdk::dpp::identity::KeyType::{BIP13_SCRIPT_HASH, ECDSA_HASH160};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::hash::IdentityPublicKeyHashMethodsV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::async_trait::async_trait;
 use dash_sdk::dpp::identity::signer::Signer;
 use dash_sdk::dpp::identity::{Identity, KeyID, KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::key_wallet::bip32::ChildNumber;
@@ -304,8 +305,9 @@ impl Display for QualifiedIdentity {
     }
 }
 
+#[async_trait]
 impl Signer<IdentityPublicKey> for QualifiedIdentity {
-    fn sign(
+    async fn sign(
         &self,
         identity_public_key: &IdentityPublicKey,
         data: &[u8],
@@ -481,7 +483,7 @@ impl Signer<IdentityPublicKey> for QualifiedIdentity {
         ))
     }
 
-    fn sign_create_witness(
+    async fn sign_create_witness(
         &self,
         identity_public_key: &IdentityPublicKey,
         data: &[u8],
@@ -490,7 +492,7 @@ impl Signer<IdentityPublicKey> for QualifiedIdentity {
 
         // First, sign the data to get the signature (compact recoverable signature)
         // The public key will be recovered from the signature during verification
-        let signature = self.sign(identity_public_key, data)?;
+        let signature = self.sign(identity_public_key, data).await?;
 
         // Create the appropriate AddressWitness based on the key type
         match identity_public_key.key_type() {

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -6,6 +6,7 @@ use crate::model::qualified_identity::qualified_identity_public_key::QualifiedId
 use crate::model::wallet::{Wallet, WalletSeedHash};
 use bincode::{Decode, Encode};
 use dash_sdk::dashcore_rpc::dashcore::{PubkeyHash, signer};
+use dash_sdk::dpp::async_trait::async_trait;
 use dash_sdk::dpp::bls_signatures::{Bls12381G2Impl, SignatureSchemes};
 use dash_sdk::dpp::dashcore::address::Payload;
 use dash_sdk::dpp::dashcore::hashes::Hash;
@@ -17,7 +18,6 @@ use dash_sdk::dpp::identity::KeyType::{BIP13_SCRIPT_HASH, ECDSA_HASH160};
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::hash::IdentityPublicKeyHashMethodsV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::async_trait::async_trait;
 use dash_sdk::dpp::identity::signer::Signer;
 use dash_sdk::dpp::identity::{Identity, KeyID, KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::key_wallet::bip32::ChildNumber;

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -2733,6 +2733,9 @@ impl AddressProvider for WalletAddressProvider {
         // Re-derive the PlatformAddress for each stored balance from the pending
         // map by index; entries whose index is no longer pending or whose core
         // address can't be re-encoded are skipped (they carry no usable key).
+        // Lossless for current usage: stored_balances is seeded from `pending`
+        // (with_stored_state) and `pending` is only ever inserted into, never
+        // pruned — so every stored index is present here.
         self.stored_balances
             .iter()
             .filter_map(|(index, _key, funds)| {

--- a/src/model/wallet/mod.rs
+++ b/src/model/wallet/mod.rs
@@ -17,7 +17,11 @@ use dash_sdk::dpp::key_wallet::bip32::{
 };
 use dash_sdk::dpp::key_wallet::psbt::serialize::Serialize;
 use dash_sdk::dpp::prelude::AddressNonce;
-use dash_sdk::platform::address_sync::{AddressFunds, AddressIndex, AddressKey, AddressProvider};
+use dash_sdk::platform::address_sync::{AddressFunds, AddressIndex, AddressProvider};
+
+/// Raw GroveDB address-funds key bytes (1-byte variant tag + 20-byte hash),
+/// as produced by `PlatformAddress::to_bytes()`.
+type AddressKey = Vec<u8>;
 
 use dash_sdk::dpp::dashcore::secp256k1::{Message, Secp256k1};
 use dash_sdk::dpp::dashcore::sighash::SighashCache;
@@ -2295,8 +2299,9 @@ impl Wallet {
 
 /// Signer implementation for Platform addresses
 /// Allows the wallet to sign transactions that spend from Platform addresses
+#[async_trait]
 impl Signer<PlatformAddress> for Wallet {
-    fn sign(
+    async fn sign(
         &self,
         platform_address: &PlatformAddress,
         data: &[u8],
@@ -2329,7 +2334,7 @@ impl Signer<PlatformAddress> for Wallet {
         Ok(BinaryData::new(signature.to_vec()))
     }
 
-    fn sign_create_witness(
+    async fn sign_create_witness(
         &self,
         platform_address: &PlatformAddress,
         data: &[u8],
@@ -2647,19 +2652,31 @@ impl WalletAddressProvider {
 
 #[async_trait]
 impl AddressProvider for WalletAddressProvider {
+    type Tag = AddressIndex;
+    type Address = PlatformAddress;
+
     fn gap_limit(&self) -> AddressIndex {
         self.gap_limit
     }
 
-    fn pending_addresses(&self) -> Vec<(AddressIndex, AddressKey)> {
+    fn pending_addresses(&self) -> impl Iterator<Item = (Self::Tag, Self::Address)> + '_ {
         self.pending
             .iter()
             .filter(|(index, _)| !self.resolved.contains(index))
-            .map(|(index, (key, _))| (*index, key.clone()))
-            .collect()
+            .filter_map(|(index, (_, core_address))| {
+                PlatformAddress::try_from(core_address.clone())
+                    .ok()
+                    .map(|pa| (*index, pa))
+            })
     }
 
-    async fn on_address_found(&mut self, index: AddressIndex, _key: &[u8], funds: AddressFunds) {
+    async fn on_address_found(
+        &mut self,
+        tag: Self::Tag,
+        _address: &Self::Address,
+        funds: AddressFunds,
+    ) {
+        let index = tag;
         self.resolved.insert(index);
 
         // Log what the SDK is returning
@@ -2700,8 +2717,8 @@ impl AddressProvider for WalletAddressProvider {
         }
     }
 
-    async fn on_address_absent(&mut self, index: AddressIndex, _key: &[u8]) {
-        self.resolved.insert(index);
+    async fn on_address_absent(&mut self, tag: Self::Tag, _address: &Self::Address) {
+        self.resolved.insert(tag);
     }
 
     fn has_pending(&self) -> bool {
@@ -2710,12 +2727,19 @@ impl AddressProvider for WalletAddressProvider {
             .any(|index| !self.resolved.contains(index))
     }
 
-    fn highest_found_index(&self) -> Option<AddressIndex> {
-        self.highest_found
-    }
-
-    fn current_balances(&self) -> Vec<(AddressIndex, AddressKey, AddressFunds)> {
-        self.stored_balances.clone()
+    fn current_balances(
+        &self,
+    ) -> impl Iterator<Item = (Self::Tag, Self::Address, AddressFunds)> + '_ {
+        // Re-derive the PlatformAddress for each stored balance from the pending
+        // map by index; entries whose index is no longer pending or whose core
+        // address can't be re-encoded are skipped (they carry no usable key).
+        self.stored_balances
+            .iter()
+            .filter_map(|(index, _key, funds)| {
+                let (_, core_address) = self.pending.get(index)?;
+                let pa = PlatformAddress::try_from(core_address.clone()).ok()?;
+                Some((*index, pa, *funds))
+            })
     }
 
     fn last_sync_height(&self) -> u64 {

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -15,6 +15,7 @@ use dash_sdk::dash_spv::types::ValidationMode;
 use dash_sdk::dash_spv::{ClientConfig, DashSpvClient, Hash, LLMQType, QuorumHash};
 use dash_sdk::dpp::dashcore::{Address, InstantLock, Network, Transaction, Txid};
 use dash_sdk::dpp::key_wallet::bip32::{DerivationPath, ExtendedPrivKey};
+use dash_sdk::dpp::key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 use dash_sdk::dpp::key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::{
     ManagedWalletInfo, transaction_building::AccountTypePreference,
@@ -129,12 +130,8 @@ pub struct SpvStatusSnapshot {
 }
 
 /// Type alias for the SPV client with our specific configuration
-type SpvClient = DashSpvClient<
-    WalletManager<ManagedWalletInfo>,
-    PeerNetworkManager,
-    DiskStorageManager,
-    SpvEventHandler,
->;
+type SpvClient =
+    DashSpvClient<WalletManager<ManagedWalletInfo>, PeerNetworkManager, DiskStorageManager>;
 
 /// EventHandler implementation that bridges dash-spv push events into
 /// SpvManager's shared state (progress, status, peer count, errors).
@@ -819,22 +816,28 @@ impl SpvManager {
             wallet_map.clear();
         }
 
-        // Reset the in-memory WalletManager's filter_committed_height so the next
-        // SPV session scans filters from genesis instead of the stale height from the
-        // previous run. We reset filter_committed_height (not synced_height) because at
-        // rust-dashcore 309fac8 these became independent fields — FiltersManager::new()
-        // reads filter_committed_height() for its "already synced" guard.
+        // Reset every wallet's synced height so the next SPV session scans
+        // filters from genesis instead of the stale height from the previous run.
+        //
+        // TODO(v3.1-bump): key-wallet 0.43 replaced the single global
+        // `filter_committed_height` with a per-wallet `synced_height`
+        // (update_wallet_synced_height / wallets_behind). We reset each wallet to
+        // 0 to preserve the prior "rescan from genesis on data clear" behaviour.
+        // Verify against SPV that filter coverage actually restarts from genesis
+        // after a clear (the old global field and the new per-wallet heights may
+        // gate FiltersManager differently).
         //
         // This must succeed before we wipe the on-disk data; otherwise the in-memory
         // height would stay stale while on-disk filters are gone, re-triggering the
         // skipped-rescan bug this clear is meant to prevent.
         {
             let mut wm = self.wallet.try_write().map_err(|e| {
-                format!(
-                    "Failed to reset WalletManager filter_committed_height during SPV data clear: {e}"
-                )
+                format!("Failed to reset wallet synced heights during SPV data clear: {e}")
             })?;
-            wm.update_filter_committed_height(0);
+            let wallet_ids: Vec<_> = wm.list_wallets().into_iter().copied().collect();
+            for wallet_id in wallet_ids {
+                wm.update_wallet_synced_height(&wallet_id, 0);
+            }
         }
 
         self.write_sync_progress(None).map_err(|e| e.to_string())?;
@@ -1007,17 +1010,8 @@ impl SpvManager {
 
         let mut wm = self.wallet.write().await;
 
-        let result = wm
-            .get_receive_address(
-                &wallet_id,
-                account_index,
-                AccountTypePreference::BIP44,
-                true,
-            )
-            .map_err(|e| format!("get_receive_address failed: {e}"))?;
-
-        let address = result
-            .address
+        let address = wm
+            .next_receive_address(&wallet_id, account_index, AccountTypePreference::BIP44, true)
             .ok_or_else(|| "Wallet manager did not return an address".to_string())?;
 
         let derivation_path = {
@@ -1177,8 +1171,11 @@ impl SpvManager {
         }
 
         let outcome = {
-            let run_cancel = CancellationToken::new();
-            let run_future = client.run(run_cancel.clone());
+            // key-wallet 0.43: `run()` no longer takes a cancellation token; it
+            // runs until `stop()` flips the client's internal running flag. Both
+            // `run` and `stop` take `&self`, so we can drive `stop()` concurrently
+            // while `run_future` borrows the same client.
+            let run_future = client.run();
             tokio::pin!(run_future);
 
             // stop_token is a child of global_cancel, so it fires on either
@@ -1186,7 +1183,11 @@ impl SpvManager {
             tokio::select! {
                 result = &mut run_future => Outcome::RunCompleted(result),
                 _ = stop_token.cancelled() => {
-                    run_cancel.cancel();
+                    if let Err(e) = client.stop().await {
+                        tracing::warn!("client.stop() during cancellation failed: {e}");
+                    }
+                    // Let run() observe the stop flag and unwind its monitors.
+                    let _ = (&mut run_future).await;
                     Outcome::Cancelled
                 },
             }
@@ -1434,7 +1435,7 @@ impl SpvManager {
             network_manager,
             storage_manager,
             Arc::clone(&self.wallet),
-            event_handler,
+            vec![event_handler as Arc<dyn EventHandler>],
         )
         .await
         .map_err(|e| format!("Failed to create SPV client: {e}"))

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1011,7 +1011,12 @@ impl SpvManager {
         let mut wm = self.wallet.write().await;
 
         let address = wm
-            .next_receive_address(&wallet_id, account_index, AccountTypePreference::BIP44, true)
+            .next_receive_address(
+                &wallet_id,
+                account_index,
+                AccountTypePreference::BIP44,
+                true,
+            )
             .ok_or_else(|| "Wallet manager did not return an address".to_string())?;
 
         let derivation_path = {

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -816,16 +816,17 @@ impl SpvManager {
             wallet_map.clear();
         }
 
-        // Reset every wallet's synced height so the next SPV session scans
-        // filters from genesis instead of the stale height from the previous run.
+        // Rewind every wallet's sync checkpoint to genesis so the next SPV
+        // session re-fetches filter coverage from height 0 instead of trusting
+        // the now-deleted on-disk filters.
         //
-        // TODO(v3.1-bump): key-wallet 0.43 replaced the single global
-        // `filter_committed_height` with a per-wallet `synced_height`
-        // (update_wallet_synced_height / wallets_behind). We reset each wallet to
-        // 0 to preserve the prior "rescan from genesis on data clear" behaviour.
-        // Verify against SPV that filter coverage actually restarts from genesis
-        // after a clear (the old global field and the new per-wallet heights may
-        // gate FiltersManager differently).
+        // key-wallet 0.43 replaced the single global `filter_committed_height`
+        // with a per-wallet `synced_height`, gated by `wallets_behind()` /
+        // `FiltersManager`. The trait setter `update_wallet_synced_height` is
+        // forward-only monotonic (a value below the current is silently ignored),
+        // so it cannot express a rewind. We therefore write the metadata fields
+        // directly — a deliberate downward reset, the per-wallet equivalent of
+        // the old unconditional `update_filter_committed_height(0)`.
         //
         // This must succeed before we wipe the on-disk data; otherwise the in-memory
         // height would stay stale while on-disk filters are gone, re-triggering the
@@ -836,7 +837,10 @@ impl SpvManager {
             })?;
             let wallet_ids: Vec<_> = wm.list_wallets().into_iter().copied().collect();
             for wallet_id in wallet_ids {
-                wm.update_wallet_synced_height(&wallet_id, 0);
+                if let Some(info) = wm.get_wallet_info_mut(&wallet_id) {
+                    info.metadata.synced_height = 0;
+                    info.metadata.last_processed_height = 0;
+                }
             }
         }
 

--- a/src/spv/manager.rs
+++ b/src/spv/manager.rs
@@ -1192,11 +1192,18 @@ impl SpvManager {
             tokio::select! {
                 result = &mut run_future => Outcome::RunCompleted(result),
                 _ = stop_token.cancelled() => {
-                    if let Err(e) = client.stop().await {
-                        tracing::warn!("client.stop() during cancellation failed: {e}");
+                    match client.stop().await {
+                        Ok(()) => {
+                            // Let run() observe the stop flag and unwind its monitors.
+                            let _ = (&mut run_future).await;
+                        }
+                        Err(e) => {
+                            // stop() may not have flipped the run flag; do NOT await
+                            // run_future (it could block forever). Drop it and treat
+                            // as a hard cancellation.
+                            tracing::warn!("client.stop() during cancellation failed: {e}");
+                        }
                     }
-                    // Let run() observe the stop flag and unwind its monitors.
-                    let _ = (&mut run_future).await;
                     Outcome::Cancelled
                 },
             }

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -656,7 +656,7 @@ async fn test_live_testnet_sync_and_shutdown() {
 /// Then the wallet's synced height is 0 AND `wallets_behind(tip)` reports it as needing
 /// filter coverage (i.e. a genesis rescan will actually run).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_clear_data_dir_resets_filter_committed_height() {
+async fn test_clear_data_dir_rewinds_wallet_synced_height() {
     let (manager, _tm, _tmp_dir) = create_test_manager();
 
     // Load a wallet so there is a per-wallet synced height to rewind.

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -641,25 +641,25 @@ async fn test_live_testnet_sync_and_shutdown() {
     let _ = task_manager.shutdown();
 }
 
-/// Regression test: clear_data_dir must reset filter_committed_height (not just synced_height).
+/// Regression test: clear_data_dir must rewind each wallet's sync checkpoint to genesis
+/// so the next SPV session re-fetches filter coverage from height 0.
 ///
-/// At rust-dashcore 309fac8, WalletManager gained an independent filter_committed_height
-/// field. FiltersManager::new() reads filter_committed_height() for its "already synced"
-/// guard — the field is no longer derived from synced_height. Calling update_synced_height(0)
-/// alone leaves filter_committed_height stale and causes the next SPV session to declare
-/// itself "already synced" and skip the rescan, producing zero balance after a Clear SPV Data.
+/// key-wallet 0.43 replaced the single global `filter_committed_height` with a per-wallet
+/// `synced_height`, gated by `wallets_behind()` / `FiltersManager`. The trait setter
+/// `update_wallet_synced_height` is forward-only monotonic, so it cannot express the
+/// downward reset a data-clear needs. If the rewind is a no-op, the next session sees the
+/// wallet as already synced, skips the genesis rescan, and the user gets a stale/zero
+/// balance after a Clear SPV Data.
 ///
-/// key-wallet 0.43 replaced the single global `filter_committed_height` with a
-/// per-wallet `synced_height`, so this now seeds and asserts the per-wallet height.
-///
-/// Given a loaded wallet with a non-zero synced height,
+/// Given a loaded wallet synced to a non-zero height,
 /// When clear_data_dir() is called,
-/// Then that wallet's synced height is reset to 0.
+/// Then the wallet's synced height is 0 AND `wallets_behind(tip)` reports it as needing
+/// filter coverage (i.e. a genesis rescan will actually run).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_clear_data_dir_resets_filter_committed_height() {
     let (manager, _tm, _tmp_dir) = create_test_manager();
 
-    // Load a wallet so there is a per-wallet synced height to reset.
+    // Load a wallet so there is a per-wallet synced height to rewind.
     let seed_hash = [7u8; 32];
     let seed_bytes = [9u8; 64];
     let wallet_id = manager
@@ -675,7 +675,8 @@ async fn test_clear_data_dir_resets_filter_committed_height() {
         wm.update_wallet_synced_height(&wallet_id, PRESEED_HEIGHT);
     }
 
-    // Verify pre-condition.
+    // Verify pre-condition. `wallets_behind` is strict-less-than, so a wallet synced
+    // exactly to PRESEED_HEIGHT is NOT reported behind PRESEED_HEIGHT.
     {
         let wm = wallet_arc.read().await;
         assert_eq!(
@@ -683,17 +684,25 @@ async fn test_clear_data_dir_resets_filter_committed_height() {
             PRESEED_HEIGHT,
             "pre-condition: wallet synced height should be PRESEED_HEIGHT"
         );
+        assert!(
+            !wm.wallets_behind(PRESEED_HEIGHT).contains(&wallet_id),
+            "pre-condition: a fully-synced wallet is not behind its own synced height"
+        );
     }
 
     manager
         .clear_data_dir()
         .expect("clear_data_dir should succeed");
 
-    // After clearing, the wallet's synced height must be 0.
+    // After clearing, the wallet must be rewound to genesis and flagged for rescan.
     let wm = wallet_arc.read().await;
     assert_eq!(
         wm.wallet_synced_height(&wallet_id),
         0,
-        "clear_data_dir must reset the wallet synced height to 0"
+        "clear_data_dir must rewind the wallet synced height to 0"
+    );
+    assert!(
+        wm.wallets_behind(PRESEED_HEIGHT).contains(&wallet_id),
+        "clear_data_dir must leave the wallet behind so a genesis rescan runs"
     );
 }

--- a/src/spv/tests.rs
+++ b/src/spv/tests.rs
@@ -649,28 +649,39 @@ async fn test_live_testnet_sync_and_shutdown() {
 /// alone leaves filter_committed_height stale and causes the next SPV session to declare
 /// itself "already synced" and skip the rescan, producing zero balance after a Clear SPV Data.
 ///
-/// Given a manager with a non-zero filter_committed_height,
+/// key-wallet 0.43 replaced the single global `filter_committed_height` with a
+/// per-wallet `synced_height`, so this now seeds and asserts the per-wallet height.
+///
+/// Given a loaded wallet with a non-zero synced height,
 /// When clear_data_dir() is called,
-/// Then filter_committed_height is reset to 0.
+/// Then that wallet's synced height is reset to 0.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_clear_data_dir_resets_filter_committed_height() {
     let (manager, _tm, _tmp_dir) = create_test_manager();
 
-    // Pre-seed a non-zero filter_committed_height to simulate a previous session.
+    // Load a wallet so there is a per-wallet synced height to reset.
+    let seed_hash = [7u8; 32];
+    let seed_bytes = [9u8; 64];
+    let wallet_id = manager
+        .load_wallet_from_seed(seed_hash, seed_bytes)
+        .await
+        .expect("load_wallet_from_seed should succeed");
+
+    // Pre-seed a non-zero synced height to simulate a previous session.
     const PRESEED_HEIGHT: u32 = 5_000;
     let wallet_arc = manager.wallet();
     {
         let mut wm = wallet_arc.write().await;
-        wm.update_filter_committed_height(PRESEED_HEIGHT);
+        wm.update_wallet_synced_height(&wallet_id, PRESEED_HEIGHT);
     }
 
     // Verify pre-condition.
     {
         let wm = wallet_arc.read().await;
         assert_eq!(
-            wm.filter_committed_height(),
+            wm.wallet_synced_height(&wallet_id),
             PRESEED_HEIGHT,
-            "pre-condition: filter_committed_height should be PRESEED_HEIGHT"
+            "pre-condition: wallet synced height should be PRESEED_HEIGHT"
         );
     }
 
@@ -678,11 +689,11 @@ async fn test_clear_data_dir_resets_filter_committed_height() {
         .clear_data_dir()
         .expect("clear_data_dir should succeed");
 
-    // After clearing, filter_committed_height must be 0.
+    // After clearing, the wallet's synced height must be 0.
     let wm = wallet_arc.read().await;
     assert_eq!(
-        wm.filter_committed_height(),
+        wm.wallet_synced_height(&wallet_id),
         0,
-        "clear_data_dir must reset filter_committed_height to 0"
+        "clear_data_dir must reset the wallet synced height to 0"
     );
 }

--- a/src/ui/tokens/view_token_claims_screen.rs
+++ b/src/ui/tokens/view_token_claims_screen.rs
@@ -41,6 +41,9 @@ impl ViewTokenClaimsScreen {
         Self {
             identity_token_basic_info: identity_token_basic_info.clone(),
             new_claims_query: DocumentQuery {
+                select: Default::default(),
+                group_by: vec![],
+                having: vec![],
                 data_contract: app_context.token_history_contract.clone(),
                 document_type_name: "claim".to_string(),
                 where_clauses: vec![

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -325,13 +325,10 @@ impl ShieldScreen {
                             *guard = ShieldStage::BuildingProof { nonce };
                         }
 
-                        // TODO(v3.1-bump): build_shield_credit is now async (the
-                        // upstream shield builder routes signing through an async
-                        // Signer), so it can no longer run inside spawn_blocking.
-                        // The Halo2 proof generation now executes on the async
-                        // worker rather than the blocking pool. If this proves to
-                        // starve the runtime, wrap the CPU-bound proof step alone
-                        // in spawn_blocking inside the builder.
+                        // build_shield_credit is async (the upstream shield builder
+                        // routes signing through an async Signer) but offloads its
+                        // Halo2 proving onto the blocking pool internally, so awaiting
+                        // it here does not block a tokio worker.
                         let result = bundle::build_shield_credit(
                             &app_ctx,
                             &seed_hash,

--- a/src/ui/wallets/shield_screen.rs
+++ b/src/ui/wallets/shield_screen.rs
@@ -325,19 +325,23 @@ impl ShieldScreen {
                             *guard = ShieldStage::BuildingProof { nonce };
                         }
 
-                        let result = tokio::task::spawn_blocking(move || {
-                            bundle::build_shield_credit(
-                                &app_ctx,
-                                &seed_hash,
-                                &default_address,
-                                amount,
-                                addr,
-                                nonce,
-                            )
-                        })
+                        // TODO(v3.1-bump): build_shield_credit is now async (the
+                        // upstream shield builder routes signing through an async
+                        // Signer), so it can no longer run inside spawn_blocking.
+                        // The Halo2 proof generation now executes on the async
+                        // worker rather than the blocking pool. If this proves to
+                        // starve the runtime, wrap the CPU-bound proof step alone
+                        // in spawn_blocking inside the builder.
+                        let result = bundle::build_shield_credit(
+                            &app_ctx,
+                            &seed_hash,
+                            &default_address,
+                            amount,
+                            addr,
+                            nonce,
+                        )
                         .await
-                        .map_err(|e| e.to_string())
-                        .and_then(|r| r.map_err(|e| e.to_string()));
+                        .map_err(|e| e.to_string());
 
                         match &result {
                             Ok(_) => {

--- a/tests/backend-e2e/z_broadcast_st_tasks.rs
+++ b/tests/backend-e2e/z_broadcast_st_tasks.rs
@@ -111,6 +111,7 @@ async fn step_broadcast_valid(
         platform_version,
         None,
     )
+    .await
     .expect("failed to build IdentityUpdateTransition");
 
     tracing::info!("state transition built and signed, broadcasting...");
@@ -246,6 +247,7 @@ async fn step_broadcast_invalid(
         platform_version,
         None,
     )
+    .await
     .expect("failed to build (invalid-nonce) IdentityUpdateTransition");
 
     tracing::info!("broadcasting invalid state transition (nonce=u64::MAX)...");


### PR DESCRIPTION
## Summary

Bumps `dash-sdk` and `rs-sdk-trusted-context-provider` from platform pin `54048b9352` to **`v3.1-dev` HEAD `9e00c8b894`** (v3.1.0-dev.8).

This is a prerequisite step ahead of the v0.10-alpha release. It is an **L-sized, semantic** migration (537 commits / 300 files upstream), dominated by an async `Signer<K>` rework, the reworked identity state-transition API, and a rust-dashcore/key-wallet `0.42 → 0.43` sideways move — **not** a mechanical version bump.

## What changed (27 files, +414 / −439)

| Theme | Kind | Notes |
|---|---|---|
| **A** `DocumentQuery` gained `select` / `group_by` / `having` | mechanical | 15 sites |
| **B** `Signer` is now `async` + generic `Signer<K>` with `sign_create_witness` | semantic | both DET impls → `#[async_trait]` + `async fn`; every `.sign()` caller now `.await` |
| **C** Identity ST API renames | semantic | `top_up_identity_with_private_key`, `put_to_platform_and_wait_for_response_with_private_key`, `try_from_identity_with_private_key`, `try_from_identity_with_signer_and_private_key` (async), `sign_external_with_options` (async) |
| **D** `TransactionBuilder` reshaped | semantic | `set_selection_strategy` / `set_current_height` / `add_inputs` + `build_unsigned()`; removed old string-classification |
| **E** `ManagedAccount*` / `WalletManager` | semantic | `managed_account_type()`, `next_change_address`, `next_receive_address`, `ManagedAccountTrait` import |
| **F** `AddressProvider` associated types | semantic | `Tag = AddressIndex`, `Address = PlatformAddress`; iterator returns + callbacks reshaped |
| **G** `WalletManager` per-wallet `synced_height`, `DashSpvClient<W,N,S>` 3 params, `run()`/`stop()` lifecycle | semantic | — |

## Verification

- ✅ `cargo build --all-features`
- ✅ `cargo clippy --all-features --all-targets -- -D warnings` (lib + bins + kittest + e2e + backend-e2e)
- ✅ `cargo +nightly fmt --all`
- ⚠️ Network/`#[ignore]` test suites **not** executed — see pre-merge gates below.

## ⚠️ Behavioural risk — the dashcore move is *sideways*, not forward

The dashcore bump is a divergent move (~90 commits theirs we lacked; 1 squashed commit ours they lack), so **compile-clean ≠ behaviour-equal**. The compiler cannot catch regressions in these areas — they require a runtime smoke test:

- SPV filter-height gating / rescan-from-genesis trigger
- Coin selection, fee, and change-output parity
- Address derivation
- Orchard `0.12 → 0.13` shielded path
- SPV client cancellation/lifecycle

### Behaviour-ambiguous sites flagged for audit (`TODO(v3.1-bump)`)

1. `src/spv/manager.rs:822` — global filter-height → per-wallet `synced_height` reset on data clear; verify rescan-from-genesis still fires.
2. `src/ui/wallets/shield_screen.rs:328` — Halo2 proof gen moved off `spawn_blocking` onto the async worker (builder is now async); watch for runtime starvation.
3. `backend_task/core/mod.rs` — change-address: index-peek → `next_change_address(…, add_to_state=false)`.
4. `model/wallet/mod.rs` `current_balances` — now skips stored balances whose index left the pending window.

## Pre-merge gates

- [ ] QA audit of the 4 behaviour-ambiguous sites + dashcore regression surface (Marvin, in progress)
- [ ] Regtest/testnet smoke run: wallet sync, send, identity top-up, shielded path
- [ ] **Release-gate note:** platform PR [#3625](https://github.com/dashpay/platform/pull/3625) (the SQLite `platform-wallet-storage` persister crate) is **still open** against `v3.1-dev`. This bump is *necessary-but-not-sufficient* if the upcoming architecture work (PR #860) requires that crate specifically. This PR does **not** unblock #860 on its own.

<sub>Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing async/await operations in identity creation, updates, and contract state transitions
  * Improved wallet address synchronization and per-wallet sync height tracking behavior
  * Enhanced document query field initialization for consistent data retrieval across operations
  * Corrected SPV wallet address derivation metadata and synchronization workflow

* **Chores**
  * Updated dash-sdk and trusted-context-provider dependencies to latest platform commit

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/dash-evo-tool/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->