### PR TITLE
fix(platform): keep cause-less transition results unconfirmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Submitted Platform actions are no longer reported as rejected when only
+  confirmation failed**: if a state transition was broadcast but its result
+  could not be confirmed, the app now tells you to check whether it completed
+  before trying again instead of showing an unsafe rejection-and-retry message.
+
 - **Shielded actions now say when they are unavailable instead of failing
   obscurely**: if shielding, sending, or withdrawing shielded funds is not
   available on your network yet, the app says so and points you at a regular

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -1095,6 +1095,15 @@ pub enum TaskError {
         source_error: Box<SdkError>,
     },
 
+    /// Platform accepted the request, but its result could not be confirmed.
+    #[error(
+        "Your request was submitted, but its result could not be confirmed. Check whether it completed before trying again."
+    )]
+    PlatformResultUnconfirmed {
+        #[source]
+        source_error: Box<SdkError>,
+    },
+
     /// Object already exists on Platform (SdkError::AlreadyExists).
     #[error("This object already exists on the platform.")]
     PlatformAlreadyExists {
@@ -2529,8 +2538,8 @@ impl From<SdkError> for TaskError {
         // after the borrow-checked match on the consensus cause ends.
         type SdkErrorMapper = Box<dyn FnOnce(Box<SdkError>) -> TaskError>;
 
-        let mapper: Option<SdkErrorMapper> = consensus_cause(&error)
-            .and_then(|ce| -> Option<SdkErrorMapper> {
+        let mapper: Option<SdkErrorMapper> =
+            consensus_cause(&error).and_then(|ce| -> Option<SdkErrorMapper> {
                 match ce {
                     ConsensusError::StateError(
                         StateError::DuplicatedIdentityPublicKeyStateError(_),
@@ -2672,17 +2681,6 @@ impl From<SdkError> for TaskError {
                     }
                     _ => None,
                 }
-            })
-            .or_else(|| -> Option<SdkErrorMapper> {
-                if let SdkError::StateTransitionBroadcastError(broadcast_err) = &error
-                    && broadcast_err.cause.is_none()
-                    && broadcast_err.message.to_lowercase().contains("duplicate")
-                {
-                    return Some(Box::new(|source_error| {
-                        TaskError::DuplicateIdentityPublicKey { source_error }
-                    }));
-                }
-                None
             });
 
         if let Some(mapper) = mapper {
@@ -2751,6 +2749,13 @@ impl From<SdkError> for TaskError {
                 source_error: boxed,
             },
             // SDK-level errors
+            SdkError::StateTransitionBroadcastError(broadcast_error)
+                if broadcast_error.cause.is_none() =>
+            {
+                TaskError::PlatformResultUnconfirmed {
+                    source_error: boxed,
+                }
+            }
             SdkError::StateTransitionBroadcastError(_) => TaskError::PlatformRejected {
                 source_error: boxed,
             },
@@ -3111,7 +3116,7 @@ mod tests {
     }
 
     #[test]
-    fn from_sdk_error_broadcast_cause_none_message_duplicate_falls_back_to_duplicate_key() {
+    fn from_sdk_error_broadcast_cause_none_message_duplicate_remains_unconfirmed() {
         let broadcast_err = dash_sdk::error::StateTransitionBroadcastError {
             code: 40206,
             message: "DuplicateIdentityPublicKeyStateError".to_string(),
@@ -3120,9 +3125,30 @@ mod tests {
         let sdk_err = SdkError::StateTransitionBroadcastError(broadcast_err);
         let err = TaskError::from(sdk_err);
         assert!(
-            matches!(err, TaskError::DuplicateIdentityPublicKey { .. }),
-            "Expected DuplicateIdentityPublicKey, got: {err:?}"
+            matches!(err, TaskError::PlatformResultUnconfirmed { .. }),
+            "A message without a structured consensus cause must remain unconfirmed: {err:?}"
         );
+        assert!(err.to_string().contains("could not be confirmed"));
+    }
+
+    #[test]
+    fn from_sdk_error_broadcast_cause_none_unavailable_is_not_a_rejection() {
+        let broadcast_err = dash_sdk::error::StateTransitionBroadcastError {
+            code: Code::Unavailable as u32,
+            message: "Tenderdash is not available".to_string(),
+            cause: None,
+        };
+        let sdk_err = SdkError::StateTransitionBroadcastError(broadcast_err);
+        let err = TaskError::from(sdk_err);
+
+        assert!(
+            matches!(err, TaskError::PlatformResultUnconfirmed { .. }),
+            "A failed result wait after broadcast must not be presented as rejection: {err:?}"
+        );
+        let message = err.to_string();
+        assert!(message.contains("submitted"));
+        assert!(message.contains("could not be confirmed"));
+        assert!(message.contains("before trying again"));
     }
 
     #[test]


### PR DESCRIPTION
## Why this PR exists

- **Problem**: Dash Platform can accept a state-transition broadcast while the
  separate result wait fails. The SDK represents a cause-less wait failure as
  `StateTransitionBroadcastError`, and DET currently reports every such error as
  a Platform rejection.
- **What breaks without it**: A mainnet identity withdrawal was delivered after
  its broadcast succeeded, but DET displayed “The platform rejected this
  request” and invited a retry. Retrying an action that may already have
  completed can duplicate a funds-moving or paid operation.
- **Blocking relationship**: Stacked on #894. The generic Platform-side
  retry/error-contract fix is tracked in dashpay/platform#4137.

## What was done

- Added `TaskError::PlatformResultUnconfirmed` with a user-facing message that
  says the request was submitted but could not be confirmed and directs the user
  to check whether it completed before retrying.
- Classify `StateTransitionBroadcastError { cause: None, .. }` as unconfirmed.
- Keep structured `cause: Some(consensus_error)` errors on the existing
  consensus-specific or `PlatformRejected` paths.
- Removed the message-only duplicate-key fallback for cause-less broadcast
  envelopes. Without a structured consensus cause, message text alone does not
  prove rejection.
- Added regression coverage for the observed code-14
  `Tenderdash is not available` response and for a cause-less message that looks
  like a duplicate-key rejection.
- Updated the changelog.

## Testing

- Regression tests confirmed failing before the production change.
- `cargo +nightly fmt --all -- --check`
- `cargo test --lib backend_task::error::tests::` — 98 passed
- `cargo clippy --lib --all-features -- -D warnings`

## Breaking changes

None.

## Checklist

- [x] The branch is based on the current PR #894 head.
- [x] User-visible behavior is covered by regression tests.
- [x] Formatting and targeted lint/test gates pass.
- [x] No dependencies or persisted data formats changed.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
