### PR TITLE
ci: raise claudius-review timeout from 40 to 60 minutes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claudius-review'))
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Summary
- Run [29744073162](https://github.com/dashpay/dash-evo-tool/actions/runs/29744073162) (PR #908, first run after `lklimek/claudius-review-action`'s run_in_background fix landed) took 30m37s wall-clock against the 40-minute cap — under 10 minutes of headroom.
- A larger PR would trip the timeout and lose the entire review after real work was already done (specialists dispatched, partially or fully collected, nothing written).
- Companion fix: lklimek/claudius-review-action#7 (`fix/ci-run-followups`) hardens the same workflow's TaskOutput-blocking behavior, adds a write-access preflight, and fixes a missing report-rendering dependency.

## Test plan
- [ ] Next `claudius-review` run on a real PR completes within the new 60-minute window without needing it (no behavior change expected for typical-sized PRs, just headroom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the automated code review time limit to allow longer-running reviews to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->