### PR TITLE
feat(user-role): role-picker UI on Settings + Welcome, single-source persistence (Phase 3/3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ LOCAL_core_rpc_user=dashmate
 LOCAL_core_rpc_password=password
 LOCAL_core_zmq_endpoint=tcp://127.0.0.1:50298
 
+# Interface mode seed (Default view / Detailed view / Developer tools).
+# Read only once, on the very first launch, when no mode has been chosen yet.
+# Once a mode is chosen (via this seed or the in-app selector under Network
+# Settings), this value is never consulted again. See docs/user-roles.md.
+DEVELOPER_MODE=false
+
 # MCP Server (Model Context Protocol)
 # Set an API key to enable the MCP HTTP server for programmatic access.
 # Leave empty or remove to disable. Binds to localhost only by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   including pasting a raw shielded address in hex form — there are just fewer
   screens to navigate between.
 
+- **Expert mode replaced by three interface levels**: the single Expert-mode
+  toggle is now a three-way choice — **Default view**, **Detailed view**, and
+  **Developer tools** — set from Network Settings or during first-time setup.
+  Detailed view unlocks everything the old Expert mode did (account
+  breakdowns, address tables, masternode tools); a few of the most advanced
+  actions (state-transition signing overrides, proceeding without a locally
+  held key, clearing Platform addresses) now require the new Developer tools
+  level. The choice is remembered and can be changed anytime; `DEVELOPER_MODE`
+  in `.env` still works as a one-time starting point on first launch but no
+  longer overrides your choice afterward. See [User Roles](docs/user-roles.md)
+  for details.
+
 ### Known Limitations
 
 - **Single-key wallets — send and balance refresh not available**: importing a

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ When the application runs for the first time, it creates an application director
 | Variable | Values | Default | Description |
 | - | - | - | - |
 | `DASH_EVO_TOOL_ACCESSIBILITY` | `1` / unset | unset | Force-enable accessibility support. Activates AccessKit eagerly so the UI element tree is populated every frame and (on macOS) forces the platform accessibility adapter to initialize. Without this flag, accessibility still works normally — VoiceOver and other assistive technologies trigger AccessKit's lazy activation automatically. This flag is needed for tools that query the accessibility tree without registering as assistive technology clients (e.g. AXUIElement-based automation like Peekaboo). |
+| `DEVELOPER_MODE` | `true` / `false` | `false` | One-time starting point for the interface mode (Default view / Detailed view / Developer tools) on first launch only — not a live toggle. See [docs/user-roles.md](docs/user-roles.md). |
 
 ## Contributing
 

--- a/docs/user-roles.md
+++ b/docs/user-roles.md
@@ -1,0 +1,81 @@
+# User Roles (Interface Mode)
+
+Dash Evo Tool adapts its interface to how you use it. Instead of a single
+"Expert mode" on/off switch, the app offers three interface modes, each
+revealing more advanced controls than the one before it:
+
+| Mode | What it shows |
+| - | - |
+| **Default view** | Your balance, send and receive, and usernames. |
+| **Detailed view** | Adds account details, address tables, and masternode tools. |
+| **Developer tools** | Adds raw protocol data, Devnet, and signing overrides. |
+
+Each mode includes everything the one before it does — Developer tools has
+everything Detailed view has, plus more. **Default view** is the starting
+point for a fresh install; pick a higher mode only once you need the
+additional controls it unlocks.
+
+## Where to set it
+
+The three modes are chosen the same way, with the same descriptions, in two
+places:
+
+- **Network Settings** — open the network chooser screen. An **Interface
+  mode** card sits above Advanced Settings, always visible (it is not tucked
+  inside a collapsed section).
+- **Welcome screen** — on first launch, the onboarding screen shows a
+  "Choose your experience level" row with the same three options before you
+  create or load a wallet.
+
+Picking a mode in either place updates the other — there is only one active
+mode, shared across the whole app.
+
+**This choice is reversible.** You are not locking yourself into a mode by
+picking one at onboarding: open **Network Settings** at any time and change
+it from the **Interface mode** card. The app applies the change immediately,
+with no restart required.
+
+## `.env` behavior: `DEVELOPER_MODE`
+
+The `.env` file in the application directory still has a `DEVELOPER_MODE`
+entry (`true` or `false`), but it now works differently than it used to:
+
+- **It is a one-time starting point, not a live switch.** `DEVELOPER_MODE` is
+  only read once — the very first time the app runs and no interface mode has
+  ever been chosen yet (via the UI or a previous `.env` read).
+- **Once a mode is chosen, `.env` is never consulted again.** This applies
+  whether the mode was set by picking it in the UI or by the one-time
+  `DEVELOPER_MODE` seed itself. Editing `DEVELOPER_MODE` afterward has no
+  effect — use **Network Settings** to change modes instead.
+
+### Migration from an older install
+
+If you are upgrading from a version that had the old `DEVELOPER_MODE`
+on/off toggle, your existing `.env` value is used exactly once, the first
+time you launch this version:
+
+- `DEVELOPER_MODE=true` seeds **Detailed view** — this app's earlier
+  "developer mode" corresponded to what is now Detailed view (account
+  details, address tables, masternode tools), not the new Developer tools
+  mode.
+- `DEVELOPER_MODE=false`, or no `DEVELOPER_MODE` entry at all, seeds
+  **Default view** — no change from today's default.
+
+After that one-time seed, the value in `.env` is ignored; change modes from
+**Network Settings** going forward.
+
+The application directory is:
+
+| Operating System | Path |
+| - | - |
+| macOS | `~/Library/Application Support/Dash-Evo-Tool/.env` |
+| Windows | `C:\Users\<User>\AppData\Roaming\Dash-Evo-Tool\config\.env` |
+| Linux | `~/.config/dash-evo-tool/.env` |
+
+## Migration note: obsolete per-network values
+
+Earlier builds used per-network entries such as `MAINNET_developer_mode=true`
+and `TESTNET_developer_mode=false` in `.env`. These are obsolete and ignored —
+the interface mode is a single global setting, not configured per network.
+Any leftover `*_developer_mode` entries from older configurations can be
+removed safely.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1050,20 +1050,21 @@ As a user, I want to choose between light, dark, or auto theme so that the app m
 - Light, dark, and system-auto options.
 - Theme change applied immediately.
 
-### NET-005: Toggle developer mode [Implemented]
+### NET-005: Unlock advanced features by interface mode [Implemented]
 **Persona:** Priya, Jordan
 
-As a user, I want to enable developer mode so that I can access advanced features like address tables, refresh controls, and debug tools.
+As a user, I want a higher interface mode to reveal advanced features like address tables, refresh controls, and debug tools, so that complexity stays out of my way until I ask for it.
 
-- Toggles visibility of advanced UI elements.
+- Detailed view and Developer tools each add capabilities on top of the mode below them.
+- Feature availability is monotonic: anything a lower mode can do, a higher mode can too.
 
-### NET-006: Select user mode [Gap]
-**Persona:** Alex, Priya
+### NET-006: Select interface mode [Implemented]
+**Persona:** Alex, Priya, Jordan
 
-As a user, I want to choose between Beginner and Advanced mode so that the interface matches my experience level.
+As a user, I want to choose between Default view, Detailed view, and Developer tools so that the interface matches my experience level.
 
-- Beginner mode hides complexity; Advanced mode shows full detail.
-- `UserMode` enum and database persistence exist but no UI control is implemented.
+- Same three choices and descriptions on the Network Settings "Interface mode" card and the Welcome screen onboarding row.
+- Choice persists and applies immediately, and can be changed again at any time.
 
 ### NET-007: Granular refresh controls [Implemented]
 **Persona:** Priya
@@ -1136,7 +1137,7 @@ As an everyday user, I want to install and use Dash Evo Tool without having to r
 
 - Fresh install connects to the Dash network via the built-in SPV light client with zero configuration.
 - The user sees sync progress and status clearly; the default everyday-user UI avoids mentions of SPV, RPC, or nodes.
-- Technical/protocol terminology may appear in Expert mode or advanced settings, where Dash Core RPC remains available as an opt-in for users who do run a local node.
+- Technical/protocol terminology may appear in Detailed view, Developer tools, or advanced settings, where Dash Core RPC remains available as an opt-in for users who do run a local node.
 
 ---
 
@@ -1289,7 +1290,7 @@ As a masternode operator, I want a card list of my loaded masternodes showing ty
 
 - Each card shows a shortened ProTxHash (or alias as heading), a Masternode/Evonode type badge, voter-identity readiness ("Voting ready" / "No voting key"), a compact Voting/Owner/Payout key-status indicator, a DPNS-voting status line, and an identity status dot with a text label.
 - An empty state explains what a masternode identity is for and offers a primary "Load a masternode" action when none are loaded.
-- The Masternodes tab and its nav entry are visible only with Expert Mode enabled; turning Expert Mode off while the tab is active falls back to the Identities screen.
+- The Masternodes tab and its nav entry are visible only at the Detailed view interface mode or above; dropping below Detailed view while the tab is active falls back to the Identities screen.
 
 ### MN-003: Open a masternode and vote [Implemented]
 **Persona:** Priya

--- a/src/app.rs
+++ b/src/app.rs
@@ -564,21 +564,15 @@ impl AppState {
 
         let saved_network = settings.network;
 
-        // App-global user role: seeded once from the legacy `.env DEVELOPER_MODE`
-        // flag (true → Power, else Everyday — today's dev mode is power-user
-        // mode) and shared into every per-network context (including any created
-        // later by a network switch), so a live change is observed everywhere
-        // without a restart.
-        let seeded_role = if crate::config::Config::load_from(&data_dir)
-            .ok()
-            .and_then(|c| c.developer_mode)
-            .unwrap_or(false)
-        {
-            crate::model::user_role::UserRole::Power
-        } else {
-            crate::model::user_role::UserRole::Everyday
-        };
-        let user_role = Arc::new(std::sync::atomic::AtomicU8::new(seeded_role as u8));
+        // App-global user role, shared into every per-network context (including
+        // any created later by a network switch) so a live change is observed
+        // everywhere without a restart. Seeded below from `get_app_settings()`
+        // once the active context exists — the single persisted source of truth,
+        // which resolves a role-less blob via the one-time `.env DEVELOPER_MODE`
+        // reconciliation and persists the result.
+        let user_role = Arc::new(std::sync::atomic::AtomicU8::new(
+            crate::model::user_role::UserRole::default() as u8,
+        ));
 
         // Build a helper to create AppContext for a given network.
         let make_context = |network: Network| -> Option<Arc<AppContext>> {
@@ -642,6 +636,18 @@ impl AppState {
             .get(&chosen_network)
             .expect("invariant: chosen_network was just taken from network_contexts")
             .clone();
+
+        // Seed the shared role atomic from AppSettings — the single source of
+        // truth. `get_app_settings` resolves a role-less blob via the one-time
+        // `.env DEVELOPER_MODE` seed and persists the canonical string, so `.env`
+        // is consulted at most once ever. `set_user_role` publishes the value to
+        // the shared atomic (visible to every context) and syncs animation gating.
+        active_context.set_user_role(
+            active_context
+                .get_app_settings()
+                .user_role
+                .unwrap_or_default(),
+        );
 
         // load fonts
         ctx.set_fonts(crate::bundled::fonts().expect("failed to load fonts"));

--- a/src/context/settings_db.rs
+++ b/src/context/settings_db.rs
@@ -64,6 +64,18 @@ impl AppContext {
         Ok(())
     }
 
+    /// Set the app-global user role and persist it as the canonical string in
+    /// [`AppSettings`] — the single source of truth the runtime atomic is seeded
+    /// from at the next boot. Both role-setting UI surfaces (Settings selector,
+    /// onboarding row) go through here so the runtime atomic and the persisted
+    /// value never diverge.
+    pub fn set_and_persist_user_role(&self, role: UserRole) {
+        self.set_user_role(role);
+        if let Err(e) = self.update_app_settings(|s| s.user_role = Some(role)) {
+            tracing::warn!(error = ?e, "Failed to persist the selected user role");
+        }
+    }
+
     /// Invalidates the settings cache and returns a guard.
     ///
     /// The cache is invalidated immediately and the guard prevents concurrent access
@@ -120,7 +132,24 @@ impl AppContext {
                 AppSettings::default()
             }
         };
-        self.seed_user_role_from_env(settings)
+        let seeded_role = settings.user_role.is_none();
+        let settings = self.seed_user_role_from_env(settings);
+        if seeded_role {
+            // Persist the one-time `.env` reconciliation so the sentinel slot is
+            // consumed exactly once: later loads read the canonical role string
+            // and never consult `.env` again. (The `.env DEVELOPER_MODE` parser
+            // itself stays — the v34 SPV migration still reads it.)
+            if let Err(e) = self
+                .app_kv
+                .put(DetScope::Global, AppSettings::KV_KEY, &settings)
+            {
+                tracing::warn!(
+                    error = ?e,
+                    "Failed to persist the seeded user role; it will be re-seeded on the next load"
+                );
+            }
+        }
+        settings
     }
 
     /// Seeds `user_role` from the legacy `.env DEVELOPER_MODE` flag when the
@@ -417,6 +446,31 @@ mod tests {
             got.user_role,
             Some(UserRole::Everyday),
             "an explicit role must survive; the .env seed only fills a role-less blob"
+        );
+    }
+
+    /// The `.env` seed is consumed exactly once: the first `get_app_settings`
+    /// that resolves a role-less blob persists the canonical role, so a later
+    /// change to `.env DEVELOPER_MODE` no longer moves the role.
+    #[test]
+    fn env_seed_is_persisted_and_consulted_only_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = test_app_context(tmp.path());
+        let env_path = tmp.path().join(".env");
+
+        // First resolution: DEVELOPER_MODE=true seeds Power and persists it.
+        std::fs::write(&env_path, "DEVELOPER_MODE=true\n").unwrap();
+        drop(ctx.invalidate_settings_cache());
+        assert_eq!(ctx.get_app_settings().user_role, Some(UserRole::Power));
+
+        // Flip `.env` to false and drop the cache. The persisted Power role must
+        // win — the seed is not consulted a second time.
+        std::fs::write(&env_path, "DEVELOPER_MODE=false\n").unwrap();
+        drop(ctx.invalidate_settings_cache());
+        assert_eq!(
+            ctx.get_app_settings().user_role,
+            Some(UserRole::Power),
+            "the seeded role must be persisted and survive a later .env change"
         );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -381,11 +381,7 @@ pub async fn init_app_context() -> Result<Arc<AppContext>, McpError> {
         app_kv,
         secret_store,
         std::sync::Arc::new(std::sync::atomic::AtomicU8::new(
-            if config.developer_mode.unwrap_or(false) {
-                crate::model::user_role::UserRole::Power as u8
-            } else {
-                crate::model::user_role::UserRole::Everyday as u8
-            },
+            crate::model::user_role::UserRole::default() as u8,
         )),
     )
     .ok_or_else(|| {
@@ -394,6 +390,13 @@ pub async fn init_app_context() -> Result<Arc<AppContext>, McpError> {
             None,
         )
     })?;
+
+    // Seed the role from AppSettings — the single source of truth, matching the
+    // GUI boot path. `get_app_settings` resolves a role-less blob via the
+    // one-time `.env DEVELOPER_MODE` seed and persists the canonical string, so a
+    // role chosen in the GUI is honoured here instead of being re-derived from
+    // `.env`.
+    app_context.set_user_role(app_context.get_app_settings().user_role.unwrap_or_default());
 
     // Chain sync is SPV-only (owned by upstream platform-wallet). Starting it
     // here would fast-fail: the wallet backend is not wired yet at boot. SPV is

--- a/src/model/user_role.rs
+++ b/src/model/user_role.rs
@@ -60,6 +60,28 @@ impl UserRole {
         }
     }
 
