### PR TITLE
docs: record the local-vs-CI split so local runs stop duplicating CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ On every **non-draft** PR that touches Rust code, and on pushes to `v*-dev`, Git
 | `tests.yml` | `cargo test --all-features --workspace` and `cargo test --doc --all-features --workspace` |
 | `clippy.yml` | `cargo fmt --all -- --check` and `cargo clippy --all-features --all-targets -- -D warnings` |
 
-Both are path-filtered to changes that can affect a build or test result: `**/*.rs` (which includes `build.rs`), `**/Cargo.toml`, `Cargo.lock`, `.cargo/config.toml`, `rust-toolchain.toml`, and the workflow file itself. A documentation-only change deliberately runs neither.
+The workflows are path-filtered independently, each on `**/*.rs` (which includes `build.rs`), `**/Cargo.toml`, `Cargo.lock`, `.cargo/config.toml`, and its own workflow file. `tests.yml` additionally watches `tests/backend-e2e/**`, so a documentation-only change under that directory (e.g. `tests/backend-e2e/README.md`) still triggers the test workflow; other documentation-only changes run neither workflow.
 
 Because CI always runs the full sweep, locally you should:
 
@@ -66,7 +66,7 @@ Because CI always runs the full sweep, locally you should:
 
 Two gaps where CI will **not** cover you:
 
-- **Draft PRs run no automatic CI.** Both workflows are gated on `github.event.pull_request.draft != true`, so a draft PR's `pull_request` runs are suppressed. Either mark it ready for review (`ready_for_review` triggers the full run), or trigger a run by hand — both workflows expose `workflow_dispatch`, so you can run them against the branch from the Actions tab or with `gh workflow run tests.yml --ref <branch>`. A manual run tests the **branch head**, not the PR merge commit, so it does not prove the merged result is green.
+- **Draft PRs run no automatic CI.** Both workflows are gated on `github.event.pull_request.draft != true`, so a draft PR's `pull_request` runs are suppressed. Neither workflow declares a `workflow_dispatch` trigger, so there is no way to run them by hand against a draft branch — mark the PR ready for review (`ready_for_review` triggers the full run) to get CI coverage.
 - **Backend E2E tests are not in CI.** The step is commented out in `tests.yml`, and the tests are `#[ignore]`d. If a change touches backend behaviour that only `tests/backend-e2e/` covers, run those locally; CI will not.
 
 A green CI run is only meaningful if it actually executed your tests. `cargo test <filter>` exits 0 and prints `test result: ok` even when the filter matches nothing — when checking a run, confirm your new test names appear in the log rather than trusting the exit code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,13 @@ Test locations:
 
 Driving the actual compiled binary through a real display — for flows that need real navigation, real async/network timing, or visual verification beyond what `kittest` (no display) or `backend-e2e` (no UI) can cover. Read `docs/gui-testing/README.md` before running this kind of test — it has the safety rules (isolated data dir, credential handling, fund-movement caps) and the reusable scenario library under `docs/gui-testing/scenarios/`.
 
-Always run `cargo +nightly fmt` when finalizing your work. For `cargo clippy`, see the scope guidance below.
+Always run `cargo fmt --all` when finalizing your work — this honors the `rust-toolchain.toml` pin (1.92), matching what `clippy.yml`'s `cargo fmt --all -- --check` actually validates. For `cargo clippy`, see the scope guidance below.
 
 ### Local vs CI — avoid duplicate test runs
 
-CI is the full-suite backstop. Do not reproduce it locally.
+CI is the full-suite backstop. Do not reproduce it locally. (This section covers your own machine — an agent running *inside* the Claude Code review GitHub Action should follow "CI: Safe Cargo Wrapper" below instead.)
 
-On every **non-draft** PR that touches Rust code, and on pushes to `v*-dev`, GitHub Actions runs the complete gate:
+On every **non-draft** PR that touches Rust code, and on pushes to `v*-dev`, GitHub Actions runs the full non-ignored-test gate:
 
 | Workflow | Runs |
 |---|---|
