### PR TITLE
ci: resume Claude PR review with auto permission mode; move weekly build to Tuesdays

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,3 +35,4 @@ jobs:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN_LKLIMEK }}
           memcan_url: ${{ vars.MEMCAN_URL }}
           memcan_api_key: ${{ secrets.MEMCAN_API_KEY }}
+          claude_extra_args: "--permission-mode auto"

--- a/.github/workflows/weekly-build.yml
+++ b/.github/workflows/weekly-build.yml
@@ -1,6 +1,6 @@
 name: "Weekly Draft Pre-release"
 
-# Cuts a DRAFT pre-release every Saturday from v1.0-dev, versioned
+# Cuts a DRAFT pre-release every Tuesday from v1.0-dev, versioned
 # v<core>-weekly.<YYYYMMDD> (core read live from Cargo.toml), skipping when
 # there are no new commits since the last weekly tag or when CI is red.
 # Posts a Slack notification linking to the release page.
@@ -13,7 +13,7 @@ name: "Weekly Draft Pre-release"
 
 on:
   schedule:
-    - cron: "0 2 * * 6" # Every Saturday at 02:00 UTC
+    - cron: "30 3 * * 2" # Every Tuesday at 03:30 UTC
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Why this PR exists
- **Problem**: `claude-code-review.yml` (the `claudius-review` label-triggered PR review) has been effectively dormant — it was gated to a hand-maintained `--allowedTools` list, and its OAuth secret had also been revoked (fixed separately, out of band). The weekly draft pre-release also currently cuts on a day (Saturday) that no longer matches the desired cadence.
- **What breaks without it**: the review workflow either silently no-ops (label applied, nothing usable happens) or, once the token is valid again, keeps failing/getting stuck on any tool call outside the fixed allowlist as the review skills evolve. The weekly draft keeps landing on the wrong day for anyone relying on it.
- **Blocking relationship**: none.

## What was done
- `claude-code-review.yml`: added `claude_extra_args: "--permission-mode auto"` so the Claude Code session backing the review runs in [auto permission mode](https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode) — a background classifier model vets each tool call instead of hard-denying anything not on the static `allowedTools` list. Existing narrow `allowedTools` entries still fast-path past the classifier.
- `weekly-build.yml`: moved the `schedule` cron from `0 2 * * 6` (Saturdays 02:00 UTC) to `30 3 * * 2` (Tuesdays 03:30 UTC), with the header/inline comments updated to match.

## Testing
- `python3 -c "import yaml; yaml.safe_load(open(...))"` on both files — parses cleanly.
- Diffs are minimal/scoped (1 line and 2 lines respectively) — reviewed by hand against the original files.
- Not run live: auto mode's actual behavior depends on account-level eligibility (Opus 4.6+/Sonnet 4.6+, and an Owner-enabled toggle if this org is Team/Enterprise) — first labeled PR after merge will be the real test.

## Breaking changes
None.

## Checklist
- [x] YAML validated
- [x] No secrets touched or introduced
- [ ] First live run of the review workflow post-merge (external verification, can't be done from this PR)

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>