### PR TITLE
fix(migration/wallet): QA follow-ups for #885 — resurrection, banners, decode limit, wallet naming

### DIFF
--- a/docs/ai-design/2026-07-13-legacy-identity-migration/design.md
+++ b/docs/ai-design/2026-07-13-legacy-identity-migration/design.md
@@ -154,14 +154,55 @@ det:migration:identities:<net>:v1
 
 ```rust
 pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
-    let app_data  = migrate_app_data(app_context);            // unchanged
-    let wallet_moved = drain_wallets(app_context).await?;     // unchanged
-    let app_data  = app_data?;
-    let identities = migrate_identities(app_context)?;        // NEW — after the drain
+    // Held, NOT unwrapped: DET's own rows may not gate the funds path.
+    let app_data = migrate_app_data(app_context);
+
+    // Funds first. Nothing above may withhold a seed.
+    let wallet_moved = drain_wallets(app_context).await?;
+
+    // Held too — the two DET-owned passes must not gate each other.
+    let identities = migrate_identities(app_context)?;
+
+    if identities.unreadable > 0 {
+        // `app_data` is judged HERE, never before: unwrapping it first would
+        // return its (deterministic) error and mask the identity signal on this
+        // launch AND every retry, stranding a masternode owner's keys over a
+        // corrupt vote queue. Each arm publishes its own terminal state and
+        // returns `Ok` — a returned `Err` would be re-published as a plain
+        // `Failed`, dropping the identity count.
+        match app_data {
+            // SucceededWithUnreadableIdentities, or …AndVotes when the durable
+            // vote-warning record reads back non-empty. A failing *read* costs
+            // only the vote half — never the identity half, and never a `Failed`.
+            Ok(outcome) => {
+                let moved_data =
+                    wallet_moved || outcome.moved_data() || identities.moved_data();
+                …
+                return Ok(moved_data);
+            }
+            // The one true FailedWithUnreadableIdentities: a hard app-data
+            // failure. Both signals ride one retryable banner.
+            Err(app_data_error) => {
+                let moved_data = wallet_moved || identities.moved_data();
+                …
+                return Ok(moved_data);
+            }
+        }
+    }
+
+    // Every identity decoded, so app-data no longer masks anything: unwrap it.
+    let app_data = app_data?;
     let moved_data = wallet_moved || app_data.moved_data() || identities.moved_data();
     …
 }
 ```
+
+**Held, then judged.** Each DET-owned pass runs unconditionally and its `Result`
+is *held* — the order in which the two are **unwrapped** is the load-bearing part,
+not the order in which they run. An app-data failure is deterministic (one
+malformed vote-index blob is enough) and never writes its sentinel, so unwrapping
+it ahead of the identity outcome would skip the identity import forever, not just
+once.
 
 **Why after `drain_wallets`, not inside it.** The import needs three things the
 drain produces: the wallet backend wired (`det_kv()` is `wallet_backend()?.kv()`),
@@ -283,10 +324,16 @@ Ordered; each is independently reviewable.
 - **T-ID-01 — `database/legacy_import.rs`: `read_identities`.**
   `pub(crate) fn read_identities(conn: &Connection, network: Network) -> rusqlite::Result<LegacyIdentities>`
   returning `{ identities: Vec<LegacyIdentityRow>, unreadable: u32 }` where
-  `LegacyIdentityRow { id: [u8; 32], qi: QualifiedIdentity, status: u8, wallet: Option<([u8; 32], u32)> }`.
-  SQL: `SELECT id, data, status, wallet, wallet_index FROM identity WHERE is_local = 1 AND data IS NOT NULL AND network IN (?1, ?2)`,
-  params `(network.to_string(), mainnet_alias_for(network))`. Missing table ⇒
-  empty. Per-row decode failure ⇒ `unreadable += 1`, warn, continue. Mirrors
+  `LegacyIdentityRow { id: [u8; 32], qi: QualifiedIdentity, wallet: Option<([u8; 32], u32)> }`.
+  There is **no separate `status` field**: the reader restores `status` (and
+  `alias`) from their columns straight onto `qi` before the row is yielded, so the
+  caller receives one already-correct `QualifiedIdentity` and cannot forget to
+  apply them (the blob encodes neither — see §6).
+  SQL: `SELECT id, data, status, wallet, wallet_index, alias FROM identity WHERE is_local = 1 AND data IS NOT NULL AND network IN (?1, ?2)`,
+  params `(network.to_string(), mainnet_alias_for(network))`. `alias` is selected
+  because the column — not the blob's stale copy — is authoritative (§6). Missing
+  table ⇒ empty. Per-row decode failure ⇒ `unreadable += 1`, warn, continue; a
+  wrong SQLite storage class costs its own row, not the whole read. Mirrors
   `read_scheduled_votes` exactly.
   *Depends on:* nothing.
 
@@ -368,13 +415,26 @@ this design consumes — keep it, then add the outcome):
 
 **Assertions in `second_launch_after_a_v093_upgrade_changes_nothing`:**
 
-9. Edit A's alias post-migration (`ctx.set_identity_alias`), re-run
-   `finish_unwire::run` ⇒ the alias survives. This is the skip-if-present rule
-   (§7): an identity already in the store is skipped wholesale — never
-   re-persisted with the stale legacy blob. It must go **RED** against a naive
-   implementation that re-inserts unconditionally.
-10. Identity count is unchanged; `run()` returns `false`.
-11. The legacy `identity` rows are still in `data.db` (count unchanged).
+9. Identity count is unchanged; `run()` returns `false`.
+10. The legacy `identity` rows are still in `data.db` (count unchanged).
+
+**Assertions in `a_retry_after_an_unreadable_identity_preserves_user_edits`:**
+
+11. Edit A's alias post-migration (`ctx.set_identity_alias`), re-run
+    `finish_unwire::run` ⇒ the alias survives. This is the skip-if-present rule
+    (§7): an identity already in the store is skipped wholesale — never
+    re-persisted with the stale legacy blob. It must go **RED** against a naive
+    implementation that re-inserts unconditionally.
+
+    This assertion lives on the **retry** path, not the clean second launch, because
+    only the retry path actually reaches the check. A clean upgrade writes the
+    identity sentinel, and on the next launch that sentinel short-circuits the pass
+    before any row is examined — so `second_launch_after_a_v093_upgrade_changes_nothing`
+    would pass even against an importer with no skip-if-present rule at all, proving
+    nothing. Withholding the sentinel is what forces the re-run: the test seeds one
+    undecodable blob (`unreadable > 0` ⇒ sentinel not written), so the following
+    launch re-imports over identities that already landed — exactly the case where an
+    unconditional INSERT-OR-REPLACE would silently overwrite the user's rename.
 
 **Negative test (own `#[test]`, on `migrate_identities_from_conn`):** a row whose
 `data` is garbage ⇒ `unreadable == 1`, the readable rows still import, and the

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -629,7 +629,9 @@ As a user, I want the identities I loaded before an upgrade — and the keys the
 - Identities stored before the upgrade are imported from the previous version's storage on the first launch afterward, keeping each identity's keys, alias, and wallet link. Progress is shown as its own step.
 - An identity that cannot be read is reported in a banner naming the recovery action (load it again), rather than dropped silently. The previous version's data is never deleted, so a later build can still import it.
 - A single unreadable identity costs only itself: the readable identities in the same batch still import, and neither the wallet migration that restores access to funds nor the scheduled-vote import is blocked by it.
-- When identities and scheduled votes are both unreadable on the same launch, one banner names both remedies — the identity report, which returns on every launch, never buries the vote report whose deadline may still be open.
+- The report of unreadable identities returns on every launch until it is explicitly acknowledged, so a user who stepped away cannot lose the only notice that some of their keys were not carried over.
+- When identities and scheduled votes are both unreadable on the same launch, one banner names both remedies, and acknowledging it retires both reports — neither report can bury the other.
+- An identity the user deletes after the upgrade stays deleted. The import runs once, so a later launch never restores a removed identity, its alias, or its keys.
 
 ---
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,22 @@ pub const MIGRATION_RETRY_ACTION_ID: &str = "migration:retry:finish_unwire";
 /// still have a live deadline. Exposed for kittest coverage.
 pub const MIGRATION_VOTES_ACK_ACTION_ID: &str = "migration:ack:unreadable_votes";
 
+/// Banner action id pushed when the user acknowledges the unreadable-identity
+/// warning. Until it fires, the warning is re-raised on every launch — a
+/// dismissed banner is not an acknowledgement, because the identities it names
+/// hold keys the user cannot sign with until they are loaded again. Exposed for
+/// kittest coverage.
+pub const MIGRATION_IDENTITIES_ACK_ACTION_ID: &str = "migration:ack:unreadable_identities";
+
+/// Banner action id pushed when the user acknowledges the combined warning — the
+/// launch where both unreadable identities and unreadable votes were left behind.
+/// One banner names both problems, so its single acknowledgement retires both
+/// records: re-raising either half after the user has read and dismissed the
+/// sentence describing it would be a notice they have already acted on. Exposed
+/// for kittest coverage.
+pub const MIGRATION_UNREADABLE_ACK_ACTION_ID: &str =
+    "migration:ack:unreadable_identities_and_votes";
+
 /// Action id for the SPV-sync block's "Continue in the background" escape button.
 /// SPV sync is **unbounded** — with no peers it stays Connecting/Syncing forever
 /// with no terminal signal — so a button-less hard block would trap the user
@@ -1937,6 +1953,25 @@ mod migration_banner_tests {
     #[test]
     fn migration_retry_action_id_is_stable() {
         assert_eq!(MIGRATION_RETRY_ACTION_ID, "migration:retry:finish_unwire");
+    }
+
+    /// Every banner action id is distinct. `drain_actions` dispatches on these
+    /// strings, so a collision would silently route one banner's acknowledgement
+    /// to another's task — retiring a warning the user was never shown.
+    #[test]
+    fn migration_action_ids_are_distinct() {
+        let ids = [
+            MIGRATION_RETRY_ACTION_ID,
+            MIGRATION_VOTES_ACK_ACTION_ID,
+            MIGRATION_IDENTITIES_ACK_ACTION_ID,
+            MIGRATION_UNREADABLE_ACK_ACTION_ID,
+        ];
+        let unique: std::collections::BTreeSet<_> = ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            ids.len(),
+            "banner action ids must not collide"
+        );
     }
 
     /// The combined-failure banner must surface BOTH signals in one message: the