+    /// Short UI label for the interface-mode selectors (Settings and the
+    /// onboarding row share this vocabulary so a role picked in one is findable
+    /// by name in the other). Distinct from [`as_str`](Self::as_str), which is
+    /// the persisted wire string and must stay stable.
+    pub fn label(self) -> &'static str {
+        match self {
+            UserRole::Everyday => "Default view",
+            UserRole::Power => "Detailed view",
+            UserRole::Developer => "Developer tools",
+        }
+    }
+
+    /// One-line description of what this interface mode reveals, shown under the
+    /// selectors on both surfaces.
+    pub fn description(self) -> &'static str {
+        match self {
+            UserRole::Everyday => "Shows your balance, send and receive, and usernames.",
+            UserRole::Power => "Adds account details, address tables, and masternode tools.",
+            UserRole::Developer => "Adds raw protocol data, Devnet, and signing overrides.",
+        }
+    }
+
     /// Whether this role is at least `min` — the monotonic availability check
     /// (Invariant I1). Anything a lower role can do, a higher role can too.
     pub fn at_least(self, min: UserRole) -> bool {
@@ -121,6 +143,20 @@ mod tests {
                 None,
                 "'{s}' must be treated as a legacy sentinel, not a role"
             );
+        }
+    }
+
+    #[test]
+    fn labels_and_descriptions_are_distinct_per_role() {
+        let roles = [UserRole::Everyday, UserRole::Power, UserRole::Developer];
+        let labels: Vec<_> = roles.iter().map(|r| r.label()).collect();
+        assert_eq!(labels, ["Default view", "Detailed view", "Developer tools"]);
+        // Every role has a non-empty description and no two share one.
+        for (i, a) in roles.iter().enumerate() {
+            assert!(!a.description().is_empty());
+            for b in &roles[i + 1..] {
+                assert_ne!(a.description(), b.description());
+            }
         }
     }
 

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -39,16 +39,6 @@ enum DatabaseClearMessage {
     Error(String),
 }
 
