### PR TITLE
fix(theme): log OS theme-detection failure once instead of every poll

### DIFF
--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,6 +1,7 @@
 use egui::{
     Button, Color32, CursorIcon, FontFamily, FontId, RichText, Stroke, Ui, Vec2, WidgetText,
 };
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Theme mode enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -20,16 +21,35 @@ pub fn detect_system_theme() -> Result<ThemeMode, String> {
     }
 }
 
+/// Latches so a persistent detection failure (e.g. no XDG portal on
+/// headless Linux) is logged once instead of on every poll. Cleared on the
+/// next successful detection so a later failure logs again.
+static THEME_DETECTION_FAILURE_LOGGED: AtomicBool = AtomicBool::new(false);
+
+/// Returns `true` the first time it's called since the latch was last reset
+/// by a successful detection, `false` on every subsequent call.
+fn should_log_theme_detection_failure() -> bool {
+    !THEME_DETECTION_FAILURE_LOGGED.swap(true, Ordering::Relaxed)
+}
+
 /// Detect system theme, returning `None` only on detection errors.
 /// Use this for polling: a `None` means "keep the previous theme" rather than
 /// flipping to an arbitrary default. `Unspecified` maps to Light (common on
 /// Linux where `dark_light` often can't determine the theme).
 pub fn try_detect_system_theme() -> Option<ThemeMode> {
     match dark_light::detect() {
-        Ok(dark_light::Mode::Dark) => Some(ThemeMode::Dark),
-        Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) => Some(ThemeMode::Light),
+        Ok(dark_light::Mode::Dark) => {
+            THEME_DETECTION_FAILURE_LOGGED.store(false, Ordering::Relaxed);
+            Some(ThemeMode::Dark)
+        }
+        Ok(dark_light::Mode::Light | dark_light::Mode::Unspecified) => {
+            THEME_DETECTION_FAILURE_LOGGED.store(false, Ordering::Relaxed);
+            Some(ThemeMode::Light)
+        }
         Err(e) => {
-            tracing::debug!("OS theme detection failed: {e}");
+            if should_log_theme_detection_failure() {
+                tracing::debug!("OS theme detection failed: {e}");
+            }
             None
         }
     }
@@ -1176,4 +1196,34 @@ pub fn apply_theme(ctx: &egui::Context, theme_mode: ThemeMode) {
     style.visuals.faint_bg_color = DashColors::background(dark_mode);
 
     ctx.set_global_style(style);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn theme_detection_failure_logs_once_until_reset() {
+        THEME_DETECTION_FAILURE_LOGGED.store(false, Ordering::Relaxed);
+
+        assert!(
+            should_log_theme_detection_failure(),
+            "first failure should log"
+        );
+        assert!(
+            !should_log_theme_detection_failure(),
+            "repeated failure should be suppressed"
+        );
+        assert!(
+            !should_log_theme_detection_failure(),
+            "still suppressed while failure persists"
+        );
+
+        // A successful detection resets the latch.
+        THEME_DETECTION_FAILURE_LOGGED.store(false, Ordering::Relaxed);
+        assert!(
+            should_log_theme_detection_failure(),
+            "failure after a success should log again"
+        );
+    }
 }


### PR DESCRIPTION
## Why this PR exists
- **Problem**: On Linux without XDG Desktop Portal (headless boxes, minimal desktop environments), OS theme detection fails on every poll and logs the failure at DEBUG roughly every 2 seconds — ~30×/min, 275+×/session.
- **What breaks without it**: `det.log` is flooded with identical `OS theme detection failed: XDG Desktop Portal error…` lines, drowning out useful diagnostics. Observed continuously on the headless test box.

## What was done
- `try_detect_system_theme()` (`src/ui/theme.rs`) now logs the detection failure **at most once while it persists**, and **resets on a successful detection** (so a later failure logs again). Implemented via a module-level `AtomicBool` latch + a small `should_log_theme_detection_failure()` helper.
- Detection and polling behaviour are unchanged — only the redundant log line is suppressed. Log level stays `debug!`.
- Added unit test `theme_detection_failure_logs_once_until_reset` (logs once → suppresses repeats → logs again after a success).

## Testing
- `cargo build`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo +nightly fmt --all` — clean.
- `cargo test theme_detection_failure_logs_once_until_reset` — passes.

## Breaking changes
None — logging-only change.

## Base / stacking
Targets `docs/platform-wallet-migration-design` (#860) because the fix was branched from its tip (`637dc603`), keeping the diff to a single file. Trivial to retarget to `v1.0-dev` via cherry-pick if a standalone merge is preferred.

## Checklist
- [x] Conventional commit
- [x] Build / clippy / fmt clean
- [x] Unit test added and passing
- [x] Logging-only; no behaviour change to detection/polling

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>