--- a/src/app/reconcilers.rs
+++ b/src/app/reconcilers.rs
@@ -30,9 +30,10 @@ use crate::ui::components::{
 };
 
 use super::{
-    COLD_START_BACKEND_READY_TIMEOUT, COLD_START_STUCK_MESSAGE, MIGRATION_RETRY_ACTION_ID,
-    MIGRATION_VOTES_ACK_ACTION_ID, SPV_CONNECTING_DESCRIPTION, SPV_CONTINUE_BACKGROUND_ACTION,
-    SPV_SYNCING_DESCRIPTION, SpvBlockStep, cold_start_backend_wait_timed_out,
+    COLD_START_BACKEND_READY_TIMEOUT, COLD_START_STUCK_MESSAGE, MIGRATION_IDENTITIES_ACK_ACTION_ID,
+    MIGRATION_RETRY_ACTION_ID, MIGRATION_UNREADABLE_ACK_ACTION_ID, MIGRATION_VOTES_ACK_ACTION_ID,
+    SPV_CONNECTING_DESCRIPTION, SPV_CONTINUE_BACKGROUND_ACTION, SPV_SYNCING_DESCRIPTION,
+    SpvBlockStep, cold_start_backend_wait_timed_out,
     migration_failed_with_unreadable_identities_text, migration_running_text,
     migration_unreadable_identities_and_votes_text, migration_unreadable_identities_text,
     migration_unreadable_votes_text, should_dispatch_cold_start, spv_block_step,
@@ -496,29 +497,32 @@ impl MigrationReconciler {
                 // Same shape as the vote warning: the drain is done and the rows
                 // are still in the previous version's storage, so no retry action
                 // — but the keys those identities held are not loaded, so the user
-                // must be told even if they stepped away.
+                // must be told even if they stepped away. Sticky, and re-raised on
+                // every launch until the "Got it" action retires the durable
+                // record: a dismissal is not an acknowledgement.
                 let handle = MessageBanner::set_global(
                     ctx,
                     migration_unreadable_identities_text(count),
                     MessageType::Warning,
                 );
                 handle.disable_auto_dismiss();
+                handle.with_action("Got it", MIGRATION_IDENTITIES_ACK_ACTION_ID);
                 self.banner_handle = Some(handle);
             }
             MigrationState::SucceededWithUnreadableIdentitiesAndVotes { identities, votes } => {
                 // Both kinds of row were left behind. One Warning banner names both
                 // remedies — no retry, since neither corrupt row decodes better on a
-                // second pass. Sticky and acknowledgeable: the "Got it" action
-                // retires the durable vote warning (the deadline-critical half the
-                // user must not miss), after which the identity half keeps arriving
-                // on its own until a build with a fixed decoder imports the rows.
+                // second pass. Sticky and acknowledgeable: because this single banner
+                // names both problems, its one "Got it" retires both durable records
+                // — re-raising either half afterwards would be a notice the user has
+                // already read and acted on.
                 let handle = MessageBanner::set_global(
                     ctx,
                     migration_unreadable_identities_and_votes_text(identities, votes),
                     MessageType::Warning,
                 );
                 handle.disable_auto_dismiss();
-                handle.with_action("Got it", MIGRATION_VOTES_ACK_ACTION_ID);
+                handle.with_action("Got it", MIGRATION_UNREADABLE_ACK_ACTION_ID);
                 self.banner_handle = Some(handle);
             }
             MigrationState::FailedWithUnreadableIdentities { count, error } => {
@@ -592,10 +596,12 @@ impl MigrationReconciler {
         }
     }
 
-    /// Drain pending banner-action clicks. Two actions are registered: the
-    /// migration Retry, which re-dispatches `FinishUnwire` after resetting the
-    /// cold-start guard, and the unreadable-vote acknowledgement, which clears the
-    /// durable warning. Both are returned for `AppState` to dispatch.
+    /// Drain pending banner-action clicks. Two kinds of action are registered:
+    /// the migration Retry, which re-dispatches `FinishUnwire` after resetting the
+    /// cold-start guard, and the three unreadable-row acknowledgements (votes,
+    /// identities, or the combined banner naming both), each of which clears the
+    /// durable warning records its banner named. All are returned for `AppState`
+    /// to dispatch.
     pub(super) fn drain_actions(
         &mut self,
         ctx: &egui::Context,
@@ -624,6 +630,24 @@ impl MigrationReconciler {
                 task = Some(BackendTask::MigrationTask(
                     MigrationTask::AcknowledgeUnreadableVotes,
                 ));
+            } else if action_id == MIGRATION_IDENTITIES_ACK_ACTION_ID {
+                tracing::info!(
+                    target = "migration::cold_start",
+                    ?network,
+                    "User acknowledged the unreadable-identity warning",
+                );
+                task = Some(BackendTask::MigrationTask(
+                    MigrationTask::AcknowledgeUnreadableIdentities,
+                ));
+            } else if action_id == MIGRATION_UNREADABLE_ACK_ACTION_ID {
+                tracing::info!(
+                    target = "migration::cold_start",
+                    ?network,
+                    "User acknowledged the combined unreadable-identity and unreadable-vote warning",
+                );
+                task = Some(BackendTask::MigrationTask(
+                    MigrationTask::AcknowledgeUnreadableIdentitiesAndVotes,
+                ));
             } else {
                 tracing::warn!(
                     target = "ui::banner",
@@ -633,5 +657,114 @@ impl MigrationReconciler {
             }
         }
         task
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use egui_kittest::Harness;
+    use egui_kittest::kittest::Queryable;
+
+    fn test_app_context(dir: &std::path::Path) -> Arc<AppContext> {
+        crate::app_dir::ensure_env_file(dir);
+        let db = Arc::new(crate::database::Database::new(dir.join("data.db")).expect("db"));
+        db.create_tables(true).expect("create tables");
+        db.set_default_version().expect("set version");
+
+        let app_kv = AppContext::open_app_kv(dir).expect("open app k/v");
+        let secret_store = AppContext::open_secret_store(dir).expect("open secret store");
+        AppContext::new(
+            dir.to_path_buf(),
+            Network::Testnet,
+            db,
+            Default::default(),
+            Default::default(),
+            egui::Context::default(),
+            app_kv,
+            secret_store,
+            crate::model::user_role::UserRoleCell::default(),
+        )
+        .expect("AppContext")
+    }
+
+    /// Publish `state`, let the reconciler build its banner, click the named
+    /// button, and return whatever task the click routed to. Drives the real
+    /// `update_banner` → render → click → `drain_actions` chain, so a banner that
+    /// never wires its action fails here instead of passing a test that hand-rolls
+    /// the wiring it was supposed to prove.
+    fn click_banner_action(state: MigrationState, label: &str) -> Option<BackendTask> {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let app_context = test_app_context(tmp.path());
+        app_context.migration_status().set_state(state);
+
+        let mut reconciler = MigrationReconciler::new();
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(600.0, 260.0))
+            .build_ui(MessageBanner::show_global);
+
+        reconciler.update_banner(&harness.ctx, &app_context);
+        harness.run();
+        harness.get_by_label(label).click();
+        harness.run();
+
+        reconciler.drain_actions(&harness.ctx, app_context.network)
+    }
+
+    /// The unreadable-identity warning is acknowledgeable. It used to render as a
+    /// sticky banner with NO action button at all: the user was told their signing
+    /// keys had not come across and given no way to say "I understand", so the
+    /// warning returned on every launch with no gesture that could retire it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unreadable_identities_banner_acknowledgement_routes_to_its_task() {
+        let task = click_banner_action(
+            MigrationState::SucceededWithUnreadableIdentities { count: 2 },
+            "Got it",
+        );
+        assert_eq!(
+            task,
+            Some(BackendTask::MigrationTask(
+                MigrationTask::AcknowledgeUnreadableIdentities
+            )),
+            "the identity warning must offer an acknowledgement that reaches its backend task",
+        );
+    }
+
+    /// The combined banner names both problems in one message, so its single
+    /// acknowledgement must retire BOTH records. Routing it to either single-signal
+    /// task would leave the other half to re-raise on the next launch — a notice the
+    /// user has already read and acted on.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn combined_unreadable_banner_acknowledgement_routes_to_the_combined_task() {
+        let task = click_banner_action(
+            MigrationState::SucceededWithUnreadableIdentitiesAndVotes {
+                identities: 2,
+                votes: 3,
+            },
+            "Got it",
+        );
+        assert_eq!(
+            task,
+            Some(BackendTask::MigrationTask(
+                MigrationTask::AcknowledgeUnreadableIdentitiesAndVotes
+            )),
+            "one banner naming both problems must retire both warnings on one click",
+        );
+    }
+
+    /// The vote warning keeps its own acknowledgement — the identity work above
+    /// must not have re-routed the sibling banner to the wrong task.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unreadable_votes_banner_acknowledgement_routes_to_its_task() {
+        let task = click_banner_action(
+            MigrationState::SucceededWithUnreadableVotes { count: 2 },
+            "Got it",
+        );
+        assert_eq!(
+            task,
+            Some(BackendTask::MigrationTask(
+                MigrationTask::AcknowledgeUnreadableVotes
+            )),
+        );
     }
 }

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -37,8 +37,13 @@ pub enum TaskError {
     /// [`Self::WalletBackendNotYetWired`]: the backend is ready, but this
     /// particular wallet is not yet registered with it (still loading, or
     /// skipped during load). User-actionable — waiting and retrying resolves it.
-    #[error("This wallet is still loading. Please wait a moment and try again.")]
-    WalletNotLoaded,
+    #[error("The wallet \"{wallet_label}\" is still loading. Please wait a moment and try again.")]
+    WalletNotLoaded {
+        /// Display alias for the affected wallet, or a fallback hex prefix of
+        /// the seed hash when no alias has been set. With several wallets
+        /// loaded, this is the only thing that says *which* one to wait for.
+        wallet_label: String,
+    },
 
     /// An internal wallet-state inconsistency: the wallet backend's records
     /// disagree with each other in a way that should never happen (a wallet

--- a/src/backend_task/migration/finish_unwire.rs
+++ b/src/backend_task/migration/finish_unwire.rs
@@ -212,6 +212,16 @@ pub enum MigrationError {
         source: KvAdapterError,
     },
 
+    /// Could not read, write or clear the durable unreadable-identity warning.
+    /// That record is the only thing that survives the identity sentinel, so a
+    /// failure here is surfaced rather than dropped — a silently-lost warning is
+    /// a user who never learns their signing keys did not come across.
+    #[error("could not access the unreadable-identity warning")]
+    IdentityWarningRecord {
+        #[source]
+        source: KvAdapterError,
+    },
+
     /// The wallet backend was not yet wired when the migration ran.
     /// This is a hard configuration bug: the orchestrator runs after
     /// `ensure_wallet_backend`, so this should never fire in
@@ -310,16 +320,21 @@ fn app_data_error_chain(error: TaskError) -> Arc<MigrationError> {
 /// letting it short-circuit the identity import would strand those keys outside
 /// the vault on every launch, not just this one.
 ///
-/// A pending [`UnreadableVotesWarning`] is re-published on every launch — not
-/// only the one that discovered it — until [`acknowledge_unreadable_votes`]
-/// clears it. That includes the launches where identities are *also* unreadable:
-/// both counts then ride one
-/// [`MigrationState::SucceededWithUnreadableIdentitiesAndVotes`], because the
-/// identity pass keeps its sentinel unwritten while any row fails to decode, so
-/// a lone identity warning would outrank the vote warning on every launch and
-/// silently cost the user a live vote deadline. If reading that record fails, the
-/// vote half is withheld until a later launch reads it successfully — the identity
-/// half still reaches the user, and neither is reported as a failed migration.
+/// Both passes write their sentinel unconditionally, so their counters exist for
+/// exactly one launch. What outlives them are the durable
+/// [`UnreadableVotesWarning`] and [`UnreadableIdentitiesWarning`] records, and
+/// those — never the counters — are what this function publishes: each is
+/// re-raised on every launch, not only the one that discovered it, until
+/// [`acknowledge_unreadable_votes`] / [`acknowledge_unreadable_identities`]
+/// retires it. When both are pending they ride one
+/// [`MigrationState::SucceededWithUnreadableIdentitiesAndVotes`], so a lone
+/// identity warning can never outrank the vote warning and silently cost the
+/// user a live vote deadline. If reading the vote-warning record fails, the vote
+/// half is withheld until a later launch reads it successfully — the identity
+/// half still reaches the user, and neither is reported as a failed migration —
+/// a *hard* app-data failure (not merely a failed later read of this record) is
+/// the only thing that publishes [`MigrationState::FailedWithUnreadableIdentities`]
+/// instead; see the `# Errors` section below.
 ///
 /// # Errors
 ///
@@ -404,6 +419,32 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
         }
     };
 
+    // The identity warning is read back from storage rather than taken from this
+    // pass's counters: the identity sentinel is written unconditionally, so every
+    // launch after the discovery run short-circuits the import and honestly
+    // reports zero unreadable rows — while the rows it could not decode still
+    // hold keys the user cannot sign with. Re-published until
+    // [`acknowledge_unreadable_identities`] retires it.
+    //
+    // A read failure here is surfaced, never dropped: this record is the only
+    // thing standing between the user and the news about their own keys.
+    let identities_warning = match read_identities_warning(
+        &app_context.app_kv(),
+        app_context.network,
+    ) {
+        Ok(warning) => warning,
+        Err(warning_error) => {
+            if let Err(app_data_error) = &app_data {
+                tracing::warn!(
+                    target = "migration::finish_unwire",
+                    error = ?app_data_error,
+                    "App-data import failed on the launch where the identity-warning record could not be read; the app-data import retries on the next launch",
+                );
+            }
+            return Err(warning_error.into());
+        }
+    };
+
     // Unreadable identities outrank a *readable* app-data pass: an identity that
     // did not come across took its keys with it, so the user cannot sign — let
     // alone vote — until it is loaded again. But a *hard* app-data failure on the
@@ -416,21 +457,22 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
     // This branch runs BEFORE `app_data` is unwrapped with `?`: unwrapping first
     // would return the deterministic app-data error and permanently mask the
     // identity outcome. `app_data` is moved here by value; the fall-through path
-    // below (no unreadable identities) still owns it because this branch always
+    // below (no pending identity warning) still owns it because this branch always
     // returns.
