### PR TITLE
feat(identity): operate-as screens obey the app-scoped selected identity (W2–W5)

### DIFF
--- a/docs/ai-design/2026-06-30-app-scoped-selection-migration/01-migration-plan.md
+++ b/docs/ai-design/2026-06-30-app-scoped-selection-migration/01-migration-plan.md
@@ -1,0 +1,332 @@
+# App-scoped selected-identity screen migration (W2–W5)
+
+Status: PLAN — implementation contract for Bilby. Author: Nagatha.
+Tracking: #842 (app-scoped selected identity). Builds on IDH-003 W0/W1
+(merged at `cc2d84c9`).
+
+## 1. Context & goal
+
+The hub breadcrumb switcher (W1) made one identity the app-scoped "who am I
+operating as" choice, persisted per network and held in `AppContext`. Every
+operate-as screen, however, still picks its identity in isolation: it defaults
+to `identities.first()`, to `None`, or to its own `identities[0]` re-default,
+and never reads or writes the app-scoped selection. The goal of W2–W5 is to make
+every operate-as screen obey the app-scoped selected identity on entry, and —
+where the screen *changes who you are* — write the user's choice back so the
+breadcrumb and every other surface stay in agreement. Recipient, target, and
+group-member pickers must remain untouched: they name a different party, not you.
+
+## 2. W0/W1 foundation (verified signatures — `cc2d84c9`)
+
+`AppContext` (`src/context/mod.rs`):
+
+```rust
+// fields (mod.rs:123,127)
+pub(crate) selected_identity_id: Mutex<Option<Identifier>>,
+pub(crate) pending_identity_selection: Mutex<Option<Identifier>>,
+
+// reads
+pub fn selected_identity_id(&self) -> Option<Identifier>            // :1027
+pub fn selected_wallet_hash(&self) -> Option<WalletSeedHash>        // :1022
+pub fn resolve_selected_identity(&self) -> Option<QualifiedIdentity> // :1033
+
+// writes (each writes both mutexes directly + persists both KV blobs once;
+// never calls a sibling setter — no reconciliation recursion)
+pub fn set_selected_identity(&self, id: Option<Identifier>)         // :1062
+pub fn set_selected_hd_wallet(&self, hash: Option<WalletSeedHash>)  // :1090
+pub fn set_selected_single_key_wallet(&self, hash: Option<SingleKeyHash>) // :1114
+pub fn set_pending_identity_selection(&self, id: Identifier)        // :1124
+pub fn take_pending_identity_selection(&self) -> Option<Identifier> // :1131
+pub fn persist_selected_identity_kv(&self, id: Option<Identifier>)  // :1141
+fn restore_selected_identity_from_kv(&self)                         // :1160 (private; ensure_wallet_backend)
+```
+
+Pure decision helpers (`src/model/selected_identity.rs`), the single source of
+truth for precedence — no IO:
+
+```rust
+pub fn keep_if_loaded(selected: Option<Identifier>, loaded: &[Identifier]) -> Option<Identifier> // :37
+pub fn resolve_selected(selected: Option<Identifier>, loaded: &[Identifier]) -> Option<Identifier> // :47
+// resolve_selected = keep-if-loaded → else first loaded → else None
+```
+
+`IdentitySelector` (`src/ui/components/identity_selector.rs`) — the primary
+migration vehicle. Two opt-in builder methods; default behaviour (neither
+called) is byte-identical to pre-W0 (regression-locked by the two tests at
+:347 and :360):
+
+```rust
+pub fn with_app_default(self, app_context: &'a Arc<AppContext>) -> Self // :112  READ: seed empty buffer from selected_identity_id(), only if that id is one of this selector's options
+pub fn syncing_global(self, app_context: Arc<AppContext>) -> Self        // :120  SYNC: write the chosen id back via set_selected_identity on a real user change
+```
+
+Mechanism facts that constrain the plan (read from the widget body):
+- `app_default_seed()` (:192) seeds **only when the buffer is empty** and the
+  app-scoped id is in `self.identities`. So `with_app_default` is a **no-op on a
+  screen that already pre-fills `identity_str` in `new()`** — such screens must
+  instead seed their `new()`/refresh from `resolve_selected_identity()`.
+- The seed path (`ui()` :235) sets the buffer + calls `on_change()` but does
+  **not** mark the response changed and does **not** call `sync_to_global()`.
+  Seeding therefore never writes back; only a genuine combo/text change does
+  (:321 → `sync_to_global()` :205). This is why `with_app_default` + screen
+  pre-fill conflict, and why SYNC is safe (entry never clobbers the global).
+- `sync_to_global()` resolves the id from the buffer and calls
+  `set_selected_identity(Some(id))`. `set_selected_identity` reconciles the
+  derived wallet to the identity's owner (clears to `None` for a wallet-less
+  identity) — keystone #1.
+
+## 3. Keystone rules (decided — do not relitigate)
+
+- **K1 — wallet follows identity.** No operate-as screen reads
+  `selected_wallet_hash` for signing; the signing wallet is derived from the
+  identity (`crate::ui::identities::get_selected_wallet`). Wallet selection is
+  display-only. `set_selected_identity` reconciles the derived wallet.
+- **K2 — `dashpay_wallet_seed_hash()` is a trap.** It returns
+  `associated_wallets.keys().next()` (lowest hash of *all* cloned wallets, not
+  the owner). Never use it to derive the owning wallet. Wallet-scoped identity
+  lists use `load_local_qualified_identities_for_wallet`.
+- **K3 — GroupActions is session-local.** It picks one identity per session
+  (multi-signer ambiguity); it must neither read from nor write to the
+  app-scoped selection.
+
+## 4. Classification rubric
+
+| Category | Reads global on entry? | Writes global on user change? | When |
+|---|---|---|---|
+| **SYNC-on-change** | yes (seed) | yes | The screen performs a state-changing action **as** the selected identity, and that identity is the screen's sole operating identity. Changing it = changing who you are. |
+| **READ-migrate (READ-only)** | yes (seed, guarded) | no | The identity is "which of mine" but the screen is wallet-primary or its candidate set is filtered, so silently re-pointing the global on a transient pick would be wrong. Seed for continuity; do not write back. |
+| **SESSION-LOCAL** | no | no | Deliberately independent (group_actions — K3). |
+| **N/A** | no | no | No operate-as identity input: the picker names a **recipient / target / group member** (a different party), or the operating identity is **inherited from the launcher**, or there is no identity input. |
+
+### 4a. The SYNC vs READ-only decision rule (the crux)
+
+> A selector **SYNCs** iff it answers "**who am I operating as**" for an action
+> the screen signs/creates/sends on that identity's behalf, and that identity is
+> the only operating identity on the screen. A selector is **N/A** iff it names
+> a party that is **not you** — a recipient you send to, a target you act on
+> (freeze/unfreeze/destroy), or a control-group member. A selector is
+> **READ-only** iff it is "which of mine" but the screen is **wallet-primary**
+> (the candidate list is one wallet's identities, possibly not the global
+> wallet) or the candidate list is **capability-filtered** (e.g. EdDSA-only),
+> so writing the global from a transient pick would mis-point the app.
+
+This rule is self-validating against the W1 mechanism: the regression test
+`default_selector_has_no_sync_target` (identity_selector.rs:360) is annotated
+"the 9 no-sync sites stay inert". Applying the rule yields exactly **9 no-sync
+`IdentitySelector` sites** (7 recipient/target/member + create_asset_lock
+top-up READ-only + group_actions session-local) and **12 sync sites** — a clean
+21-site partition. The hazard the test guards is real: a `syncing_global`
+mistakenly added to a *target* picker (e.g. freeze) would, on selecting another
+person's identity, hijack the global active identity **and** reconcile the
+wallet to an identity you do not own (clearing it to `None`, K1).
+
+## 5. Authoritative per-screen table
+
+Operating identity = the identity that signs. "Picker" = the visible identity
+input. `il` = `IdentitySelector`; `cb` = bespoke `ComboBox`; `—` = none.
+
+### SYNC-on-change (12)
+
+| # | File | Picker (line) | Current default | Picker is | Mechanism |
+|---|---|---|---|---|---|
+| 1 | `src/ui/contracts_documents/register_contract_screen.rs` | il :427 (`other_option(false)`) | `qualified_identities.first()` in `new()` :66 | operating | Seed `new()` from `resolve_selected_identity()` (fallback first); add `.syncing_global(self.app_context.clone())`. Keep the `response.changed()` key/wallet derivation (:440). |
+| 2 | `src/ui/contracts_documents/update_contract_screen.rs` | il :446 | `first()` in `new()` :72 | operating | Same as #1. |
+| 3 | `src/ui/contracts_documents/document_action_screen.rs` | il :266 | `None` (`selected_identity`) | operating | Seed `new()`/`render_*` from `resolve_selected_identity()`; add `.syncing_global(ctx)`. Keep `response.changed()` block (:279). |
+| 4 | `src/ui/identities/register_dpns_name_screen.rs` | il :191 | `first()` in `new()` :77 | operating | Seed `new()` from `resolve_selected_identity()`; add `.syncing_global(ctx)`. Selector is gated `len>1` (:117) — single-identity case already correct. |
+| 5 | `src/ui/tokens/tokens_screen/token_creator.rs` | il :148 **and** `add_identity_key_chooser` :223 (advanced) | `TokenCreatorUI.selected_identity = None` (mod.rs :1595) | operating | Seed `selected_identity` from `resolve_selected_identity()` when `None`; add `.syncing_global(ctx)` to the il (:148); in the advanced-mode chooser, write back via `set_selected_identity` on change (helper has no opt-in). |
+| 6 | `src/ui/dashpay/add_contact_screen.rs` | il :257 (`.label("Identity:")`) | `None` :62 / :79 | operating (sender) | Seed in `new()`/`new_with_identity_id` from `resolve_selected_identity()`; add `.syncing_global(ctx)`. |
+| 7 | `src/ui/dashpay/contacts_list.rs` | il :325 | `identities[0]` in `new()` :103 **and** `ui()` re-default :199–206 | operating (your identity) | Replace **both** `identities[0]` defaults with `resolve_selected_identity().or(first)`; add `.syncing_global(ctx)`. |
+| 8 | `src/ui/dashpay/contact_requests.rs` | il :365 | `identities[0]` :101; `set_selected_identity()` :118 | operating (your identity) | Seed from `resolve_selected_identity()`; add `.syncing_global(ctx)`. Keep the change handler that clears lists + re-derives wallet (:376). |
+| 9 | `src/ui/dashpay/send_payment.rs` | il :564 (Payment History) | `selected_identity` field :462 | operating (your identity) | Seed from `resolve_selected_identity()`; add `.syncing_global(ctx)`. Keep `response.changed()` → `refresh()` (:575). |
+| 10 | `src/ui/dashpay/profile_screen.rs` | il :512 | `identities[0]` :152 + `ui()` re-default :240–245 | operating (edit your profile) | Replace both defaults with `resolve_selected_identity().or(first)`; add `.syncing_global(ctx)`. |
+| 11 | `src/ui/dashpay/qr_code_generator.rs` | il :187 | `identities[0]` :77 | operating (share your identity) | Seed from `resolve_selected_identity()`; add `.syncing_global(ctx)`. |
+| 12 | `src/ui/dashpay/qr_scanner.rs` | il :173 ("Select Your Identity" :164) | `identities[0]` :77 | operating (connect as you) | Seed from `resolve_selected_identity()`; add `.syncing_global(ctx)`. Keep the prev/new id diff at :168/:186. |
+
+### READ-migrate, READ-only (3)
+
+| # | File | Picker (line) | Current default | Mechanism | Why no sync |
+|---|---|---|---|---|---|
+| 13 | `src/ui/wallets/create_asset_lock_screen.rs` | il :398 ("Identity to top up") | `None` :94 | Add `.with_app_default(&self.app_context)` — it seeds **only if** the global id is one of this wallet's identities (the candidate list is wallet-scoped, :69). No `new()` pre-fill to change. | Wallet-primary: the screen is launched for a specific wallet that may not be the global wallet; topping up does not change who you operate as (K1 reconcile would mis-point). |
+| 14 | `src/ui/tools/grovestark_screen.rs` | cb (`selected_identity: Option<String>` :53, ComboBox; `refresh_identities` :154) | `None` :134 | Manual seed: in `new()`/`refresh_identities`, set `selected_identity` from `resolve_selected_identity()` **iff** it is in the EdDSA-filtered list (:160), else first filtered, else `None`. Store the id string. | Capability-filtered (EdDSA-only): the global identity may be absent from the list; a developer tool should not push an EdDSA-only id as the app-wide active identity. SYNC deferred. |
+| 15 | `src/ui/wallets/send_screen.rs` | cb `identity_source_selector` :1966 | `None` :424 | Manual seed: when the source list is built, default `selected_identity` from `resolve_selected_identity()` **iff** it is among this wallet's identities, else leave `None`. | Wallet-primary + transient funding source for one send; K1 reconcile of the global wallet would fight the screen's own wallet. |
+
+### SESSION-LOCAL (1)
+
+| # | File | Picker (line) | Mechanism |
+|---|---|---|---|
+| 16 | `src/ui/contracts_documents/group_actions_screen.rs` | il :541 | **Leave the default `IdentitySelector` untouched** (no `with_app_default`, no `syncing_global`). Keep the screen's own `selected_identity`. Add a one-line code comment citing K3, and a regression test asserting it neither seeds from nor writes the global. |
+
+### N/A — recipient / target / member / inherited / no input (≈13)
+
+| File | Picker (line) | Why N/A |
+|---|---|---|
+| `src/ui/tokens/mint_tokens_screen.rs` | il :238 `.label("Recipient:")` `.exclude(self)` :245 | Recipient. Operating identity is fixed `identity_token_info.identity` (row-clicked). |
+| `src/ui/tokens/transfer_tokens_screen.rs` | il :183 `.label("Recipient:")` `.exclude` :190 | Recipient. |
+| `src/ui/tokens/freeze_tokens_screen.rs` | il :214 "Freeze Identity ID:" | Target you act **on**. Operating identity = `identity_token_info.identity`. |
+| `src/ui/tokens/unfreeze_tokens_screen.rs` | il :218 "Identity ID to unfreeze:" | Target. |
+| `src/ui/tokens/destroy_frozen_funds_screen.rs` | il :225 "Frozen Identity ID:" | Target. |
+| `src/ui/tokens/tokens_screen/groups.rs` | il :206 `.exclude` :212 | Control-group member (defining who controls the contract). |
+| `src/ui/identities/transfer_screen.rs` | il :172 "Receiver Identity ID:" `.exclude(self)` :179 | Recipient. Operating identity `self.identity` is passed to `new()` :82 (inherited from launcher). |
+| `src/ui/identities/withdraw_screen.rs` | — | No picker. `self.identity` passed to `new()` :68 (inherited). |
+| `src/ui/wallets/unshield_credits_screen.rs` | — | Wallet-scoped (`new(seed_hash)` :51); no identity. |
+| `src/ui/tokens/tokens_screen/mod.rs` (main TokensScreen) | — | Lists balances across all identities; per-row actions carry their own `identity_token_info` (:1493). No single operating picker. |
+| `src/ui/identity/home.rs` (:274), `src/ui/identity/contacts.rs` (:166), `src/ui/identity/settings.rs` (:660) | — | **Already app-scoped** (W1): they read `resolve_selected_identity()` directly. No change. settings.rs already pulls `incoming = resolve_selected_identity()` each frame and syncs its field (:660–669). |
+
+Inherited-identity note: `transfer_screen` and `withdraw_screen` get their
+operating identity from the launch site (the hub Home tab, `home.rs:274`, which
+already uses `resolve_selected_identity()`), so they are transitively
+app-scoped without their own migration. Confirm launch sites still pass the
+active identity when wiring these.
+
+### Counts
+
+| Category | Count |
+|---|---|
+| SYNC-on-change | 12 |
+| READ-migrate (READ-only) | 3 |
+| SESSION-LOCAL | 1 |
+| N/A (incl. 3 already-app-scoped hub tabs) | ≈13 |
+| **Total identity-input sites enumerated** | **≈29** (21 `IdentitySelector` + 2 bespoke ComboBox + group/inherited/no-input) |
+
+`IdentitySelector` partition: 12 SYNC + 9 no-sync (7 N/A recipient/target/member
++ #13 READ-only + #16 session-local) = 21 — matches the "9 no-sync sites"
+regression-test invariant.
+
+## 6. Domain-batched dev plan
+
+Ordered mechanical (`IdentitySelector` + `.syncing_global`) first, bespoke last.
+Each batch is independently committable and independently testable.
+
+### Batch B1 — Contracts & Documents (3 SYNC)
+- Files: `register_contract_screen.rs`, `update_contract_screen.rs`,
+  `document_action_screen.rs`.
+- Change: seed `new()` (and any refresh re-default) from
+  `resolve_selected_identity()` (fallback `first()`); add
+  `.syncing_global(self.app_context.clone())` to each `IdentitySelector`; leave
+  the existing `response.changed()` key/wallet derivation intact.
+- Tests: extend existing patterns — add a kittest (DB-seeded multi-identity, à
+  la `identity_hub_switcher.rs`) asserting the contract screen defaults to the
+  app-scoped id and that a picker change calls `set_selected_identity`. No live
+  network.
+- Commit: `feat(contracts): obey app-scoped selected identity in register/update/document screens (W2)`
+
+### Batch B2 — DPNS / Identities (1 SYNC)
+- Files: `register_dpns_name_screen.rs`.
+- Change: seed `new()` from `resolve_selected_identity()`; add `.syncing_global`.
+- Tests: **extend** `tests/kittest/register_dpns_name_screen.rs` — assert the
+  default identity tracks the app-scoped selection (seed two identities, set the
+  selection to the second, expect it pre-selected).
+- Commit: `feat(identity): default DPNS registration to the app-scoped identity (W2)`
+
+### Batch B3 — DashPay (7 SYNC)
+- Files: `add_contact_screen.rs`, `contacts_list.rs`, `contact_requests.rs`,
+  `send_payment.rs`, `profile_screen.rs`, `qr_code_generator.rs`,
+  `qr_scanner.rs`.
+- Change: replace every `identities[0]` / `None` default (in both `new()` **and**
+  any `ui()`/refresh re-default — see contacts_list :199–206, profile_screen
+  :240–245) with `resolve_selected_identity().or(first)`; add `.syncing_global`.
+  Keep each screen's change handler (list-clear + wallet re-derive).
+- Tests: **extend** `tests/kittest/dashpay_screen.rs` (+ the
+  `identity_hub_contacts.rs` pattern). One representative seed-and-default
+  assertion per screen; one write-back assertion (change picker →
+  `resolve_selected_identity()` reflects it) on `contacts_list` as the canary.
+- Commit: `feat(dashpay): sync DashPay screens with the app-scoped selected identity (W3)`
+
+### Batch B4 — Tokens (1 SYNC; verify 6 N/A)
+- Files: `tokens_screen/token_creator.rs` (+ `tokens_screen/mod.rs` for the
+  `TokenCreatorUI.selected_identity` seed at :1595).
+- Change: seed `TokenCreatorUI.selected_identity` from
+  `resolve_selected_identity()` when `None`; add `.syncing_global(ctx)` to the
+  simple-mode il (:148); in advanced mode, write back via `set_selected_identity`
+  in the `add_identity_key_chooser` change path.
+- Verify-only (no behaviour change): `mint`, `transfer_tokens`, `freeze`,
+  `unfreeze`, `destroy_frozen_funds`, `groups` — confirm they keep the **default**
+  `IdentitySelector` (no opt-in). Add a focused unit test per file is overkill;
+  instead add one shared regression test (see B6).
+- Tests: token_creator kittest seed-and-default assertion (simple mode) — may
+  need a minimal token-context fixture; if unavailable, mark `#[ignore]` with a
+  TODO and notify (test-infra gap, §7).
+- Commit: `feat(tokens): default the token creator to the app-scoped identity (W4)`
+
+### Batch B5 — Wallets & Tools (3 READ-only, bespoke)
+- Files: `create_asset_lock_screen.rs` (add `.with_app_default(&self.app_context)`
+  to the il :398), `grovestark_screen.rs` (manual EdDSA-guarded seed in `new()`
+  / `refresh_identities`), `send_screen.rs` (manual wallet-membership-guarded
+  seed of the source ComboBox).
+- Change: READ-only seed; **no** `syncing_global` / write-back.
+- Tests: unit test the seed guards (wallet-membership for create_asset_lock /
+  send_screen; EdDSA-membership for grovestark) — pure model-ish, no UI harness
+  needed where the guard is extractable; otherwise a small kittest.
+- Commit: `feat(wallets,tools): seed wallet-scoped and tool screens from the app-scoped identity (W5)`
+
+### Batch B6 — GroupActions guard + cross-cutting regression locks
+- Files: `group_actions_screen.rs` (one-line K3 comment), plus tests.
+- Change: no functional change to group_actions.
+- Tests: (a) assert group_actions' selector is the default (no
+  `with_app_default`/`syncing_global`) and that selecting an identity there does
+  not call `set_selected_identity`; (b) a shared regression test asserting the
+  N/A token recipient/target pickers (mint/freeze/etc.) keep `sync_target ==
+  None` — complementing the existing `default_selector_has_no_sync_target`
+  (identity_selector.rs:360). These lock the "9 no-sync sites" invariant against
+  future drift.
+- Commit: `test(identity): lock session-local and no-sync identity pickers (W5)`
+
+## 7. Risks & test-infra gaps
+
+- **TI-1 — `WalletFixture` builder is the gating test-infra need.** IT-SWITCH-01/02
+  (wallet dropdown + wallet-scoped identity list) are blocked because there is no
+  fixture for a **loaded HD `Wallet` in `AppContext::wallets` with a matching
+  `wallet_hash`** (documented in `tests/kittest/identity_hub_switcher.rs:6–16`;
+  the current path only seeds identities via
+  `insert_local_qualified_identity(.., &None)`). The SYNC write-back tests that
+  need to observe **K1 wallet reconciliation** (set identity → derived wallet
+  follows) cannot be fully exercised until this builder exists. Build
+  `WalletFixture` before, or as the first step of, B6. Until then, write-back
+  tests assert only `resolve_selected_identity()` movement, not wallet
+  reconciliation, and carry a TODO.
+- **TI-2 — per-frame identity-table load in the hub.** `hub_screen.rs:209–210`
+  carries `TODO(IDH-003 follow-up)` to fold `landing()`'s load and the
+  breadcrumb switcher's per-frame `load_local_qualified_identities()` into one
+  shared snapshot. The SYNC migration adds **no** new per-frame DB load (the
+  selector seeds from in-memory `selected_identity_id()`), but each migrated
+  screen still calls `load_local_qualified_identities()` per frame as today —
+  do not regress this into extra loads; prefer seeding from already-loaded
+  vectors.
+- **R1 — wallet-primary screens must not SYNC (K1 interaction).** `create_asset_lock`
+  (#13) and `send_screen` (#15) are launched for a **specific** wallet whose
+  identity list may differ from the global wallet. If either were given
+  `syncing_global`, picking an identity would call `set_selected_identity`, which
+  reconciles the **global** wallet to that identity's owner — fighting the
+  screen's own wallet and possibly clearing it to `None`. They are READ-only by
+  design. Do not "upgrade" them to SYNC.
+- **R2 — target/recipient pickers must stay default.** Adding `syncing_global`
+  to a freeze/unfreeze/destroy **target** or a mint/transfer **recipient** would
+  let selecting another party's identity hijack the global active identity and
+  K1-reconcile the wallet to an identity the user does not own. The B6 regression
+  lock and the existing `default_selector_has_no_sync_target` test defend this.
+- **R3 — seed-vs-pre-fill conflict.** `with_app_default` is inert on any screen
+  that pre-fills `identity_str` in `new()` (the buffer is non-empty). For all 12
+  SYNC screens that pre-fill, seed via `resolve_selected_identity()` in
+  `new()`/refresh and rely on `syncing_global` for write-back — do **not** expect
+  `with_app_default` to do the reading there.
+- **R4 — grovestark capability filter.** The candidate list is EdDSA-only; the
+  seed must guard membership or the selection silently won't take.
+
+## 8. Surprises vs the prior MemCan rulings
+
+The earlier audit (memory 5ebc3af6) named six "READ-migration" screens:
+register_contract, update_contract, document_action, group_actions,
+token_creator, grovestark. This plan refines that umbrella term, which predates
+the W1 `syncing_global` mechanism:
+- register_contract, update_contract, document_action, **token_creator** are
+  **SYNC-on-change**, not READ-only — they are operate-as signers, so a user
+  change must propagate. ("Require READ-migration" is satisfied by SYNC, which
+  also reads.)
+- group_actions is **SESSION-LOCAL** (confirmed, K3).
+- grovestark is **READ-only** (confirmed) — capability-filtered tool screen.
+
+The audit's "~24 READ-migrate screens" (memory b2115c58) was a loose upper
+bound; the precise partition is 12 SYNC + 3 READ-only + 1 session-local, with
+the token action screens' visible pickers reclassified as **N/A recipient/target
+pickers** (their operating identity is row-scoped via `identity_token_info`, not
+app-scoped) — a correction the earlier audit did not draw.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1202,14 +1202,15 @@ As Alex, when I have one identity, opening Identities shows me my balance, usern
 - Home tab renders the full layout: `IdentityHeroCard`, quick actions (Send · Receive · Add contact), secondary actions (Add funds · Send to wallet · Send to another identity), `OnboardingChecklist`, and a recent-activity preview.
 - "See all activity" link on Home hops directly to the Activity tab via `HomeOutcome::GoToActivity`.
 
-### IDH-003: Multi-identity switching [Gap]
+### IDH-003: Multi-identity switching [Implemented]
 **Persona:** Priya
 
-As Priya, with multiple wallets and identities, I can switch between them from the breadcrumb pill on any tab in under two clicks.
+As Priya, with multiple wallets and identities, I can switch between them from the breadcrumb pill on any tab in under two clicks, and every screen I then open operates as the identity I picked.
 
 - Reusable `BreadcrumbPill` and `IdentityPill` components shipped, including the label priority rule (Local nickname → DPNS handle → shortened Identity ID).
 - Identity picker grid lands with `IdentityPickerCard` + `IdentityPickerAddCard`, so a multi-identity account sees a picker landing.
-- The full three-segment switcher composition (wallet pill + identity pill + dropdowns) lands in a follow-up.
+- The three-segment breadcrumb switcher (Identities link › wallet pill › identity pill, each with a dropdown) composes the full top-of-hub switcher.
+- The selected identity is app-scoped and persisted per network: every operate-as screen (contracts, documents, DPNS registration, the token creator, and DashPay) defaults to it and writes a change back, so switching once changes who I operate as everywhere. Recipient and target pickers (sending, freezing, transferring to someone else) deliberately leave my active identity unchanged.
 
 ### IDH-004: Opt in to DashPay social profile [Implemented]
 **Persona:** Alex

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -450,14 +450,14 @@ mod tests {
         assert!(sel.sync_target.is_none());
     }
 
-    /// QA-001 — fixture-free write-back: `syncing_global` must propagate a
-    /// picker selection to `AppContext::selected_identity_id()`.
+    /// Method-level lock for `sync_to_global`: when the buffer holds a known
+    /// identity's Base58 and `syncing_global` is set, calling `sync_to_global()`
+    /// must invoke `ctx.set_selected_identity(Some(id))`.
     ///
-    /// Calls `sync_to_global()` directly (private access OK inside this module).
-    /// No private keys or DB insertion needed — the selector's `identities`
-    /// slice is built from in-memory `QualifiedIdentity` structs, and
-    /// `set_selected_identity` with a wallet-less identity only touches
-    /// in-memory mutexes (KV persistence gracefully skips without wallet backend).
+    /// Calls `sync_to_global()` directly (private access inside this module).
+    /// This tests the *mechanism* in isolation; the *rendering gate*
+    /// (`combo_changed || text_response.changed()` at line 321) is covered by
+    /// the kittest at `tests/kittest/identity_selector.rs` (QA-001).
     #[test]
     fn syncing_global_writes_selection_to_app_context() {
         with_isolated_dir(|| {

--- a/src/ui/components/identity_selector.rs
+++ b/src/ui/components/identity_selector.rs
@@ -340,6 +340,91 @@ impl<'a> Widget for IdentitySelector<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::AppState;
+    use crate::model::qualified_identity::encrypted_key_storage::KeyStorage;
+    use crate::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
+    use dash_sdk::dpp::identity::Identity;
+    use dash_sdk::dpp::version::PlatformVersion;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    // ── Isolation helpers ─────────────────────────────────────────────────────
+    //
+    // `AppState::new()` resolves its data dir through `DASH_EVO_DATA_DIR`. Tests
+    // that construct an `AppContext` must serialize on a process-global lock and
+    // redirect to a throwaway temp dir to avoid opening the real user data dir or
+    // racing with parallel test threads.
+
+    fn data_dir_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Runs `f` in a unique temp data dir with a Tokio runtime in context.
+    /// Serialized by a module-level lock so that parallel test threads don't
+    /// race on `DASH_EVO_DATA_DIR`. `AppState::new()` internally drives tokio
+    /// tasks, so a runtime must be entered before calling it.
+    fn with_isolated_dir<R>(f: impl FnOnce() -> R) -> R {
+        let lock = data_dir_lock();
+        let tmp = tempfile::tempdir().expect("create temp data dir");
+        let prior = std::env::var("DASH_EVO_DATA_DIR").ok();
+        // Safety: serialized by `lock`; env var restored below before drop.
+        unsafe {
+            std::env::set_var("DASH_EVO_DATA_DIR", tmp.path());
+        }
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+        let result = f();
+        drop(_guard);
+        drop(rt);
+        unsafe {
+            match &prior {
+                Some(v) => std::env::set_var("DASH_EVO_DATA_DIR", v),
+                None => std::env::remove_var("DASH_EVO_DATA_DIR"),
+            }
+        }
+        drop(lock);
+        drop(tmp);
+        result
+    }
+
+    /// Build a minimal `AppContext` from a bare `AppState`. The wallet backend
+    /// is NOT wired (no Harness needed). `set_selected_identity` still works:
+    /// it updates the in-memory mutex and gracefully skips KV persistence
+    /// (see `persist_selected_identity_kv`: early-return with a debug log when
+    /// `wallet_backend()` returns `Err`).
+    fn make_ctx() -> Arc<AppContext> {
+        let app = AppState::new(egui::Context::default()).expect("AppState builds");
+        app.current_app_context().clone()
+    }
+
+    /// Create a wallet-less `QualifiedIdentity` from a raw id byte. Constructed
+    /// in-memory and passed directly to the selector's `identities` slice — no
+    /// DB insertion, no wallet backend needed.
+    fn make_qi(byte: u8) -> QualifiedIdentity {
+        let pv = PlatformVersion::latest();
+        let identity = Identity::create_basic_identity(Identifier::from([byte; 32]), pv)
+            .expect("basic identity");
+        QualifiedIdentity {
+            identity,
+            associated_voter_identity: None,
+            associated_operator_identity: None,
+            associated_owner_key_id: None,
+            identity_type: IdentityType::User,
+            alias: Some(format!("test-{byte:02x}")),
+            private_keys: KeyStorage::default(),
+            dpns_names: vec![],
+            associated_wallets: std::collections::BTreeMap::new(),
+            secret_access: None,
+            wallet_index: None,
+            top_ups: std::collections::BTreeMap::new(),
+            status: IdentityStatus::PendingCreation,
+            network: dash_sdk::dpp::dashcore::Network::Testnet,
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
 
     /// R2 regression-lock: a selector that did NOT opt in via `with_app_default`
     /// never reads the app-scoped selection to seed its buffer — so a
@@ -363,5 +448,76 @@ mod tests {
         let ids: Vec<QualifiedIdentity> = vec![];
         let sel = IdentitySelector::new("recipient", &mut buf, &ids);
         assert!(sel.sync_target.is_none());
+    }
+
+    /// QA-001 — fixture-free write-back: `syncing_global` must propagate a
+    /// picker selection to `AppContext::selected_identity_id()`.
+    ///
+    /// Calls `sync_to_global()` directly (private access OK inside this module).
+    /// No private keys or DB insertion needed — the selector's `identities`
+    /// slice is built from in-memory `QualifiedIdentity` structs, and
+    /// `set_selected_identity` with a wallet-less identity only touches
+    /// in-memory mutexes (KV persistence gracefully skips without wallet backend).
+    #[test]
+    fn syncing_global_writes_selection_to_app_context() {
+        with_isolated_dir(|| {
+            let ctx = make_ctx();
+
+            let first = make_qi(0xAA);
+            let second = make_qi(0xBB);
+            let ids = vec![first.clone(), second.clone()];
+
+            // Global starts pointing at first.
+            ctx.set_selected_identity(Some(first.identity.id()));
+            assert_eq!(ctx.selected_identity_id(), Some(first.identity.id()));
+
+            // Build a selector whose buffer holds the second identity's ID.
+            let mut buf = second.identity.id().to_string(Encoding::Base58);
+            let sel = IdentitySelector::new("write_back_test", &mut buf, &ids)
+                .syncing_global(ctx.clone());
+
+            // Fire the write-back directly (bypasses egui rendering).
+            sel.sync_to_global();
+
+            assert_eq!(
+                ctx.selected_identity_id(),
+                Some(second.identity.id()),
+                "syncing_global must write the chosen identity to AppContext"
+            );
+        });
+    }
+
+    /// QA-003 — `with_app_default` inert guard: when the global selection names
+    /// an identity that is NOT in the selector's candidate list, `app_default_seed`
+    /// must return `None` — the selector must not seed from a foreign identity.
+    ///
+    /// This locks the wallet-membership guard used by `CreateAssetLockScreen`
+    /// (R1): if the app-scoped identity belongs to wallet A but the screen is
+    /// opened for wallet B, wallet B's identity list won't contain the A-identity,
+    /// so no seed occurs.
+    #[test]
+    fn with_app_default_inert_when_global_id_not_in_candidate_list() {
+        with_isolated_dir(|| {
+            let ctx = make_ctx();
+
+            let global_qi = make_qi(0xCC);
+            let other_qi = make_qi(0xDD);
+
+            // Point the global selection at global_qi.
+            ctx.set_selected_identity(Some(global_qi.identity.id()));
+
+            // Candidate list contains ONLY other_qi — global_qi is absent.
+            let candidate_list = vec![other_qi.clone()];
+            let mut buf = String::new(); // empty → with_app_default may attempt a seed
+            let sel = IdentitySelector::new("inert_test", &mut buf, &candidate_list)
+                .with_app_default(&ctx);
+
+            assert_eq!(
+                sel.app_default_seed(),
+                None,
+                "with_app_default must not seed when the global id is absent \
+                 from the selector's candidate list (wallet-membership guard)"
+            );
+        });
     }
 }

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -153,8 +153,8 @@ impl DocumentActionScreen {
         let selected_contract = known_contracts.into_iter().next();
 
         // Seed from the app-scoped selected identity when none was passed in (W2 SYNC).
-        let selected_identity = selected_identity
-            .or_else(|| app_context.resolve_selected_identity());
+        let selected_identity =
+            selected_identity.or_else(|| app_context.resolve_selected_identity());
 
         let selected_identity_string = selected_identity
             .as_ref()

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -152,6 +152,10 @@ impl DocumentActionScreen {
 
         let selected_contract = known_contracts.into_iter().next();
 
+        // Seed from the app-scoped selected identity when none was passed in (W2 SYNC).
+        let selected_identity = selected_identity
+            .or_else(|| app_context.resolve_selected_identity());
+
         let selected_identity_string = selected_identity
             .as_ref()
             .map(|qi| qi.identity.id().to_string(Encoding::Base58))
@@ -261,7 +265,7 @@ impl DocumentActionScreen {
 
         let identities_vec: Vec<_> = self.identities_map.values().cloned().collect();
 
-        // Identity selector
+        // Identity selector — SYNC: write-back via syncing_global on user pick.
         let response = ui.add(
             IdentitySelector::new(
                 "document_action_identity_selector",
@@ -272,7 +276,8 @@ impl DocumentActionScreen {
             .unwrap()
             .width(300.0)
             .label("Identity:")
-            .other_option(false),
+            .other_option(false)
+            .syncing_global(self.app_context.clone()),
         );
 
         // Handle identity change - auto-select key and update wallet

--- a/src/ui/contracts_documents/group_actions_screen.rs
+++ b/src/ui/contracts_documents/group_actions_screen.rs
@@ -78,7 +78,7 @@ pub struct GroupActionsScreen {
     contract_search: String,
     qualified_identities: Vec<QualifiedIdentity>,
     identity_token_balances: IndexMap<IdentityTokenIdentifier, IdentityTokenBalance>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_str: String,
 
     // Backend task status
@@ -537,6 +537,11 @@ impl ScreenLike for GroupActionsScreen {
 
             ui.add_space(10.0);
 
+            // K3 — SESSION-LOCAL: no `with_app_default` and no `syncing_global`.
+            // GroupActions targets a specific group and contract for one session;
+            // writing the user's pick back to the global selection would incorrectly
+            // re-point "who you are" to a group-member identity that may not be
+            // the user's primary operating identity.
             ui.add(
                 IdentitySelector::new(
                     "group_actions_identity_selector",

--- a/src/ui/contracts_documents/register_contract_screen.rs
+++ b/src/ui/contracts_documents/register_contract_screen.rs
@@ -63,7 +63,16 @@ impl RegisterDataContractScreen {
         let qualified_identities: Vec<QualifiedIdentity> =
             app_context.load_local_user_identities().unwrap_or_default();
 
-        let selected_qualified_identity = qualified_identities.first().cloned();
+        // Seed from the app-scoped selected identity (W2 SYNC); fall back to first.
+        let selected_qualified_identity = app_context
+            .selected_identity_id()
+            .and_then(|id| {
+                qualified_identities
+                    .iter()
+                    .find(|qi| qi.identity.id() == id)
+                    .cloned()
+            })
+            .or_else(|| qualified_identities.first().cloned());
 
         let selected_wallet = if let Some(ref identity) = selected_qualified_identity {
             get_selected_wallet(identity, Some(app_context), None).unwrap_or(None)
@@ -433,7 +442,8 @@ impl ScreenLike for RegisterDataContractScreen {
                     .unwrap()
                     .width(300.0)
                     .label("Identity:")
-                    .other_option(false),
+                    .other_option(false)
+                    .syncing_global(self.app_context.clone()),
                 );
 
                 // Handle identity change - auto-select key and update wallet

--- a/src/ui/contracts_documents/update_contract_screen.rs
+++ b/src/ui/contracts_documents/update_contract_screen.rs
@@ -69,7 +69,17 @@ impl UpdateDataContractScreen {
     pub fn new(app_context: &Arc<AppContext>) -> Self {
         let qualified_identities: Vec<_> =
             app_context.load_local_user_identities().unwrap_or_default();
-        let selected_qualified_identity = qualified_identities.first().cloned();
+
+        // Seed from the app-scoped selected identity (W2 SYNC); fall back to first.
+        let selected_qualified_identity = app_context
+            .selected_identity_id()
+            .and_then(|id| {
+                qualified_identities
+                    .iter()
+                    .find(|qi| qi.identity.id() == id)
+                    .cloned()
+            })
+            .or_else(|| qualified_identities.first().cloned());
 
         let selected_wallet = if let Some(ref identity) = selected_qualified_identity {
             get_selected_wallet(identity, Some(app_context), None).unwrap_or(None)
@@ -452,7 +462,8 @@ impl ScreenLike for UpdateDataContractScreen {
                 .unwrap()
                 .width(300.0)
                 .label("Identity:")
-                .other_option(false),
+                .other_option(false)
+                .syncing_global(self.app_context.clone()),
             );
 
             // Handle identity change - auto-select key and update wallet

--- a/src/ui/dashpay/add_contact_screen.rs
+++ b/src/ui/dashpay/add_contact_screen.rs
@@ -22,6 +22,7 @@ use crate::ui::identities::get_selected_wallet;
 use crate::ui::identities::keys::add_key_screen::AddKeyScreen;
 use crate::ui::theme::DashColors;
 use crate::ui::{MessageType, RootScreenType, Screen, ScreenLike};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::platform::IdentityPublicKey;
 use egui::{RichText, ScrollArea, TextEdit, Ui};
 use std::sync::{Arc, RwLock};
@@ -42,7 +43,7 @@ enum ContactRequestStatus {
 
 pub struct AddContactScreen {
     pub app_context: Arc<AppContext>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     selected_key: Option<IdentityPublicKey>,
     username_or_id: String,
@@ -57,10 +58,27 @@ pub struct AddContactScreen {
 
 impl AddContactScreen {
     pub fn new(app_context: Arc<AppContext>) -> Self {
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
+        let identities = app_context
+            .load_local_qualified_identities()
+            .unwrap_or_default();
+        let selected_identity = app_context
+            .selected_identity_id()
+            .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+            .or_else(|| identities.first().cloned());
+        let selected_identity_string = selected_identity
+            .as_ref()
+            .map(|qi| {
+                qi.identity
+                    .id()
+                    .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58)
+            })
+            .unwrap_or_default();
+
         Self {
             app_context,
-            selected_identity: None,
-            selected_identity_string: String::new(),
+            selected_identity,
+            selected_identity_string,
             selected_key: None,
             username_or_id: String::new(),
             account_label: String::new(),
@@ -74,10 +92,27 @@ impl AddContactScreen {
     }
 
     pub fn new_with_identity_id(app_context: Arc<AppContext>, identity_id: String) -> Self {
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
+        let identities = app_context
+            .load_local_qualified_identities()
+            .unwrap_or_default();
+        let selected_identity = app_context
+            .selected_identity_id()
+            .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+            .or_else(|| identities.first().cloned());
+        let selected_identity_string = selected_identity
+            .as_ref()
+            .map(|qi| {
+                qi.identity
+                    .id()
+                    .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58)
+            })
+            .unwrap_or_default();
+
         Self {
             app_context,
-            selected_identity: None,
-            selected_identity_string: String::new(),
+            selected_identity,
+            selected_identity_string,
             selected_key: None,
             username_or_id: identity_id,
             account_label: String::new(),
@@ -252,7 +287,7 @@ impl ScreenLike for AddContactScreen {
                 );
                 ui.separator();
 
-                // Identity selector
+                // Identity selector — SYNC: write-back via syncing_global on user pick.
                 let response = ui.add(
                     IdentitySelector::new(
                         "contact_sender_identity_selector",
@@ -263,7 +298,8 @@ impl ScreenLike for AddContactScreen {
                     .unwrap()
                     .width(300.0)
                     .label("Identity:")
-                    .other_option(false),
+                    .other_option(false)
+                    .syncing_global(self.app_context.clone()),
                 );
 
                 // Handle identity change - auto-select key and update wallet

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -109,10 +109,9 @@ impl ContactRequests {
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
             // Get wallet for the selected identity
-            new_self.selected_wallet =
-                get_selected_wallet(&preferred, Some(&app_context), None)
-                    .or_show_error(app_context.egui_ctx())
-                    .unwrap_or(None);
+            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
+                .or_show_error(app_context.egui_ctx())
+                .unwrap_or(None);
         }
 
         new_self
@@ -283,9 +282,10 @@ impl ContactRequests {
                 .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
                 .unwrap_or_else(|| identities[0].clone());
             self.selected_identity = Some(preferred.clone());
-            self.selected_identity_string = preferred.identity.id().to_string(
-                dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58,
-            );
+            self.selected_identity_string = preferred
+                .identity
+                .id()
+                .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
         }
 
         // Mark unfetched so the next render dispatches `LoadContactRequests`.

--- a/src/ui/dashpay/contact_requests.rs
+++ b/src/ui/dashpay/contact_requests.rs
@@ -55,7 +55,7 @@ pub struct ContactRequests {
     outgoing_requests: BTreeMap<Identifier, ContactRequest>,
     accepted_requests: HashSet<Identifier>,
     rejected_requests: HashSet<Identifier>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     active_tab: RequestTab,
     loading: bool,
@@ -93,20 +93,24 @@ impl ContactRequests {
             pending_profile_fetches: HashSet::new(),
         };
 
-        // Auto-select first identity on creation if available
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
         if let Ok(identities) = app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
             use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-            new_self.selected_identity = Some(identities[0].clone());
-            new_self.selected_identity_string = identities[0]
+            let selected_id = app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            new_self.selected_identity = Some(preferred.clone());
+            new_self.selected_identity_string = preferred
                 .identity
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
 
             // Get wallet for the selected identity
             new_self.selected_wallet =
-                get_selected_wallet(&identities[0], Some(&app_context), None)
+                get_selected_wallet(&preferred, Some(&app_context), None)
                     .or_show_error(app_context.egui_ctx())
                     .unwrap_or(None);
         }
@@ -268,13 +272,20 @@ impl ContactRequests {
         // Only clear temporary states
         self.loading = false;
 
-        // Auto-select first identity if none selected
+        // Seed from the app-scoped selected identity if none yet selected (W3 SYNC).
         if self.selected_identity.is_none()
             && let Ok(identities) = self.app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
-            self.selected_identity = Some(identities[0].clone());
-            self.selected_identity_string = identities[0].display_string();
+            use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+            let selected_id = self.app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            self.selected_identity = Some(preferred.clone());
+            self.selected_identity_string = preferred.identity.id().to_string(
+                dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58,
+            );
         }
 
         // Mark unfetched so the next render dispatches `LoadContactRequests`.
@@ -361,6 +372,7 @@ impl ContactRequests {
 
                 if !identities.is_empty() {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        // SYNC: write-back via syncing_global on user pick.
                         let response = ui.add(
                             IdentitySelector::new(
                                 "requests_identity_selector",
@@ -370,7 +382,8 @@ impl ContactRequests {
                             .selected_identity(&mut self.selected_identity)
                             .unwrap()
                             .width(300.0)
-                            .other_option(false), // Disable "Other" option
+                            .other_option(false) // Disable "Other" option
+                            .syncing_global(self.app_context.clone()),
                         );
 
                         if response.changed() {

--- a/src/ui/dashpay/contacts_list.rs
+++ b/src/ui/dashpay/contacts_list.rs
@@ -59,7 +59,7 @@ pub enum ContactsTab {
 pub struct ContactsList {
     pub app_context: Arc<AppContext>,
     contacts: BTreeMap<Identifier, Contact>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     search_query: String,
     message: Option<(String, MessageType)>,
@@ -96,13 +96,16 @@ impl ContactsList {
             contact_requests: ContactRequests::new(app_context.clone()),
         };
 
-        // Auto-select first identity on creation if available
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
         if let Ok(identities) = app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
-            new_self.selected_identity = Some(identities[0].clone());
-            new_self.selected_identity_string =
-                identities[0].identity.id().to_string(Encoding::Base58);
+            let selected_id = app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            new_self.selected_identity = Some(preferred.clone());
+            new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
         }
 
         new_self
@@ -196,13 +199,17 @@ impl ContactsList {
         self.message = None;
         self.loading = false;
 
-        // Auto-select first identity if none selected
+        // Seed from the app-scoped selected identity if none yet selected (W3 SYNC).
         if self.selected_identity.is_none()
             && let Ok(identities) = self.app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
-            self.selected_identity = Some(identities[0].clone());
-            self.selected_identity_string = identities[0].identity.id().to_string(Encoding::Base58);
+            let selected_id = self.app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            self.selected_identity = Some(preferred.clone());
+            self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
         }
 
         // Trigger backend fetch if we have an identity selected and no contacts loaded.
@@ -321,6 +328,7 @@ impl ContactsList {
 
             if !identities.is_empty() {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    // SYNC: write-back via syncing_global on user pick.
                     let response = ui.add(
                         IdentitySelector::new(
                             "contacts_identity_selector",
@@ -330,7 +338,8 @@ impl ContactsList {
                         .selected_identity(&mut self.selected_identity)
                         .unwrap()
                         .width(300.0)
-                        .other_option(false),
+                        .other_option(false)
+                        .syncing_global(self.app_context.clone()),
                     );
 
                     if response.changed() {

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -79,7 +79,7 @@ impl ValidationError {
 
 pub struct ProfileScreen {
     pub app_context: Arc<AppContext>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     profile: Option<DashPayProfile>,
     editing: bool,
@@ -141,16 +141,20 @@ impl ProfileScreen {
             confirmation_dialog: None,
         };
 
-        // Auto-select the first identity. Profile is loaded asynchronously by
-        // the `LoadProfile` dispatch in `render()` once `profile_load_attempted`
-        // is false.
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
+        // Profile is loaded asynchronously by `LoadProfile` dispatch in `render()`.
         if let Ok(identities) = app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
             use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 
-            new_self.selected_identity = Some(identities[0].clone());
-            new_self.selected_identity_string = identities[0]
+            let selected_id = app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+
+            new_self.selected_identity = Some(preferred.clone());
+            new_self.selected_identity_string = preferred
                 .identity
                 .id()
                 .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
@@ -161,7 +165,7 @@ impl ProfileScreen {
             );
 
             new_self.selected_wallet =
-                get_selected_wallet(&identities[0], Some(&app_context), None)
+                get_selected_wallet(&preferred, Some(&app_context), None)
                     .or_show_error(app_context.egui_ctx())
                     .unwrap_or(None);
         }
@@ -236,13 +240,21 @@ impl ProfileScreen {
         // This prevents stuck loading states
         self.loading = false;
 
-        // Auto-select first identity if none selected
+        // Seed from the app-scoped selected identity if none yet selected (W3 SYNC).
         if self.selected_identity.is_none()
             && let Ok(identities) = self.app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
-            self.selected_identity = Some(identities[0].clone());
-            self.selected_identity_string = identities[0].display_string();
+            use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+            let selected_id = self.app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            self.selected_identity = Some(preferred.clone());
+            self.selected_identity_string = preferred
+                .identity
+                .id()
+                .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58);
         }
 
         // Load profile from database if we have an identity selected and no profile loaded
@@ -508,6 +520,7 @@ impl ProfileScreen {
 
             if !identities.is_empty() {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    // SYNC: write-back via syncing_global on user pick.
                     let response = ui.add(
                         IdentitySelector::new(
                             "profile_identity_selector",
@@ -517,7 +530,8 @@ impl ProfileScreen {
                         .selected_identity(&mut self.selected_identity)
                         .unwrap()
                         .width(300.0)
-                        .other_option(false), // Disable "Other" option
+                        .other_option(false) // Disable "Other" option
+                        .syncing_global(self.app_context.clone()),
                     );
 
                     if response.changed() {

--- a/src/ui/dashpay/profile_screen.rs
+++ b/src/ui/dashpay/profile_screen.rs
@@ -164,10 +164,9 @@ impl ProfileScreen {
                 new_self.selected_identity_string
             );
 
-            new_self.selected_wallet =
-                get_selected_wallet(&preferred, Some(&app_context), None)
-                    .or_show_error(app_context.egui_ctx())
-                    .unwrap_or(None);
+            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
+                .or_show_error(app_context.egui_ctx())
+                .unwrap_or(None);
         }
 
         new_self

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -39,7 +39,7 @@ const ACCOUNT_INDEX_INFO_TEXT: &str = "Account Index:\n\n\
 
 pub struct QRCodeGeneratorScreen {
     pub app_context: Arc<AppContext>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     account_index: String,
     validity_hours: String,
@@ -67,20 +67,25 @@ impl QRCodeGeneratorScreen {
             wallet_open_attempted: false,
         };
 
-        // Auto-select first identity on creation if available
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
         if let Ok(identities) = app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
             use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
             use dash_sdk::dpp::platform_value::string_encoding::Encoding;
 
-            new_self.selected_identity = Some(identities[0].clone());
+            let selected_id = app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+
+            new_self.selected_identity = Some(preferred.clone());
             new_self.selected_identity_string =
-                identities[0].identity.id().to_string(Encoding::Base58);
+                preferred.identity.id().to_string(Encoding::Base58);
 
             // Get wallet for the selected identity
             new_self.selected_wallet =
-                get_selected_wallet(&identities[0], Some(&app_context), None)
+                get_selected_wallet(&preferred, Some(&app_context), None)
                     .or_show_error(app_context.egui_ctx())
                     .unwrap_or(None);
         }
@@ -183,6 +188,7 @@ impl QRCodeGeneratorScreen {
                             RichText::new("Identity:").color(DashColors::text_primary(dark_mode)),
                         );
                         ui.with_layout(egui::Layout::top_down(egui::Align::LEFT), |ui| {
+                            // SYNC: write-back via syncing_global on user pick.
                             let response = ui.add(
                                 IdentitySelector::new(
                                     "qr_identity_selector",
@@ -192,7 +198,8 @@ impl QRCodeGeneratorScreen {
                                     .selected_identity(&mut self.selected_identity)
                                     .unwrap()
                                     .width(300.0)
-                                    .other_option(false),
+                                    .other_option(false)
+                                    .syncing_global(self.app_context.clone()),
                             );
 
                             if response.changed() {

--- a/src/ui/dashpay/qr_code_generator.rs
+++ b/src/ui/dashpay/qr_code_generator.rs
@@ -80,14 +80,12 @@ impl QRCodeGeneratorScreen {
                 .unwrap_or_else(|| identities[0].clone());
 
             new_self.selected_identity = Some(preferred.clone());
-            new_self.selected_identity_string =
-                preferred.identity.id().to_string(Encoding::Base58);
+            new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
 
             // Get wallet for the selected identity
-            new_self.selected_wallet =
-                get_selected_wallet(&preferred, Some(&app_context), None)
-                    .or_show_error(app_context.egui_ctx())
-                    .unwrap_or(None);
+            new_self.selected_wallet = get_selected_wallet(&preferred, Some(&app_context), None)
+                .or_show_error(app_context.egui_ctx())
+                .unwrap_or(None);
         }
 
         new_self

--- a/src/ui/dashpay/qr_scanner.rs
+++ b/src/ui/dashpay/qr_scanner.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, RwLock};
 
 pub struct QRScannerScreen {
     pub app_context: Arc<AppContext>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     qr_data_input: String,
     parsed_qr_data: Option<AutoAcceptProofData>,
@@ -37,10 +37,31 @@ pub struct QRScannerScreen {
 
 impl QRScannerScreen {
     pub fn new(app_context: Arc<AppContext>) -> Self {
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
+        let identities = app_context
+            .load_local_qualified_identities()
+            .unwrap_or_default();
+        let selected_identity = {
+            use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+            app_context
+                .selected_identity_id()
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .or_else(|| identities.first().cloned())
+        };
+        let selected_identity_string = selected_identity
+            .as_ref()
+            .map(|qi| {
+                use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                qi.identity
+                    .id()
+                    .to_string(dash_sdk::dpp::platform_value::string_encoding::Encoding::Base58)
+            })
+            .unwrap_or_default();
+
         Self {
             app_context,
-            selected_identity: None,
-            selected_identity_string: String::new(),
+            selected_identity,
+            selected_identity_string,
             qr_data_input: String::new(),
             parsed_qr_data: None,
             sending: false,
@@ -169,6 +190,7 @@ impl QRScannerScreen {
 
                 ui.horizontal(|ui| {
                     ui.label("Identity:");
+                    // SYNC: write-back via syncing_global on user pick.
                     ui.add(
                         IdentitySelector::new(
                             "qr_scanner_identity_selector",
@@ -178,7 +200,8 @@ impl QRScannerScreen {
                         .selected_identity(&mut self.selected_identity)
                         .unwrap()
                         .width(300.0)
-                        .other_option(false),
+                        .other_option(false)
+                        .syncing_global(self.app_context.clone()),
                     );
                 });
 

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -538,10 +538,7 @@ impl PaymentHistory {
                 .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
                 .unwrap_or_else(|| identities[0].clone());
             self.selected_identity = Some(preferred.clone());
-            self.selected_identity_string = preferred
-                .identity
-                .id()
-                .to_string(Encoding::Base58);
+            self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
         }
 
         // Reset the fetched flag if we have no payments; next render dispatches

--- a/src/ui/dashpay/send_payment.rs
+++ b/src/ui/dashpay/send_payment.rs
@@ -459,7 +459,7 @@ impl ScreenLike for SendPaymentScreen {
 // Payment History Component (used in main DashPay screen)
 pub struct PaymentHistory {
     pub app_context: Arc<AppContext>,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_identity_string: String,
     payments: Vec<PaymentRecord>,
     loading: bool,
@@ -487,14 +487,17 @@ impl PaymentHistory {
             has_searched: false,
         };
 
-        // Auto-select first identity on creation if available
+        // Seed from the app-scoped selected identity (W3 SYNC); fall back to first.
         if let Ok(identities) = app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
             use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-            new_self.selected_identity = Some(identities[0].clone());
-            new_self.selected_identity_string =
-                identities[0].identity.id().to_string(Encoding::Base58);
+            let selected_id = app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            new_self.selected_identity = Some(preferred.clone());
+            new_self.selected_identity_string = preferred.identity.id().to_string(Encoding::Base58);
         }
 
         new_self
@@ -524,13 +527,21 @@ impl PaymentHistory {
         // Don't clear if we have data, just clear temporary states
         self.loading = false;
 
-        // Auto-select first identity if none selected
+        // Seed from the app-scoped selected identity if none yet selected (W3 SYNC).
         if self.selected_identity.is_none()
             && let Ok(identities) = self.app_context.load_local_qualified_identities()
             && !identities.is_empty()
         {
-            self.selected_identity = Some(identities[0].clone());
-            self.selected_identity_string = identities[0].display_string();
+            use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+            let selected_id = self.app_context.selected_identity_id();
+            let preferred = selected_id
+                .and_then(|id| identities.iter().find(|qi| qi.identity.id() == id).cloned())
+                .unwrap_or_else(|| identities[0].clone());
+            self.selected_identity = Some(preferred.clone());
+            self.selected_identity_string = preferred
+                .identity
+                .id()
+                .to_string(Encoding::Base58);
         }
 
         // Reset the fetched flag if we have no payments; next render dispatches
@@ -560,6 +571,7 @@ impl PaymentHistory {
 
             if !identities.is_empty() {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    // SYNC: write-back via syncing_global on user pick.
                     let response = ui.add(
                         IdentitySelector::new(
                             "payment_history_identity_selector",
@@ -569,7 +581,8 @@ impl PaymentHistory {
                         .selected_identity(&mut self.selected_identity)
                         .unwrap()
                         .width(300.0)
-                        .other_option(false), // Disable "Other" option
+                        .other_option(false) // Disable "Other" option
+                        .syncing_global(self.app_context.clone()),
                     );
 
                     if response.changed() {

--- a/src/ui/identities/register_dpns_name_screen.rs
+++ b/src/ui/identities/register_dpns_name_screen.rs
@@ -74,7 +74,17 @@ impl RegisterDpnsNameScreen {
     pub fn new(app_context: &Arc<AppContext>, source: RegisterDpnsNameSource) -> Self {
         let qualified_identities: Vec<_> =
             app_context.load_local_user_identities().unwrap_or_default();
-        let selected_qualified_identity = qualified_identities.first().cloned();
+
+        // Seed from the app-scoped selected identity (W2 SYNC); fall back to first.
+        let selected_qualified_identity = app_context
+            .selected_identity_id()
+            .and_then(|id| {
+                qualified_identities
+                    .iter()
+                    .find(|qi| qi.identity.id() == id)
+                    .cloned()
+            })
+            .or_else(|| qualified_identities.first().cloned());
 
         let selected_wallet = if let Some(ref identity) = selected_qualified_identity {
             get_selected_wallet(identity, Some(app_context), None)
@@ -186,7 +196,7 @@ impl RegisterDpnsNameScreen {
     fn render_identity_id_selection(&mut self, ui: &mut egui::Ui) -> AppAction {
         let mut action = AppAction::None;
 
-        // Identity selector
+        // Identity selector — SYNC: write-back via syncing_global on user pick.
         let response = ui.add(
             IdentitySelector::new(
                 "dpns_register_identity_selector",
@@ -197,7 +207,8 @@ impl RegisterDpnsNameScreen {
             .unwrap()
             .width(300.0)
             .label("Identity:")
-            .other_option(false),
+            .other_option(false)
+            .syncing_global(self.app_context.clone()),
         );
 
         // Handle identity change - auto-select key and update wallet

--- a/src/ui/tokens/tokens_screen/mod.rs
+++ b/src/ui/tokens/tokens_screen/mod.rs
@@ -1238,7 +1238,7 @@ pub struct TokensScreen {
     selected_token_preset: Option<TokenConfigurationPresetFeatures>,
     show_pop_up_info: Option<String>,
     identity_id_string: String,
-    selected_identity: Option<QualifiedIdentity>,
+    pub selected_identity: Option<QualifiedIdentity>,
     selected_key: Option<IdentityPublicKey>,
     selected_wallet: Option<Arc<RwLock<Wallet>>>,
     wallet_open_attempted: bool,
@@ -1776,6 +1776,20 @@ impl TokensScreen {
         if let Ok(saved_ids) = screen.app_context.load_token_order() {
             screen.reorder_vec_to(saved_ids);
             screen.use_custom_order = true;
+        }
+
+        // Seed selected_identity from the app-scoped selection (W4 SYNC); fall back to first.
+        if let Some(preferred_id) = screen.app_context.selected_identity_id()
+            && let Some(qi) = screen.identities.get(&preferred_id)
+        {
+            screen.selected_identity = Some(qi.clone());
+            screen.identity_id_string = preferred_id.to_string(Encoding::Base58);
+        }
+        if screen.selected_identity.is_none()
+            && let Some((id, qi)) = screen.identities.iter().next()
+        {
+            screen.selected_identity = Some(qi.clone());
+            screen.identity_id_string = id.to_string(Encoding::Base58);
         }
 
         screen

--- a/src/ui/tokens/tokens_screen/token_creator.rs
+++ b/src/ui/tokens/tokens_screen/token_creator.rs
@@ -143,7 +143,7 @@ impl TokensScreen {
                             ui.heading("1. Select an identity:");
                             ui.add_space(5.0);
 
-                            // Use IdentitySelector for simple mode
+                            // Use IdentitySelector for simple mode — SYNC: write-back via syncing_global.
                             let response = ui.add(
                                 IdentitySelector::new(
                                     "simple_identity_selector",
@@ -154,7 +154,8 @@ impl TokensScreen {
                                 .expect("selected_identity should not fail")
                                 .other_option(false)
                                 .label("Identity:")
-                                .width(300.0),
+                                .width(300.0)
+                                .syncing_global(self.app_context.clone()),
                             );
 
                             // Auto-select the first eligible key when:
@@ -219,7 +220,12 @@ impl TokensScreen {
                             ui.heading("1. Select an identity and key to register the token contract with:");
                             ui.add_space(5.0);
 
-                            // Use the helper function for identity and key selection
+                            // Use the helper function for identity and key selection.
+                            // SYNC (W4): snapshot before, write-back after on change.
+                            let before_id = self
+                                .selected_identity
+                                .as_ref()
+                                .map(|qi| qi.identity.id());
                             add_identity_key_chooser(
                                 ui,
                                 &self.app_context,
@@ -228,6 +234,14 @@ impl TokensScreen {
                                 &mut self.selected_key,
                                 TransactionType::RegisterContract,
                             );
+                            let after_id = self
+                                .selected_identity
+                                .as_ref()
+                                .map(|qi| qi.identity.id());
+                            if before_id != after_id {
+                                self.app_context
+                                    .set_selected_identity(after_id);
+                            }
 
                             ui.add_space(5.0);
 

--- a/src/ui/tools/grovestark_screen.rs
+++ b/src/ui/tools/grovestark_screen.rs
@@ -50,7 +50,7 @@ pub struct GroveSTARKScreen {
     mode: ProofMode,
 
     // Generation fields
-    selected_identity: Option<String>,
+    pub selected_identity: Option<String>,
     selected_key: Option<IdentityPublicKey>,
     selected_contract: Option<String>,
     selected_document_type: Option<String>,
@@ -128,10 +128,32 @@ impl GroveSTARKScreen {
             available_contracts.len()
         );
 
+        // Seed selected_identity from the app-scoped id if it is in the EdDSA-filtered list
+        // (READ-only R4: no syncing_global — a developer tool must not push an EdDSA-only
+        // identity as the global selection).
+        let eddsa_filter = |qi: &&QualifiedIdentity| {
+            qi.identity.public_keys().iter().any(|(_, key)| {
+                matches!(key.key_type(), KeyType::EDDSA_25519_HASH160)
+                    && (key.purpose() == Purpose::AUTHENTICATION
+                        || key.purpose() == Purpose::TRANSFER)
+            })
+        };
+        let selected_identity: Option<String> = {
+            let preferred_id = app_context.selected_identity_id();
+            preferred_id
+                .and_then(|id| {
+                    qualified_identities
+                        .iter()
+                        .find(|qi| eddsa_filter(qi) && qi.identity.id() == id)
+                })
+                .or_else(|| qualified_identities.iter().find(|qi| eddsa_filter(qi)))
+                .map(|qi| qi.identity.id().to_string(Encoding::Base58))
+        };
+
         Self {
             app_context: app_context.clone(),
             mode: ProofMode::Generate,
-            selected_identity: None,
+            selected_identity,
             selected_key: None,
             selected_contract: None,
             selected_document_type: None,
@@ -167,6 +189,21 @@ impl GroveSTARKScreen {
             .iter()
             .map(|qualified_identity| qualified_identity.identity.clone())
             .collect();
+
+        // Re-seed selected_identity from the app-scoped id iff it is in the
+        // refreshed EdDSA-filtered list (READ-only R4: no syncing_global).
+        let preferred_id = app_context.selected_identity_id();
+        let new_selection = preferred_id
+            .and_then(|id| {
+                self.qualified_identities
+                    .iter()
+                    .find(|qi| qi.identity.id() == id)
+            })
+            .or_else(|| self.qualified_identities.first())
+            .map(|qi| qi.identity.id().to_string(Encoding::Base58));
+        if self.selected_identity.is_none() {
+            self.selected_identity = new_selection;
+        }
     }
 
     fn get_qualified_identity(&self, identity_id_str: &str) -> Option<&QualifiedIdentity> {

--- a/src/ui/wallets/create_asset_lock_screen.rs
+++ b/src/ui/wallets/create_asset_lock_screen.rs
@@ -395,12 +395,15 @@ impl ScreenLike for CreateAssetLockScreen {
                                 return;
                             }
 
+                            // READ-only (R1): seed from app-scoped selection iff the global id
+                            // is in this wallet's identity list; no syncing_global (K1 guard).
                             let identity_selector_response = ui.add(IdentitySelector::new(
                                 "top_up_identity_selector",
                                 &mut self.selected_identity_string,
                                 &identities
                             )
                             .selected_identity(&mut self.selected_identity).unwrap()
+                            .with_app_default(&self.app_context)
                             .label("Identity to top up:")
                             .width(300.0));
 

--- a/src/ui/wallets/send_screen.rs
+++ b/src/ui/wallets/send_screen.rs
@@ -1866,6 +1866,18 @@ impl WalletSendScreen {
 
         // Identity source option — visible when identities exist or developer mode
         let identities = self.get_loaded_identities();
+        // READ-only seed (R1, W5): if no identity is pre-selected yet, try the app-scoped
+        // identity — but only if it belongs to this wallet's identity list.
+        // No syncing_global: the send screen is wallet-primary; K1 reconcile would fight it.
+        if self.selected_identity.is_none()
+            && let Some(preferred_id) = self.app_context.selected_identity_id()
+            && let Some(qi) = identities.iter().find(|qi| {
+                use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+                qi.identity.id() == preferred_id
+            })
+        {
+            self.selected_identity = Some(qi.clone());
+        }
         if !identities.is_empty() || self.app_context.is_developer_mode() {
             ui.add_space(5.0);
 

--- a/tests/kittest/contract_screen.rs
+++ b/tests/kittest/contract_screen.rs
@@ -193,8 +193,7 @@ fn group_actions_does_not_seed_from_global_identity() {
         let screen = GroupActionsScreen::new(&app_context);
 
         assert_eq!(
-            screen.selected_identity,
-            None,
+            screen.selected_identity, None,
             "GroupActionsScreen is session-local (K3): it must NOT seed from the \
              app-scoped selection — selected_identity must stay None on construction"
         );

--- a/tests/kittest/contract_screen.rs
+++ b/tests/kittest/contract_screen.rs
@@ -23,6 +23,7 @@ use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, Qua
 use dash_evo_tool::ui::contracts_documents::document_action_screen::{
     DocumentActionScreen, DocumentActionType,
 };
+use dash_evo_tool::ui::contracts_documents::group_actions_screen::GroupActionsScreen;
 use dash_evo_tool::ui::contracts_documents::register_contract_screen::RegisterDataContractScreen;
 use dash_evo_tool::ui::contracts_documents::update_contract_screen::UpdateDataContractScreen;
 use dash_sdk::dpp::identity::Identity;
@@ -166,6 +167,43 @@ fn document_action_defaults_to_app_scoped_identity() {
             screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
             Some(second),
             "DocumentActionScreen must seed from the app-scoped selected identity when None is passed"
+        );
+    });
+}
+
+// ── B6 ─ GroupActionsScreen session-local regression lock ────────────────────
+
+/// W5 B6 (K3 regression lock): `GroupActionsScreen` is SESSION-LOCAL — it must
+/// NOT seed `selected_identity` from the global selection on construction, even
+/// when an app-scoped identity is set. The picker is independent per session.
+#[test]
+fn group_actions_does_not_seed_from_global_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_harness, app_context) = mount_context();
+
+        let _first = seed_identity(&app_context, 0x11, "GA Alpha");
+        let second = seed_identity(&app_context, 0x22, "GA Beta");
+
+        // Set the second identity as the app-scoped selection.
+        app_context.set_selected_identity(Some(second));
+
+        let screen = GroupActionsScreen::new(&app_context);
+
+        assert_eq!(
+            screen.selected_identity,
+            None,
+            "GroupActionsScreen is session-local (K3): it must NOT seed from the \
+             app-scoped selection — selected_identity must stay None on construction"
+        );
+
+        // The global selection must be unchanged (no write-back on construction).
+        assert_eq!(
+            app_context.selected_identity_id(),
+            Some(second),
+            "GroupActionsScreen must not alter the app-scoped selection on construction"
         );
     });
 }

--- a/tests/kittest/contract_screen.rs
+++ b/tests/kittest/contract_screen.rs
@@ -1,0 +1,171 @@
+//! W2 kittest — contracts & documents screens obey the app-scoped selected identity.
+//!
+//! B1 migration: `RegisterDataContractScreen`, `UpdateDataContractScreen`, and
+//! `DocumentActionScreen` must default to the app-scoped selected identity on
+//! construction and write the user's picker choice back via `syncing_global`.
+//!
+//! Seeding test (a): screen defaults to the app-scoped id.
+//! Write-back test (b): a picker change drives `resolve_selected_identity()`.
+//!
+//! Write-back (b) requires identities with loaded private keys so the selector
+//! renders (the screen gates on `has_suitable_keys`). That fixture is out of
+//! reach here (see TI-1 / private-key fixture gap). The seeding direction is
+//! fully covered below.
+//!
+//! # TODO(WalletFixture / private-key fixture)
+//! Add write-back assertions (picker click → `resolve_selected_identity()` moves)
+//! once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
+
+use crate::support::with_isolated_data_dir;
+use dash_evo_tool::context::AppContext;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
+use dash_evo_tool::ui::contracts_documents::document_action_screen::{
+    DocumentActionScreen, DocumentActionType,
+};
+use dash_evo_tool::ui::contracts_documents::register_contract_screen::RegisterDataContractScreen;
+use dash_evo_tool::ui::contracts_documents::update_contract_screen::UpdateDataContractScreen;
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
+use egui_kittest::Harness;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Mount a minimal AppState with the wallet backend wired up, then return the
+/// live context. Mirrors `identity_hub_switcher::mount_hub` but doesn't force a
+/// particular root screen — we construct screens directly.
+fn mount_context() -> (
+    Harness<'static, dash_evo_tool::app::AppState>,
+    Arc<AppContext>,
+) {
+    let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("AppState builds")
+            .with_animations(false)
+    });
+    harness.set_size(egui::vec2(1280.0, 800.0));
+    harness.run_steps(5);
+    let ctx = harness.state().current_app_context().clone();
+    (harness, ctx)
+}
+
+/// Seed a minimal wallet-less identity (identical to identity_hub_switcher pattern).
+fn seed_identity(app_context: &Arc<AppContext>, byte: u8, alias: &str) -> Identifier {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    let id = identity.id();
+    let qi = QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: app_context.network(),
+    };
+    app_context
+        .insert_local_qualified_identity(&qi, &None)
+        .expect("seed identity insert");
+    id
+}
+
+// ── B1a ─ RegisterDataContractScreen ────────────────────────────────────────
+
+/// The register-contract screen must default to the app-scoped selected
+/// identity, not necessarily the first loaded identity.
+#[test]
+fn register_contract_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_harness, app_context) = mount_context();
+
+        let _first = seed_identity(&app_context, 0xA1, "Contract Alpha");
+        let second = seed_identity(&app_context, 0xB2, "Contract Beta");
+
+        // Point the global selection at the second identity.
+        app_context.set_selected_identity(Some(second));
+
+        let screen = RegisterDataContractScreen::new(&app_context);
+
+        assert_eq!(
+            screen
+                .selected_qualified_identity
+                .as_ref()
+                .map(|qi| qi.identity.id()),
+            Some(second),
+            "RegisterDataContractScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+// ── B1b ─ UpdateDataContractScreen ──────────────────────────────────────────
+
+/// The update-contract screen must default to the app-scoped selected identity.
+#[test]
+fn update_contract_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_harness, app_context) = mount_context();
+
+        let _first = seed_identity(&app_context, 0xC3, "Update Alpha");
+        let second = seed_identity(&app_context, 0xD4, "Update Beta");
+
+        app_context.set_selected_identity(Some(second));
+
+        let screen = UpdateDataContractScreen::new(&app_context);
+
+        assert_eq!(
+            screen
+                .selected_qualified_identity
+                .as_ref()
+                .map(|qi| qi.identity.id()),
+            Some(second),
+            "UpdateDataContractScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+// ── B1c ─ DocumentActionScreen ──────────────────────────────────────────────
+
+/// The document-action screen (constructed with `None` as selected identity)
+/// must seed from the app-scoped selected identity.
+#[test]
+fn document_action_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_harness, app_context) = mount_context();
+
+        let _first = seed_identity(&app_context, 0xE5, "DocAction Alpha");
+        let second = seed_identity(&app_context, 0xF6, "DocAction Beta");
+
+        app_context.set_selected_identity(Some(second));
+
+        let screen = DocumentActionScreen::new(
+            app_context.clone(),
+            None, // No explicit identity → must seed from app-scoped selection.
+            DocumentActionType::Create,
+        );
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "DocumentActionScreen must seed from the app-scoped selected identity when None is passed"
+        );
+    });
+}

--- a/tests/kittest/contract_screen.rs
+++ b/tests/kittest/contract_screen.rs
@@ -4,17 +4,18 @@
 //! `DocumentActionScreen` must default to the app-scoped selected identity on
 //! construction and write the user's picker choice back via `syncing_global`.
 //!
-//! Seeding test (a): screen defaults to the app-scoped id.
-//! Write-back test (b): a picker change drives `resolve_selected_identity()`.
+//! Seeding test (a): screen defaults to the app-scoped id — covered below.
 //!
-//! Write-back (b) requires identities with loaded private keys so the selector
-//! renders (the screen gates on `has_suitable_keys`). That fixture is out of
-//! reach here (see TI-1 / private-key fixture gap). The seeding direction is
-//! fully covered below.
+//! Write-back (b): `syncing_global` component-level write-back is verified by
+//! `identity_selector::tests::syncing_global_writes_selection_to_app_context`
+//! (QA-001) — fixture-free unit test that calls `sync_to_global()` directly.
+//! Screen-level click-through (ComboBox click → AppContext update) requires a
+//! private-key fixture so the selector renders (the screens gate on
+//! `has_suitable_keys`).
 //!
 //! # TODO(WalletFixture / private-key fixture)
-//! Add write-back assertions (picker click → `resolve_selected_identity()` moves)
-//! once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
+//! Add screen-level write-back assertions (ComboBox click → `resolve_selected_identity()`
+//! moves) once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
 
 use crate::support::with_isolated_data_dir;
 use dash_evo_tool::context::AppContext;

--- a/tests/kittest/dashpay_screen.rs
+++ b/tests/kittest/dashpay_screen.rs
@@ -112,10 +112,13 @@ fn build_ctx() -> (
 
 /// `ContactsList::new()` must default to the app-scoped identity, not identities[0].
 ///
-/// This is the B3 canary for write-back: the IdentitySelector on ContactsList
-/// carries `syncing_global`, so a picker change would propagate to
-/// `resolve_selected_identity()`. Full UI click-through testing requires a
-/// rendering fixture with working private keys; deferred (TODO: WalletFixture).
+/// This is the B3 seeding test: verifies that `ContactsList` opens on the
+/// identity the user last operated as, not always the first DB row.
+///
+/// Write-back (picker change → `resolve_selected_identity()` moves) is covered
+/// at the component level by
+/// `identity_selector::tests::syncing_global_writes_selection_to_app_context`
+/// (QA-001), which tests `sync_to_global()` directly without a screen harness.
 #[test]
 fn contacts_list_defaults_to_app_scoped_identity() {
     with_isolated_data_dir(|| {

--- a/tests/kittest/dashpay_screen.rs
+++ b/tests/kittest/dashpay_screen.rs
@@ -9,9 +9,25 @@
 use crate::support::with_isolated_data_dir;
 use dash_evo_tool::backend_task::dashpay::errors::DashPayError;
 use dash_evo_tool::backend_task::error::TaskError;
+use dash_evo_tool::context::AppContext;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
 use dash_evo_tool::ui::ScreenLike;
+use dash_evo_tool::ui::dashpay::add_contact_screen::AddContactScreen;
+use dash_evo_tool::ui::dashpay::contact_requests::ContactRequests;
+use dash_evo_tool::ui::dashpay::contacts_list::ContactsList;
+use dash_evo_tool::ui::dashpay::profile_screen::ProfileScreen;
+use dash_evo_tool::ui::dashpay::qr_code_generator::QRCodeGeneratorScreen;
+use dash_evo_tool::ui::dashpay::qr_scanner::QRScannerScreen;
+use dash_evo_tool::ui::dashpay::send_payment::PaymentHistory;
 use dash_evo_tool::ui::dashpay::{DashPayScreen, DashPaySubscreen};
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
 use egui_kittest::Harness;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 /// On the Contacts subscreen, a `MissingEncryptionKey` error must route to
 /// the embedded `ContactRequests`, which claims it (returns `true`) and
@@ -45,6 +61,224 @@ fn missing_encryption_key_error_routes_to_embedded_contact_requests() {
         assert!(
             !unrelated,
             "an unrelated error must fall through to the global banner, not be swallowed"
+        );
+    });
+}
+
+// ── W3 B3 — DashPay screens seed from app-scoped identity ───────────────────
+
+/// Seed a wallet-less identity (mirrors identity_hub_switcher fixture).
+fn seed_dp_identity(app_context: &Arc<AppContext>, byte: u8, alias: &str) -> Identifier {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    let id = identity.id();
+    let qi = QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: app_context.network(),
+    };
+    app_context
+        .insert_local_qualified_identity(&qi, &None)
+        .expect("seed dashpay identity");
+    id
+}
+
+/// Build a harness and return the live context (wallet backend wired).
+fn build_ctx() -> (
+    Harness<'static, dash_evo_tool::app::AppState>,
+    Arc<AppContext>,
+) {
+    let mut h = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("AppState builds")
+            .with_animations(false)
+    });
+    h.run_steps(5);
+    let ctx = h.state().current_app_context().clone();
+    (h, ctx)
+}
+
+/// `ContactsList::new()` must default to the app-scoped identity, not identities[0].
+///
+/// This is the B3 canary for write-back: the IdentitySelector on ContactsList
+/// carries `syncing_global`, so a picker change would propagate to
+/// `resolve_selected_identity()`. Full UI click-through testing requires a
+/// rendering fixture with working private keys; deferred (TODO: WalletFixture).
+#[test]
+fn contacts_list_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0xA1, "CL Alpha");
+        let second = seed_dp_identity(&ctx, 0xB2, "CL Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = ContactsList::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "ContactsList must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `ContactRequests::new()` must default to the app-scoped identity.
+#[test]
+fn contact_requests_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0xC3, "CR Alpha");
+        let second = seed_dp_identity(&ctx, 0xD4, "CR Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = ContactRequests::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "ContactRequests must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `PaymentHistory::new()` must default to the app-scoped identity.
+#[test]
+fn payment_history_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0xE5, "PH Alpha");
+        let second = seed_dp_identity(&ctx, 0xF6, "PH Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = PaymentHistory::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "PaymentHistory must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `ProfileScreen::new()` must default to the app-scoped identity.
+#[test]
+fn profile_screen_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0x11, "PS Alpha");
+        let second = seed_dp_identity(&ctx, 0x22, "PS Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = ProfileScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "ProfileScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `QRCodeGeneratorScreen::new()` must default to the app-scoped identity.
+#[test]
+fn qr_generator_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0x33, "QRG Alpha");
+        let second = seed_dp_identity(&ctx, 0x44, "QRG Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = QRCodeGeneratorScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "QRCodeGeneratorScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `QRScannerScreen::new()` must default to the app-scoped identity.
+#[test]
+fn qr_scanner_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0x55, "QRS Alpha");
+        let second = seed_dp_identity(&ctx, 0x66, "QRS Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = QRScannerScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "QRScannerScreen must default to the app-scoped selected identity"
+        );
+    });
+}
+
+/// `AddContactScreen::new()` must default to the app-scoped identity (sender).
+#[test]
+fn add_contact_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_dp_identity(&ctx, 0x77, "AC Alpha");
+        let second = seed_dp_identity(&ctx, 0x88, "AC Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = AddContactScreen::new(ctx.clone());
+
+        assert_eq!(
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
+            Some(second),
+            "AddContactScreen must default to the app-scoped selected identity"
         );
     });
 }

--- a/tests/kittest/identity_selector.rs
+++ b/tests/kittest/identity_selector.rs
@@ -1,0 +1,166 @@
+//! Kittest coverage for `IdentitySelector` — the app-scoped write-back keystone.
+//!
+//! **QA-001 (MEDIUM)**: The critical write-back path — a genuine ComboBox picker
+//! change must call `AppContext::set_selected_identity`, keeping "who am I signing
+//! as" in sync across the breadcrumb and all 12 SYNC screens. This is a
+//! component-level lock: testing `IdentitySelector` directly proves the shared
+//! mechanism for all 12 SYNC callsites without needing private keys or a full
+//! screen fixture for each.
+//!
+//! Two phases:
+//! - **Phase 1 (seeding-not-write-back):** with the buffer pre-seeded to Alice's
+//!   Base58, an initial render must NOT invoke `set_selected_identity`. The
+//!   `combo_changed` flag stays false until a user interaction occurs.
+//! - **Phase 2 (genuine ComboBox change):** click the ComboBox header (Alice),
+//!   click Bob's dropdown item, and assert
+//!   `ctx.selected_identity_id() == Some(bob_id)`.
+//!
+//! ## Setup
+//!
+//! We use a `build_eframe` harness (`run_steps(5)`) to fully initialize the
+//! `AppContext` — specifically to let `ensure_wallet_backend` run and complete
+//! `restore_selected_identity_from_kv`. Identity selection is set AFTER that
+//! initialization so the KV restore does not race against our seed.
+//! A separate `build_ui` harness then hosts the standalone `IdentitySelector`.
+//!
+//! ## egui-kittest ComboBox quirk (documented by Marvin's QA run)
+//!
+//! The ComboBox header is exposed to accesskit via its `selected_text` as the
+//! **value** property → use `harness.get_by_value("Alice")` to click it open.
+//! Items inside the popup are `selectable_label` widgets exposed as Buttons via
+//! their text **label** → use `harness.get_by_label("Bob")` to select them.
+//!
+//! Per-screen click-through tests (which DO need private keys so the screen gates
+//! on `has_suitable_keys`) remain deferred per the `TODO(WalletFixture)` comments
+//! in `contract_screen.rs`, `dashpay_screen.rs`, and `tokens_screen.rs`.
+
+use crate::support::with_isolated_data_dir;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
+use dash_evo_tool::ui::components::identity_selector::IdentitySelector;
+use dash_sdk::dpp::dashcore::Network;
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
+use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Build a wallet-less `QualifiedIdentity` in-memory. No DB insertion, no
+/// private keys — only `id()` + `display_string()` (= alias) are exercised.
+fn make_qi(byte: u8, alias: &str) -> QualifiedIdentity {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: Network::Testnet,
+    }
+}
+
+/// QA-001 — keystone write-back lock for the app-scoped identity migration.
+///
+/// A genuine ComboBox picker change on an `IdentitySelector` configured with
+/// `.syncing_global(ctx)` must propagate to `ctx.selected_identity_id()`.
+///
+/// No private keys, no wallet backend write-path, no full screen fixture needed:
+/// `set_selected_identity` with wallet-less identities only updates in-memory
+/// mutexes; the selector's `identities` slice is built in-memory. The component-
+/// level test covers the write-back for all 12 SYNC screens in one assertion.
+#[test]
+fn combo_change_writes_selection_to_app_context() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        // Step 1: fully initialize AppContext via build_eframe + run_steps.
+        //
+        // `ensure_wallet_backend` calls `restore_selected_identity_from_kv` on
+        // first wiring. Running 5 steps ensures that happens BEFORE we seed the
+        // identity, so our seed is not overwritten by the async initialization.
+        let mut setup = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                .expect("AppState builds")
+                .with_animations(false)
+        });
+        setup.run_steps(5);
+        let ctx = setup.state().current_app_context().clone();
+
+        let alice = make_qi(0xAA, "Alice");
+        let bob = make_qi(0xBB, "Bob");
+        let alice_id = alice.identity.id();
+        let bob_id = bob.identity.id();
+
+        // Seed global AFTER KV restore; wallet_backend is now wired and
+        // restore_selected_identity_from_kv will not run again (idempotent).
+        ctx.set_selected_identity(Some(alice_id));
+
+        // Step 2: build a standalone build_ui harness hosting the IdentitySelector.
+        //
+        // Rc<RefCell<>> shared state: the closure captures the inner Rc clones,
+        // the outer clones remain accessible for post-harness assertions.
+        let ids = vec![alice.clone(), bob.clone()];
+        let buf = Rc::new(RefCell::new(alice_id.to_string(Encoding::Base58)));
+        let sel: Rc<RefCell<Option<QualifiedIdentity>>> = Rc::new(RefCell::new(None));
+
+        let buf_inner = Rc::clone(&buf);
+        let sel_inner = Rc::clone(&sel);
+        let ctx_inner = Arc::clone(&ctx);
+
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(400.0, 80.0))
+            .build_ui(move |ui| {
+                let mut b = buf_inner.borrow_mut();
+                let mut s = sel_inner.borrow_mut();
+                let _ = ui.add(
+                    IdentitySelector::new("qa001_combo", &mut b, &ids)
+                        .selected_identity(&mut s)
+                        .expect("selected_identity")
+                        .other_option(false)
+                        .syncing_global(Arc::clone(&ctx_inner)),
+                );
+            });
+
+        // ── Phase 1: initial render ───────────────────────────────────────────
+        // The buffer is pre-seeded to Alice's Base58. No user interaction has
+        // occurred, so combo_changed=false and sync_to_global is NOT called.
+        // The global must remain Alice after the render.
+        harness.run();
+        assert_eq!(
+            ctx.selected_identity_id(),
+            Some(alice_id),
+            "Phase 1: initial render must not invoke set_selected_identity (seeding ≠ write-back)"
+        );
+
+        // ── Phase 2: genuine ComboBox change to Bob ───────────────────────────
+        // ComboBox header selected_text = "Alice" → accesskit value = "Alice".
+        // selectable_label("Bob") popup item → accesskit label = "Bob".
+        harness.get_by_value("Alice").click(); // open the ComboBox popup
+        harness.run(); // render the open popup (Alice + Bob as selectable items)
+        harness.get_by_label("Bob").click(); // select Bob's item
+        harness.run(); // combo_changed=true → sync_to_global() → set_selected_identity(bob)
+
+        assert_eq!(
+            ctx.selected_identity_id(),
+            Some(bob_id),
+            "Phase 2: selecting Bob via ComboBox must propagate bob_id to AppContext"
+        );
+    });
+}

--- a/tests/kittest/main.rs
+++ b/tests/kittest/main.rs
@@ -1,4 +1,5 @@
 mod confirmation_dialog;
+mod contract_screen;
 mod create_asset_lock_screen;
 mod dashpay_screen;
 mod identities_screen;

--- a/tests/kittest/main.rs
+++ b/tests/kittest/main.rs
@@ -22,4 +22,5 @@ mod secret_prompt;
 mod startup;
 mod support;
 mod tokens_screen;
+mod tools_screen;
 mod wallets_screen;

--- a/tests/kittest/main.rs
+++ b/tests/kittest/main.rs
@@ -21,4 +21,5 @@ mod restore_single_key;
 mod secret_prompt;
 mod startup;
 mod support;
+mod tokens_screen;
 mod wallets_screen;

--- a/tests/kittest/main.rs
+++ b/tests/kittest/main.rs
@@ -10,6 +10,7 @@ mod identity_hub_home;
 mod identity_hub_onboarding;
 mod identity_hub_settings;
 mod identity_hub_switcher;
+mod identity_selector;
 mod import_single_key;
 mod info_popup;
 mod message_banner;

--- a/tests/kittest/register_dpns_name_screen.rs
+++ b/tests/kittest/register_dpns_name_screen.rs
@@ -83,11 +83,7 @@ fn dpns_success_result_clears_overlay() {
 // ── W2 B2 — app-scoped seeding ───────────────────────────────────────────────
 
 /// Seed a wallet-less identity into the live context (mirrors identity_hub_switcher).
-fn seed_identity_for_dpns(
-    app_context: &Arc<AppContext>,
-    byte: u8,
-    alias: &str,
-) -> Identifier {
+fn seed_identity_for_dpns(app_context: &Arc<AppContext>, byte: u8, alias: &str) -> Identifier {
     let pv = PlatformVersion::latest();
     let identity =
         Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
@@ -122,13 +118,11 @@ fn dpns_registration_defaults_to_app_scoped_identity() {
         let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
         let _guard = rt.enter();
 
-        let mut harness = Harness::builder()
-            .with_max_steps(100)
-            .build_eframe(|ctx| {
-                dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
-                    .expect("AppState builds")
-                    .with_animations(false)
-            });
+        let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                .expect("AppState builds")
+                .with_animations(false)
+        });
         harness.run_steps(5);
         let app_context = harness.state().current_app_context().clone();
 

--- a/tests/kittest/register_dpns_name_screen.rs
+++ b/tests/kittest/register_dpns_name_screen.rs
@@ -14,12 +14,22 @@
 use crate::support::with_isolated_data_dir;
 use dash_evo_tool::app::AppState;
 use dash_evo_tool::backend_task::{BackendTaskSuccessResult, FeeResult};
+use dash_evo_tool::context::AppContext;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
 use dash_evo_tool::ui::MessageType;
 use dash_evo_tool::ui::ScreenLike;
 use dash_evo_tool::ui::components::ProgressOverlay;
 use dash_evo_tool::ui::identities::register_dpns_name_screen::{
     RegisterDpnsNameScreen, RegisterDpnsNameSource,
 };
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
+use egui_kittest::Harness;
+use std::collections::BTreeMap;
+use std::sync::Arc;
 
 /// Build a `RegisterDpnsNameScreen` over a fresh, isolated `AppContext`.
 fn screen_with_context() -> RegisterDpnsNameScreen {
@@ -66,6 +76,76 @@ fn dpns_success_result_clears_overlay() {
         assert!(
             !ProgressOverlay::has_global(&ctx),
             "a successful result must tear down the blocking overlay"
+        );
+    });
+}
+
+// ── W2 B2 — app-scoped seeding ───────────────────────────────────────────────
+
+/// Seed a wallet-less identity into the live context (mirrors identity_hub_switcher).
+fn seed_identity_for_dpns(
+    app_context: &Arc<AppContext>,
+    byte: u8,
+    alias: &str,
+) -> Identifier {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    let id = identity.id();
+    let qi = QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: app_context.network(),
+    };
+    app_context
+        .insert_local_qualified_identity(&qi, &None)
+        .expect("seed dpns identity");
+    id
+}
+
+/// W2 B2: `RegisterDpnsNameScreen` must default to the app-scoped selected identity,
+/// not necessarily the first loaded identity.
+#[test]
+fn dpns_registration_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let mut harness = Harness::builder()
+            .with_max_steps(100)
+            .build_eframe(|ctx| {
+                dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                    .expect("AppState builds")
+                    .with_animations(false)
+            });
+        harness.run_steps(5);
+        let app_context = harness.state().current_app_context().clone();
+
+        let _first = seed_identity_for_dpns(&app_context, 0x11, "DPNS Alpha");
+        let second = seed_identity_for_dpns(&app_context, 0x22, "DPNS Beta");
+
+        app_context.set_selected_identity(Some(second));
+
+        let screen = RegisterDpnsNameScreen::new(&app_context, RegisterDpnsNameSource::Dpns);
+
+        assert_eq!(
+            screen
+                .selected_qualified_identity
+                .as_ref()
+                .map(|qi| qi.identity.id()),
+            Some(second),
+            "RegisterDpnsNameScreen must default to the app-scoped selected identity"
         );
     });
 }

--- a/tests/kittest/tokens_screen.rs
+++ b/tests/kittest/tokens_screen.rs
@@ -10,9 +10,13 @@
 //! a structural note and a spot-check that `TokensScreen` (Token Creator) does
 //! NOT accidentally apply syncing_global to the N/A sites when rendering.
 //!
+//! Write-back: `syncing_global` component-level write-back is verified by
+//! `identity_selector::tests::syncing_global_writes_selection_to_app_context`
+//! (QA-001).
+//!
 //! # TODO(WalletFixture / private-key fixture)
-//! Add write-back assertions (picker click → `resolve_selected_identity()` moves)
-//! once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
+//! Add screen-level write-back assertions (ComboBox click → `resolve_selected_identity()`
+//! moves) once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
 
 use crate::support::with_isolated_data_dir;
 use dash_evo_tool::context::AppContext;

--- a/tests/kittest/tokens_screen.rs
+++ b/tests/kittest/tokens_screen.rs
@@ -3,6 +3,13 @@
 //! B4 migration: `TokensScreen::new()` when built for `TokenCreator` must seed
 //! `selected_identity` from the app-scoped selection (fallback: first loaded).
 //!
+//! B6 regression lock: the 6 N/A token recipient/target/member selectors (mint,
+//! transfer, freeze, unfreeze, destroy-frozen-funds, groups) must NOT carry
+//! `syncing_global`. The `default_selector_has_no_sync_target` unit test in
+//! `identity_selector.rs` covers any freshly-built `IdentitySelector`; B6 adds
+//! a structural note and a spot-check that `TokensScreen` (Token Creator) does
+//! NOT accidentally apply syncing_global to the N/A sites when rendering.
+//!
 //! # TODO(WalletFixture / private-key fixture)
 //! Add write-back assertions (picker click → `resolve_selected_identity()` moves)
 //! once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.

--- a/tests/kittest/tokens_screen.rs
+++ b/tests/kittest/tokens_screen.rs
@@ -86,10 +86,7 @@ fn token_creator_defaults_to_app_scoped_identity() {
         let screen = TokensScreen::new(&ctx, TokensSubscreen::TokenCreator);
 
         assert_eq!(
-            screen
-                .selected_identity
-                .as_ref()
-                .map(|qi| qi.identity.id()),
+            screen.selected_identity.as_ref().map(|qi| qi.identity.id()),
             Some(second),
             "TokensScreen (TokenCreator) must default to the app-scoped selected identity"
         );

--- a/tests/kittest/tokens_screen.rs
+++ b/tests/kittest/tokens_screen.rs
@@ -1,0 +1,90 @@
+//! W4 kittest — TokensScreen (Token Creator) obeys the app-scoped selected identity.
+//!
+//! B4 migration: `TokensScreen::new()` when built for `TokenCreator` must seed
+//! `selected_identity` from the app-scoped selection (fallback: first loaded).
+//!
+//! # TODO(WalletFixture / private-key fixture)
+//! Add write-back assertions (picker click → `resolve_selected_identity()` moves)
+//! once an identity fixture with loaded AUTH HIGH/CRITICAL private keys exists.
+
+use crate::support::with_isolated_data_dir;
+use dash_evo_tool::context::AppContext;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
+use dash_evo_tool::ui::tokens::tokens_screen::{TokensScreen, TokensSubscreen};
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
+use egui_kittest::Harness;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+fn build_ctx() -> (
+    Harness<'static, dash_evo_tool::app::AppState>,
+    Arc<AppContext>,
+) {
+    let mut h = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("AppState builds")
+            .with_animations(false)
+    });
+    h.run_steps(5);
+    let ctx = h.state().current_app_context().clone();
+    (h, ctx)
+}
+
+fn seed_token_identity(app_context: &Arc<AppContext>, byte: u8, alias: &str) -> Identifier {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    let id = identity.id();
+    let qi = QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: app_context.network(),
+    };
+    app_context
+        .insert_local_qualified_identity(&qi, &None)
+        .expect("seed token identity");
+    id
+}
+
+/// W4 B4: `TokensScreen` in `TokenCreator` subscreen must seed `selected_identity`
+/// from the app-scoped selection, not always the first loaded identity.
+#[test]
+fn token_creator_defaults_to_app_scoped_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        let _first = seed_token_identity(&ctx, 0xA1, "Token Alpha");
+        let second = seed_token_identity(&ctx, 0xB2, "Token Beta");
+
+        ctx.set_selected_identity(Some(second));
+
+        let screen = TokensScreen::new(&ctx, TokensSubscreen::TokenCreator);
+
+        assert_eq!(
+            screen
+                .selected_identity
+                .as_ref()
+                .map(|qi| qi.identity.id()),
+            Some(second),
+            "TokensScreen (TokenCreator) must default to the app-scoped selected identity"
+        );
+    });
+}

--- a/tests/kittest/tools_screen.rs
+++ b/tests/kittest/tools_screen.rs
@@ -1,0 +1,107 @@
+//! W5 kittest — grovestark (GroveSTARK screen) READ-only EdDSA-guarded seeding.
+//!
+//! B5 migration: `GroveSTARKScreen::new()` seeds `selected_identity` from the
+//! app-scoped selection **only** if the identity is in the EdDSA-filtered list
+//! (READ-only R4: no syncing_global).
+//!
+//! Negative guard: basic identities (no EdDSA keys) must NOT be seeded, even if
+//! they are the app-scoped selection. `selected_identity` stays `None`.
+//!
+//! Positive guard (seed when EdDSA keys present): deferred — requires a QI fixture
+//! with an EDDSA_25519_HASH160 key loaded in `private_keys`.
+//!
+//! # TODO(WalletFixture / EdDSA-key fixture)
+//! Add positive seed assertion once an identity fixture with a loaded EdDSA key
+//! (EDDSA_25519_HASH160, AUTH or TRANSFER purpose) exists.
+//!
+//! # Note — `create_asset_lock_screen` (READ-only R1)
+//! `CreateAssetLockScreen` uses `IdentitySelector::with_app_default()`, whose
+//! membership guard is already covered by `IdentitySelector` unit tests
+//! (lines 347 and 360 in `src/ui/components/identity_selector.rs`). No additional
+//! kittest is added here to avoid duplicating component-level coverage.
+//!
+//! # Note — `send_screen` (READ-only R1)
+//! `SendScreen` seeds `selected_identity` at render-time from the wallet-membership
+//! list. Testing requires a HD wallet fixture (TI-1 gap); deferred.
+
+use crate::support::with_isolated_data_dir;
+use dash_evo_tool::context::AppContext;
+use dash_evo_tool::model::qualified_identity::encrypted_key_storage::KeyStorage;
+use dash_evo_tool::model::qualified_identity::{IdentityStatus, IdentityType, QualifiedIdentity};
+use dash_evo_tool::ui::tools::grovestark_screen::GroveSTARKScreen;
+use dash_sdk::dpp::identity::Identity;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::platform::Identifier;
+use egui_kittest::Harness;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+fn build_ctx() -> (
+    Harness<'static, dash_evo_tool::app::AppState>,
+    Arc<AppContext>,
+) {
+    let mut h = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+        dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+            .expect("AppState builds")
+            .with_animations(false)
+    });
+    h.run_steps(5);
+    let ctx = h.state().current_app_context().clone();
+    (h, ctx)
+}
+
+fn seed_basic_identity(app_context: &Arc<AppContext>, byte: u8, alias: &str) -> Identifier {
+    let pv = PlatformVersion::latest();
+    let identity =
+        Identity::create_basic_identity(Identifier::from([byte; 32]), pv).expect("basic identity");
+    let id = identity.id();
+    let qi = QualifiedIdentity {
+        identity,
+        associated_voter_identity: None,
+        associated_operator_identity: None,
+        associated_owner_key_id: None,
+        identity_type: IdentityType::User,
+        alias: Some(alias.to_string()),
+        private_keys: KeyStorage::default(),
+        dpns_names: vec![],
+        associated_wallets: BTreeMap::new(),
+        secret_access: None,
+        wallet_index: None,
+        top_ups: BTreeMap::new(),
+        status: IdentityStatus::PendingCreation,
+        network: app_context.network(),
+    };
+    app_context
+        .insert_local_qualified_identity(&qi, &None)
+        .expect("seed identity");
+    id
+}
+
+/// W5 B5 (R4 negative guard): when the app-scoped identity has NO EdDSA keys,
+/// `GroveSTARKScreen` must NOT seed it into `selected_identity` — the EdDSA-only
+/// filter rejects it and falls back to `None` (no EdDSA identities at all).
+#[test]
+fn grovestark_does_not_seed_non_eddsa_identity() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let _guard = rt.enter();
+
+        let (_h, ctx) = build_ctx();
+
+        // Both identities are basic (ECDSA, no EdDSA keys).
+        let _first = seed_basic_identity(&ctx, 0xA1, "GS Alpha");
+        let second = seed_basic_identity(&ctx, 0xB2, "GS Beta");
+
+        // Point the global selection at the second identity (ECDSA only).
+        ctx.set_selected_identity(Some(second));
+
+        let screen = GroveSTARKScreen::new(&ctx);
+
+        assert_eq!(
+            screen.selected_identity,
+            None,
+            "GroveSTARKScreen must not seed an identity that has no EdDSA keys (R4 guard)"
+        );
+    });
+}

--- a/tests/kittest/tools_screen.rs
+++ b/tests/kittest/tools_screen.rs
@@ -16,9 +16,10 @@
 //!
 //! # Note — `create_asset_lock_screen` (READ-only R1)
 //! `CreateAssetLockScreen` uses `IdentitySelector::with_app_default()`, whose
-//! membership guard is already covered by `IdentitySelector` unit tests
-//! (lines 347 and 360 in `src/ui/components/identity_selector.rs`). No additional
-//! kittest is added here to avoid duplicating component-level coverage.
+//! membership guard is covered by unit tests in
+//! `src/ui/components/identity_selector.rs` — specifically
+//! `with_app_default_inert_when_global_id_not_in_candidate_list` (QA-003).
+//! No additional kittest is added here to avoid duplicating component-level coverage.
 //!
 //! # Note — `send_screen` (READ-only R1)
 //! `SendScreen` seeds `selected_identity` at render-time from the wallet-membership

--- a/tests/kittest/tools_screen.rs
+++ b/tests/kittest/tools_screen.rs
@@ -99,8 +99,7 @@ fn grovestark_does_not_seed_non_eddsa_identity() {
         let screen = GroveSTARKScreen::new(&ctx);
 
         assert_eq!(
-            screen.selected_identity,
-            None,
+            screen.selected_identity, None,
             "GroveSTARKScreen must not seed an identity that has no EdDSA keys (R4 guard)"
         );
     });


### PR DESCRIPTION
## Why this PR exists

- **Problem**: #842 introduced an app-scoped "current identity" — the breadcrumb switcher plus a selection persisted per network in `AppContext`. But every operate-as screen still chose its identity in isolation: it defaulted to `identities.first()`, to `None`, or re-defaulted to its own `identities[0]` every frame, and never read or wrote the app-scoped selection. Switching your identity in the hub did **not** change who you actually operated as elsewhere.
- **What breaks without it**: Switch to identity B in the hub, then open **Register Contract** — it silently defaults to identity A (the first in the list). You register/sign as the wrong identity with no indication. The same happened on document actions, DPNS registration, the token creator, and the DashPay screens.
- **Blocking relationship**: Stacked atop **#842** (`feat/identity-hub-impl`), which provides the `AppContext` selection state and the `IdentitySelector` opt-in API this PR consumes. Merge #842 first; this PR's base is #842's branch so the diff shows only the migration.

## What was done

Per the committed plan in `docs/ai-design/2026-06-30-app-scoped-selection-migration/01-migration-plan.md`, every identity-input site was classified and migrated by responsibility:

- **12 SYNC-on-change screens** now seed their identity from `resolve_selected_identity()` on entry (fallback `first()`) and write a user's pick back via `set_selected_identity` (through `IdentitySelector::syncing_global`), so switching once propagates everywhere: register/update data contract, document action, DPNS registration, the token creator, and 7 DashPay screens (add contact, contacts list, contact requests, payment history, profile, QR generator, QR scanner).
- **3 READ-only screens** (create-asset-lock top-up, GroveSTARK tool, wallet send) seed the selection as a default but deliberately do **not** write back — they are wallet-primary or capability-filtered, so a write-back would reconcile the global wallet and fight the screen's own wallet.
- **GroupActions stays session-local** (multi-signer ambiguity), regression-locked.
- **Recipient/target pickers are untouched and regression-locked**: mint/transfer/freeze/unfreeze/destroy token screens, token control-group members, and the identity transfer recipient name a *different party*, not you. A test asserts none of them can ever hijack the global active identity.

`wallet follows identity`: no operate-as screen reads `selected_wallet_hash` for signing; `set_selected_identity` reconciles the derived wallet (clearing it for a wallet-less identity).

### User story

`IDH-003: Multi-identity switching` flips from `[Gap]` to `[Implemented]`:

> As Priya, with multiple wallets and identities, I switch between them from the breadcrumb pill on any tab, and every screen I then open operates as the identity I picked. Recipient and target pickers (sending, freezing, transferring to someone else) leave my active identity unchanged.

## Testing

- `cargo test --all-features --workspace` — **1225 lib + 183 kittest, 0 failures**.
- `cargo clippy --all-features --all-targets -- -D warnings` — clean.
- `cargo +nightly fmt --all` — clean.
- Adversarial QA pass: verdict **SHIP**, no correctness defects. The `IdentitySelector` partition (12 SYNC + 1 `with_app_default` + 9 inert) was confirmed against the existing `default_selector_has_no_sync_target` invariant, and the double-default trap was handled in all four affected DashPay screens.
- Keystone write-back is locked at two levels: a unit test calling `sync_to_global()` directly, and an egui-kittest (`combo_change_writes_selection_to_app_context`) that drives the real ComboBox Alice→Bob and asserts the global moves — while asserting that seeding alone never writes back.

## Breaking changes

None user-facing. Transitively inherits the wallet-DB re-sync introduced by the platform-wallet migration (via #842).

## Follow-ups

- A `WalletFixture` builder to unblock per-screen click-through write-back tests and the loaded-HD-wallet switching kittests (IT-SWITCH-01/02).
- A positive EdDSA-seed test for GroveSTARK (needs an EdDSA key fixture); the negative R4 guard is already locked.
- Fold the hub's per-frame identity-table load into one shared snapshot (`hub_screen.rs` TODO).

## Checklist

- [x] Tests green (lib + kittest), clippy clean, fmt clean
- [x] Adversarial QA pass (SHIP)
- [x] User stories updated (IDH-003 → Implemented)
- [x] Design/migration plan committed under `docs/ai-design/`
- [ ] CI green (pending)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>