### PR TITLE
fix(wallet): surface DAPI endpoint exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,9 +288,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Two settings changes made in quick succession could occasionally cause one
   of them to be silently lost. Saving settings is now a single atomic step,
   so no change is dropped.
-- A burst of unreachable Dash network servers could show a raw, technical
-  "Could not reach a Dash network server" error, even once the app's own
-  sync was otherwise healthy. This happens when every server the app currently
-  knows about becomes briefly unreachable at once — a temporary, self-recovering
-  condition. The app now recognizes it and says "All Dash network servers are
-  temporarily unreachable. Please wait a minute and retry." instead.
+- A burst of unreachable Dash network servers could show a message that
+  understated the outage as a problem reaching one server, even once the app's
+  own sync was otherwise healthy. This happens when every server the app
+  currently knows about becomes briefly unreachable at once — a temporary,
+  self-recovering condition. The app now recognizes it and says "All Dash network
+  servers are temporarily unreachable. Please wait a minute and retry." instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,3 +288,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Two settings changes made in quick succession could occasionally cause one
   of them to be silently lost. Saving settings is now a single atomic step,
   so no change is dropped.
+- A burst of unreachable Dash network servers could show a raw, technical
+  "Could not reach a Dash network server" error, even once the app's own
+  sync was otherwise healthy. This happens when every server the app currently
+  knows about becomes briefly unreachable at once — a temporary, self-recovering
+  condition. The app now recognizes it and says "All Dash network servers are
+  temporarily unreachable. Please wait a minute and retry." instead.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2123,7 +2123,9 @@ impl App for AppState {
                 }
                 TaskResult::Error {
                     context,
-                    error: err @ TaskError::ScheduledVoteSweepFailed { network, .. },
+                    error:
+                        err @ (TaskError::ScheduledVoteSweepFailed { network, .. }
+                        | TaskError::ScheduledVoteSweepAllAddressesExhausted { network, .. }),
                 } => {
                     self.scheduled_vote_sweeps_in_progress.remove(&network);
                     self.visible_screen_mut()

--- a/src/backend_task/contested_names/query_dpns_contested_resources.rs
+++ b/src/backend_task/contested_names/query_dpns_contested_resources.rs
@@ -1,6 +1,6 @@
 use crate::app::TaskResult;
-use crate::backend_task::BackendTaskSuccessResult;
-use crate::backend_task::error::TaskError;
+use crate::backend_task::error::{DapiAddressAvailability, TaskError};
+use crate::backend_task::{BackendTaskSuccessResult, contextualize_dapi_task_result};
 use crate::context::AppContext;
 use crate::model::request_type::RequestType;
 use dash_sdk::Sdk;
@@ -132,7 +132,10 @@ impl AppContext {
                     }
                 };
 