-    if identities.unreadable > 0 {
+    if let Some(identities_warning) = identities_warning {
+        let unreadable = identities_warning.count;
         match app_data {
             Ok(outcome) => {
                 let moved_data = wallet_moved || outcome.moved_data() || identities.moved_data();
 
                 // A pending vote warning must ride along, or the identity signal
-                // buries it forever: the identity sentinel stays unwritten while any
-                // row fails to decode, so this branch runs on *every* launch and
-                // would return ahead of the `read_vote_warning` re-publish below.
-                // The count comes from storage, not from `outcome`: after the
-                // discovery run the app-data pass short-circuits on its own sentinel
-                // and honestly reports zero unreadable votes — exactly on the
-                // launches where this branch is the only one the user ever sees.
+                // buries it forever: the identity warning is re-published on every
+                // launch until acknowledged, so this branch would otherwise return
+                // ahead of the `read_vote_warning` re-publish below. Both counts
+                // come from storage, not from this launch's counters: after the
+                // discovery run both passes short-circuit on their sentinels and
+                // honestly report zero — exactly on the launches where this branch
+                // is the only one the user ever sees.
                 //
                 // A k/v read that itself fails costs only the vote half of the
                 // banner, never the identity half: the record is durable and this
@@ -443,7 +485,7 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                     Ok(Some(warning)) => {
                         tracing::warn!(
                             target = "migration::finish_unwire",
-                            unreadable = identities.unreadable,
+                            unreadable,
                             imported = identities.imported,
                             votes_unreadable = warning.count,
                             network = ?app_context.network,
@@ -451,7 +493,7 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                         );
                         status.set_state(
                             MigrationState::SucceededWithUnreadableIdentitiesAndVotes {
-                                identities: identities.unreadable,
+                                identities: unreadable,
                                 votes: warning.count,
                             },
                         );
@@ -459,26 +501,26 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                     Ok(None) => {
                         tracing::warn!(
                             target = "migration::finish_unwire",
-                            unreadable = identities.unreadable,
+                            unreadable,
                             imported = identities.imported,
                             network = ?app_context.network,
                             "Some legacy identities could not be decoded; they stay in the previous version's data.db and must be loaded again",
                         );
                         status.set_state(MigrationState::SucceededWithUnreadableIdentities {
-                            count: identities.unreadable,
+                            count: unreadable,
                         });
                     }
                     Err(warning_error) => {
                         tracing::warn!(
                             target = "migration::finish_unwire",
-                            unreadable = identities.unreadable,
+                            unreadable,
                             imported = identities.imported,
                             error = ?warning_error,
                             network = ?app_context.network,
                             "Some legacy identities could not be decoded, and the pending vote-warning record could not be read so any vote notice is withheld until the next launch; the identity rows stay in the previous version's data.db and must be loaded again",
                         );
                         status.set_state(MigrationState::SucceededWithUnreadableIdentities {
-                            count: identities.unreadable,
+                            count: unreadable,
                         });
                     }
                 }
@@ -488,14 +530,14 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                 let moved_data = wallet_moved || identities.moved_data();
                 tracing::warn!(
                     target = "migration::finish_unwire",
-                    unreadable = identities.unreadable,
+                    unreadable,
                     imported = identities.imported,
                     error = ?app_data_error,
                     network = ?app_context.network,
                     "Both DET-owned passes failed on the same launch: some legacy identities could not be decoded and the app-data import hit a hard error; both retry on the next launch",
                 );
                 status.set_state(MigrationState::FailedWithUnreadableIdentities {
-                    count: identities.unreadable,
+                    count: unreadable,
                     error: app_data_error_chain(app_data_error),
                 });
                 return Ok(moved_data);
@@ -503,8 +545,8 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
         }
     }
 
-    // Every identity decoded, so app-data no longer masks anything critical: a
-    // hard failure here is the user's "Retry now" banner.
+    // No identity warning is pending, so app-data no longer masks anything
+    // critical: a hard failure here is the user's "Retry now" banner.
     let app_data = app_data?;
     let moved_data = wallet_moved || app_data.moved_data() || identities.moved_data();
 
@@ -758,6 +800,89 @@ pub fn acknowledge_unreadable_votes(app_context: &Arc<AppContext>) -> Result<(),
     Ok(())
 }
 
+/// Per-network key of the un-acknowledged unreadable-identity warning. Distinct
+/// from the identity sentinel: the sentinel records that the import *ran*, this
+/// record that the user has not yet been *told* what it could not carry across.
+fn identities_warning_key_for(network: Network) -> String {
+    format!(
+        "det:migration:unreadable_identities:{}:v1",
+        network_prefix(network)
+    )
+}
+
+/// Durable "some identities could not be read" warning.
+///
+/// The import runs once (the identity sentinel short-circuits every later
+/// launch), so the pass counters exist for exactly one launch. A user who was
+/// away, or who dismissed the banner without reading it, would otherwise never
+/// hear that the keys those identities held — a masternode's owner / voting key,
+/// say — are not loaded. This record outlives the pass: [`run`] re-publishes it
+/// on every launch until [`acknowledge_unreadable_identities`] clears it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnreadableIdentitiesWarning {
+    /// Legacy identity rows the import could not decode. Never `0` — a
+    /// zero-count warning is not written at all.
+    pub count: u32,
+}
+
+/// The pending unreadable-identity warning for `network`, if the user has not
+/// acknowledged it yet.
+fn read_identities_warning(
+    app_kv: &crate::wallet_backend::DetKv,
+    network: Network,
+) -> Result<Option<UnreadableIdentitiesWarning>, MigrationError> {
+    app_kv
+        .get::<UnreadableIdentitiesWarning>(DetScope::Global, &identities_warning_key_for(network))
+        .map_err(|source| MigrationError::IdentityWarningRecord { source })
+}
+
+/// Record `count` unreadable identity rows as a pending warning. A zero count
+/// writes nothing — there is nothing to tell the user.
+///
+/// Written BEFORE the identity sentinel: a crash between the two re-runs the
+/// idempotent import, whereas the reverse order would lose the warning for good.
+fn write_identities_warning(
+    app_kv: &crate::wallet_backend::DetKv,
+    network: Network,
+    count: u32,
+) -> Result<(), MigrationError> {
+    if count == 0 {
+        return Ok(());
+    }
+    app_kv
+        .put(
+            DetScope::Global,
+            &identities_warning_key_for(network),
+            &UnreadableIdentitiesWarning { count },
+        )
+        .map_err(|source| MigrationError::IdentityWarningRecord { source })
+}
+
+/// Retire the unreadable-identity warning for the active network: the user has
+/// read it. Clears the durable record so later launches stay quiet, and drops
+/// the banner. The legacy rows in `data.db` are untouched — only the notice is
+/// retired, so a build with a better decoder can still recover the identities.
+///
+/// This gesture does not gate the import loop: [`migrate_identities`] writes its
+/// sentinel unconditionally, so the import is already a once-only event whether
+/// or not the user ever clicks. Acknowledgement retires the notice, nothing more.
+pub fn acknowledge_unreadable_identities(app_context: &Arc<AppContext>) -> Result<(), TaskError> {
+    let network = app_context.network;
+    app_context
+        .app_kv()
+        .delete(DetScope::Global, &identities_warning_key_for(network))
+        .map_err(|source| MigrationError::IdentityWarningRecord { source })?;
+    tracing::info!(
+        target = "migration::finish_unwire",
+        network = ?network,
+        "User acknowledged the unreadable-identity warning",
+    );
+    app_context
+        .migration_status()
+        .set_state(MigrationState::Idle);
+    Ok(())
+}
+
 /// Import the DET-owned rows the wallet drain never touched: scheduled DPNS
 /// votes (deadline-critical) and top-up history (audit trail).
 ///
@@ -987,9 +1112,13 @@ pub fn identities_sentinel_key_for(network: Network) -> String {
 ///
 /// Key material is never handled here. Each decoded identity goes straight to
 /// [`AppContext::insert_local_qualified_identity`], which routes the keys
-/// through the vault seam and writes only `InVault` placeholders to disk. The
-/// sentinel is withheld while any row is unreadable, so a later build with a
-/// fixed decoder retries — the legacy rows are never deleted.
+/// through the vault seam and writes only `InVault` placeholders to disk.
+///
+/// Runs exactly once: the sentinel is written even when rows were unreadable, so
+/// a deletion the user makes afterwards is durable. Undecodable rows are counted
+/// into a durable [`UnreadableIdentitiesWarning`] and left in `data.db`, never
+/// deleted — recovering them after a decoder fix is an explicit user gesture
+/// (dashpay/dash-evo-tool#889), not an automatic retry.
 ///
 /// # Errors
 ///
@@ -1053,13 +1182,23 @@ fn migrate_identities(
         "Identity migration pass complete",
     );
 
-    // Sentinel iff everything decoded. An unreadable blob may be a *decoder*
-    // defect (a bincode drift), not data rot, so the door stays open for a later
-    // build to retry; the skip-if-present rule makes that retry a no-op for
-    // every identity that already landed.
-    if outcome.unreadable == 0 {
-        write_completion_sentinel(&app_kv, &sentinel_key)?;
-    }
+    // Persist the warning before the sentinel: this pass counts the undecodable
+    // rows exactly once (the sentinel short-circuits every later launch), so the
+    // count has to outlive it or the user gets one banner and no second chance.
+    // Ordered before the sentinel so a crash in between re-runs the idempotent
+    // import rather than losing the warning.
+    write_identities_warning(&app_kv, network, outcome.unreadable)?;
+
+    // The sentinel is written even when rows were unreadable — the same rule the
+    // app-data pass follows, for the same reason. Every *importable* row is now
+    // in the store, and a withheld sentinel would re-run this import on every
+    // launch: harmless for an identity the user has edited (skip-if-present), but
+    // it would resurrect one the user has DELETED, restoring its alias and
+    // re-writing its legacy plaintext keys into the vault, forever. The
+    // undecodable rows stay in `data.db` and are reported by the durable warning
+    // above; re-importing them after a decoder fix is an explicit user gesture
+    // (dashpay/dash-evo-tool#889), not an automatic retry that costs a deletion.
+    write_completion_sentinel(&app_kv, &sentinel_key)?;
 
     Ok(outcome)
 }
@@ -1141,9 +1280,10 @@ struct IdentityMigrationOutcome {
     imported: u32,
     /// Identities already in the store and therefore left untouched.
     skipped_existing: u32,
-    /// Legacy rows that could not be decoded. Withholds the sentinel so a later
-    /// build can retry, but never fails the pass — the identities that *did*
-    /// decode must not be held hostage by one that did not.
+    /// Legacy rows that could not be decoded. Recorded as a durable
+    /// [`UnreadableIdentitiesWarning`] so the user still hears about them, but
+    /// never fails the pass — the identities that *did* decode must not be held
+    /// hostage by one that did not.
     unreadable: u32,
 }
 
@@ -2478,7 +2618,7 @@ mod tests {
         }
 
         /// A minimal, genuinely-encodable identity blob.
