### PR TITLE
docs: add standing GUI-testing guidelines and scenario library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ Test locations:
 - E2E: `tests/e2e/`
 - Backend E2E: `tests/backend-e2e/` (network-dependent, `#[ignore]`)
 
+### GUI testing (live app, real display)
+
+Driving the actual compiled binary through a real display — for flows that need real navigation, real async/network timing, or visual verification beyond what `kittest` (no display) or `backend-e2e` (no UI) can cover. Read `docs/gui-testing/README.md` before running this kind of test — it has the safety rules (isolated data dir, credential handling, fund-movement caps) and the reusable scenario library under `docs/gui-testing/scenarios/`.
+
 Always run `cargo clippy` and `cargo +nightly fmt` when finalizing your work.
 
 ### User stories catalog
@@ -108,6 +112,7 @@ User-facing error messages (shown in `MessageBanner` via `Display`) must follow 
 - **docs/personas** contains user personas (Everyday User, Power User, Platform Developer) that define the three target user archetypes and the progressive disclosure model for UI complexity. Consult these when making UX decisions about what to show/hide or how to structure wallet features.
 - **docs/user-stories.md** catalogs user stories across feature areas, tagged by persona and marked `[Implemented]` or `[Gap]`. Reference when planning new features or verifying coverage.
 - **docs/ux-design-patterns.md** is the UI/UX reference card — explains **when and how** to use design tokens, buttons, dialogs, forms, accessibility rules, and progressive disclosure. For exact values (sizes, colors, padding), refer to source files (`src/ui/theme.rs`, `src/ui/components/`). Consult when building or reviewing UI.