-                match self_ref.query_dpns_ending_times(sdk, sender.clone()).await {
+                match self_ref
+                    .query_dpns_ending_times(sdk.clone(), sender.clone())
+                    .await
+                {
                     Ok(_) => {
                         if let Err(e) = sender.send(TaskResult::Refresh).await {
                             tracing::warn!(
@@ -143,8 +146,11 @@ impl AppContext {
                     }
                     Err(e) => {
                         tracing::error!("Error querying dpns end times: {}", e);
-                        if let Err(send_err) = sender.send(TaskResult::unattributed_error(e)).await
-                        {
+                        let result = contextualize_dapi_task_result(
+                            TaskResult::unattributed_error(e),
+                            DapiAddressAvailability::from_sdk(&sdk),
+                        );
+                        if let Err(send_err) = sender.send(result).await {
                             tracing::warn!(
                                 "Failed to send error for dpns end times query: {}",
                                 send_err
@@ -191,8 +197,11 @@ impl AppContext {
                     }
                     Err(e) => {
                         tracing::error!("Error querying dpns vote contenders for {}: {}", name, e);
-                        if let Err(send_err) = sender.send(TaskResult::unattributed_error(e)).await
-                        {
+                        let result = contextualize_dapi_task_result(
+                            TaskResult::unattributed_error(e),
+                            DapiAddressAvailability::from_sdk(&sdk),
+                        );
+                        if let Err(send_err) = sender.send(result).await {
                             tracing::warn!(
                                 "Failed to send error for vote contenders query for {}: {}",
                                 name,

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -20,6 +20,26 @@ use dash_sdk::platform::Identifier;
 use std::fmt;
 use thiserror::Error;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DapiAddressAvailability {
+    pub(crate) configured_total: usize,
+    pub(crate) live_count: usize,
+}
+
+impl DapiAddressAvailability {
+    pub(crate) fn from_sdk(sdk: &dash_sdk::Sdk) -> Self {
+        let address_list = sdk.address_list();
+        Self {
+            configured_total: address_list.len(),
+            live_count: address_list.get_live_addresses().len(),
+        }
+    }
+
+    fn all_configured_addresses_are_exhausted(self) -> bool {
+        self.configured_total != 0 && self.live_count == 0
+    }
+}
+
 /// Why an existing DashPay `contactInfo` payload could not be preserved.
 #[derive(Debug, Error)]
 pub enum ContactInfoReadError {
@@ -591,10 +611,18 @@ pub enum TaskError {
         source: crate::wallet_backend::KvAdapterError,
     },
 
-    /// Platform rejected a scheduled vote inside the otherwise successful
-    /// per-voter result payload.
+    /// A scheduled vote failed inside the otherwise successful per-voter result payload.
     #[error("The scheduled vote was not accepted. Wait a moment and try again.")]
     ScheduledVoteRejected {
+        #[source]
+        source: std::sync::Arc<TaskError>,
+    },
+
+    /// Every configured DAPI address was exhausted while casting a scheduled vote.
+    #[error(
+        "All Dash network servers are temporarily unreachable. Please wait a minute and retry."
+    )]
+    ScheduledVoteAllAddressesExhausted {
         #[source]
         source: std::sync::Arc<TaskError>,
     },
@@ -607,6 +635,16 @@ pub enum TaskError {
     /// structured context for the app's per-network retry bookkeeping.
     #[error("Scheduled votes could not be checked. Wait a moment and try again.")]
     ScheduledVoteSweepFailed {
+        network: Network,
+        #[source]
+        source: Box<TaskError>,
+    },
+
+    /// Every configured DAPI address was exhausted during a scheduled-vote sweep.
+    #[error(
+        "All Dash network servers are temporarily unreachable. Please wait a minute and retry."
+    )]
+    ScheduledVoteSweepAllAddressesExhausted {
         network: Network,
         #[source]
         source: Box<TaskError>,
@@ -1048,13 +1086,13 @@ pub enum TaskError {
         source_error: Box<SdkError>,
     },
 
-    /// All DAPI servers exhausted (NoAvailableAddressesToRetry).
+    /// Every configured DAPI address is exhausted or currently unreachable.
     #[error(
         "All Dash network servers are temporarily unreachable. Please wait a minute and retry."
     )]
     DapiAllAddressesExhausted {
         #[source]
-        source_error: Box<SdkError>,
+        source: std::sync::Arc<TaskError>,
     },
 
     /// SDK operation timed out (SdkError::TimeoutReached).
@@ -2255,29 +2293,33 @@ pub enum TaskError {
 
 impl TaskError {
     /// Reclassifies SDK reachability failures when every configured DAPI address is exhausted.
-    pub fn contextualize_dapi_availability(
+    pub(crate) fn contextualize_dapi_availability(
         self,
-        configured_total: usize,
-        live_count: usize,
+        availability: DapiAddressAvailability,
     ) -> Self {
-        if configured_total == 0 || live_count != 0 {
+        if !availability.all_configured_addresses_are_exhausted()
+            || self.is_dapi_availability_contextualized()
+            || !self.contains_dapi_reachability_failure()
+        {
             return self;
         }
 
         match self {
-            Self::DapiUnavailable { source_error }
-            | Self::DapiTimeout { source_error }
-            | Self::DapiConnectionRefused { source_error }
-            | Self::DapiNoAddresses { source_error } => {
-                Self::DapiAllAddressesExhausted { source_error }
+            Self::WalletDataClearIncomplete {
+                failed,
+                first_error,
+            } => Self::WalletDataClearIncomplete {
+                failed,
+                first_error: Box::new((*first_error).contextualize_dapi_availability(availability)),
+            },
+            Self::IdentityKeyAddedButNotSaved { source } => Self::IdentityKeyAddedButNotSaved {
+                source: Box::new((*source).contextualize_dapi_availability(availability)),
+            },
+            Self::ScheduledVoteRejected { source } => {
+                Self::ScheduledVoteAllAddressesExhausted { source }
             }
-            Self::DashPayContactRequestActionFailed { request_id, source } => {
-                Self::DashPayContactRequestActionFailed {
-                    request_id,
-                    source: Box::new(
-                        (*source).contextualize_dapi_availability(configured_total, live_count),
-                    ),
-                }
+            Self::ScheduledVoteSweepFailed { network, source } => {
+                Self::ScheduledVoteSweepAllAddressesExhausted { network, source }
             }
             Self::DashPayContactInfoActionFailed {
                 identity_id,
@@ -2286,12 +2328,86 @@ impl TaskError {
             } => Self::DashPayContactInfoActionFailed {
                 identity_id,
                 contact_id,
-                source: Box::new(
-                    (*source).contextualize_dapi_availability(configured_total, live_count),
-                ),
+                source: Box::new((*source).contextualize_dapi_availability(availability)),
             },
-            other => other,
+            Self::DashPayContactRequestActionFailed { request_id, source } => {
+                Self::DashPayContactRequestActionFailed {
+                    request_id,
+                    source: Box::new((*source).contextualize_dapi_availability(availability)),
+                }
+            }
+            Self::WalletRegistrationFlightFailed { source } => {
+                Self::WalletRegistrationFlightFailed {
+                    source: source.contextualize_shared_dapi_availability(availability),
+                }
+            }
+            other => Self::DapiAllAddressesExhausted {
+                source: std::sync::Arc::new(other),
+            },
         }
+    }
+
+    pub(crate) fn contextualize_shared_dapi_availability(
+        self: std::sync::Arc<Self>,
+        availability: DapiAddressAvailability,
+    ) -> std::sync::Arc<Self> {
+        if !availability.all_configured_addresses_are_exhausted()
+            || self.is_dapi_availability_contextualized()
+            || !self.contains_dapi_reachability_failure()
+        {
+            return self;
+        }
+
+        std::sync::Arc::new(Self::DapiAllAddressesExhausted { source: self })
+    }
+
+    fn is_dapi_availability_contextualized(&self) -> bool {
+        matches!(
+            self,
+            Self::DapiAllAddressesExhausted { .. }
+                | Self::ScheduledVoteAllAddressesExhausted { .. }
+                | Self::ScheduledVoteSweepAllAddressesExhausted { .. }
+        )
+    }
+
+    pub(crate) fn contains_dapi_reachability_failure(&self) -> bool {
+        let mut current: Option<&(dyn std::error::Error + 'static)> = Some(self);
+
+        while let Some(error) = current {
+            if let Some(task_error) = error.downcast_ref::<Self>()
+                && matches!(
+                    task_error,
+                    Self::DapiUnavailable { .. }
+                        | Self::DapiTimeout { .. }
+                        | Self::DapiConnectionRefused { .. }
+                        | Self::DapiNoAddresses { .. }
+                )
+            {
+                return true;
+            }
+
+            if let Some(task_error) = error.downcast_ref::<Box<Self>>()
+                && task_error.contains_dapi_reachability_failure()
+            {
+                return true;
+            }
+
+            if let Some(task_error) = error.downcast_ref::<std::sync::Arc<Self>>()
+                && task_error.contains_dapi_reachability_failure()
+            {
+                return true;
+            }
+
+            if let Some(sdk_error) = error.downcast_ref::<SdkError>()
+                && sdk_error_is_dapi_reachability_failure(sdk_error)
+            {
+                return true;
+            }
+
+            current = error.source();
+        }
+
+        false
     }
 
     /// Map a wallet-storage open failure to the right user-facing variant.
@@ -2841,7 +2957,9 @@ impl From<SdkError> for TaskError {
             }
             SdkError::DapiClientError(DapiClientError::NoAvailableAddressesToRetry(_)) => {
                 TaskError::DapiAllAddressesExhausted {
-                    source_error: boxed,
+                    source: std::sync::Arc::new(TaskError::SdkError {
+                        source_error: boxed,
+                    }),
                 }
             }
             SdkError::DapiClientError(_) => TaskError::SdkError {
@@ -2866,7 +2984,9 @@ impl From<SdkError> for TaskError {
                 source_error: boxed,
             },
             SdkError::NoAvailableAddressesToRetry(_) => TaskError::DapiAllAddressesExhausted {
-                source_error: boxed,
+                source: std::sync::Arc::new(TaskError::SdkError {
+                    source_error: boxed,
+                }),
             },
             SdkError::Cancelled(_) => TaskError::OperationCancelled {
                 source_error: boxed,
@@ -2891,6 +3011,18 @@ impl From<SdkError> for TaskError {
                 source_error: boxed,
             },
         }
+    }
+}
+
+fn sdk_error_is_dapi_reachability_failure(error: &SdkError) -> bool {
+    match error {
+        SdkError::DapiClientError(DapiClientError::Transport(TransportError::Grpc(status))) => {
+            status.code() == Code::Unavailable
+        }
+        SdkError::DapiClientError(DapiClientError::NoAvailableAddresses)
+        | SdkError::DapiClientError(DapiClientError::NoAvailableAddressesToRetry(_))
+        | SdkError::NoAvailableAddressesToRetry(_) => true,
+        _ => false,
     }
 }
 
@@ -2922,10 +3054,24 @@ mod tests {
         TaskError::DapiConnectionRefused { source_error }
     }
 
+    fn wallet_sdk_connection_refused_error() -> platform_wallet::error::PlatformWalletError {
+        let status = dash_sdk::dapi_grpc::tonic::Status::unavailable("tcp connect error");
+        platform_wallet::error::PlatformWalletError::Sdk(SdkError::DapiClientError(
+            DapiClientError::Transport(TransportError::Grpc(status)),
+        ))
+    }
+
+    fn availability(configured_total: usize, live_count: usize) -> DapiAddressAvailability {
+        DapiAddressAvailability {
+            configured_total,
+            live_count,
+        }
+    }
+
     fn dapi_sdk_source_ptr(error: &TaskError) -> *const SdkError {
         match error {
-            TaskError::DapiConnectionRefused { source_error }
-            | TaskError::DapiAllAddressesExhausted { source_error } => &**source_error,
+            TaskError::DapiConnectionRefused { source_error } => &**source_error,
+            TaskError::DapiAllAddressesExhausted { source } => dapi_sdk_source_ptr(source),
             other => panic!("expected a DAPI reachability error, got {other:?}"),
         }
     }
@@ -2935,12 +3081,12 @@ mod tests {
         let error = dapi_connection_refused_error();
         let original_source = dapi_sdk_source_ptr(&error);
 
-        let contextualized = error.contextualize_dapi_availability(1, 0);
+        let contextualized = error.contextualize_dapi_availability(availability(1, 0));
 
         assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
         match contextualized {
-            TaskError::DapiAllAddressesExhausted { source_error } => {
-                assert!(std::ptr::eq(&*source_error, original_source));
+            TaskError::DapiAllAddressesExhausted { source } => {
+                assert!(std::ptr::eq(dapi_sdk_source_ptr(&source), original_source));
             }
             other => panic!("expected DapiAllAddressesExhausted, got {other:?}"),
         }
@@ -2948,7 +3094,8 @@ mod tests {
 
     #[test]
     fn dapi_availability_context_keeps_connection_refused_when_an_address_is_live() {
-        let contextualized = dapi_connection_refused_error().contextualize_dapi_availability(1, 1);
+        let contextualized =
+            dapi_connection_refused_error().contextualize_dapi_availability(availability(1, 1));
 
         assert!(matches!(
             contextualized,
@@ -2961,11 +3108,11 @@ mod tests {
         let exhausted = TaskError::from(SdkError::DapiClientError(
             DapiClientError::NoAvailableAddresses,
         ))
-        .contextualize_dapi_availability(1, 0);
+        .contextualize_dapi_availability(availability(1, 0));
         let unconfigured = TaskError::from(SdkError::DapiClientError(
             DapiClientError::NoAvailableAddresses,
         ))
-        .contextualize_dapi_availability(0, 0);
+        .contextualize_dapi_availability(availability(0, 0));
 
         assert!(matches!(
             exhausted,
@@ -2976,7 +3123,8 @@ mod tests {
 
     #[test]
     fn dapi_availability_context_leaves_unrelated_errors_unchanged() {
-        let contextualized = TaskError::DocumentNotFound.contextualize_dapi_availability(1, 0);
+        let contextualized =
+            TaskError::DocumentNotFound.contextualize_dapi_availability(availability(1, 0));
 
         assert!(matches!(contextualized, TaskError::DocumentNotFound));
     }
@@ -2991,7 +3139,7 @@ mod tests {
             source: Box::new(source),
         };
 
-        let contextualized = error.contextualize_dapi_availability(1, 0);
+        let contextualized = error.contextualize_dapi_availability(availability(1, 0));
 
         assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
         match contextualized {
@@ -3006,7 +3154,7 @@ mod tests {
                 ));
                 assert!(std::ptr::eq(dapi_sdk_source_ptr(&source), original_source));
             }
-            other => panic!("expected DashPayContactRequestActionFailed, got {other:?}"),
+            other => panic!("expected contact-request context, got {other:?}"),
         }
     }
 
@@ -3022,7 +3170,7 @@ mod tests {
             source: Box::new(source),
         };
 
-        let contextualized = error.contextualize_dapi_availability(1, 0);
+        let contextualized = error.contextualize_dapi_availability(availability(1, 0));
 
         assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
         match contextualized {
@@ -3039,8 +3187,104 @@ mod tests {
                 ));
                 assert!(std::ptr::eq(dapi_sdk_source_ptr(&source), original_source));
             }
-            other => panic!("expected DashPayContactInfoActionFailed, got {other:?}"),
+            other => panic!("expected contact-info context, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn dapi_availability_context_detects_wallet_operation_sdk_failures() {
+        let identity_id = Identifier::from([8; 32]);
+        let errors = [
+            TaskError::IdentityCreateRejected {
+                source: Box::new(wallet_sdk_connection_refused_error()),
+            },
+            TaskError::IdentityTopUpRejected {
+                identity_id,
+                source: Box::new(wallet_sdk_connection_refused_error()),
+            },
+            TaskError::PlatformAddressFundRejected {
+                source: Box::new(wallet_sdk_connection_refused_error()),
+            },
+        ];
+
+        for (index, error) in errors.into_iter().enumerate() {
+            let contextualized = error.contextualize_dapi_availability(availability(1, 0));
+            assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
+            let TaskError::DapiAllAddressesExhausted { source } = contextualized else {
+                panic!("expected wallet SDK failure to be classified as endpoint exhaustion");
+            };
+            match index {
+                0 => assert!(matches!(
+                    source.as_ref(),
+                    TaskError::IdentityCreateRejected { .. }
+                )),
+                1 => assert!(matches!(
+                    source.as_ref(),
+                    TaskError::IdentityTopUpRejected {
+                        identity_id: actual,
+                        ..
+                    } if *actual == identity_id
+                )),
+                2 => assert!(matches!(
+                    source.as_ref(),
+                    TaskError::PlatformAddressFundRejected { .. }
+                )),
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    #[test]
+    fn dapi_availability_context_detects_reachability_through_any_task_error_source() {
+        let error = TaskError::ScheduledVoteSweepFailed {
+            network: Network::Testnet,
+            source: Box::new(dapi_connection_refused_error()),
+        };
+
+        let contextualized = error.contextualize_dapi_availability(availability(1, 0));
+
+        assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
+        let TaskError::ScheduledVoteSweepAllAddressesExhausted { network, source } = contextualized
+        else {
+            panic!("expected exhausted scheduled-vote sweep context");
+        };
+        assert_eq!(network, Network::Testnet);
+        assert!(matches!(
+            source.as_ref(),
+            TaskError::DapiConnectionRefused { .. }
+        ));
+
+        let shared_error = TaskError::ScheduledVoteRejected {
+            source: std::sync::Arc::new(dapi_connection_refused_error()),
+        };
+        let contextualized = shared_error.contextualize_dapi_availability(availability(1, 0));
+        assert!(matches!(
+            contextualized,
+            TaskError::ScheduledVoteAllAddressesExhausted { source }
+                if matches!(source.as_ref(), TaskError::DapiConnectionRefused { .. })
+        ));
+    }
+
+    #[test]
+    fn dapi_context_keeps_non_dapi_scheduled_vote_messages() {
+        let rejected = TaskError::ScheduledVoteRejected {
+            source: std::sync::Arc::new(TaskError::DocumentNotFound),
+        }
+        .contextualize_dapi_availability(availability(1, 0));
+        assert_eq!(
+            rejected.to_string(),
+            "The scheduled vote was not accepted. Wait a moment and try again."
+        );
+
+        let sweep = TaskError::ScheduledVoteSweepFailed {
+            network: Network::Testnet,
+            source: Box::new(TaskError::DocumentNotFound),
+        }
+        .contextualize_dapi_availability(availability(1, 0));
+        assert_eq!(
+            sweep.to_string(),
+            "Scheduled votes could not be checked. Wait a moment and try again."
+        );
     }
 
     #[test]

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -2254,6 +2254,46 @@ pub enum TaskError {
 }
 
 impl TaskError {
+    /// Reclassifies SDK reachability failures when every configured DAPI address is exhausted.
+    pub fn contextualize_dapi_availability(
+        self,
+        configured_total: usize,
+        live_count: usize,
+    ) -> Self {
+        if configured_total == 0 || live_count != 0 {
+            return self;
+        }
+
+        match self {
+            Self::DapiUnavailable { source_error }
+            | Self::DapiTimeout { source_error }
+            | Self::DapiConnectionRefused { source_error }
+            | Self::DapiNoAddresses { source_error } => {
+                Self::DapiAllAddressesExhausted { source_error }
+            }
+            Self::DashPayContactRequestActionFailed { request_id, source } => {
+                Self::DashPayContactRequestActionFailed {
+                    request_id,
+                    source: Box::new(
+                        (*source).contextualize_dapi_availability(configured_total, live_count),
+                    ),
+                }
+            }
+            Self::DashPayContactInfoActionFailed {
+                identity_id,
+                contact_id,
+                source,
+            } => Self::DashPayContactInfoActionFailed {
+                identity_id,
+                contact_id,
+                source: Box::new(
+                    (*source).contextualize_dapi_availability(configured_total, live_count),
+                ),
+            },
+            other => other,
+        }
+    }
+
     /// Map a wallet-storage open failure to the right user-facing variant.
     ///
     /// Three storage failures get honest, distinct copy; everything else keeps
@@ -2870,6 +2910,138 @@ mod tests {
     use dash_sdk::dpp::consensus::state::identity::identity_public_key_already_exists_for_unique_contract_bounds_error::IdentityPublicKeyAlreadyExistsForUniqueContractBoundsError;
     use dash_sdk::dpp::identity::Purpose;
     use dash_sdk::platform::Identifier;
+
+    const DAPI_EXHAUSTED_MESSAGE: &str =
+        "All Dash network servers are temporarily unreachable. Please wait a minute and retry.";
+
+    fn dapi_connection_refused_error() -> TaskError {
+        let status = dash_sdk::dapi_grpc::tonic::Status::unavailable("tcp connect error");
+        let source_error = Box::new(SdkError::DapiClientError(DapiClientError::Transport(
+            TransportError::Grpc(status),
+        )));
+        TaskError::DapiConnectionRefused { source_error }
+    }
+
+    fn dapi_sdk_source_ptr(error: &TaskError) -> *const SdkError {
+        match error {
+            TaskError::DapiConnectionRefused { source_error }
+            | TaskError::DapiAllAddressesExhausted { source_error } => &**source_error,
+            other => panic!("expected a DAPI reachability error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dapi_availability_context_exhausts_connection_refused_and_preserves_source() {
+        let error = dapi_connection_refused_error();
+        let original_source = dapi_sdk_source_ptr(&error);
+
+        let contextualized = error.contextualize_dapi_availability(1, 0);
+
+        assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
+        match contextualized {
+            TaskError::DapiAllAddressesExhausted { source_error } => {
+                assert!(std::ptr::eq(&*source_error, original_source));
+            }
+            other => panic!("expected DapiAllAddressesExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dapi_availability_context_keeps_connection_refused_when_an_address_is_live() {
+        let contextualized = dapi_connection_refused_error().contextualize_dapi_availability(1, 1);
+
+        assert!(matches!(
+            contextualized,
+            TaskError::DapiConnectionRefused { .. }
+        ));
+    }
+
+    #[test]
+    fn dapi_availability_context_distinguishes_exhaustion_from_missing_configuration() {
+        let exhausted = TaskError::from(SdkError::DapiClientError(
+            DapiClientError::NoAvailableAddresses,
+        ))
+        .contextualize_dapi_availability(1, 0);
+        let unconfigured = TaskError::from(SdkError::DapiClientError(
+            DapiClientError::NoAvailableAddresses,
+        ))
+        .contextualize_dapi_availability(0, 0);
+
+        assert!(matches!(
+            exhausted,
+            TaskError::DapiAllAddressesExhausted { .. }
+        ));
+        assert!(matches!(unconfigured, TaskError::DapiNoAddresses { .. }));
+    }
+
+    #[test]
+    fn dapi_availability_context_leaves_unrelated_errors_unchanged() {
+        let contextualized = TaskError::DocumentNotFound.contextualize_dapi_availability(1, 0);
+
+        assert!(matches!(contextualized, TaskError::DocumentNotFound));
+    }
+
+    #[test]
+    fn dapi_availability_context_recurses_through_contact_request_envelope() {
+        let request_id = Identifier::from([7; 32]);
+        let source = dapi_connection_refused_error();
+        let original_source = dapi_sdk_source_ptr(&source);
+        let error = TaskError::DashPayContactRequestActionFailed {
+            request_id,
+            source: Box::new(source),
+        };
+
+        let contextualized = error.contextualize_dapi_availability(1, 0);
+
+        assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
+        match contextualized {
+            TaskError::DashPayContactRequestActionFailed {
+                request_id: actual_request_id,
+                source,
+            } => {
+                assert_eq!(actual_request_id, request_id);
+                assert!(matches!(
+                    source.as_ref(),
+                    TaskError::DapiAllAddressesExhausted { .. }
+                ));
+                assert!(std::ptr::eq(dapi_sdk_source_ptr(&source), original_source));
+            }
+            other => panic!("expected DashPayContactRequestActionFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dapi_availability_context_recurses_through_contact_info_envelope() {
+        let identity_id = Identifier::from([6; 32]);
+        let contact_id = Identifier::from([7; 32]);
+        let source = dapi_connection_refused_error();
+        let original_source = dapi_sdk_source_ptr(&source);
+        let error = TaskError::DashPayContactInfoActionFailed {
+            identity_id,
+            contact_id,
+            source: Box::new(source),
+        };
+
+        let contextualized = error.contextualize_dapi_availability(1, 0);
+
+        assert_eq!(contextualized.to_string(), DAPI_EXHAUSTED_MESSAGE);
+        match contextualized {
+            TaskError::DashPayContactInfoActionFailed {
+                identity_id: actual_identity_id,
+                contact_id: actual_contact_id,
+                source,
+            } => {
+                assert_eq!(actual_identity_id, identity_id);
+                assert_eq!(actual_contact_id, contact_id);
+                assert!(matches!(
+                    source.as_ref(),
+                    TaskError::DapiAllAddressesExhausted { .. }
+                ));
+                assert!(std::ptr::eq(dapi_sdk_source_ptr(&source), original_source));
+            }
+            other => panic!("expected DashPayContactInfoActionFailed, got {other:?}"),
+        }
+    }
 
     #[test]
     fn a_request_action_failure_shows_the_underlying_reason_to_the_user() {

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -105,6 +105,16 @@ where
     }
 }
 
+fn contextualize_dapi_result<T>(
+    result: Result<T, TaskError>,
+    availability: impl FnOnce() -> (usize, usize),
+) -> Result<T, TaskError> {
+    result.map_err(|error| {
+        let (configured_total, live_count) = availability();
+        error.contextualize_dapi_availability(configured_total, live_count)
+    })
+}
+
 /// Returns `true` for backend tasks that read or write the
 /// `WalletBackend` (and therefore the upstream `SecretStore` / sidecar
 /// k/v). These tasks must short-circuit with
@@ -737,20 +747,22 @@ impl AppContext {
         task: BackendTask,
         sender: SenderAsync<TaskResult>,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
-        let result = self.run_backend_task_inner(task, sender).await;
-        let (configured_total, live_count) = {
-            let sdk = self.sdk.load();
-            let address_list = sdk.address_list();
-            (address_list.len(), address_list.get_live_addresses().len())
-        };
+        let task_sdk = self.sdk.load_full();
+        let result = self
+            .run_backend_task_inner(task, sender, task_sdk.as_ref())
+            .await;
 
-        result.map_err(|error| error.contextualize_dapi_availability(configured_total, live_count))
+        contextualize_dapi_result(result, || {
+            let address_list = task_sdk.address_list();
+            (address_list.len(), address_list.get_live_addresses().len())
+        })
     }
 
     async fn run_backend_task_inner(
         self: &Arc<Self>,
         task: BackendTask,
         sender: SenderAsync<TaskResult>,
+        sdk: &dash_sdk::Sdk,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
         // Refuse a shielded fund movement while shielded operations are
         // unavailable BEFORE `ensure_wallet_backend` runs. That bootstrap does
@@ -787,8 +799,6 @@ impl AppContext {
         // covers every way a load can end before its claim, not just these two.
         let _load_dispatch = identity_load_ticket(&task)
             .map(|(identity_id, token)| self.backstop_identity_load(identity_id, token));
-
-        let sdk = self.sdk.load().as_ref().clone();
 
         // Wallet/identity/DashPay/core/shielded flows go through
         // `WalletBackend`. Build it lazily on first such task (idempotent) —
@@ -837,35 +847,35 @@ impl AppContext {
 
         match task {
             BackendTask::ContractTask(contract_task) => {
-                Ok(self.run_contract_task(*contract_task, &sdk, sender).await?)
+                Ok(self.run_contract_task(*contract_task, sdk, sender).await?)
             }
             BackendTask::ContestedResourceTask(contested_resource_task) => Ok(self
-                .run_contested_resource_task(contested_resource_task, &sdk, sender)
+                .run_contested_resource_task(contested_resource_task, sdk, sender)
                 .await?),
             BackendTask::IdentityTask(identity_task) => {
-                Ok(self.run_identity_task(identity_task, &sdk, sender).await?)
+                Ok(self.run_identity_task(identity_task, sdk, sender).await?)
             }
             BackendTask::DocumentTask(document_task) => {
-                Ok(self.run_document_task(*document_task, &sdk).await?)
+                Ok(self.run_document_task(*document_task, sdk).await?)
             }
             BackendTask::CoreTask(core_task) => Ok(self.run_core_task(core_task).await?),
             BackendTask::DashPayTask(dashpay_task) => {
-                Ok(self.run_dashpay_task(*dashpay_task, &sdk).await?)
+                Ok(self.run_dashpay_task(*dashpay_task, sdk).await?)
             }
             BackendTask::BroadcastStateTransition(state_transition) => Ok(self
-                .broadcast_state_transition(state_transition, &sdk)
+                .broadcast_state_transition(state_transition, sdk)
                 .await?),
             BackendTask::TokenTask(token_task) => {
-                Ok(self.run_token_task(*token_task, &sdk, sender).await?)
+                Ok(self.run_token_task(*token_task, sdk, sender).await?)
             }
             BackendTask::SystemTask(system_task) => {
                 Ok(self.run_system_task(system_task, sender).await?)
             }
-            BackendTask::PlatformInfo(platform_info_task) => Ok(self
-                .run_platform_info_task(platform_info_task, &sdk)
-                .await?),
+            BackendTask::PlatformInfo(platform_info_task) => {
+                Ok(self.run_platform_info_task(platform_info_task, sdk).await?)
+            }
             BackendTask::GroveSTARKTask(grovestark_task) => {
-                Ok(grovestark::run_grovestark_task(grovestark_task, &sdk).await?)
+                Ok(grovestark::run_grovestark_task(grovestark_task, sdk).await?)
             }
             BackendTask::WalletTask(wallet_task) => Ok(self.run_wallet_task(wallet_task).await?),
             BackendTask::ShieldedTask(shielded_task) => {
@@ -1075,6 +1085,66 @@ impl AppContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dapi_connection_refused_error() -> TaskError {
+        use dash_sdk::Error as SdkError;
+        use dash_sdk::dapi_client::DapiClientError;
+        use dash_sdk::dapi_client::transport::TransportError;
+
+        let status = dash_sdk::dapi_grpc::tonic::Status::unavailable("tcp connect error");
+        TaskError::from(SdkError::DapiClientError(DapiClientError::Transport(
+            TransportError::Grpc(status),
+        )))
+    }
+
+    #[test]
+    fn dapi_context_uses_the_task_sdk_generation() {
+        use dash_sdk::dapi_client::{Address, AddressList};
+
+        let exhausted_address: Address = "http://127.0.0.1:3000".parse().expect("address");
+        let mut task_addresses = AddressList::new();
+        task_addresses.add(exhausted_address.clone());
+        assert!(task_addresses.ban(&exhausted_address));
+
+        let mut replacement_addresses = AddressList::new();
+        replacement_addresses.add("http://127.0.0.1:3001".parse().expect("address"));
+        let replacement_result =
+            contextualize_dapi_result::<()>(Err(dapi_connection_refused_error()), || {
+                (
+                    replacement_addresses.len(),
+                    replacement_addresses.get_live_addresses().len(),
+                )
+            });
+        assert!(matches!(
+            replacement_result,
+            Err(TaskError::DapiConnectionRefused { .. })
+        ));
+
+        let result = contextualize_dapi_result::<()>(Err(dapi_connection_refused_error()), || {
+            (
+                task_addresses.len(),
+                task_addresses.get_live_addresses().len(),
+            )
+        });
+
+        assert!(matches!(
+            result,
+            Err(TaskError::DapiAllAddressesExhausted { .. })
+        ));
+    }
+
+    #[test]
+    fn dapi_success_skips_availability_inspection() {
+        let inspected = std::cell::Cell::new(false);
+
+        let result = contextualize_dapi_result(Ok(42), || {
+            inspected.set(true);
+            (1, 0)
+        });
+
+        assert!(matches!(result, Ok(42)));
+        assert!(!inspected.get());
+    }
 
     #[test]
     fn backend_task_context_preserves_document_query_and_fetch_kind() {

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -120,6 +120,13 @@ fn contextualize_dapi_result(
     }
 }
 
+fn contextualize_wallet_backend_dapi_result(
+    result: Result<BackendTaskSuccessResult, TaskError>,
+    backend: &crate::wallet_backend::WalletBackend,
+) -> Result<BackendTaskSuccessResult, TaskError> {
+    contextualize_dapi_result(result, || DapiAddressAvailability::from_sdk(backend.sdk()))
+}
+
 fn contextualize_dapi_task_result(
     result: TaskResult,
     availability: DapiAddressAvailability,
@@ -810,14 +817,22 @@ impl AppContext {
         task: BackendTask,
         sender: SenderAsync<TaskResult>,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
+        let uses_wallet_backend_sdk = matches!(
+            &task,
+            BackendTask::WalletTask(_) | BackendTask::ShieldedTask(_)
+        );
         let task_sdk = self.sdk.load_full();
         let result = self
             .run_backend_task_inner(task, sender, task_sdk.as_ref())
             .await;
 
-        contextualize_dapi_result(result, || {
-            DapiAddressAvailability::from_sdk(task_sdk.as_ref())
-        })
+        if uses_wallet_backend_sdk {
+            result
+        } else {
+            contextualize_dapi_result(result, || {
+                DapiAddressAvailability::from_sdk(task_sdk.as_ref())
+            })
+        }
     }
 
     async fn run_backend_task_inner(
@@ -1034,7 +1049,8 @@ impl AppContext {
         self: &Arc<Self>,
         task: WalletTask,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
-        match task {
+        let backend = self.wallet_backend()?;
+        let result = match task {
             WalletTask::GenerateReceiveAddress { seed_hash } => {
                 self.generate_receive_address(seed_hash).await
             }
@@ -1083,13 +1099,10 @@ impl AppContext {
                 self.sign_message_with_identity_key(identity_id, target, key_id, message, key_type)
                     .await
             }
-            WalletTask::ListTrackedAssetLocks { seed_hash } => {
-                let locks = self
-                    .wallet_backend()?
-                    .list_tracked_asset_locks(&seed_hash)
-                    .await?;
-                Ok(BackendTaskSuccessResult::TrackedAssetLocks { seed_hash, locks })
-            }
+            WalletTask::ListTrackedAssetLocks { seed_hash } => backend
+                .list_tracked_asset_locks(&seed_hash)
+                .await
+                .map(|locks| BackendTaskSuccessResult::TrackedAssetLocks { seed_hash, locks }),
             WalletTask::FetchPlatformAddressBalances { seed_hash } => {
                 self.fetch_platform_address_balances(seed_hash).await
             }
@@ -1140,7 +1153,9 @@ impl AppContext {
                 )
                 .await
             }
-        }
+        };
+
+        contextualize_wallet_backend_dapi_result(result, backend.as_ref())
     }
 }
 
@@ -1194,6 +1209,53 @@ mod tests {
             result,
             Err(TaskError::DapiAllAddressesExhausted { .. })
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn wallet_dapi_context_uses_the_wired_backend_sdk_after_app_sdk_swap() {
+        use crate::context::test_support::test_app_context;
+        use crate::utils::egui_mpsc::SenderAsync;
+
+        let wallet_tmp = tempfile::tempdir().expect("wallet tempdir");
+        let ctx = test_app_context(wallet_tmp.path());
+        let wallet_sdk = ctx.sdk.load_full();
+        let wallet_addresses = wallet_sdk.address_list();
+        let addresses = wallet_addresses.get_live_addresses();
+        assert!(!addresses.is_empty(), "wallet SDK must have DAPI addresses");
+        for address in addresses {
+            assert!(wallet_addresses.ban(&address));
+        }
+
+        let (tx, _rx) = tokio::sync::mpsc::channel::<TaskResult>(32);
+        let sender = SenderAsync::new(tx, ctx.egui_ctx().clone());
+        ctx.ensure_wallet_backend(sender)
+            .await
+            .expect("wire wallet backend");
+
+        let replacement_tmp = tempfile::tempdir().expect("replacement tempdir");
+        let replacement_ctx = test_app_context(replacement_tmp.path());
+        let replacement_sdk = replacement_ctx.sdk.load_full();
+        assert!(
+            !replacement_sdk
+                .address_list()
+                .get_live_addresses()
+                .is_empty(),
+            "replacement SDK must have a live DAPI address"
+        );
+        ctx.sdk.store(replacement_sdk);
+
+        let backend = ctx.wallet_backend().expect("wired wallet backend");
+        let result = contextualize_wallet_backend_dapi_result(
+            Err(dapi_connection_refused_error()),
+            backend.as_ref(),
+        );
+
+        assert!(matches!(
+            result,
+            Err(TaskError::DapiAllAddressesExhausted { .. })
+        ));
+
+        backend.shutdown().await;
     }
 
     #[test]

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -1,5 +1,5 @@
 use crate::app::TaskResult;
-use crate::backend_task::error::TaskError;
+use crate::backend_task::error::{DapiAddressAvailability, TaskError};
 use crate::backend_task::contested_names::ContestedResourceTask;
 use crate::backend_task::contract::ContractTask;
 use crate::backend_task::core::{CoreItem, CoreTask};
@@ -105,14 +105,40 @@ where
     }
 }
 
-fn contextualize_dapi_result<T>(
-    result: Result<T, TaskError>,
-    availability: impl FnOnce() -> (usize, usize),
-) -> Result<T, TaskError> {
-    result.map_err(|error| {
-        let (configured_total, live_count) = availability();
-        error.contextualize_dapi_availability(configured_total, live_count)
-    })
+fn contextualize_dapi_result(
+    result: Result<BackendTaskSuccessResult, TaskError>,
+    availability: impl FnOnce() -> DapiAddressAvailability,
+) -> Result<BackendTaskSuccessResult, TaskError> {
+    match result {
+        Ok(value) if value.contains_dapi_reachability_failure() => {
+            Ok(value.contextualize_dapi_availability(availability()))
+        }
+        Err(error) if error.contains_dapi_reachability_failure() => {
+            Err(error.contextualize_dapi_availability(availability()))
+        }
+        other => other,
+    }
+}
+
+fn contextualize_dapi_task_result(
+    result: TaskResult,
+    availability: DapiAddressAvailability,
+) -> TaskResult {
+    match result {
+        TaskResult::Success { context, result } if result.contains_dapi_reachability_failure() => {
+            TaskResult::Success {
+                context,
+                result: Box::new((*result).contextualize_dapi_availability(availability)),
+            }
+        }
+        TaskResult::Error { context, error } if error.contains_dapi_reachability_failure() => {
+            TaskResult::Error {
+                context,
+                error: error.contextualize_dapi_availability(availability),
+            }
+        }
+        other => other,
+    }
 }
 
 /// Returns `true` for backend tasks that read or write the
@@ -709,6 +735,43 @@ pub enum BackendTaskSuccessResult {
     },
 }
 
+impl BackendTaskSuccessResult {
+    fn contains_dapi_reachability_failure(&self) -> bool {
+        match self {
+            Self::DPNSVoteResults(results) => results.iter().any(|(_, _, result)| {
+                result
+                    .as_ref()
+                    .is_err_and(|error| error.contains_dapi_reachability_failure())
+            }),
+            Self::RefreshedWallet { warning } => warning
+                .as_ref()
+                .is_some_and(|error| error.contains_dapi_reachability_failure()),
+            _ => false,
+        }
+    }
+
+    fn contextualize_dapi_availability(self, availability: DapiAddressAvailability) -> Self {
+        match self {
+            Self::DPNSVoteResults(results) => Self::DPNSVoteResults(
+                results
+                    .into_iter()
+                    .map(|(name, choice, result)| {
+                        let result = result.map_err(|error| {
+                            error.contextualize_shared_dapi_availability(availability)
+                        });
+                        (name, choice, result)
+                    })
+                    .collect(),
+            ),
+            Self::RefreshedWallet { warning } => Self::RefreshedWallet {
+                warning: warning
+                    .map(|error| error.contextualize_shared_dapi_availability(availability)),
+            },
+            other => other,
+        }
+    }
+}
+
 impl AppContext {
     /// Run backend tasks sequentially
     pub async fn run_backend_tasks_sequential(
@@ -753,8 +816,7 @@ impl AppContext {
             .await;
 
         contextualize_dapi_result(result, || {
-            let address_list = task_sdk.address_list();
-            (address_list.len(), address_list.get_live_addresses().len())
+            DapiAddressAvailability::from_sdk(task_sdk.as_ref())
         })
     }
 
@@ -1108,24 +1170,25 @@ mod tests {
 
         let mut replacement_addresses = AddressList::new();
         replacement_addresses.add("http://127.0.0.1:3001".parse().expect("address"));
-        let replacement_result =
-            contextualize_dapi_result::<()>(Err(dapi_connection_refused_error()), || {
-                (
-                    replacement_addresses.len(),
-                    replacement_addresses.get_live_addresses().len(),
-                )
+        let replacement_result: Result<BackendTaskSuccessResult, TaskError> =
+            contextualize_dapi_result(Err(dapi_connection_refused_error()), || {
+                DapiAddressAvailability {
+                    configured_total: replacement_addresses.len(),
+                    live_count: replacement_addresses.get_live_addresses().len(),
+                }
             });
         assert!(matches!(
             replacement_result,
             Err(TaskError::DapiConnectionRefused { .. })
         ));
 
-        let result = contextualize_dapi_result::<()>(Err(dapi_connection_refused_error()), || {
-            (
-                task_addresses.len(),
-                task_addresses.get_live_addresses().len(),
-            )
-        });
+        let result: Result<BackendTaskSuccessResult, TaskError> =
+            contextualize_dapi_result(Err(dapi_connection_refused_error()), || {
+                DapiAddressAvailability {
+                    configured_total: task_addresses.len(),
+                    live_count: task_addresses.get_live_addresses().len(),
+                }
+            });
 
         assert!(matches!(
             result,
@@ -1137,13 +1200,78 @@ mod tests {
     fn dapi_success_skips_availability_inspection() {
         let inspected = std::cell::Cell::new(false);
 
-        let result = contextualize_dapi_result(Ok(42), || {
+        let result = contextualize_dapi_result(Ok(BackendTaskSuccessResult::None), || {
             inspected.set(true);
-            (1, 0)
+            DapiAddressAvailability {
+                configured_total: 1,
+                live_count: 0,
+            }
         });
 
-        assert!(matches!(result, Ok(42)));
+        assert!(matches!(result, Ok(BackendTaskSuccessResult::None)));
         assert!(!inspected.get());
+    }
+
+    #[test]
+    fn dapi_context_maps_errors_embedded_in_success_results() {
+        let result = contextualize_dapi_result(
+            Ok(BackendTaskSuccessResult::DPNSVoteResults(vec![(
+                "alice".to_owned(),
+                ResourceVoteChoice::Lock,
+                Err(Arc::new(dapi_connection_refused_error())),
+            )])),
+            || DapiAddressAvailability {
+                configured_total: 1,
+                live_count: 0,
+            },
+        );
+
+        let Ok(BackendTaskSuccessResult::DPNSVoteResults(results)) = result else {
+            panic!("expected DPNS vote results");
+        };
+        assert!(matches!(
+            results[0].2,
+            Err(ref error) if matches!(error.as_ref(), TaskError::DapiAllAddressesExhausted { .. })
+        ));
+    }
+
+    #[test]
+    fn dapi_context_maps_spawned_dpns_query_task_result() {
+        let result = contextualize_dapi_task_result(
+            TaskResult::unattributed_error(dapi_connection_refused_error()),
+            DapiAddressAvailability {
+                configured_total: 1,
+                live_count: 0,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            TaskResult::Error {
+                error: TaskError::DapiAllAddressesExhausted { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn dapi_context_maps_refreshed_wallet_warning() {
+        let result = contextualize_dapi_result(
+            Ok(BackendTaskSuccessResult::RefreshedWallet {
+                warning: Some(Arc::new(dapi_connection_refused_error())),
+            }),
+            || DapiAddressAvailability {
+                configured_total: 1,
+                live_count: 0,
+            },
+        );
+
+        assert!(matches!(
+            result,
+            Ok(BackendTaskSuccessResult::RefreshedWallet {
+                warning: Some(error)
+            }) if matches!(error.as_ref(), TaskError::DapiAllAddressesExhausted { .. })
+        ));
     }
 
     #[test]

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -737,6 +737,21 @@ impl AppContext {
         task: BackendTask,
         sender: SenderAsync<TaskResult>,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
+        let result = self.run_backend_task_inner(task, sender).await;
+        let (configured_total, live_count) = {
+            let sdk = self.sdk.load();
+            let address_list = sdk.address_list();
+            (address_list.len(), address_list.get_live_addresses().len())
+        };
+
+        result.map_err(|error| error.contextualize_dapi_availability(configured_total, live_count))
+    }
+
+    async fn run_backend_task_inner(
+        self: &Arc<Self>,
+        task: BackendTask,
+        sender: SenderAsync<TaskResult>,
+    ) -> Result<BackendTaskSuccessResult, TaskError> {
         // Refuse a shielded fund movement while shielded operations are
         // unavailable BEFORE `ensure_wallet_backend` runs. That bootstrap does
         // real work for any wallet-touching task — building the backend and, for

--- a/src/backend_task/shielded/mod.rs
+++ b/src/backend_task/shielded/mod.rs
@@ -78,6 +78,15 @@ impl AppContext {
         }
 
         let backend = self.wallet_backend()?;
+        let result = self.run_shielded_task_inner(task, backend.as_ref()).await;
+        super::contextualize_wallet_backend_dapi_result(result, backend.as_ref())
+    }
+
+    async fn run_shielded_task_inner(
+        self: &Arc<Self>,
+        task: ShieldedTask,
+        backend: &crate::wallet_backend::WalletBackend,
+    ) -> Result<BackendTaskSuccessResult, TaskError> {
         match task {
             ShieldedTask::ShieldFromAssetLock {
                 seed_hash,

--- a/src/backend_task/wallet/fetch_platform_address_balances.rs
+++ b/src/backend_task/wallet/fetch_platform_address_balances.rs
@@ -54,7 +54,7 @@ impl AppContext {
             .await?;
 
         // Sync using SDK's privacy-preserving method (handles both full and incremental)
-        let sdk = self.sdk.load().as_ref().clone();
+        let sdk = backend.sdk().clone();
 
         let config = if sdk.network == Network::Regtest {
             Some(AddressSyncConfig {

--- a/src/backend_task/wallet/fund_platform_address_from_asset_lock.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_asset_lock.rs
@@ -155,7 +155,7 @@ impl AppContext {
 
         let (wallet, sdk) = {
             let wallet = self.wallet_arc(&seed_hash)?.read()?.clone();
-            let sdk = self.sdk.load().as_ref().clone();
+            let sdk = backend.sdk().clone();
             (wallet, sdk)
         };
 

--- a/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
+++ b/src/backend_task/wallet/fund_platform_address_from_wallet_utxos.rs
@@ -310,7 +310,7 @@ impl AppContext {
             .await?;
 
         let wallet_arc = self.wallet_arc(&seed_hash)?;
-        let sdk = self.sdk.load().as_ref().clone();
+        let sdk = backend.sdk().clone();
 
         // Derive the change address, build the outputs, and sign — all inside
         // one held-seed scope so the operation prompts at most once and the

--- a/src/backend_task/wallet/transfer_platform_credits.rs
+++ b/src/backend_task/wallet/transfer_platform_credits.rs
@@ -19,10 +19,12 @@ impl AppContext {
         use dash_sdk::dpp::address_funds::AddressFundsFeeStrategyStep;
         use dash_sdk::platform::transition::transfer_address_funds::TransferAddressFunds;
 
+        let backend = self.wallet_backend()?;
+
         // Clone wallet and SDK before the async operation to avoid holding guards across await
         let (wallet, sdk) = {
             let wallet = self.wallet_arc(&seed_hash)?.read()?.clone();
-            let sdk = self.sdk.load().as_ref().clone();
+            let sdk = backend.sdk().clone();
             (wallet, sdk)
         };
 
@@ -47,7 +49,6 @@ impl AppContext {
         // the scope returns — it never enters this layer by value.
         let network = self.network;
         let path_index = PlatformPathIndex::from_wallet(&wallet, network);
-        let backend = self.wallet_backend()?;
         let (address_infos, _height) = backend
             .secret_access()
             .with_secret_session(

--- a/src/backend_task/wallet/withdraw_from_platform_address.rs
+++ b/src/backend_task/wallet/withdraw_from_platform_address.rs
@@ -26,7 +26,8 @@ impl AppContext {
         // Resolve the shared wallet handle and SDK before the async operation.
         let network = self.network;
         let wallet_arc = self.wallet_arc(&seed_hash)?;
-        let sdk = self.sdk.load().as_ref().clone();
+        let backend = self.wallet_backend()?;
+        let sdk = backend.sdk().clone();
 
         // Deduct fee from the specified input (should be the one with highest balance)
         let fee_strategy = vec![AddressFundsFeeStrategyStep::DeductFromInput(
@@ -42,7 +43,6 @@ impl AppContext {
         // Sign each withdrawal input through a JIT platform signer that borrows
         // the HD seed only for the duration of the SDK call. The seed zeroizes
         // on return.
-        let backend = self.wallet_backend()?;
         let _result = backend
             .secret_access()
             .with_secret_session(

--- a/src/ui/dpns/dpns_contested_names_screen.rs
+++ b/src/ui/dpns/dpns_contested_names_screen.rs
@@ -1852,8 +1852,10 @@ impl ScreenLike for DPNSScreen {
         if matches!(
             error,
             TaskError::ScheduledVoteRejected { .. }
+                | TaskError::ScheduledVoteAllAddressesExhausted { .. }
                 | TaskError::ScheduledVoteResultUnavailable
                 | TaskError::ScheduledVoteSweepFailed { .. }
+                | TaskError::ScheduledVoteSweepAllAddressesExhausted { .. }
         ) {
             self.scheduled_vote_cast_in_progress = false;
             if let Ok(mut guard) = self.scheduled_votes.lock() {
@@ -2237,5 +2239,17 @@ mod tests {
             source: Box::new(TaskError::ScheduledVoteResultUnavailable),
         };
         assert!(!screen.display_task_error(&sweep_error));
+
+        screen.scheduled_vote_cast_in_progress = true;
+        let exhausted_error = TaskError::ScheduledVoteSweepAllAddressesExhausted {
+            network: Network::Regtest,
+            source: Box::new(TaskError::DapiNoAddresses {
+                source_error: Box::new(dash_sdk::Error::DapiClientError(
+                    dash_sdk::dapi_client::DapiClientError::NoAvailableAddresses,
+                )),
+            }),
+        };
+        assert!(!screen.display_task_error(&exhausted_error));
+        assert!(!screen.scheduled_vote_cast_in_progress);
     }
 }

--- a/src/wallet_backend/mod.rs
+++ b/src/wallet_backend/mod.rs
@@ -416,6 +416,10 @@ impl std::fmt::Debug for WalletBackend {
 }
 
 impl WalletBackend {
+    pub(crate) fn sdk(&self) -> &Sdk {
+        self.inner.pwm.sdk()
+    }
+
     /// Construct the backend: open the upstream SQLite persister, build the
     /// `PlatformWalletManager` with the DET `EventBridge`, then register every
     /// persisted wallet via [`Self::load_from_persistor_seedless`] (per


### PR DESCRIPTION
## Why this PR exists
- **Problem**: Users saw a raw, technical `DapiConnectionRefused` banner ("Could not reach a Dash network server. Please retry.") that looked like it correlated with SPV not being fully synced yet.
- **What breaks without it**: When several DAPI addresses time out in a short window, the upstream SDK (`rs_dapi_client`) bans each one on the spot — even for an ordinary TCP connect timeout, not a protocol violation. If enough addresses get banned close together, the whole configured pool can empty out, and the caller gets back whichever raw transport error happened to be last, instead of a message that says "this is temporary and will recover on its own." Confirmed against a real session log: all 8 exhaustion episodes found there occurred *after* the masternode list was already `Synced` — this is a steady-state condition, not a startup-window gate gap.
- **Blocking relationship**: none.

## What was done
- Added `TaskError::contextualize_dapi_availability(configured_total, live_count)`, called once at the shared `run_backend_task` boundary (`src/backend_task/mod.rs`) after every backend task result. When the SDK reports addresses are configured but none are currently live, DAPI reachability errors (`DapiUnavailable`/`DapiTimeout`/`DapiConnectionRefused`/`DapiNoAddresses`) get reclassified into the existing — previously unreachable — `DapiAllAddressesExhausted` variant.
- User now sees: *"All Dash network servers are temporarily unreachable. Please wait a minute and retry."* instead of the generic connection-refused text. The original typed SDK error is preserved for "Hide details."
- The two DashPay error envelopes that transparently forward an inner `TaskError` (`DashPayContactRequestActionFailed`, `DashPayContactInfoActionFailed`) recurse through this reclassification while preserving their request/identity/contact IDs.
- Errors with any live endpoint, or with zero configured endpoints (a different, unrelated condition — `DapiNoAddresses`), are left unchanged.
- No new SPV-readiness gate was added: the log evidence shows the existing `masternodes_ready()` gate (`wallet_backend/coordinator_gate.rs`, `context_provider.rs::get_quorum_public_key`) was already satisfied in every observed exhaustion episode, so a readiness gate wouldn't have prevented this.

## Testing
- `cargo +nightly fmt --all`, `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings` — clean
- `cargo build --bin dash-evo-tool` — clean
- 6 new unit tests in `src/backend_task/error.rs` covering: reclassification + SDK-source preservation, staying unchanged when an address is live, distinguishing exhaustion from zero-configured-addresses, leaving unrelated errors untouched, and both DashPay envelope recursion cases (with pointer-identity checks proving the original SDK source isn't lost).

## Breaking changes
None.

## Checklist
- [x] Conventional commits
- [x] `CHANGELOG.md` updated (Unreleased → Fixed)
- [x] `docs/user-stories.md` — not touched; this is a bug fix to error classification, not a new feature

## Upstream scope (not part of this PR)
Part of the root cause lives in `dashpay/platform`'s `rs_dapi_client` (bans an address on any transport failure, including a bare TCP timeout) — filing that separately.

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-facing messaging when all Dash network servers are temporarily unreachable, advising to wait briefly and retry.
  * Enhanced contextual handling of network reachability failures during syncing and related operations, preserving the most relevant underlying cause.
  * Updated scheduled vote sweep error handling so the UI clears in-progress state consistently for “all addresses exhausted” cases.
  * Applied the same improved reachability context to failures coming from contested-name/DPNS background queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->