-        fn identity_blob(id: [u8; 32]) -> Vec<u8> {
+        pub(super) fn identity_blob(id: [u8; 32]) -> Vec<u8> {
             let identity = dash_sdk::dpp::identity::Identity::create_basic_identity(
                 Identifier::from(id),
                 PlatformVersion::latest(),
@@ -2503,7 +2643,12 @@ mod tests {
             .to_bytes()
         }
 
-        fn insert_identity(conn: &Connection, id: [u8; 32], data: Option<Vec<u8>>, is_local: bool) {
+        pub(super) fn insert_identity(
+            conn: &Connection,
+            id: [u8; 32],
+            data: Option<Vec<u8>>,
+            is_local: bool,
+        ) {
             conn.execute(
                 "INSERT INTO identity (id, data, status, is_local, network)
                  VALUES (?1, ?2, 2, ?3, ?4)",
@@ -2526,7 +2671,7 @@ mod tests {
 
         /// A blob that will never decode must not take the identities around it
         /// down with it: the readable rows still import, and the failure is
-        /// counted so the caller can withhold the sentinel and retry later.
+        /// counted so the caller can record a durable warning for the user.
         #[test]
         fn an_undecodable_blob_never_blocks_the_identities_that_do_decode() {
             let conn = Connection::open_in_memory().expect("in-memory db");
@@ -2561,8 +2706,8 @@ mod tests {
             );
             assert!(
                 outcome.unreadable > 0,
-                "a non-zero `unreadable` is what withholds the sentinel, keeping the \
-                 retry door open for a build with a fixed decoder",
+                "a non-zero `unreadable` is what raises the durable warning that tells \
+                 the user which keys did not come across",
             );
         }
 
@@ -2606,7 +2751,8 @@ mod tests {
 
         /// Observed (`is_local = 0`) rows are v0.9.3's lookup cache and NULL-blob
         /// rows have nothing in them. Neither is user data: both are skipped, and
-        /// neither counts as a failure that would withhold the sentinel forever.
+        /// neither counts as unreadable — so neither raises a warning about keys
+        /// that were never there.
         #[test]
         fn observed_and_null_blob_rows_are_skipped_without_failing_the_pass() {
             let conn = Connection::open_in_memory().expect("in-memory db");
@@ -4624,7 +4770,11 @@ mod tests {
             "the migrated wallet must be reachable",
         );
 
-        // Neither DET-owned sentinel is written, so both passes retry next launch.
+        // The app-data pass hard-failed, so its sentinel stays unwritten and the
+        // import retries next launch. The identity pass did NOT fail — it imported
+        // what decoded and counted what did not — so it completes, and the
+        // undecodable row is carried forward by its durable warning instead of by
+        // an endlessly-retried import that would resurrect deleted identities.
         assert!(
             ctx.app_kv()
                 .get::<MigrationCompletion>(DetScope::Global, &app_data_sentinel_key_for(network))
@@ -4636,8 +4786,9 @@ mod tests {
             ctx.app_kv()
                 .get::<MigrationCompletion>(DetScope::Global, &identities_sentinel_key_for(network))
                 .expect("read identity sentinel")
-                .is_none(),
-            "the identity sentinel must stay unwritten so the unreadable row retries",
+                .is_some(),
+            "an unreadable row is not a pass failure: the import completes, and the row is \
+             reported by the durable warning rather than retried forever",
         );
 
         backend.shutdown().await;
@@ -4767,13 +4918,13 @@ mod tests {
     }
 
     /// An unreadable identity must not permanently hide an unreadable *vote*.
-    /// Both damaged on the same launch is the trap: the identity sentinel stays
-    /// unwritten while any row fails to decode, so the identity branch runs again
-    /// on every launch — and before the fix it returned early, ahead of the
-    /// durable vote-warning read, so the vote half was never published once, let
-    /// alone re-published. The user would silently miss a vote whose deadline is
-    /// still live. Both counts now ride one terminal state, the vote half stays
-    /// reachable across restarts, and acknowledging it retires only that half.
+    /// Both damaged on the same launch is the trap: the identity branch returns
+    /// early, ahead of the durable vote-warning read, so a lone identity signal
+    /// would bury the vote half — and the user would silently miss a vote whose
+    /// deadline is still live. Both counts ride one terminal state instead, both
+    /// halves survive a restart (each re-read from its own durable record, since
+    /// both sentinels short-circuit their passes by then), and acknowledging the
+    /// vote half retires only that half.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn unreadable_identities_do_not_hide_the_unreadable_vote_warning() {
         use dash_sdk::dpp::dashcore::Network;
@@ -4793,7 +4944,7 @@ mod tests {
         );
         {
             // A corrupt identity blob → the identity pass counts it unreadable and
-            // leaves its sentinel unwritten, so this launch's branch recurs forever.
+            // records a durable warning, so the identity branch recurs on every launch.
             let conn = Connection::open(tmp.path().join("data.db")).expect("open data.db");
             conn.execute(
                 "INSERT INTO identity (id, data, status, is_local, network)
@@ -4821,10 +4972,10 @@ mod tests {
         let votes = ctx.get_scheduled_votes().expect("read scheduled votes");
         assert_eq!(votes.len(), 1, "the readable vote must still be imported");
 
-        // The two sentinels now disagree, which is what makes the next launch a
-        // real test of the durable read: app-data is done (so its pass will
-        // short-circuit and report zero unreadable votes), while the identity
-        // sentinel stays unwritten (so its corrupt row is counted again).
+        // Both sentinels are now written, which is what makes the next launch a
+        // real test of the durable reads: both passes short-circuit and report
+        // zero unreadable rows, so *neither* half of the banner can come from a
+        // counter — each must be re-read from its own durable warning record.
         assert!(
             ctx.app_kv()
                 .get::<MigrationCompletion>(DetScope::Global, &app_data_sentinel_key_for(network))
@@ -4836,13 +4987,13 @@ mod tests {
             ctx.app_kv()
                 .get::<MigrationCompletion>(DetScope::Global, &identities_sentinel_key_for(network))
                 .expect("read identity sentinel")
-                .is_none(),
-            "precondition: the identity sentinel stays unwritten, so its branch recurs",
+                .is_some(),
+            "precondition: the identity pass completed too — a withheld sentinel would re-run \
+             the import forever and resurrect identities the user has deleted",
         );
 
-        // Later launch: the app-data sentinel short-circuits its pass (it reports
-        // zero unreadable votes now), while the identity pass counts its corrupt
-        // row again. The vote half must come from the durable record, not counters.
+        // Later launch: both sentinels short-circuit their passes, so both halves
+        // of the combined banner must come from the durable records, not counters.
         ctx.migration_status().set_state(MigrationState::Idle);
         run(&ctx).await.expect("second launch");
         assert_eq!(
@@ -4863,6 +5014,156 @@ mod tests {
             *ctx.migration_status().state(),
             MigrationState::SucceededWithUnreadableIdentities { count: 1 },
             "an acknowledged vote warning must not come back, but the identity one must",
+        );
+
+        backend.shutdown().await;
+    }
+
+    /// The resurrection regression. One genuinely corrupt legacy row must not
+    /// make the identity import re-run forever: while it did, an identity the
+    /// user had deliberately DELETED — a routine security gesture, offered on
+    /// both the Identities and the Masternode screens — was silently re-imported
+    /// on the very next launch, its alias restored and its legacy plaintext keys
+    /// re-written into the vault. The skip-if-present rule cannot help here: a
+    /// deleted identity is, by construction, no longer present.
+    ///
+    /// The import now writes its sentinel unconditionally, exactly like the
+    /// app-data pass, so it is a once-only event and a deletion is durable. The
+    /// unreadable row is still reported — from a record that outlives the pass.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_deleted_identity_is_not_resurrected_by_an_unreadable_sibling_row() {
+        use dash_sdk::dpp::dashcore::Network;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = fresh_app_context(tmp.path());
+        let network = Network::Testnet;
+
+        seed_legacy_wallet(&ctx, &[0x9Au8; 64], "funds", network);
+
+        // One identity that decodes, and one genuinely corrupt row beside it —
+        // the row that used to hold the sentinel hostage forever.
+        let deleted = [0x11u8; 32];
+        {
+            let conn = Connection::open(tmp.path().join("data.db")).expect("open data.db");
+            identities::insert_identity(
+                &conn,
+                deleted,
+                Some(identities::identity_blob(deleted)),
+                true,
+            );
+            identities::insert_identity(&conn, [0x22u8; 32], Some(vec![0xFFu8; 8]), true);
+        }
+
+        wire_backend(&ctx).await;
+        let backend = ctx.wallet_backend().expect("backend wired");
+
+        run(&ctx).await.expect("first launch");
+
+        let deleted_id = Identifier::from(deleted);
+        assert!(
+            ctx.has_local_qualified_identity(&deleted_id)
+                .expect("read identity store"),
+            "precondition: the readable identity is imported by the discovery run",
+        );
+        assert_eq!(
+            *ctx.migration_status().state(),
+            MigrationState::SucceededWithUnreadableIdentities { count: 1 },
+            "precondition: the corrupt row is reported to the user",
+        );
+
+        // The user deliberately removes the identity — the gesture whose entire
+        // point is that those keys stop living in this install.
+        ctx.delete_local_qualified_identity(&deleted_id)
+            .expect("delete identity");
+        assert!(
+            !ctx.has_local_qualified_identity(&deleted_id)
+                .expect("read identity store"),
+            "precondition: the delete took effect",
+        );
+
+        // The next launch, with the corrupt row still sitting in `data.db`.
+        ctx.migration_status().set_state(MigrationState::Idle);
+        run(&ctx).await.expect("second launch");
+
+        assert!(
+            !ctx.has_local_qualified_identity(&deleted_id)
+                .expect("read identity store"),
+            "a deleted identity must STAY deleted: re-importing it would restore the alias \
+             the user cleared and re-write their legacy plaintext keys into the vault, on \
+             every launch, with no banner to explain it and no way to stop it",
+        );
+
+        // Closing the retry door must not cost the user the notice about the row
+        // that never decoded.
+        assert_eq!(
+            *ctx.migration_status().state(),
+            MigrationState::SucceededWithUnreadableIdentities { count: 1 },
+            "the unreadable row is still reported once the import itself is complete",
+        );
+
+        backend.shutdown().await;
+    }
+
+    /// The unreadable-identity warning is acknowledgeable, and durable until it
+    /// is. Before, it was a sticky banner with no action button: the user could
+    /// not retire it, and the only thing keeping it on screen was an import that
+    /// re-ran forever. The record now outlives the (once-only) import, is
+    /// re-published on every launch, and only an explicit acknowledgement stops
+    /// it — the legacy rows themselves are never touched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unreadable_identity_warning_is_republished_until_acknowledged() {
+        use dash_sdk::dpp::dashcore::Network;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = fresh_app_context(tmp.path());
+        let network = Network::Testnet;
+
+        seed_legacy_wallet(&ctx, &[0xB4u8; 64], "funds", network);
+        {
+            let conn = Connection::open(tmp.path().join("data.db")).expect("open data.db");
+            identities::insert_identity(&conn, [0x44u8; 32], Some(vec![0xFFu8; 8]), true);
+        }
+
+        wire_backend(&ctx).await;
+        let backend = ctx.wallet_backend().expect("backend wired");
+
+        run(&ctx).await.expect("first launch");
+        assert_eq!(
+            *ctx.migration_status().state(),
+            MigrationState::SucceededWithUnreadableIdentities { count: 1 },
+            "the discovery run surfaces the warning",
+        );
+
+        assert!(
+            ctx.app_kv()
+                .get::<MigrationCompletion>(DetScope::Global, &identities_sentinel_key_for(network))
+                .expect("read identity sentinel")
+                .is_some(),
+            "the import completes even with an unreadable row: a withheld sentinel would \
+             re-run it on every launch and resurrect identities the user has deleted",
+        );
+
+        // The import is done, so the pass reports zero from here on — the warning
+        // has to come from storage or the user never hears it again.
+        ctx.migration_status().set_state(MigrationState::Idle);
+        run(&ctx).await.expect("second launch");
+        assert_eq!(
+            *ctx.migration_status().state(),
+            MigrationState::SucceededWithUnreadableIdentities { count: 1 },
+            "a warning the user may have missed must survive a restart",
+        );
+
+        acknowledge_unreadable_identities(&ctx).expect("acknowledge");
+        assert!(
+            matches!(*ctx.migration_status().state(), MigrationState::Idle),
+            "acknowledging clears the banner immediately",
+        );
+
+        ctx.migration_status().set_state(MigrationState::Idle);
+        run(&ctx).await.expect("third launch");
+        assert!(
+            matches!(*ctx.migration_status().state(), MigrationState::Idle),
+            "an acknowledged warning must never come back",
         );
 
         backend.shutdown().await;

--- a/src/backend_task/migration/finish_unwire.rs
+++ b/src/backend_task/migration/finish_unwire.rs
@@ -317,7 +317,9 @@ fn app_data_error_chain(error: TaskError) -> Arc<MigrationError> {
 /// [`MigrationState::SucceededWithUnreadableIdentitiesAndVotes`], because the
 /// identity pass keeps its sentinel unwritten while any row fails to decode, so
 /// a lone identity warning would outrank the vote warning on every launch and
-/// silently cost the user a live vote deadline.
+/// silently cost the user a live vote deadline. If reading that record fails, the
+/// vote half is withheld until a later launch reads it successfully — the identity
+/// half still reaches the user, and neither is reported as a failed migration.
 ///
 /// # Errors
 ///
@@ -430,9 +432,13 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                 // and honestly reports zero unreadable votes — exactly on the
                 // launches where this branch is the only one the user ever sees.
                 //
-                // A k/v read that itself fails is surfaced as the retryable half of
-                // the combined failure banner rather than dropped: neither signal
-                // may vanish silently.
+                // A k/v read that itself fails costs only the vote half of the
+                // banner, never the identity half: the record is durable and this
+                // branch re-runs on every launch (the identity sentinel stays
+                // unwritten), so the next successful read re-publishes it. Reporting
+                // the read error as a *failure* state instead would tell the user the
+                // app-data pass did not finish — it did, and wrote its sentinel — and
+                // offer a retry that re-runs nothing.
                 match read_vote_warning(&app_context.app_kv(), app_context.network) {
                     Ok(Some(warning)) => {
                         tracing::warn!(
@@ -469,11 +475,10 @@ pub async fn run(app_context: &Arc<AppContext>) -> Result<bool, TaskError> {
                             imported = identities.imported,
                             error = ?warning_error,
                             network = ?app_context.network,
-                            "Some legacy identities could not be decoded and the pending vote-warning record could not be read; the identity rows stay in the previous version's data.db",
+                            "Some legacy identities could not be decoded, and the pending vote-warning record could not be read so any vote notice is withheld until the next launch; the identity rows stay in the previous version's data.db and must be loaded again",
                         );
-                        status.set_state(MigrationState::FailedWithUnreadableIdentities {
+                        status.set_state(MigrationState::SucceededWithUnreadableIdentities {
                             count: identities.unreadable,
-                            error: Arc::new(warning_error),
                         });
                     }
                 }
@@ -4633,6 +4638,77 @@ mod tests {
                 .expect("read identity sentinel")
                 .is_none(),
             "the identity sentinel must stay unwritten so the unreadable row retries",
+        );
+
+        backend.shutdown().await;
+    }
+
+    /// A failed *vote-warning read* is not an app-data failure, and the banner may
+    /// not say it is. Here the app-data pass SUCCEEDS (its sentinel is written) and
+    /// only the follow-up warning-record read fails, alongside an undecodable
+    /// identity row. `FailedWithUnreadableIdentities` tells the user "updating the
+    /// rest of your previous data did not finish" and offers a "Retry now" that
+    /// re-runs a pass which already completed — false on both counts. The identity
+    /// signal is the one the user must act on, so the run falls through to the
+    /// honest `SucceededWithUnreadableIdentities` and the unreadable notice record
+    /// is left for the next launch to re-read.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_unreadable_vote_warning_record_does_not_claim_the_app_data_pass_failed() {
+        use dash_sdk::dpp::dashcore::Network;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let ctx = fresh_app_context(tmp.path());
+        let network = Network::Testnet;
+
+        // Funds: a normal legacy wallet, so the drain completes and `moved_data`.
+        seed_legacy_wallet(&ctx, &[0xD7u8; 64], "funds", network);
+
+        {
+            let conn = Connection::open(tmp.path().join("data.db")).expect("open data.db");
+            // A corrupt identity blob → unreadable == 1, which is what steers the run
+            // into the branch under test. The legacy `top_up` table is left alone, so
+            // the app-data pass runs clean and writes its sentinel.
+            conn.execute(
+                "INSERT INTO identity (id, data, status, is_local, network)
+                 VALUES (?1, ?2, 2, 1, 'testnet')",
+                rusqlite::params![[0x45u8; 32].as_slice(), vec![0xFFu8; 8]],
+            )
+            .expect("corrupt identity row");
+        }
+
+        // Poison the warning record: a unit value encodes to an empty bincode body,
+        // so decoding it back as an `UnreadableVotesWarning` hits an unexpected end
+        // of input. The app-data pass decodes zero unreadable votes and therefore
+        // never overwrites it.
+        ctx.app_kv()
+            .put(DetScope::Global, &vote_warning_key_for(network), &())
+            .expect("poison the vote-warning record");
+        assert!(
+            read_vote_warning(&ctx.app_kv(), network).is_err(),
+            "precondition: the poisoned record must make the warning read fail, \
+             otherwise this test would pass for the wrong reason",
+        );
+
+        wire_backend(&ctx).await;
+        let backend = ctx.wallet_backend().expect("backend wired");
+
+        let did_work = run(&ctx).await.expect("a failed notice read is not fatal");
+        assert!(did_work, "the wallet drain moved data");
+
+        assert_eq!(
+            *ctx.migration_status().state(),
+            MigrationState::SucceededWithUnreadableIdentities { count: 1 },
+            "an unreadable notice record must not be reported as an app-data failure",
+        );
+
+        // The fact the old banner denied: the app-data pass really did finish.
+        assert!(
+            ctx.app_kv()
+                .get::<MigrationCompletion>(DetScope::Global, &app_data_sentinel_key_for(network))
+                .expect("read app-data sentinel")
+                .is_some(),
+            "the app-data sentinel proves the pass completed — a banner offering to \
+             'finish updating' it would be lying",
         );
 
         backend.shutdown().await;

--- a/src/backend_task/migration/mod.rs
+++ b/src/backend_task/migration/mod.rs
@@ -40,6 +40,16 @@ pub enum MigrationTask {
     /// acknowledges it, so this is the one gesture that stops it — the legacy
     /// vote rows themselves are never touched.
     AcknowledgeUnreadableVotes,
+    /// Retire the "some identities could not be read" warning for the active
+    /// network. Same contract as [`Self::AcknowledgeUnreadableVotes`]: the
+    /// warning is re-raised on every launch until the user acknowledges it, and
+    /// the legacy identity rows themselves are never touched.
+    AcknowledgeUnreadableIdentities,
+    /// Retire both warnings at once — the acknowledgement of the single combined
+    /// banner that names both problems. Retiring only one half would re-raise the
+    /// other on the next launch, as a notice the user has already read and acted
+    /// on.
+    AcknowledgeUnreadableIdentitiesAndVotes,
 }
 
 impl AppContext {
@@ -79,6 +89,15 @@ impl AppContext {
             },
             MigrationTask::AcknowledgeUnreadableVotes => {
                 finish_unwire::acknowledge_unreadable_votes(self)?;
+                Ok(BackendTaskSuccessResult::Refresh)
+            }
+            MigrationTask::AcknowledgeUnreadableIdentities => {
+                finish_unwire::acknowledge_unreadable_identities(self)?;
+                Ok(BackendTaskSuccessResult::Refresh)
+            }
+            MigrationTask::AcknowledgeUnreadableIdentitiesAndVotes => {
+                finish_unwire::acknowledge_unreadable_votes(self)?;
+                finish_unwire::acknowledge_unreadable_identities(self)?;
                 Ok(BackendTaskSuccessResult::Refresh)
             }
         }

--- a/src/backend_task/migration/v093_upgrade.rs
+++ b/src/backend_task/migration/v093_upgrade.rs
@@ -1172,10 +1172,9 @@ async fn second_launch_after_a_v093_upgrade_changes_nothing() {
     ctx.clear_all_scheduled_votes()
         .expect("user casts the vote");
 
-    // …and renames the imported masternode identity. On this (clean) path the
-    // identity sentinel is what must protect the edit; the skip-if-present rule
-    // is exercised by `a_retry_after_an_unreadable_identity_preserves_user_edits`,
-    // where the sentinel is deliberately withheld.
+    // …and renames the imported masternode identity. The identity sentinel is what
+    // must protect the edit; the same guarantee under an undecodable row is covered
+    // by `a_second_launch_after_an_unreadable_identity_preserves_user_edits_and_deletions`.
     ctx.set_identity_alias(&Identifier::from(IDENTITY_ID), Some("my-renamed-node"))
         .expect("user renames the identity");
 
@@ -1390,23 +1389,22 @@ async fn a_corrupt_vote_index_never_strands_the_identity_keys() {
     backend.shutdown().await;
 }
 
-/// The retry path, which is the only path where skip-if-present is load-bearing.
+/// A corrupt legacy row must not make the import re-run forever, on a real
+/// v0.9.3 database.
 ///
-/// An undecodable identity blob withholds the identity sentinel, so the **next**
-/// launch runs the import again over identities that already landed. Without a
-/// skip-if-present check, that re-run would push the stale legacy blob back over
-/// them with `insert_local_qualified_identity`'s INSERT-OR-REPLACE — silently
-/// undoing anything the user changed in between.
-///
-/// (`second_launch_after_a_v093_upgrade_changes_nothing` cannot prove this: on a
-/// clean upgrade the sentinel short-circuits the pass before the check is
-/// reached.)
+/// The import used to withhold its sentinel while any row was undecodable, so it
+/// ran again on **every** launch. Skip-if-present made that harmless for an
+/// identity the user had *edited* — and did nothing for one the user had
+/// *deleted*: the next launch re-imported it, restored the alias the user had
+/// cleared and re-wrote its legacy plaintext keys into the vault, forever. The
+/// import now completes even with an undecodable row (the row is reported by a
+/// durable warning instead), so a second launch changes nothing the user did.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_retry_after_an_unreadable_identity_preserves_user_edits() {
+async fn a_second_launch_after_an_unreadable_identity_preserves_user_edits_and_deletions() {
     let tmp = tempfile::tempdir().expect("tempdir");
     write_v093_database(tmp.path());
 
-    // One corrupt blob is enough to withhold the sentinel for the whole pass.
+    // One corrupt blob used to be enough to re-run the whole pass on every launch.
     let corrupt_id = [0x0C; 32];
     let conn = Connection::open(tmp.path().join("data.db")).expect("open data.db");
     insert_identity(
@@ -1441,7 +1439,8 @@ async fn a_retry_after_an_unreadable_identity_preserves_user_edits() {
         },
         "the user must learn that an identity did not come across",
     );
-    // …and the sentinel stays unwritten, so the next launch retries.
+    // …and the import is nonetheless COMPLETE: the corrupt row rides on the
+    // durable warning, not on an import that re-runs until it decodes.
     assert!(
         ctx.app_kv()
             .get::<MigrationCompletion>(
@@ -1449,32 +1448,44 @@ async fn a_retry_after_an_unreadable_identity_preserves_user_edits() {
                 &identities_sentinel_key_for(USER_NETWORK)
             )
             .expect("read identity sentinel")
-            .is_none(),
-        "an unreadable row must withhold the sentinel, keeping the retry door open for \
-         a later build with a fixed decoder",
+            .is_some(),
+        "an unreadable row must not withhold the sentinel: a re-running import resurrects \
+         identities the user has deleted",
     );
 
-    // The user renames the imported masternode before the next launch.
+    // Between launches the user renames the imported masternode and deletes one
+    // identity outright — the security gesture whose whole point is that those
+    // keys stop living in this install.
     ctx.set_identity_alias(&Identifier::from(IDENTITY_ID), Some("my-renamed-node"))
         .expect("rename identity");
+    let deleted = Identifier::from(USER_IDENTITY_ID);
+    ctx.delete_local_qualified_identity(&deleted)
+        .expect("delete identity");
 
-    // Second launch: with no sentinel, the identity import genuinely runs again.
-    finish_unwire::run(&ctx).await.expect("retry migration");
+    // Second launch.
+    finish_unwire::run(&ctx).await.expect("second migration");
 
     assert_eq!(
         ctx.get_identity_alias(&Identifier::from(IDENTITY_ID))
             .expect("read alias")
             .as_deref(),
         Some("my-renamed-node"),
-        "the retry must skip identities already imported — re-inserting would overwrite \
-         the user's edit with the stale legacy blob",
+        "a second launch must not overwrite the user's edit with the stale legacy blob",
+    );
+    assert!(
+        !ctx.has_local_qualified_identity(&deleted)
+            .expect("read identity store"),
+        "a deleted identity must STAY deleted: re-importing it would restore the alias the \
+         user cleared and re-write their legacy plaintext keys into the vault, on every \
+         launch, with no way to stop it",
     );
     assert_eq!(
         ctx.load_local_qualified_identities()
             .expect("load identities")
             .len(),
-        4,
-        "the retry must not duplicate the identities it already imported",
+        3,
+        "the second launch must neither duplicate the identities it imported nor resurrect \
+         the one the user removed",
     );
 
     backend.shutdown().await;

--- a/src/context/migration_status.rs
+++ b/src/context/migration_status.rs
@@ -105,6 +105,12 @@ pub enum MigrationState {
     /// app-data failure and left the user no retry. Both the identity rows and
     /// the app-data sentinel stay unwritten, so a retry (or the next launch)
     /// re-attempts both. Terminal until then.
+    ///
+    /// A *hard* app-data failure is the only producer. An app-data pass that
+    /// completed and merely left a later notice-record read failing is not one:
+    /// its sentinel is written, so this state's "we did not finish updating the
+    /// rest of your data — retry" copy would be false and its retry a no-op. That
+    /// path publishes [`Self::SucceededWithUnreadableIdentities`] instead.
     FailedWithUnreadableIdentities {
         count: u32,
         error: Arc<crate::backend_task::migration::MigrationError>,

--- a/src/context/migration_status.rs
+++ b/src/context/migration_status.rs
@@ -73,10 +73,10 @@ pub enum MigrationState {
     /// The wallet drain completed, but `count` legacy identities could not be
     /// decoded and did not come across — so the keys they held (a masternode's
     /// owner / voting key, say) are not loaded. Terminal and non-fatal: the
-    /// legacy rows are never deleted and the import sentinel stays unwritten,
-    /// so a later build with a fixed decoder retries automatically. Separate
-    /// from [`Self::SucceededWithUnreadableVotes`] because the remedy differs —
-    /// re-import a key, not re-schedule a vote.
+    /// legacy rows are never deleted, so they remain recoverable. Re-published
+    /// from a durable record on every launch until the user acknowledges it, and
+    /// separate from [`Self::SucceededWithUnreadableVotes`] because the remedy
+    /// differs — re-import a key, not re-schedule a vote.
     SucceededWithUnreadableIdentities { count: u32 },
     /// The wallet drain completed, but both DET-owned passes left undecodable
     /// rows behind on the same launch: `identities` legacy identities and
@@ -84,27 +84,28 @@ pub enum MigrationState {
     /// non-fatal — like the two single-signal variants it combines, and for the
     /// same reason: a corrupt row decodes no better on a retry.
     ///
-    /// It exists because neither signal may eat the other. The identity import
-    /// leaves its sentinel unwritten while any row fails to decode, so the
-    /// identity outcome is republished on *every* launch — which, with only the
-    /// single-signal variants available, would permanently outrank the vote
-    /// warning and cost the user a vote whose deadline is still live. One banner
-    /// names both remedies: load the identities again, re-schedule the votes.
+    /// It exists because neither signal may eat the other. Both warnings are
+    /// durable and re-published on every launch until acknowledged, so with only
+    /// the single-signal variants available the identity half would permanently
+    /// outrank the vote half and cost the user a vote whose deadline is still
+    /// live. One banner names both remedies instead: load the identities again,
+    /// re-schedule the votes.
     ///
-    /// The acknowledge action retires only the durable vote half (see
-    /// [`acknowledge_unreadable_votes`](crate::backend_task::migration::finish_unwire::acknowledge_unreadable_votes));
-    /// the identity half then keeps arriving as a plain
-    /// [`Self::SucceededWithUnreadableIdentities`] until a build with a fixed
-    /// decoder imports the rows.
+    /// Because that single banner names both problems, its single acknowledge
+    /// action retires *both* durable records (see
+    /// [`acknowledge_unreadable_votes`](crate::backend_task::migration::finish_unwire::acknowledge_unreadable_votes)
+    /// and
+    /// [`acknowledge_unreadable_identities`](crate::backend_task::migration::finish_unwire::acknowledge_unreadable_identities)).
     SucceededWithUnreadableIdentitiesAndVotes { identities: u32, votes: u32 },
     /// Both DET-owned passes are damaged on the same launch: the wallet drain
     /// landed, but `count` legacy identities could not be decoded AND the
     /// app-data import hit a hard failure. Rendered as a single retryable error
     /// banner naming both problems, so neither masks the other — the plain
     /// [`Self::SucceededWithUnreadableIdentities`] would have swallowed the
-    /// app-data failure and left the user no retry. Both the identity rows and
-    /// the app-data sentinel stay unwritten, so a retry (or the next launch)
-    /// re-attempts both. Terminal until then.
+    /// app-data failure and left the user no retry. The app-data sentinel stays
+    /// unwritten, so a retry (or the next launch) re-attempts that import; the
+    /// undecodable identity rows stay in the previous version's storage, named by
+    /// a durable warning. Terminal until then.
     ///
     /// A *hard* app-data failure is the only producer. An app-data pass that
     /// completed and merely left a later notice-record read failing is not one:

--- a/src/context/wallet_lifecycle/tests.rs
+++ b/src/context/wallet_lifecycle/tests.rs
@@ -2883,9 +2883,106 @@ async fn ensure_identity_managed_unregistered_wallet_is_wallet_not_loaded() {
         .await
         .expect_err("an unregistered wallet must not resolve");
     assert!(
-        matches!(err, TaskError::WalletNotLoaded),
+        matches!(err, TaskError::WalletNotLoaded { .. }),
         "expected WalletNotLoaded, got: {err:?}"
     );
+
+    backend.shutdown().await;
+}
+
+/// Both `WalletNotLoaded` sites must name the wallet they are about: the
+/// typed field carries the label and the user-facing message repeats it.
+fn assert_wallet_not_loaded_named(err: &TaskError, expected_label: &str) {
+    match err {
+        TaskError::WalletNotLoaded { wallet_label } => {
+            assert_eq!(wallet_label, expected_label, "wrong wallet named")
+        }
+        other => panic!("expected WalletNotLoaded, got {other:?}"),
+    }
+    assert!(
+        err.to_string().contains(expected_label),
+        "message must name the wallet ({expected_label}), got: {err}"
+    );
+}
+
+/// With several wallets loaded, a `WalletNotLoaded` from either construction
+/// site (`resolve_wallet` async, `monitored_receive_addresses` sync) names the
+/// affected wallet by its alias — the user can tell which wallet to wait for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wallet_not_loaded_names_the_wallet_by_alias() {
+    let (ctx, sender, _tmp) = offline_testnet_context();
+    ctx.ensure_wallet_backend(sender)
+        .await
+        .expect("ensure_wallet_backend should succeed offline");
+    let backend = ctx.wallet_backend().expect("backend wired");
+
+    // A loaded sibling wallet, so the error cannot name "the only wallet".
+    let loaded_seed = [0x11u8; 64];
+    let loaded_hash = Wallet::new_from_seed(loaded_seed, Network::Testnet, None, None)
+        .expect("build wallet")
+        .seed_hash();
+    backend
+        .register_wallet_from_seed(&loaded_hash, &loaded_seed, None)
+        .await
+        .expect("register the sibling wallet");
+
+    // The wallet under test: known by its meta sidecar, absent from `id_map`.
+    let pending_hash: WalletSeedHash = [0x7Bu8; 32];
+    backend
+        .wallet_meta()
+        .set(
+            Network::Testnet,
+            &pending_hash,
+            &WalletMeta {
+                alias: "paycheque".into(),
+                ..Default::default()
+            },
+        )
+        .expect("persist wallet meta");
+
+    let err = backend
+        .ensure_identity_managed(&pending_hash, &basic_test_identity(), 0)
+        .await
+        .expect_err("a wallet missing from id_map must not resolve");
+    assert_wallet_not_loaded_named(&err, "paycheque");
+
+    let err = backend
+        .monitored_receive_addresses(&pending_hash)
+        .expect_err("a wallet missing from id_map has no monitored addresses");
+    assert_wallet_not_loaded_named(&err, "paycheque");
+
+    backend.shutdown().await;
+}
+
+/// An unnamed wallet still gets identified: the label falls back to the same
+/// truncated seed-hash hex `SeedLengthInvalid` uses (12 hex chars + ellipsis).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wallet_not_loaded_falls_back_to_truncated_seed_hash_when_unnamed() {
+    let (ctx, sender, _tmp) = offline_testnet_context();
+    ctx.ensure_wallet_backend(sender)
+        .await
+        .expect("ensure_wallet_backend should succeed offline");
+    let backend = ctx.wallet_backend().expect("backend wired");
+
+    // No alias in the sidecar (and, for the second case below, no sidecar row
+    // at all) — both degrade to the hex label, never to an unnamed error.
+    let unnamed_hash: WalletSeedHash = [0x9Eu8; 32];
+    backend
+        .wallet_meta()
+        .set(Network::Testnet, &unnamed_hash, &WalletMeta::default())
+        .expect("persist wallet meta");
+
+    let err = backend
+        .ensure_identity_managed(&unnamed_hash, &basic_test_identity(), 0)
+        .await
+        .expect_err("a wallet missing from id_map must not resolve");
+    assert_wallet_not_loaded_named(&err, "9e9e9e9e9e9e…");
+
+    let no_meta_hash: WalletSeedHash = [0xC4u8; 32];
+    let err = backend
+        .monitored_receive_addresses(&no_meta_hash)
+        .expect_err("a wallet missing from id_map has no monitored addresses");
+    assert_wallet_not_loaded_named(&err, "c4c4c4c4c4c4…");
 
     backend.shutdown().await;
 }

--- a/src/database/legacy_import.rs
+++ b/src/database/legacy_import.rs
@@ -73,10 +73,11 @@ pub(crate) struct LegacyIdentityRow {
 
 /// Outcome of one legacy identity read.
 ///
-/// `unreadable` counts rows whose blob could not be decoded. The caller
-/// withholds the completion sentinel while it is non-zero, so a later build
-/// with a fixed decoder can still pick those rows up — unlike a corrupt vote,
-/// an undecodable identity blob may be a decoder defect, not data rot.
+/// `unreadable` counts rows whose blob could not be decoded. The caller records
+/// them as a durable warning and leaves them in the legacy file — never deleted,
+/// so a build with a fixed decoder can still recover them on an explicit
+/// re-import. The import itself completes: re-running it on every launch would
+/// resurrect identities the user has deliberately deleted.
 #[derive(Debug, Default)]
 pub(crate) struct LegacyIdentities {
     /// Rows decoded into the modern domain type.

--- a/src/model/qualified_identity/mod.rs
+++ b/src/model/qualified_identity/mod.rs
@@ -505,6 +505,32 @@ impl Signer<IdentityPublicKey> for QualifiedIdentity {
     }
 }
 
+/// Cap on any single allocation `from_bytes` will make while decoding a
+/// `QualifiedIdentity` blob. A real identity — including its private keys,
+/// DPNS names, and wallet links — is far under this. The cap exists only as a
+/// decode-time safety net: bincode's default `NoLimit` config trusts a
+/// length-prefixed field's claimed size and pre-allocates it *before* reading
+/// anything, so a single flipped bit or a truncated blob can claim gigabytes
+/// and abort the process (`handle_alloc_error`, uncatchable, not a
+/// `Result::Err`) rather than fail the decode gracefully. `Limit` makes
+/// bincode check the claimed size against this cap first and return
+/// `DecodeError::LimitExceeded` instead — see
+/// `a_length_inflated_collection_prefix_is_rejected_not_preallocated` below
+/// for the regression coverage. Encoding is unaffected: this only bounds
+/// decode-time allocation and does not change the wire format, so it stays
+/// compatible with blobs `to_bytes` already wrote.
+const IDENTITY_BLOB_DECODE_LIMIT: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// The bincode configuration [`QualifiedIdentity::from_bytes`] decodes under.
+/// Pulled into its own function (rather than inlined at the one call site) so
+/// the decode-limit regression test below exercises the *exact* configuration
+/// production uses — sharing this function, not a second hand-typed copy of
+/// `.with_limit()` — so a future edit that weakens or drops the limit here is
+/// caught by that test rather than silently diverging from it.
+fn identity_blob_decode_config() -> impl bincode::config::Config {
+    bincode::config::standard().with_limit::<{ IDENTITY_BLOB_DECODE_LIMIT }>()
+}
+
 impl QualifiedIdentity {
     /// Serializes the QualifiedIdentity to a vector of bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -519,8 +545,12 @@ impl QualifiedIdentity {
     /// than skipping corrupted entries, because identities hold private keys
     /// and balance information — silently ignoring a corrupted identity could
     /// lead to loss of funds.
+    ///
+    /// Decodes under [`identity_blob_decode_config`] rather than bincode's
+    /// unbounded default, so a corrupted or length-inflated blob returns this
+    /// `Err` instead of aborting the process.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
-        bincode::decode_from_slice(bytes, bincode::config::standard())
+        bincode::decode_from_slice(bytes, identity_blob_decode_config())
             .map(|(identity, _)| identity)
             .map_err(|e| format!("Failed to decode QualifiedIdentity: {}", e))
     }
@@ -1167,5 +1197,83 @@ mod withdrawal_key_tests {
         );
         let selected = qi.default_withdrawal_key().expect("a key");
         assert_eq!(selected.identity_public_key.purpose(), Purpose::TRANSFER);
+    }
+}
+
+/// Regression coverage for the `from_bytes` decode-limit fix (SEC-001 from the
+/// PR #885 grumpy-review): a corrupted or length-inflated blob must decode to
+/// a graceful `Err`, never abort the process.
+///
+/// This deliberately does NOT decode a full `QualifiedIdentity` blob. Crafting
+/// a byte-exact corruption of a real encoded identity is fragile — it would
+/// tie the test to the current field order of a struct with many nested
+/// types, and it does not need to succeed through `Identity`'s own encoding
+/// to prove the point. `from_bytes`'s vulnerability lived entirely in its
+/// bincode *configuration*, not in `QualifiedIdentity`'s shape: any
+/// length-prefixed collection decoded under that configuration was exposed.
+/// Exercising the exact same configuration directly against a minimal,
+/// hand-built length-inflated prefix pins the actual fix (the config change)
+/// precisely, and stays valid regardless of future changes to
+/// `QualifiedIdentity`'s fields.
+///
+/// The prefix construction mirrors the live reproduction from the review: a
+/// `u64` varint length header (bincode's `U64_BYTE` marker, 253) claiming an
+/// enormous element count, followed by only a couple of trailing bytes --
+/// exactly what a single flipped continuation bit or a truncated file
+/// produces on a real blob. Before the fix (decoding under
+/// `bincode::config::standard()`, i.e. `NoLimit`), decoding this buffer as
+/// `Vec<u8>` pre-allocates the claimed length and aborts the process --
+/// confirmed by a standalone probe run outside the test harness during
+/// review, since an in-process abort cannot be asserted as a normal test
+/// failure (it takes the whole test binary down with it). After the fix
+/// (decoding under `IDENTITY_BLOB_DECODE_LIMIT`), the same buffer must return
+/// `DecodeError::LimitExceeded` instead.
+#[cfg(test)]
+mod decode_limit_tests {
+    use super::identity_blob_decode_config;
+
+    #[test]
+    fn a_length_inflated_collection_prefix_is_rejected_not_preallocated() {
+        // bincode 2.0.1's varint scheme: 253 (`U64_BYTE`) marks "the next 8
+        // bytes are a little-endian u64 length". Claim far more than the
+        // configured limit, then supply only 2 trailing bytes -- ordinary
+        // bit-flip/truncation corruption never has the claimed payload
+        // actually present.
+        const U64_VARINT_MARKER: u8 = 253;
+        let claimed_len: u64 = 1 << 40; // 1 TiB -- larger than any real identity blob
+        let mut corrupted = vec![U64_VARINT_MARKER];
+        corrupted.extend_from_slice(&claimed_len.to_le_bytes());
+        corrupted.extend_from_slice(&[0xAA, 0xBB]);
+
+        // Uses the SAME config function `from_bytes` calls -- not a second
+        // hand-typed `.with_limit()` -- so a regression in that shared
+        // function is what this test actually catches.
+        let result: Result<(Vec<u8>, usize), bincode::error::DecodeError> =
+            bincode::decode_from_slice(&corrupted, identity_blob_decode_config());
+
+        match result {
+            Err(bincode::error::DecodeError::LimitExceeded) => {}
+            other => panic!(
+                "expected DecodeError::LimitExceeded for a length-inflated prefix, got \
+                 {other:?} -- if from_bytes's decode config regresses to NoLimit this \
+                 same buffer would instead pre-allocate 1 TiB and abort the process"
+            ),
+        }
+    }
+
+    /// Sanity check that the limit is not so tight it rejects ordinary
+    /// legitimate data -- a real `QualifiedIdentity` with keys is far under
+    /// 16 MiB (the golden v0.9.3 fixture blob decoded elsewhere in this crate
+    /// is a few hundred bytes), so a plain in-bounds `Vec<u8>` must still
+    /// round-trip under the same limited config.
+    #[test]
+    fn an_ordinary_small_payload_still_decodes_under_the_limit() {
+        let payload = vec![0xABu8; 4096];
+        let encoded = bincode::encode_to_vec(&payload, identity_blob_decode_config())
+            .expect("encode under the limit");
+        let (decoded, _): (Vec<u8>, usize) =
+            bincode::decode_from_slice(&encoded, identity_blob_decode_config())
+                .expect("decode under the limit");
+        assert_eq!(decoded, payload);
     }
 }

--- a/src/model/wallet/meta.rs
+++ b/src/model/wallet/meta.rs
@@ -17,7 +17,32 @@
 //!   into the sidecar so an existing install keeps its names after
 //!   the upgrade.
 
+use super::WalletSeedHash;
 use serde::{Deserialize, Serialize};
+
+/// Seed-hash bytes rendered in a fallback wallet label — 6 bytes, 12 hex
+/// chars: long enough to tell two wallets apart, short enough to read out.
+const LABEL_HASH_PREFIX_BYTES: usize = 6;
+
+/// Human-readable label for a wallet: its alias when the user set one,
+/// otherwise a truncated hex prefix of its seed hash.
+///
+/// The single source of truth for how a wallet is named in user-facing
+/// errors raised where only the seed hash is at hand (the wallet may not
+/// even be loaded yet).
+///
+/// ```
+/// # use dash_evo_tool::model::wallet::meta::wallet_label;
+/// assert_eq!(wallet_label("paycheque", &[0x9E; 32]), "paycheque");
+/// assert_eq!(wallet_label("", &[0x9E; 32]), "9e9e9e9e9e9e…");
+/// ```
+pub fn wallet_label(alias: &str, seed_hash: &WalletSeedHash) -> String {
+    if alias.is_empty() {
+        format!("{}…", hex::encode(&seed_hash[..LABEL_HASH_PREFIX_BYTES]))
+    } else {
+        alias.to_string()
+    }
+}
 
 /// The original (pre-`uses_password`) [`WalletMeta`] on-disk shape, decode-only.
 ///
@@ -200,6 +225,30 @@ mod tests {
         let (decoded, _): (WalletMeta, _) =
             bincode::serde::decode_from_slice(&new_blob, cfg).expect("decode v2");
         assert_eq!(decoded, v2);
+    }
+
+    /// A named wallet is labelled by its alias verbatim, whatever its seed
+    /// hash — the alias is what the user recognises.
+    #[test]
+    fn wallet_label_uses_the_alias_when_set() {
+        assert_eq!(wallet_label("paycheque", &[0x9E; 32]), "paycheque");
+        assert_eq!(wallet_label("a", &[0x00; 32]), "a");
+    }
+
+    /// An unnamed wallet degrades to 12 hex chars of its seed hash plus an
+    /// ellipsis — never to an anonymous "this wallet". Two distinct wallets
+    /// get two distinct labels.
+    #[test]
+    fn wallet_label_falls_back_to_truncated_seed_hash_hex() {
+        assert_eq!(wallet_label("", &[0x9E; 32]), "9e9e9e9e9e9e…");
+
+        let mut other = [0x9Eu8; 32];
+        other[5] = 0x01;
+        assert_ne!(
+            wallet_label("", &other),
+            wallet_label("", &[0x9E; 32]),
+            "wallets differing inside the prefix must not share a label"
+        );
     }
 
     /// TS-NOLEAK-02 (WalletMeta) — the encoded sidecar blob carries NO secret.

--- a/src/wallet_backend/hydration.rs
+++ b/src/wallet_backend/hydration.rs
@@ -23,7 +23,7 @@ use dash_sdk::dpp::dashcore::Network;
 use dash_sdk::dpp::key_wallet::bip32::ExtendedPubKey;
 
 use crate::backend_task::error::TaskError;
-use crate::model::wallet::meta::WalletMeta;
+use crate::model::wallet::meta::{WalletMeta, wallet_label};
 use crate::model::wallet::seed_envelope::StoredSeedEnvelope;
 use crate::model::wallet::{ClosedKeyItem, OpenWalletSeed, Wallet, WalletSeed, WalletSeedHash};
 use crate::wallet_backend::secret_seam::SecretScheme;
@@ -268,14 +268,8 @@ fn wallet_from_envelope(
         // envelope is only length-checked to prove it is well-formed; the
         // open wallet parks no plaintext seed (R3).
         if encrypted_seed.len() != EXPECTED_SEED_LEN as usize {
-            let label = if meta.alias.is_empty() {
-                let hex_hash = hex::encode(seed_hash);
-                format!("{}…", &hex_hash[..hex_hash.len().min(12)])
-            } else {
-                meta.alias.clone()
-            };
             return Err(TaskError::SeedLengthInvalid {
-                wallet_label: label,
+                wallet_label: wallet_label(&meta.alias, &seed_hash),
                 got: encrypted_seed.len() as u32,
                 expected: EXPECTED_SEED_LEN,
             });

--- a/src/wallet_backend/mod.rs
+++ b/src/wallet_backend/mod.rs
@@ -123,6 +123,7 @@ use crate::context::AppContext;
 use crate::context::connection_status::ConnectionStatus;
 use crate::model::selected_identity::SelectedIdentity;
 use crate::model::selected_wallet::SelectedWallet;
+use crate::model::wallet::meta::wallet_label;
 use crate::model::wallet::{PlatformAddressEntry, WalletSeedHash};
 use crate::utils::egui_mpsc::SenderAsync;
 
@@ -1576,17 +1577,29 @@ impl WalletBackend {
         }
     }
 
+    /// [`TaskError::WalletNotLoaded`] naming the wallet the caller asked for,
+    /// so a user with several wallets open knows which one to wait for. Reads
+    /// the alias from the meta sidecar — the wallet is by definition absent
+    /// from `id_map` here, so there is no live handle to ask.
+    fn wallet_not_loaded(&self, seed_hash: &WalletSeedHash) -> TaskError {
+        let alias = self
+            .wallet_meta()
+            .get(self.inner.network, seed_hash)
+            .map(|meta| meta.alias)
+            .unwrap_or_default();
+        TaskError::WalletNotLoaded {
+            wallet_label: wallet_label(&alias, seed_hash),
+        }
+    }
+
     /// Map a DET `WalletSeedHash` to the upstream wallet handle.
     async fn resolve_wallet(
         &self,
         seed_hash: &WalletSeedHash,
     ) -> Result<Arc<platform_wallet::PlatformWallet>, TaskError> {
-        let wallet_id = *self
-            .inner
-            .id_map
-            .read()?
-            .get(seed_hash)
-            .ok_or(TaskError::WalletNotLoaded)?;
+        // The guard drops before the error path reads the meta sidecar.
+        let wallet_id = self.inner.id_map.read()?.get(seed_hash).copied();
+        let wallet_id = wallet_id.ok_or_else(|| self.wallet_not_loaded(seed_hash))?;
         self.inner
             .pwm
             .get_wallet(&wallet_id)
@@ -1628,12 +1641,8 @@ impl WalletBackend {
     ) -> Result<Vec<String>, TaskError> {
         use dash_sdk::dpp::key_wallet::account::{AccountType, StandardAccountType};
 
-        let wallet_id = *self
-            .inner
-            .id_map
-            .read()?
-            .get(seed_hash)
-            .ok_or(TaskError::WalletNotLoaded)?;
+        let wallet_id = self.inner.id_map.read()?.get(seed_hash).copied();
+        let wallet_id = wallet_id.ok_or_else(|| self.wallet_not_loaded(seed_hash))?;
         let standard = AccountType::Standard {
             index: DEFAULT_BIP44_ACCOUNT,
             standard_account_type: StandardAccountType::BIP44Account,

--- a/tests/kittest/migration_banner.rs
+++ b/tests/kittest/migration_banner.rs
@@ -6,7 +6,8 @@
 //! needing a full `AppState` harness.
 
 use dash_evo_tool::app::{
-    MIGRATION_RETRY_ACTION_ID, MIGRATION_VOTES_ACK_ACTION_ID,
+    MIGRATION_IDENTITIES_ACK_ACTION_ID, MIGRATION_RETRY_ACTION_ID,
+    MIGRATION_UNREADABLE_ACK_ACTION_ID, MIGRATION_VOTES_ACK_ACTION_ID,
     migration_failed_with_unreadable_identities_text, migration_running_text,
     migration_unreadable_identities_and_votes_text, migration_unreadable_identities_text,
     migration_unreadable_votes_text,
@@ -216,27 +217,27 @@ fn unreadable_votes_banner_acknowledgement_enqueues_action() {
     );
 }
 
-/// The identity sibling of `unreadable_votes_banner_warns_without_a_retry_action`.
-/// A drain that landed but could not decode some identities warns, names the one
-/// action that recovers the keys, and offers NO "Retry now" — the rows are still in
-/// the previous version's storage and a re-read decodes them no better.
+/// The unreadable-identity warning is acknowledgeable, exactly like its vote
+/// sibling. It used to render as a sticky, action-less banner: the user was told
+/// their keys had not come across and given no way to say "I understand" — so the
+/// warning returned on every launch with no gesture that could ever retire it.
+/// Supersedes the pre-fix "warns without a retry action" coverage: it re-asserts
+/// the same "no Retry now" fact (the drain is done; a corrupt row decodes no
+/// better) and adds the acknowledgement round-trip the fix introduced.
 #[test]
-fn unreadable_identities_banner_warns_without_a_retry_action() {
-    let text = migration_unreadable_identities_text(3);
+fn unreadable_identities_banner_acknowledgement_enqueues_action() {
+    let text = migration_unreadable_identities_text(2);
     assert!(
         text.ends_with('.'),
         "banner copy must be a complete sentence for i18n extraction: `{text}`",
     );
-    assert!(
-        text.contains('3'),
-        "the copy must name how many identities were left behind: `{text}`",
-    );
 
     let label = text.clone();
     let mut harness = Harness::builder()
-        .with_size(egui::vec2(600.0, 200.0))
+        .with_size(egui::vec2(600.0, 220.0))
         .build_ui(move |ui| {
-            MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
+            let handle = MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
+            handle.with_action("Got it", MIGRATION_IDENTITIES_ACK_ACTION_ID);
             MessageBanner::show_global(ui);
         });
     harness.run();
@@ -249,38 +250,6 @@ fn unreadable_identities_banner_warns_without_a_retry_action() {
         harness.query_by_label("Retry now").is_none(),
         "a completed drain must not offer a retry the user cannot benefit from",
     );
-}
-
-/// Both DET-owned passes left rows behind. One Warning banner names both counts and
-/// both remedies, and carries the vote acknowledgement — the identity half recurs on
-/// every launch, so it must never be the reason a live vote deadline goes unseen.
-/// Still no "Retry now": neither corrupt row decodes better on a second pass.
-#[test]
-fn unreadable_identities_and_votes_banner_names_both_and_acknowledges() {
-    let text = migration_unreadable_identities_and_votes_text(3, 2);
-    assert!(
-        text.contains('3') && text.contains('2'),
-        "the copy must name both counts so neither signal is hidden: `{text}`",
-    );
-
-    let label = text.clone();
-    let mut harness = Harness::builder()
-        .with_size(egui::vec2(600.0, 240.0))
-        .build_ui(move |ui| {
-            let handle = MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
-            handle.with_action("Got it", MIGRATION_VOTES_ACK_ACTION_ID);
-            MessageBanner::show_global(ui);
-        });
-    harness.run();
-
-    assert!(
-        harness.query_by_label(text.as_str()).is_some(),
-        "the combined banner must render both remedies verbatim",
-    );
-    assert!(
-        harness.query_by_label("Retry now").is_none(),
-        "neither corrupt row decodes better on a retry, so no retry is offered",
-    );
     assert!(MessageBanner::take_action(&harness.ctx).is_none());
 
     harness.get_by_label("Got it").click();
@@ -288,8 +257,36 @@ fn unreadable_identities_and_votes_banner_names_both_and_acknowledges() {
 
     assert_eq!(
         MessageBanner::take_action(&harness.ctx).as_deref(),
-        Some(MIGRATION_VOTES_ACK_ACTION_ID),
-        "acknowledging retires the durable vote half of the combined warning",
+        Some(MIGRATION_IDENTITIES_ACK_ACTION_ID),
+        "the acknowledgement must reach the app loop, or the warning can never be retired",
+    );
+}
+
+/// The combined banner names both problems, so its single "Got it" must enqueue
+/// the combined acknowledgement — the one that retires BOTH durable records.
+/// Routing it to either single-signal ack would leave the other half to re-raise
+/// on the next launch, as a notice the user has already read. Supersedes the
+/// pre-fix coverage that routed this banner's "Got it" to the vote-only ack —
+/// that routing no longer matches the combined-ack design this ships.
+#[test]
+fn combined_unreadable_banner_acknowledgement_enqueues_the_combined_action() {
+    let text = migration_unreadable_identities_and_votes_text(2, 3);
+    let label = text.clone();
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 260.0))
+        .build_ui(move |ui| {
+            let handle = MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
+            handle.with_action("Got it", MIGRATION_UNREADABLE_ACK_ACTION_ID);
+            MessageBanner::show_global(ui);
+        });
+    harness.run();
+
+    harness.get_by_label("Got it").click();
+    harness.run();
+
+    assert_eq!(
+        MessageBanner::take_action(&harness.ctx).as_deref(),
+        Some(MIGRATION_UNREADABLE_ACK_ACTION_ID),
     );
 }
 

--- a/tests/kittest/migration_banner.rs
+++ b/tests/kittest/migration_banner.rs
@@ -6,7 +6,9 @@
 //! needing a full `AppState` harness.
 
 use dash_evo_tool::app::{
-    MIGRATION_RETRY_ACTION_ID, MIGRATION_VOTES_ACK_ACTION_ID, migration_running_text,
+    MIGRATION_RETRY_ACTION_ID, MIGRATION_VOTES_ACK_ACTION_ID,
+    migration_failed_with_unreadable_identities_text, migration_running_text,
+    migration_unreadable_identities_and_votes_text, migration_unreadable_identities_text,
     migration_unreadable_votes_text,
 };
 use dash_evo_tool::context::migration_status::MigrationStep;
@@ -49,6 +51,7 @@ fn tc_mig_014_running_text_covers_every_step_with_sentence() {
         MigrationStep::Shielded,
         MigrationStep::WalletSeeds,
         MigrationStep::WalletMeta,
+        MigrationStep::Identities,
         MigrationStep::Finalize,
     ] {
         let text = migration_running_text(step);
@@ -210,5 +213,115 @@ fn unreadable_votes_banner_acknowledgement_enqueues_action() {
     assert_eq!(
         MessageBanner::take_action(&harness.ctx).as_deref(),
         Some(MIGRATION_VOTES_ACK_ACTION_ID),
+    );
+}
+
+/// The identity sibling of `unreadable_votes_banner_warns_without_a_retry_action`.
+/// A drain that landed but could not decode some identities warns, names the one
+/// action that recovers the keys, and offers NO "Retry now" — the rows are still in
+/// the previous version's storage and a re-read decodes them no better.
+#[test]
+fn unreadable_identities_banner_warns_without_a_retry_action() {
+    let text = migration_unreadable_identities_text(3);
+    assert!(
+        text.ends_with('.'),
+        "banner copy must be a complete sentence for i18n extraction: `{text}`",
+    );
+    assert!(
+        text.contains('3'),
+        "the copy must name how many identities were left behind: `{text}`",
+    );
+
+    let label = text.clone();
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 200.0))
+        .build_ui(move |ui| {
+            MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
+            MessageBanner::show_global(ui);
+        });
+    harness.run();
+
+    assert!(
+        harness.query_by_label(text.as_str()).is_some(),
+        "the warning banner must render the unreadable-identities copy verbatim",
+    );
+    assert!(
+        harness.query_by_label("Retry now").is_none(),
+        "a completed drain must not offer a retry the user cannot benefit from",
+    );
+}
+
+/// Both DET-owned passes left rows behind. One Warning banner names both counts and
+/// both remedies, and carries the vote acknowledgement — the identity half recurs on
+/// every launch, so it must never be the reason a live vote deadline goes unseen.
+/// Still no "Retry now": neither corrupt row decodes better on a second pass.
+#[test]
+fn unreadable_identities_and_votes_banner_names_both_and_acknowledges() {
+    let text = migration_unreadable_identities_and_votes_text(3, 2);
+    assert!(
+        text.contains('3') && text.contains('2'),
+        "the copy must name both counts so neither signal is hidden: `{text}`",
+    );
+
+    let label = text.clone();
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 240.0))
+        .build_ui(move |ui| {
+            let handle = MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Warning);
+            handle.with_action("Got it", MIGRATION_VOTES_ACK_ACTION_ID);
+            MessageBanner::show_global(ui);
+        });
+    harness.run();
+
+    assert!(
+        harness.query_by_label(text.as_str()).is_some(),
+        "the combined banner must render both remedies verbatim",
+    );
+    assert!(
+        harness.query_by_label("Retry now").is_none(),
+        "neither corrupt row decodes better on a retry, so no retry is offered",
+    );
+    assert!(MessageBanner::take_action(&harness.ctx).is_none());
+
+    harness.get_by_label("Got it").click();
+    harness.run();
+
+    assert_eq!(
+        MessageBanner::take_action(&harness.ctx).as_deref(),
+        Some(MIGRATION_VOTES_ACK_ACTION_ID),
+        "acknowledging retires the durable vote half of the combined warning",
+    );
+}
+
+/// The one identity outcome that IS a failure: unreadable identities alongside a
+/// hard app-data failure. Unlike its Warning siblings this renders as an Error with
+/// a working "Retry now" — the app-data half genuinely did not finish, and its
+/// sentinel is unwritten, so the retry re-runs it.
+#[test]
+fn failed_with_unreadable_identities_banner_offers_a_working_retry() {
+    let text = migration_failed_with_unreadable_identities_text(1);
+    let label = text.clone();
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(600.0, 240.0))
+        .build_ui(move |ui| {
+            let handle = MessageBanner::set_global(ui.ctx(), label.clone(), MessageType::Error);
+            handle.with_action("Retry now", MIGRATION_RETRY_ACTION_ID);
+            MessageBanner::show_global(ui);
+        });
+    harness.run();
+
+    assert!(
+        harness.query_by_label(text.as_str()).is_some(),
+        "the error banner must render the combined-failure copy verbatim",
+    );
+    assert!(MessageBanner::take_action(&harness.ctx).is_none());
+
+    harness.get_by_label("Retry now").click();
+    harness.run();
+
+    assert_eq!(
+        MessageBanner::take_action(&harness.ctx).as_deref(),
+        Some(MIGRATION_RETRY_ACTION_ID),
+        "the app-data half is retryable, so its banner's retry must enqueue the action",
     );
 }


### PR DESCRIPTION
## Why this PR exists
- **Problem**: PR #885's grumpy-review turned up four issues: an unbounded bincode decode limit on legacy identity blobs (SIGABRT on a corrupt blob), a migration banner that reported a successful app-data pass as failed, a design doc that had drifted from the shipped migration flow, and — most seriously — a data-resurrection bug where a corrupt legacy identity row silently un-deleted identities the user had explicitly removed on every cold start. A fifth, unrelated issue surfaced separately: `WalletNotLoaded` gave no indication of *which* wallet was still loading.
- **What breaks without it**: (1) a hand-crafted or corrupted identity blob aborts the whole process instead of failing gracefully; (2) a user who deletes a legacy identity finds it back after restarting the app, with its cleared alias and legacy plaintext keys restored; (3) a user with multiple wallets loaded gets "This wallet is still loading" with no way to tell which one.
- **Blocking relationship**: stacked on #885 (`feat/legacy-identity-migration`).

## What was done
Four independently-verified fixes, merged onto one branch:
- **Bincode decode limit** (`6af894b5`): bounds `QualifiedIdentity::from_bytes` to 16 MiB so a length-inflated collection prefix errors instead of aborting.
- **Wallet-not-loaded context** (`e4903e07`): `TaskError::WalletNotLoaded` now carries a `wallet_label` (alias, or a truncated seed-hash hex when unnamed) and names the wallet in the message. Extracted the existing `SeedLengthInvalid` alias-or-hex rule into a shared `model::wallet::meta::wallet_label` helper (DRY).
- **Docs and banner** (`2a3abe26`, `770908b8`, `90214ea5`): realigned the legacy-identity design doc with the shipped flow; stopped a readable app-data pass whose later notice-record read failed from being reported as a failed migration; added the identity-banner kittests the rustdoc promised.
- **Identity resurrection** (`5953ef7f`): the identity import pass now writes its completion sentinel unconditionally (matching its sibling app-data pass), so a corrupt row no longer causes the import to silently re-run — and re-resurrect deleted identities — on every launch. Undecodable rows are now surfaced via a durable, acknowledgeable `UnreadableIdentitiesWarning` banner instead.

Merging the last two required resolving genuine semantic conflicts (not mechanical ones) in `finish_unwire.rs`, `migration_status.rs`, and the kittest file — both branches touched the same vote-warning-read-failure code path for different reasons; the merge preserves the docs-and-banner fix on top of the resurrection branch's restructuring.

## Testing
- `cargo test --lib --all-features`: 1686 passed, 0 failed
- `cargo test --test kittest --all-features`: 218 passed, 0 failed
- `cargo clippy --all-features --all-targets -- -D warnings`: clean
- `cargo +nightly fmt --all -- --check`: clean
- All six branches' signature regression tests independently confirmed present and passing in the merged tree by name (not just aggregate pass counts)

## Breaking changes
None. `TaskError::WalletNotLoaded` changes from a unit variant to `{ wallet_label: String }` — an internal API change, not user-facing breakage (all match sites in-tree updated).

## Checklist
- [x] Tests pass
- [x] Clippy clean
- [x] Formatted
- [ ] User-facing review

## Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>