+- **docs/gui-testing/** contains standing guidelines and a reusable scenario library for testing the real compiled app through a real display (not date-grouped — this is reusable practice, not a point-in-time design record). Read `docs/gui-testing/README.md` before driving the GUI directly for verification.
 - end-user documentation is in a separate repo: https://github.com/dashpay/docs/tree/HEAD/docs/user/network/dash-evo-tool , published at https://docs.dash.org/en/stable/docs/user/network/dash-evo-tool/
 
 ### System Layers (top → bottom)

--- a/docs/gui-testing/README.md
+++ b/docs/gui-testing/README.md
@@ -1,0 +1,82 @@
+# GUI Testing Guidelines
+
+This directory holds standing guidance and reusable scenarios for testing the
+**real, compiled application** through a real display — not `kittest` (which
+drives an in-process harness with no display, no network) and not
+`backend-e2e` (which calls `BackendTask`s directly, skipping the UI entirely).
+
+Use this tier when a change needs to be verified as it actually behaves for a
+user: real screen navigation, real timing (SPV sync, async task completion),
+real visual state, or a flow that spans multiple screens in ways `kittest`
+doesn't cover.
+
+## Which test tier do I need?
+
+| Tier | Drives | Network | Good for |
+|---|---|---|---|
+| `tests/kittest/` | In-process `egui_kittest` harness, no display | None | Screen logic, widget state, gating — fast, deterministic, runs in CI |
+| `tests/backend-e2e/` | `BackendTask`s directly, no UI | Live testnet | Backend correctness (SDK calls, signing, persistence) without UI concerns |
+| **`docs/gui-testing/`** (this dir) | The actual compiled binary, real display | Live testnet (usually) | End-to-end flows a user would actually experience — navigation, real async timing, visual verification |
+
+If a scenario can be expressed as a `kittest` test, write a `kittest` test
+instead — it's faster, deterministic, and runs in CI on every PR. Reach for
+this tier only when the thing under test genuinely needs a real display, real
+network timing, or a flow `kittest` can't simulate.
+
+## How to run a scenario
+
+The mechanical launch recipe (X display setup, accessibility tree, gotchas
+like stderr redirection) lives in the global `desktop-gui` Claude Code skill
+(`~/.claude/skills/desktop-gui/SKILL.md`) — read that first, it's not repeated
+here. This directory covers what's specific to *this project*: which
+scenarios exist, what credentials they need, and the safety rules for running
+them against a live network.
+
+## Non-negotiable safety rules
+
+1. **Always use an isolated data directory.** Never point `DASH_EVO_DATA_DIR`
+   at a real user's default location. Use a fresh `mktemp -d` per run, copy
+   `.env.example` into it, and adjust network config as the scenario requires.
+2. **Never touch an already-running instance.** Check `pgrep -af dash-evo-tool`
+   before launching; if one is already running, leave it alone and launch a
+   second, separately-windowed instance for your test.
+3. **Never hardcode secrets in a scenario file.** Reference environment
+   variable *names* only (matching the `tests/backend-e2e/` convention — e.g.
+   `E2E_WALLET_MNEMONIC`, `E2E_MN_*`). Read actual values at run time via
+   `grep`/`env`, never paste them into a scenario doc, a report, or a commit.
+4. **Default to testnet.** Only use mainnet if a scenario explicitly requires
+   it and says why — and if it does, treat every fund-moving step as
+   irreversible and get explicit confirmation before broadcasting.
+5. **Cap fund movement.** When a scenario broadcasts a real transaction
+   (withdrawal, send, etc.), move the smallest amount that still proves the
+   behavior (e.g. ≤10% of an available balance), never "whatever's available."
+6. **Prefer destination paths that can't misfire.** Where the app offers a
+   consensus-enforced or otherwise fixed destination (e.g. a masternode
+   owner-key withdrawal forcing the registered payout address), use that path
+   over one where you type an arbitrary address by hand.
+7. **Check the logs, not just the screen.** A crash or panic doesn't always
+   show a UI error — check `det-stderr.log` / `det.log` in the test's data
+   directory (or the default location if unset) for a Rust panic
+   (`location=...` line) even when the UI appeared to work.
+
+## Scenario file format
+
+Each scenario is a Markdown file under `docs/gui-testing/scenarios/`, named
+`<short-slug>.md`. Use [`scenarios/TEMPLATE.md`](scenarios/TEMPLATE.md) as the
+starting point. A good scenario is written at the level of "what to look for"
+rather than pixel coordinates or exact window sizes, so it survives minor UI
+changes — describe the screen/control by its label or role, not its position.
+
+Keep a scenario file updated when the flow it describes changes shape; a
+stale scenario that no longer matches the app is worse than no scenario, since
+it wastes the next run re-discovering the drift. If a run surfaces a new gotcha
+(timing, an unexpected intermediate screen, a naming mismatch), fold it back
+into the scenario file rather than letting it live only in that run's report.
+
+## Scenario index
+
+| Scenario | What it verifies |
+|---|---|
+| _(none yet — first one lands once the masternode-withdrawal-without-a-wallet run is verified)_ | |
+
+<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

--- a/docs/gui-testing/scenarios/TEMPLATE.md
+++ b/docs/gui-testing/scenarios/TEMPLATE.md
@@ -1,0 +1,56 @@
+# Scenario: <short descriptive name>
+
+**Verifies:** one sentence — the specific behavior/assumption this scenario proves or disproves.
+
+**Tier justification:** why this can't be a `kittest` test (e.g. needs live
+network timing, needs a real broadcast, spans a flow `kittest` doesn't cover).
+
+## Prerequisites
+
+- Network: <testnet / mainnet — default testnet, justify if not>
+- Environment variables (names only — see the project's `.env`/`tests/backend-e2e/README.md`
+  for where real values come from):
+  - `VAR_NAME` — what it is
+- Any other precondition (e.g. "a registered masternode with a nonzero credit balance")
+
+## Setup
+
+```bash
+# Isolated data dir — never point at a real user's default location
+DATADIR=$(mktemp -d)
+cp .env.example "$DATADIR/.env"
+# ... any .env adjustments this scenario needs ...
+
+# Confirm no conflicting instance is already using this display/data dir
+pgrep -af dash-evo-tool
+
+DISPLAY=:99 DASH_EVO_DATA_DIR="$DATADIR" nohup /data/target/debug/dash-evo-tool >/tmp/<scenario-slug>.log 2>&1 &
+```
+
+## Procedure
+
+Describe steps by what to look for (label/role), not pixel coordinates —
+scenarios should survive minor layout changes.
+
+1. ...
+2. ...
+
+## Safety constraints specific to this scenario
+
+- (e.g. "cap withdrawal amount at 10% of available balance")
+- (e.g. "use the owner-key path so the destination is consensus-forced, never a typed address")
+
+## Expected outcome / pass criteria
+
+What "it worked" looks like — exact banner text, a specific screen state, a
+specific log line. Be precise enough that a future run can tell pass from
+fail without guessing.
+
+## Known gotchas
+
+Anything non-obvious discovered while running this — timing quirks, an
+unexpected intermediate screen, a naming mismatch between the plan and the
+real UI. Keep this section updated; it's the most valuable part of the file
+after the first real run.
+
+<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


### PR DESCRIPTION
## Why this PR exists
- **Problem**: Verifying a change against the real, compiled app on a real display is a distinct testing tier from `kittest` (in-process harness, no display) and `backend-e2e` (calls `BackendTask`s directly, no UI) — but there's no standing home for the guidance and safety rules that kind of testing needs, so every agent/session re-derives them from scratch (launch recipe, credential handling, fund-movement safety, isolated-data-dir discipline).
- **What breaks without it**: knowledge from one live-GUI test run (e.g. exact navigation steps, timing gotchas, safety constraints like "use the owner-key withdrawal path since it forces a consensus-verified destination") evaporates at the end of the session instead of compounding into a reusable, ever-more-reliable scenario library.
- **Blocking relationship**: none — pure documentation addition, stacked on `docs/platform-wallet-migration-design` (#860) since that's the current active integration branch.

## What was done
- New `docs/gui-testing/README.md`: when to reach for this tier vs. `kittest`/`backend-e2e`, non-negotiable safety rules (isolated data dir, never touch an already-running instance, credential handling by env-var name only — never hardcode secrets, testnet-by-default, capped fund movement, prefer consensus-forced destinations, always check logs for a panic even when the UI looked fine), and the scenario file format/index.
- New `docs/gui-testing/scenarios/TEMPLATE.md`: the template for individual scenario files, written at the level of "what to look for" rather than pixel coordinates so scenarios survive minor UI changes.
- `CLAUDE.md`: two new pointers — one under Testing (agents about to run a live GUI test find it), one under Documentation (consistent with how `docs/ai-design`, `docs/personas`, etc. are catalogued). Deliberately **not** date-grouped under `docs/ai-design` — this is standing, reusable practice meant to be discovered on every future GUI-verification task, not a point-in-time design record.

## Testing
Documentation-only change — no code paths affected. `cargo fmt`/`clippy`/tests unaffected (verified no source files touched).

## Breaking changes
None.

## Checklist
- [x] N/A — docs-only, no tests/clippy affected
- [ ] Reviewed by a human

## Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>