@@ -60,8 +60,8 @@ The workflows are path-filtered independently, each on `**/*.rs` (which includes
 Because CI always runs the full sweep, locally you should:
 
 - Run only the **narrowest scope covering your change** — `cargo test <test_name> --all-features`, or `cargo test --test kittest --all-features` for a UI change. Running the whole workspace suite locally only duplicates the run CI is about to do anyway.
-- Always run `cargo +nightly fmt --all` before committing. It needs no compile, and `clippy.yml` fails the build on unformatted code.
-- Run `cargo clippy` locally only for the scope you touched (`-p <crate>`), or when you expect lint fallout. CI owns the `--all-features --all-targets` sweep.
+- Always run `cargo fmt --all` before committing (honors the `rust-toolchain.toml` pin). It needs no compile, and `clippy.yml` fails the build on unformatted code.
+- Run `cargo clippy` locally only for the scope you touched, or when you expect lint fallout. This repo has no `[workspace]`, so there's no `-p <crate>` to narrow with — scope by target instead (e.g. `--bin dash-evo-tool`). CI owns the `--all-features --all-targets` sweep.
 - After pushing, watch the PR checks instead of re-running the suite locally.
 
 Two gaps where CI will **not** cover you:
@@ -69,7 +69,7 @@ Two gaps where CI will **not** cover you:
 - **Draft PRs run no automatic CI.** Both workflows are gated on `github.event.pull_request.draft != true`, so a draft PR's `pull_request` runs are suppressed. Neither workflow declares a `workflow_dispatch` trigger, so there is no way to run them by hand against a draft branch — mark the PR ready for review (`ready_for_review` triggers the full run) to get CI coverage.
 - **Backend E2E tests are not in CI.** The step is commented out in `tests.yml`, and the tests are `#[ignore]`d. If a change touches backend behaviour that only `tests/backend-e2e/` covers, run those locally; CI will not.
 
-A green CI run is only meaningful if it actually executed your tests. `cargo test <filter>` exits 0 and prints `test result: ok` even when the filter matches nothing — when checking a run, confirm your new test names appear in the log rather than trusting the exit code.
+A green CI run is only meaningful if it actually executed your tests. `cargo test <filter>` exits 0 and prints `test result: ok` even when the filter matches nothing — when checking a run, confirm your new test names appear in the log **with a pass status**, not merely present. A `#[ignore]`d test (e.g. `test_drop_zeroes_full_capacity` in `src/model/secret.rs`) can appear in the log as `ignored` without having actually run — the "full non-ignored-test gate" above intentionally excludes these; they stay a manual check.
 
 ### User stories catalog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,34 @@ Test locations:
 
 Driving the actual compiled binary through a real display — for flows that need real navigation, real async/network timing, or visual verification beyond what `kittest` (no display) or `backend-e2e` (no UI) can cover. Read `docs/gui-testing/README.md` before running this kind of test — it has the safety rules (isolated data dir, credential handling, fund-movement caps) and the reusable scenario library under `docs/gui-testing/scenarios/`.
 
-Always run `cargo clippy` and `cargo +nightly fmt` when finalizing your work.
+Always run `cargo +nightly fmt` when finalizing your work. For `cargo clippy`, see the scope guidance below.
+
+### Local vs CI — avoid duplicate test runs
+
+CI is the full-suite backstop. Do not reproduce it locally.
+
+On every **non-draft** PR that touches Rust code, and on pushes to `v*-dev`, GitHub Actions runs the complete gate:
+
+| Workflow | Runs |
+|---|---|
+| `tests.yml` | `cargo test --all-features --workspace` and `cargo test --doc --all-features --workspace` |
+| `clippy.yml` | `cargo fmt --all -- --check` and `cargo clippy --all-features --all-targets -- -D warnings` |
+
+Both are path-filtered to changes that can affect a build or test result: `**/*.rs` (which includes `build.rs`), `**/Cargo.toml`, `Cargo.lock`, `.cargo/config.toml`, `rust-toolchain.toml`, and the workflow file itself. A documentation-only change deliberately runs neither.
+
+Because CI always runs the full sweep, locally you should:
+
+- Run only the **narrowest scope covering your change** — `cargo test <test_name> --all-features`, or `cargo test --test kittest --all-features` for a UI change. Running the whole workspace suite locally only duplicates the run CI is about to do anyway.
+- Always run `cargo +nightly fmt --all` before committing. It needs no compile, and `clippy.yml` fails the build on unformatted code.
+- Run `cargo clippy` locally only for the scope you touched (`-p <crate>`), or when you expect lint fallout. CI owns the `--all-features --all-targets` sweep.
+- After pushing, watch the PR checks instead of re-running the suite locally.
+
+Two gaps where CI will **not** cover you:
+
+- **Draft PRs run no automatic CI.** Both workflows are gated on `github.event.pull_request.draft != true`, so a draft PR's `pull_request` runs are suppressed. Either mark it ready for review (`ready_for_review` triggers the full run), or trigger a run by hand — both workflows expose `workflow_dispatch`, so you can run them against the branch from the Actions tab or with `gh workflow run tests.yml --ref <branch>`. A manual run tests the **branch head**, not the PR merge commit, so it does not prove the merged result is green.
+- **Backend E2E tests are not in CI.** The step is commented out in `tests.yml`, and the tests are `#[ignore]`d. If a change touches backend behaviour that only `tests/backend-e2e/` covers, run those locally; CI will not.
+
+A green CI run is only meaningful if it actually executed your tests. `cargo test <filter>` exits 0 and prints `test result: ok` even when the filter matches nothing — when checking a run, confirm your new test names appear in the log rather than trusting the exit code.
 
 ### User stories catalog
 


### PR DESCRIPTION
## Why this PR exists

- **Problem**: CI already runs the full `--all-features --workspace` suite, doc tests, clippy and the fmt check on every non-draft PR that touches Rust code — but `CLAUDE.md` never said so. "Run the tests" therefore reads as a full local workspace run, which CI then repeats verbatim minutes later. Nothing recorded where CI *doesn't* cover you either.

- **What breaks without it**:
  1. *Every change pays for the same suite twice.* A contributor (human or agent) finishing a one-module fix runs `cargo test --all-features --workspace` locally — a long cold-ish build — then pushes, and CI runs the identical command again. The local run buys nothing the PR check wasn't about to prove.
  2. *"Let CI catch it" silently fails on drafts.* Both workflows are gated on `github.event.pull_request.draft != true`. PRs here are opened as drafts by convention, so pushing to a draft and waiting on checks waits forever — no test, clippy, or fmt run is ever queued, and nothing says so.
  3. *A green run that never ran.* `cargo test <filter>` exits 0 and prints `test result: ok` when the filter matches nothing, so a filtered run can be reported as passing without executing a single test.

- **Blocking relationship**: Targets #860's branch. The CI changes this text describes are in **#898** (against `v1.0-dev`); this documents the resulting behaviour and is otherwise independent.

## What was done

Adds `CLAUDE.md` § Testing → "Local vs CI — avoid duplicate test runs":

- States exactly what CI runs (`tests.yml`, `clippy.yml`) and when — path-filtered to `**/*.rs` (which includes `build.rs`), `**/Cargo.toml`, `Cargo.lock`, `.cargo/config.toml`, `rust-toolchain.toml`, and the workflow file; a documentation-only change deliberately runs neither.
- Scopes local runs to the narrowest thing covering the change; `cargo +nightly fmt --all` always (no compile, and `clippy.yml` fails on unformatted code); local clippy only for the touched scope.
- Records the two gaps: **draft PRs** (use `ready_for_review`, or a manual `workflow_dispatch` run — noting it tests the branch head, not the merge commit) and **backend E2E** (commented out in `tests.yml`, `#[ignore]`d).
- Notes that a green run must be confirmed by finding the expected test names in the log.

## Testing

Documentation only — no code changes, so no suite applies.

Merge-conflict checks, both clean:

| Check | Result |
|---|---|
| Based directly on #860's head | no conflict possible |
| #898 merged into `v1.0-dev`, then #860 + this merged in | **0 conflicted files** |

This was split out of #898 precisely because it collides there: #860 rewrites the same region of `CLAUDE.md` (it inserts a `### GUI testing` section immediately above the anchor line this change edits), so carrying the text on a `v1.0-dev` branch produced a `CLAUDE.md` conflict when #860 merged. Basing it on #860 instead removes the collision.

Text describes CI as of #898 (`workflow_dispatch` on both workflows, `rust-toolchain.toml` filtered, push limited to `v*-dev`), so it should land after #898.

## Breaking changes

None — documentation only.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for running local tests and CI checks.
  * Documented test, documentation-test, formatting, and lint workflows.
  * Clarified path-filter behavior and exceptions, including draft pull requests and backend end-to-end tests.
  * Added guidance for verifying that intended CI checks actually ran.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->