-/// One-line description of what each interface mode reveals, shown under the
-/// role selector.
-fn role_description(role: UserRole) -> &'static str {
-    match role {
-        UserRole::Everyday => "Balances, send and receive, and usernames.",
-        UserRole::Power => "Adds account details, address tables, and masternode tools.",
-        UserRole::Developer => "Adds raw protocol data, Devnet, and signing overrides.",
-    }
-}
-
 /// Renders DAPI endpoint status with appropriate color coding.
 fn add_dapi_status_label(
     ui: &mut Ui,
@@ -474,6 +464,44 @@ impl NetworkChooserScreen {
             }
         });
 
+        // Interface mode — rendered above Advanced Settings (which force-collapses
+        // on every arrival) so the role selector is always discoverable.
+        ui.add_space(16.0);
+        StyledCard::new().padding(20.0).show(ui, |ui| {
+            ui.label(
+                egui::RichText::new("Interface mode")
+                    .strong()
+                    .color(DashColors::text_primary(dark_mode)),
+            );
+            ui.add_space(4.0);
+
+            let previous_role = self.selected_role;
+            ui.horizontal(|ui| {
+                for role in [UserRole::Everyday, UserRole::Power, UserRole::Developer] {
+                    ui.radio_value(&mut self.selected_role, role, role.label());
+                }
+            });
+
+            ui.add_space(2.0);
+            ui.label(
+                egui::RichText::new(self.selected_role.description())
+                    .color(DashColors::text_secondary(dark_mode))
+                    .italics(),
+            );
+
+            if self.selected_role != previous_role {
+                // The role is app-global and shared by every per-network context;
+                // persist it as the canonical AppSettings value and publish it to
+                // the shared runtime atomic in one call.
+                self.current_app_context()
+                    .set_and_persist_user_role(self.selected_role);
+                // Raising the role also disables animations, which stops the
+                // continuous repaints, so request one so newly-gated nav entries
+                // (e.g. Masternodes) appear immediately.
+                ui.ctx().request_repaint();
+            }
+        });
+
         // Advanced Settings section with clean dropdown
         ui.add_space(16.0);
 
@@ -611,53 +639,6 @@ impl NetworkChooserScreen {
                             });
                     });
                 });
-
-                ui.add_space(8.0);
-
-                ui.label(
-                    egui::RichText::new("Interface mode")
-                        .strong()
-                        .color(DashColors::text_primary(dark_mode)),
-                );
-                ui.add_space(4.0);
-
-                let previous_role = self.selected_role;
-                ui.horizontal(|ui| {
-                    ui.radio_value(
-                        &mut self.selected_role,
-                        UserRole::Everyday,
-                        "Default view",
-                    );
-                    ui.radio_value(
-                        &mut self.selected_role,
-                        UserRole::Power,
-                        "Detailed view",
-                    );
-                    ui.radio_value(
-                        &mut self.selected_role,
-                        UserRole::Developer,
-                        "Developer tools",
-                    );
-                });
-
-                ui.add_space(2.0);
-                ui.label(
-                    egui::RichText::new(role_description(self.selected_role))
-                        .color(DashColors::TEXT_SECONDARY)
-                        .italics(),
-                );
-
-                if self.selected_role != previous_role {
-                    // The role is app-global and shared by every per-network
-                    // context; persist it as the canonical AppSettings value and
-                    // publish it to the shared runtime atomic in one call.
-                    self.current_app_context()
-                        .set_and_persist_user_role(self.selected_role);
-                    // Raising the role also disables animations, which stops the
-                    // continuous repaints, so request one so newly-gated nav
-                    // entries (e.g. Masternodes) appear immediately.
-                    ui.ctx().request_repaint();
-                }
 
                 // Developer-tools sub-panel — Developer role only.
                 if self.selected_role.at_least(UserRole::Developer) {
@@ -1439,6 +1420,10 @@ impl ScreenLike for NetworkChooserScreen {
         // Reload settings from the shared app k/v store to ensure we have the latest values
         let settings = self.current_app_context().get_app_settings();
         self.theme_preference = settings.theme_mode;
+        // Re-sync the role selector with the app-global role, which may have
+        // changed on another surface (e.g. the onboarding row) since this cached
+        // root screen was constructed.
+        self.selected_role = self.current_app_context().user_role();
     }
 
     fn ui(&mut self, ui: &mut egui::Ui) -> AppAction {

--- a/src/ui/network_chooser_screen.rs
+++ b/src/ui/network_chooser_screen.rs
@@ -39,6 +39,16 @@ enum DatabaseClearMessage {
     Error(String),
 }
 
+/// One-line description of what each interface mode reveals, shown under the
+/// role selector.
+fn role_description(role: UserRole) -> &'static str {
+    match role {
+        UserRole::Everyday => "Balances, send and receive, and usernames.",
+        UserRole::Power => "Adds account details, address tables, and masternode tools.",
+        UserRole::Developer => "Adds raw protocol data, Devnet, and signing overrides.",
+    }
+}
+
 /// Renders DAPI endpoint status with appropriate color coding.
 fn add_dapi_status_label(
     ui: &mut Ui,
@@ -67,7 +77,7 @@ pub struct NetworkChooserScreen {
     dashmate_password_input: PasswordInput,
     pub current_network: Network,
     pub recheck_time: Option<TimestampMillis>,
-    developer_mode: bool,
+    selected_role: UserRole,
     theme_preference: ThemeMode,
     should_reset_collapsing_states: bool,
     spv_progress_network: Option<Network>,
@@ -109,7 +119,7 @@ impl NetworkChooserScreen {
         }
 
         let current_context = contexts.get(&current_network).unwrap_or(any_context);
-        let developer_mode = current_context.user_role().at_least(UserRole::Power);
+        let selected_role = current_context.user_role();
 
         let settings = current_context.get_app_settings();
         let theme_preference = settings.theme_mode;
@@ -121,7 +131,7 @@ impl NetworkChooserScreen {
             dashmate_password_input,
             current_network,
             recheck_time: None,
-            developer_mode,
+            selected_role,
             theme_preference,
             should_reset_collapsing_states: true, // Start with collapsed state
             spv_progress_network: None,
@@ -220,7 +230,7 @@ impl NetworkChooserScreen {
                                 {
                                     app_action = AppAction::SwitchNetwork(Network::Testnet);
                                 }
-                                if self.developer_mode
+                                if self.selected_role.at_least(UserRole::Power)
                                     && ui
                                         .selectable_value(
                                             &mut self.current_network,
@@ -231,7 +241,7 @@ impl NetworkChooserScreen {
                                 {
                                     app_action = AppAction::SwitchNetwork(Network::Devnet);
                                 }
-                                if self.developer_mode
+                                if self.selected_role.at_least(UserRole::Power)
                                     && ui
                                         .selectable_value(
                                             &mut self.current_network,
@@ -604,46 +614,53 @@ impl NetworkChooserScreen {
 
                 ui.add_space(8.0);
 
-                ui.horizontal(|ui| {
-                    if StyledCheckbox::new(&mut self.developer_mode, "Expert mode")
-                        .show(ui)
-                        .clickable_tooltip(
-                            "Show advanced options for experienced users, including \
-                             Dash Core RPC, developer tools, and signing overrides.",
-                        )
-                        .clicked()
-                    {
-                        // Expert Mode is the app-global user role shared by every
-                        // per-network context, so setting it on one updates all.
-                        // The binary checkbox maps to Power; a three-way selector
-                        // replaces it in a later phase.
-                        self.current_app_context().set_user_role(if self.developer_mode {
-                            UserRole::Power
-                        } else {
-                            UserRole::Everyday
-                        });
-                        // Re-render the nav immediately: enabling Expert Mode also
-                        // disables animations, which stops continuous repaints, so
-                        // request one so the Masternodes nav entry appears now.
-                        ui.ctx().request_repaint();
+                ui.label(
+                    egui::RichText::new("Interface mode")
+                        .strong()
+                        .color(DashColors::text_primary(dark_mode)),
+                );
+                ui.add_space(4.0);
 
-                        // Persist to config file (non-blocking for UI)
-                        if let Ok(mut config) = Config::load_from(&self.data_dir) {
-                            config.developer_mode = Some(self.developer_mode);
-                            if let Err(e) = config.save(&self.data_dir) {
-                                tracing::error!("Failed to save config: {e}");
-                            }
-                        }
-                    }
-                    ui.label(
-                        egui::RichText::new("Enable advanced features")
-                            .color(DashColors::TEXT_SECONDARY)
-                            .italics(),
+                let previous_role = self.selected_role;
+                ui.horizontal(|ui| {
+                    ui.radio_value(
+                        &mut self.selected_role,
+                        UserRole::Everyday,
+                        "Default view",
+                    );
+                    ui.radio_value(
+                        &mut self.selected_role,
+                        UserRole::Power,
+                        "Detailed view",
+                    );
+                    ui.radio_value(
+                        &mut self.selected_role,
+                        UserRole::Developer,
+                        "Developer tools",
                     );
                 });
 
-                // Developer-only tools
-                if self.developer_mode {
+                ui.add_space(2.0);
+                ui.label(
+                    egui::RichText::new(role_description(self.selected_role))
+                        .color(DashColors::TEXT_SECONDARY)
+                        .italics(),
+                );
+
+                if self.selected_role != previous_role {
+                    // The role is app-global and shared by every per-network
+                    // context; persist it as the canonical AppSettings value and
+                    // publish it to the shared runtime atomic in one call.
+                    self.current_app_context()
+                        .set_and_persist_user_role(self.selected_role);
+                    // Raising the role also disables animations, which stops the
+                    // continuous repaints, so request one so newly-gated nav
+                    // entries (e.g. Masternodes) appear immediately.
+                    ui.ctx().request_repaint();
+                }
+
+                // Developer-tools sub-panel — Developer role only.
+                if self.selected_role.at_least(UserRole::Developer) {
                     ui.add_space(12.0);
                     ui.label(
                         egui::RichText::new("Developer Tools")
@@ -714,7 +731,7 @@ impl NetworkChooserScreen {
 
                 // Advanced SPV peer source configuration is Expert-only —
                 // fresh-install users get auto-discovery, which is the correct default.
-                if self.developer_mode {
+                if self.selected_role.at_least(UserRole::Power) {
                     // Auto-start SPV on startup
                     ui.add_space(12.0);
                     ui.separator();
@@ -828,7 +845,7 @@ impl NetworkChooserScreen {
                 // SPV maintenance (clear data, rescan) is Expert-only — these are
                 // diagnostic tools that can destroy wallet sync state and should not
                 // be exposed to fresh-install users.
-                if self.developer_mode {
+                if self.selected_role.at_least(UserRole::Power) {
                     // Chain sync is owned by upstream platform-wallet; the
                     // EventBridge feeds live status into ConnectionStatus.
                     let snapshot = self

--- a/src/ui/welcome_screen.rs
+++ b/src/ui/welcome_screen.rs
@@ -1,5 +1,6 @@
 use crate::app::AppAction;
 use crate::context::AppContext;
+use crate::model::user_role::UserRole;
 use crate::ui::components::icons::load_svg_icon;
 use crate::ui::components::styled::island_central_panel;
 use crate::ui::theme::{DashColors, Shadow, Shape, Spacing};
@@ -65,7 +66,13 @@ impl WelcomeScreen {
                                 .color(DashColors::text_secondary(dark_mode)),
                         );
 
-                        ui.add_space(50.0);
+                        ui.add_space(40.0);
+
+                        // Experience-level selector — sets the app-global role
+                        // before the user picks an onboarding path.
+                        self.render_role_selector(ui, dark_mode);
+
+                        ui.add_space(32.0);
 
                         // Instructional text
                         ui.label(
@@ -85,6 +92,39 @@ impl WelcomeScreen {
         });
 
         action
+    }
+
+    /// Experience-level selector shown during onboarding. Writes the app-global
+    /// role (runtime atomic + persisted `AppSettings.user_role`) the moment the
+    /// user changes it; the same value backs the Settings selector.
+    fn render_role_selector(&self, ui: &mut egui::Ui, dark_mode: bool) {
+        ui.label(
+            RichText::new("Choose your experience level:")
+                .size(14.0)
+                .color(DashColors::text_secondary(dark_mode)),
+        );
+
+        ui.add_space(8.0);
+
+        let mut role = self.app_context.user_role();
+        let previous = role;
+        ui.horizontal(|ui| {
+            ui.radio_value(&mut role, UserRole::Everyday, "Everyday");
+            ui.radio_value(&mut role, UserRole::Power, "Power");
+            ui.radio_value(&mut role, UserRole::Developer, "Developer");
+        });
+
+        if role != previous {
+            self.app_context.set_and_persist_user_role(role);
+            ui.ctx().request_repaint();
+        }
+
+        ui.add_space(6.0);
+        ui.label(
+            RichText::new("You can change this later in Network Settings.")
+                .size(11.0)
+                .color(DashColors::text_secondary(dark_mode)),
+        );
     }
 
     fn render_getting_started_section(&mut self, ui: &mut egui::Ui, dark_mode: bool) -> AppAction {

--- a/src/ui/welcome_screen.rs
+++ b/src/ui/welcome_screen.rs
@@ -109,9 +109,9 @@ impl WelcomeScreen {
         let mut role = self.app_context.user_role();
         let previous = role;
         ui.horizontal(|ui| {
-            ui.radio_value(&mut role, UserRole::Everyday, "Everyday");
-            ui.radio_value(&mut role, UserRole::Power, "Power");
-            ui.radio_value(&mut role, UserRole::Developer, "Developer");
+            for option in [UserRole::Everyday, UserRole::Power, UserRole::Developer] {
+                ui.radio_value(&mut role, option, option.label());
+            }
         });
 
         if role != previous {
@@ -120,6 +120,13 @@ impl WelcomeScreen {
         }
 
         ui.add_space(6.0);
+        // Description of the selected mode, then a reversibility hint.
+        ui.label(
+            RichText::new(role.description())
+                .size(12.0)
+                .color(DashColors::text_secondary(dark_mode)),
+        );
+        ui.add_space(2.0);
         ui.label(
             RichText::new("You can change this later in Network Settings.")
                 .size(11.0)

--- a/tests/kittest/main.rs
+++ b/tests/kittest/main.rs
@@ -28,4 +28,5 @@ mod support;
 mod tokens_screen;
 mod tools_screen;
 mod wallets_screen;
+mod welcome_screen;
 mod withdraw_screen;

--- a/tests/kittest/network_chooser.rs
+++ b/tests/kittest/network_chooser.rs
@@ -1,5 +1,8 @@
-use crate::support::with_isolated_data_dir;
+use crate::support::{mount_app, with_isolated_data_dir};
+use dash_evo_tool::model::user_role::UserRole;
+use dash_evo_tool::ui::RootScreenType;
 use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable;
 
 /// Test that the network chooser screen renders without panicking
 #[test]
@@ -21,6 +24,34 @@ fn test_network_chooser_renders() {
 
         // Run a few frames to ensure the app initializes
         harness.run_steps(10);
+    });
+}
+
+/// The Settings interface-mode selector sets the app-global role and persists
+/// it to AppSettings — the single source of truth the runtime atomic and the
+/// gates read from.
+#[test]
+fn interface_mode_selector_sets_and_persists_role() {
+    with_isolated_data_dir(|| {
+        let mut harness = mount_app(RootScreenType::RootScreenNetworkChooser);
+        let app_context = harness.state().current_app_context().clone();
+
+        // Fresh install defaults to the baseline role.
+        assert_eq!(app_context.user_role(), UserRole::Everyday);
+
+        harness.get_by_label("Developer tools").click();
+        harness.run_steps(3);
+
+        assert_eq!(
+            app_context.user_role(),
+            UserRole::Developer,
+            "selecting 'Developer tools' must raise the app-global role"
+        );
+        assert_eq!(
+            app_context.get_app_settings().user_role,
+            Some(UserRole::Developer),
+            "the selected role must be persisted to AppSettings"
+        );
     });
 }
 

--- a/tests/kittest/welcome_screen.rs
+++ b/tests/kittest/welcome_screen.rs
@@ -1,0 +1,42 @@
+use crate::support::with_isolated_data_dir;
+use dash_evo_tool::model::user_role::UserRole;
+use egui_kittest::Harness;
+use egui_kittest::kittest::Queryable;
+
+/// The onboarding welcome row sets the app-global role and persists it, sharing
+/// the same vocabulary as the Settings selector so a role picked here is
+/// findable by name there.
+#[test]
+fn welcome_role_selector_sets_and_persists_role() {
+    with_isolated_data_dir(|| {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+        let _guard = rt.enter();
+
+        // A fresh data dir leaves onboarding incomplete, so the welcome screen
+        // (not a main screen) renders on first frame.
+        let mut harness = Harness::builder().with_max_steps(100).build_eframe(|ctx| {
+            dash_evo_tool::app::AppState::new(ctx.egui_ctx.clone())
+                .expect("Failed to create AppState")
+                .with_animations(false)
+        });
+        harness.set_size(egui::vec2(1024.0, 768.0));
+        harness.run_steps(10);
+
+        let app_context = harness.state().current_app_context().clone();
+        assert_eq!(app_context.user_role(), UserRole::Everyday);
+
+        harness.get_by_label("Detailed view").click();
+        harness.run_steps(3);
+
+        assert_eq!(
+            app_context.user_role(),
+            UserRole::Power,
+            "selecting 'Detailed view' on the welcome row must set the Power role"
+        );
+        assert_eq!(
+            app_context.get_app_settings().user_role,
+            Some(UserRole::Power),
+            "the onboarding role choice must be persisted to AppSettings"
+        );
+    });
+}


### PR DESCRIPTION
## Why this PR exists
- **Problem**: Phases 1 (#879) and 2 (#880) built the three-role mechanism and reclassified every gate onto it, but there is still no UI to actually choose `Power` or `Developer` — the binary Expert-mode checkbox is all that exists, and nothing persists a chosen role anywhere durable.
- **What breaks without it**: Without this PR, #880's Developer-only signing/key-selection bypasses are permanently unreachable (no UI can select that role), and — a real bug this PR fixes, not just a missing feature — the Phase 1 persistence design was never actually wired up: the seeded role was resolved in-memory only and never written back to the database, while app boot ignored the persisted role entirely and re-read `.env DEVELOPER_MODE` fresh on every launch. Had this shipped as designed without the fix, any role choice would have been silently clobbered on next restart.
- **Blocking relationship**: Stacked on #880 (Phase 2) and #879 (Phase 1). Final PR in the three-part rollout.

Closes dashpay/dash-evo-tool#371

## What was done
- **Settings**: replaced the binary Expert-mode checkbox with a three-way "Interface mode" selector (Default view / Detailed view / Developer tools), lifted out of the force-collapsing Advanced Settings panel into its own always-visible card (a UX fix — the role selector would otherwise be effectively hidden on every screen visit).
- **Welcome screen**: added a matching role-picker row during first-run onboarding, with an explicit "you can change this later in Network Settings" reversibility note.
- **Persistence, fixed for real**: `AppSettings.user_role` is now the single source of truth. The `.env`-seed-if-unset resolution is persisted back to the database on first read (consumed exactly once, per the design's sentinel-safe migration); app boot and the standalone CLI/MCP boot path (`det-cli`, previously missed and still reading `.env` directly — caught and fixed during this PR's QA) both seed from the same persisted accessor. `DEVELOPER_MODE` in `.env` is now genuinely a one-time first-launch seed, never a live override, while its parser is kept indefinitely for an unrelated one-shot v34 migration.
- **Docs**: added `docs/user-roles.md` (replacing the stale binary-toggle framing), updated the `README.md` environment-variable table and `.env.example` comment, fixed stale "Expert mode" UI-mechanism language in `docs/user-stories.md`, and added a CHANGELOG entry.
- **Vocabulary note**: the design doc originally called for plain role names on the Welcome row and the fuller "Default view/Detailed view/Developer tools" phrasing only in Settings. During UX review we found that split made a role chosen at onboarding unfindable by name in Settings, so both surfaces were unified onto one vocabulary — a deliberate, reviewed deviation from the original design doc.

## Testing
- `cargo test --all-features --workspace`: 1468 passed, 0 failed (215 kittest, up from 213 — includes two new UI-interaction tests that click the real widgets and assert on both the runtime role and the persisted DB value, not just the underlying accessor).
- `cargo clippy --all-features --all-targets -- -D warnings`: clean.
- Independent QA pass caught the CLI/MCP boot-path gap described above before it shipped, plus a stale-radio-state bug (Settings screen not refreshing `selected_role` when the role changed on another surface) and a missing test for the persistence round-trip — all fixed and re-verified in a follow-up commit within this PR.
- UX audit covered first-run coherence, cross-surface consistency, accessibility (confirmed standard `egui::radio_value` gets automatic AccessKit labels — not hand-rolled), and i18n string quality; findings (onboarding lacked descriptions, terminology split, one sentence-fragment string, a non-theme-aware color) were fixed in the same follow-up commit.

## Breaking changes
The Expert-mode checkbox and its associated `.env` live-override behavior are gone, replaced by the three-role system described above. Anyone with `DEVELOPER_MODE=true` in `.env` seeds to `Power` (matching what "developer mode" already meant per the README), not `Developer`, on first launch after this ships — no existing user loses access to anything they previously had.

## Checklist
- [x] Tests pass
- [x] Clippy clean
- [x] `cargo +nightly fmt` applied
- [ ] Reviewed by a human

## Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>