### PR TITLE
fix(ui): clear startup transient error banners once network/migration is ready

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2350,6 +2350,15 @@ impl App for AppState {
                         // TaskError Debug output is shown to users, deliberately.
                         // Ensure inner error types don't expose secrets.
                         handle.with_details(&err);
+                        match &err {
+                            TaskError::WalletStorageNotReady => {
+                                self.migration.track_storage_startup_error(handle);
+                            }
+                            TaskError::MasternodeListNotReady { .. } => {
+                                self.connection_banner.track_quorum_startup_error(handle);
+                            }
+                            _ => {}
+                        }
                         if !is_database_clear {
                             self.visible_screen_mut()
                                 .display_message(&msg, MessageType::Error);

--- a/src/app/reconcilers.rs
+++ b/src/app/reconcilers.rs
@@ -226,6 +226,27 @@ impl SpvBlockReconciler {
     }
 }
 
+#[derive(Default)]
+struct TransientBanner(Option<BannerHandle>);
+
+impl TransientBanner {
+    fn track(&mut self, handle: BannerHandle) {
+        self.0 = Some(handle);
+    }
+
+    fn reset(&mut self) {
+        if let Some(handle) = self.0.take() {
+            handle.clear();
+        }
+    }
+
+    fn clear_if(&mut self, condition: bool) {
+        if condition {
+            self.reset();
+        }
+    }
+}
+
 /// Reconciles the connection-status banner with the overall connection state.
 pub(super) struct ConnectionBanner {
     /// Previous state, to detect transitions. `None` forces re-evaluation.
@@ -233,7 +254,7 @@ pub(super) struct ConnectionBanner {
     /// Handle to the current connection banner, if displayed.
     handle: Option<BannerHandle>,
     /// Startup proof error cleared once quorum keys become available.
-    quorum_startup_error: Option<BannerHandle>,
+    quorum_startup_error: TransientBanner,
 }
 
 impl ConnectionBanner {
@@ -241,13 +262,13 @@ impl ConnectionBanner {
         Self {
             previous_state: None,
             handle: None,
-            quorum_startup_error: None,
+            quorum_startup_error: TransientBanner::default(),
         }
     }
 
     /// Adopt a quorum-not-ready error banner from the generic task fallback.
     pub(super) fn track_quorum_startup_error(&mut self, handle: BannerHandle) {
-        self.quorum_startup_error = Some(handle);
+        self.quorum_startup_error.track(handle);
     }
 
     /// Clear the banner and force re-evaluation next frame (network switch).
@@ -255,9 +276,7 @@ impl ConnectionBanner {
         if let Some(handle) = self.handle.take() {
             handle.clear();
         }
-        if let Some(handle) = self.quorum_startup_error.take() {
-            handle.clear();
-        }
+        self.quorum_startup_error.reset();
         self.previous_state = None;
     }
 
@@ -274,11 +293,8 @@ impl ConnectionBanner {
         onboarding_active: bool,
     ) -> Option<BackendTask> {
         let connection_status = app_context.connection_status();
-        if connection_status.masternodes_ready()
-            && let Some(handle) = self.quorum_startup_error.take()
-        {
-            handle.clear();
-        }
+        self.quorum_startup_error
+            .clear_if(connection_status.masternodes_ready());
         let current_state = connection_status.overall_state();
         let state_changed = self.previous_state != Some(current_state);
 
@@ -377,8 +393,8 @@ impl ConnectionBanner {
 pub(super) struct MigrationReconciler {
     /// Handle to the current migration banner, if displayed.
     banner_handle: Option<BannerHandle>,
-    /// Wallet-storage guard error cleared when migration leaves progress state.
-    storage_startup_error: Option<BannerHandle>,
+    /// Wallet-storage error cleared once migration is terminal and its run guard is free.
+    storage_startup_error: TransientBanner,
     /// Last-seen migration state so reconciliation fires only on change.
     last_state: Option<MigrationState>,
     /// Networks whose cold-start `FinishUnwire` has been dispatched this process.
@@ -397,7 +413,7 @@ impl MigrationReconciler {
     pub(super) fn new() -> Self {
         Self {
             banner_handle: None,
-            storage_startup_error: None,
+            storage_startup_error: TransientBanner::default(),
             last_state: None,
             dispatched: BTreeSet::new(),
             backend_wait_since: BTreeMap::new(),
@@ -409,7 +425,7 @@ impl MigrationReconciler {
 
     /// Adopt a storage-not-ready error banner from the generic task fallback.
     pub(super) fn track_storage_startup_error(&mut self, handle: BannerHandle) {
-        self.storage_startup_error = Some(handle);
+        self.storage_startup_error.track(handle);
     }
 
     /// Clear the migration banner and force re-evaluation (network switch). The
@@ -419,9 +435,7 @@ impl MigrationReconciler {
         if let Some(handle) = self.banner_handle.take() {
             handle.clear();
         }
-        if let Some(handle) = self.storage_startup_error.take() {
-            handle.clear();
-        }
+        self.storage_startup_error.reset();
         self.last_state = None;
         self.wallet_unlock_popup.close();
         self.prompt_wallet = None;
@@ -519,10 +533,8 @@ impl MigrationReconciler {
             MigrationState::Idle
                 | MigrationState::Running { .. }
                 | MigrationState::AwaitingWalletPasswords { .. }
-        );
-        if storage_guard_resolved && let Some(handle) = self.storage_startup_error.take() {
-            handle.clear();
-        }
+        ) && app_context.migration_run.try_lock().is_ok();
+        self.storage_startup_error.clear_if(storage_guard_resolved);
         self.update_password_prompt(ctx, app_context, &state);
         if self.last_state.as_ref() == Some(&state) {
             return;
@@ -995,7 +1007,7 @@ mod tests {
     }
 
     #[test]
-    fn migration_reconciler_clears_storage_startup_error_when_ready() {
+    fn migration_reconciler_waits_for_storage_guard_before_clearing_startup_error() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let app_context = test_app_context(tmp.path());
         let message = TaskError::WalletStorageNotReady.to_string();
@@ -1017,6 +1029,10 @@ mod tests {
         harness.run();
         assert!(harness.query_by_label(&message).is_some());
 
+        let migration_guard = app_context
+            .migration_run
+            .try_lock()
+            .expect("migration guard");
         app_context
             .migration_status()
             .set_state(MigrationState::Ready);
@@ -1024,8 +1040,16 @@ mod tests {
         reconciler.update_banner(&harness.ctx, &app_context, state.as_ref());
         harness.run();
         assert!(
+            harness.query_by_label(&message).is_some(),
+            "terminal state must not clear the startup error while storage remains locked",
+        );
+
+        drop(migration_guard);
+        reconciler.update_banner(&harness.ctx, &app_context, state.as_ref());
+        harness.run();
+        assert!(
             harness.query_by_label(&message).is_none(),
-            "the startup error must clear when the storage update becomes ready",
+            "the startup error must clear when the storage update is ready and unlocked",
         );
     }
 

--- a/src/app/reconcilers.rs
+++ b/src/app/reconcilers.rs
@@ -232,6 +232,8 @@ pub(super) struct ConnectionBanner {
     previous_state: Option<OverallConnectionState>,
     /// Handle to the current connection banner, if displayed.
     handle: Option<BannerHandle>,
+    /// Startup proof error cleared once quorum keys become available.
+    quorum_startup_error: Option<BannerHandle>,
 }
 
 impl ConnectionBanner {
@@ -239,12 +241,21 @@ impl ConnectionBanner {
         Self {
             previous_state: None,
             handle: None,
+            quorum_startup_error: None,
         }
+    }
+
+    /// Adopt a quorum-not-ready error banner from the generic task fallback.
+    pub(super) fn track_quorum_startup_error(&mut self, handle: BannerHandle) {
+        self.quorum_startup_error = Some(handle);
     }
 
     /// Clear the banner and force re-evaluation next frame (network switch).
     pub(super) fn reset(&mut self) {
         if let Some(handle) = self.handle.take() {
+            handle.clear();
+        }
+        if let Some(handle) = self.quorum_startup_error.take() {
             handle.clear();
         }
         self.previous_state = None;
@@ -263,6 +274,11 @@ impl ConnectionBanner {
         onboarding_active: bool,
     ) -> Option<BackendTask> {
         let connection_status = app_context.connection_status();
+        if connection_status.masternodes_ready()
+            && let Some(handle) = self.quorum_startup_error.take()
+        {
+            handle.clear();
+        }
         let current_state = connection_status.overall_state();
         let state_changed = self.previous_state != Some(current_state);
 
@@ -361,6 +377,8 @@ impl ConnectionBanner {
 pub(super) struct MigrationReconciler {
     /// Handle to the current migration banner, if displayed.
     banner_handle: Option<BannerHandle>,
+    /// Wallet-storage guard error cleared when migration leaves progress state.
+    storage_startup_error: Option<BannerHandle>,
     /// Last-seen migration state so reconciliation fires only on change.
     last_state: Option<MigrationState>,
     /// Networks whose cold-start `FinishUnwire` has been dispatched this process.
@@ -379,6 +397,7 @@ impl MigrationReconciler {
     pub(super) fn new() -> Self {
         Self {
             banner_handle: None,
+            storage_startup_error: None,
             last_state: None,
             dispatched: BTreeSet::new(),
             backend_wait_since: BTreeMap::new(),
@@ -388,11 +407,19 @@ impl MigrationReconciler {
         }
     }
 
+    /// Adopt a storage-not-ready error banner from the generic task fallback.
+    pub(super) fn track_storage_startup_error(&mut self, handle: BannerHandle) {
+        self.storage_startup_error = Some(handle);
+    }
+
     /// Clear the migration banner and force re-evaluation (network switch). The
     /// per-network dispatch guard is intentionally NOT reset — it is scoped per
     /// network so a return to a seen network never re-drains.
     pub(super) fn reset_for_switch(&mut self) {
         if let Some(handle) = self.banner_handle.take() {
+            handle.clear();
+        }
+        if let Some(handle) = self.storage_startup_error.take() {
             handle.clear();
         }
         self.last_state = None;
@@ -487,6 +514,15 @@ impl MigrationReconciler {
         frame_state: &MigrationState,
     ) {
         let state = frame_state.clone();
+        let storage_guard_resolved = !matches!(
+            &state,
+            MigrationState::Idle
+                | MigrationState::Running { .. }
+                | MigrationState::AwaitingWalletPasswords { .. }
+        );
+        if storage_guard_resolved && let Some(handle) = self.storage_startup_error.take() {
+            handle.clear();
+        }
         self.update_password_prompt(ctx, app_context, &state);
         if self.last_state.as_ref() == Some(&state) {
             return;
@@ -929,6 +965,67 @@ mod tests {
             banner.handle.is_some(),
             "a genuine Disconnected state must be reported once onboarding ends, \
              even if the connection state itself never changed"
+        );
+    }
+
+    #[test]
+    fn connection_banner_clears_quorum_startup_error_when_masternodes_become_ready() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let app_context = test_app_context(tmp.path());
+        let message = "The network is still syncing. Please wait a moment and try again.";
+        let mut reconciler = ConnectionBanner::new();
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(700.0, 260.0))
+            .build_ui(MessageBanner::show_global);
+
+        let handle = MessageBanner::set_global(&harness.ctx, message, MessageType::Error);
+        handle.disable_auto_dismiss();
+        reconciler.track_quorum_startup_error(handle);
+        reconciler.update(&harness.ctx, &app_context, false, false);
+        harness.run();
+        assert!(harness.query_by_label(message).is_some());
+
+        app_context.connection_status().set_masternodes_ready(true);
+        reconciler.update(&harness.ctx, &app_context, false, false);
+        harness.run();
+        assert!(
+            harness.query_by_label(message).is_none(),
+            "the startup error must clear when quorum keys become available",
+        );
+    }
+
+    #[test]
+    fn migration_reconciler_clears_storage_startup_error_when_ready() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let app_context = test_app_context(tmp.path());
+        let message = TaskError::WalletStorageNotReady.to_string();
+        let mut reconciler = MigrationReconciler::new();
+        let mut harness = Harness::builder()
+            .with_size(egui::vec2(700.0, 260.0))
+            .build_ui(MessageBanner::show_global);
+
+        app_context
+            .migration_status()
+            .set_state(MigrationState::Running {
+                step: crate::context::migration_status::MigrationStep::Detecting,
+            });
+        let handle = MessageBanner::set_global(&harness.ctx, &message, MessageType::Error);
+        handle.disable_auto_dismiss();
+        reconciler.track_storage_startup_error(handle);
+        let state = app_context.migration_status().state();
+        reconciler.update_banner(&harness.ctx, &app_context, state.as_ref());
+        harness.run();
+        assert!(harness.query_by_label(&message).is_some());
+
+        app_context
+            .migration_status()
+            .set_state(MigrationState::Ready);
+        let state = app_context.migration_status().state();
+        reconciler.update_banner(&harness.ctx, &app_context, state.as_ref());
+        harness.run();
+        assert!(
+            harness.query_by_label(&message).is_none(),
+            "the startup error must clear when the storage update becomes ready",
         );
     }
 

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -3046,6 +3046,7 @@ impl From<SdkError> for TaskError {
 }
 
 fn sdk_error_is_masternode_list_not_ready(error: &SdkError) -> bool {
+    // Matches the `SpvProvider::get_quorum_public_key` payload from `context_provider`.
     matches!(
         error,
         SdkError::Proof(dash_sdk::ProofVerifierError::ContextProviderError(
@@ -3632,10 +3633,14 @@ mod tests {
 
     #[test]
     fn quorum_startup_error_maps_to_transient_task_error() {
+        // Recheck this upstream-format contract on every dash-sdk bump.
+        let sdk_detail = "masternode list not yet synced (quorums unavailable)";
+        assert_eq!(
+            crate::context_provider::MASTERNODE_LIST_NOT_READY_DETAIL,
+            sdk_detail
+        );
         let sdk_error = SdkError::Proof(dash_sdk::ProofVerifierError::ContextProviderError(
-            dash_sdk::error::ContextProviderError::Config(
-                crate::context_provider::MASTERNODE_LIST_NOT_READY_DETAIL.to_string(),
-            ),
+            dash_sdk::error::ContextProviderError::Config(sdk_detail.to_string()),
         ));
 
         assert!(matches!(

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -1218,6 +1218,13 @@ pub enum TaskError {
         source_error: Box<SdkError>,
     },
 
+    /// Proof verification ran before SPV had synchronized quorum keys.
+    #[error("The network is still syncing. Please wait a moment and try again.")]
+    MasternodeListNotReady {
+        #[source]
+        source_error: Box<SdkError>,
+    },
+
     // ──────────────────────────────────────────────────────────────────────────
     // Wallet / platform-address operation errors
     // ──────────────────────────────────────────────────────────────────────────
@@ -2732,6 +2739,12 @@ impl From<dashcore_rpc::Error> for TaskError {
 
 impl From<SdkError> for TaskError {
     fn from(error: SdkError) -> Self {
+        if sdk_error_is_masternode_list_not_ready(&error) {
+            return TaskError::MasternodeListNotReady {
+                source_error: Box::new(error),
+            };
+        }
+
         // Check DapiClientError for domain errors carried as gRPC Internal status.
         // The SDK's From<DapiClientError> decodes `dash-serialized-consensus-error-bin`
         // metadata, but some platform errors arrive as plain Internal with descriptive
@@ -3030,6 +3043,15 @@ impl From<SdkError> for TaskError {
             },
         }
     }
+}
+
+fn sdk_error_is_masternode_list_not_ready(error: &SdkError) -> bool {
+    matches!(
+        error,
+        SdkError::Proof(dash_sdk::ProofVerifierError::ContextProviderError(
+            dash_sdk::error::ContextProviderError::Config(detail)
+        )) if detail == crate::context_provider::MASTERNODE_LIST_NOT_READY_DETAIL
+    )
 }
 
 fn sdk_error_is_dapi_reachability_failure(error: &SdkError) -> bool {
@@ -3606,6 +3628,20 @@ mod tests {
             matches!(err, TaskError::SdkError { .. }),
             "Expected SdkError, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn quorum_startup_error_maps_to_transient_task_error() {
+        let sdk_error = SdkError::Proof(dash_sdk::ProofVerifierError::ContextProviderError(
+            dash_sdk::error::ContextProviderError::Config(
+                crate::context_provider::MASTERNODE_LIST_NOT_READY_DETAIL.to_string(),
+            ),
+        ));
+
+        assert!(matches!(
+            TaskError::from(sdk_error),
+            TaskError::MasternodeListNotReady { .. }
+        ));
     }
 
     #[test]

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -142,6 +142,7 @@ impl ContextProvider for SpvProvider {
         // pre-unlock guard below uses. Any stray early proof call thus degrades
         // gracefully instead of triggering the self-ban storm.
         if !app_ctx.connection_status().masternodes_ready() {
+            // Consumed by `sdk_error_is_masternode_list_not_ready` in `backend_task::error`.
             return Err(ContextProviderError::Config(
                 MASTERNODE_LIST_NOT_READY_DETAIL.to_string(),
             ));

--- a/src/context_provider.rs
+++ b/src/context_provider.rs
@@ -15,6 +15,10 @@ use std::sync::Arc;
 /// will reject a mismatch, catching forgotten additions at build time.
 pub(crate) const SYSTEM_CONTRACT_COUNT: usize = 5;
 
+/// Diagnostic carried by the SDK while quorum keys are unavailable at startup.
+pub(crate) const MASTERNODE_LIST_NOT_READY_DETAIL: &str =
+    "masternode list not yet synced (quorums unavailable)";
+
 /// Resolve a data contract by ID: check cached system contracts first, then DB.
 ///
 /// All system contracts are listed in `cached` — adding a new one is a single
@@ -139,7 +143,7 @@ impl ContextProvider for SpvProvider {
         // gracefully instead of triggering the self-ban storm.
         if !app_ctx.connection_status().masternodes_ready() {
             return Err(ContextProviderError::Config(
-                "masternode list not yet synced (quorums unavailable)".to_string(),
+                MASTERNODE_LIST_NOT_READY_DETAIL.to_string(),
             ));
         }
 


### PR DESCRIPTION
**TL;DR:** Keep the "storage still updating" banner visible until storage is genuinely free again, instead of letting it disappear about a frame too early.

## User story
As a user who just finished the app's first-run migration, I want the "storage update is still running" message to stay up until storage is truly available, so a retried action that fails during that window isn't left unexplained.

## Scenario
### Base flow
The app finishes cold-start migration; the user immediately retries a wallet-touching action.

### Actual behavior
Two error banners could persist indefinitely during app cold start ("storage update is still running" and a masternode-list-not-yet-synced error) — even minutes after the underlying condition fully resolved. The initial fix for that made the storage banner reactive, but it could still clear about one frame *before* storage was actually free: a background best-effort node-list refresh kept holding the lock past the point the migration state reported "ready." A retry in that narrow window failed again with the banner already gone, looking like an unexplained glitch.

### Expected behavior
Both banners clear reactively once their condition is genuinely resolved, and the storage banner specifically stays up until storage is truly free — so a failed retry in that window has a visible, honest explanation instead of none.

## Detailed discussion
### What was done
- Added a dedicated `TaskError::MasternodeListNotReady` variant with a clean, actionable message instead of falling through to the generic, opaque `SdkError` text.
- `ConnectionBanner`/`MigrationReconciler` (`app/reconcilers.rs`) now adopt these banner handles and clear them reactively once their readiness condition genuinely holds, instead of leaving them `disable_auto_dismiss()`'d forever.
- **Review fix**: `storage_guard_resolved` was computed from `MigrationState` alone, so it could flip true (and clear the banner) before the `migration_run` mutex the error actually reports on was released — a detached best-effort DAPI-node refresh keeps holding it past `MigrationState` going `Ready`. Gated the clear on both the terminal state AND a non-blocking `migration_run.try_lock()` probe.
- Extracted the repeated adopt/reset/conditional-clear banner-handle pattern (shared by `ConnectionBanner` and `MigrationReconciler`) into a small `TransientBanner` newtype — same behavior, less duplication.
- Hardened the SDK error-string sentinel test to pin the literal upstream string shape (instead of round-tripping the same constant through itself), and cross-referenced the producer/consumer sites of that string so the coupling between `context_provider.rs` and `backend_task/error.rs` is discoverable.
- Addresses `claudius:grumpy-review` findings CODE-001 (blocking), CODE-003 and PROJ-001 (non-blocking). CODE-002 (a pre-existing FIFO-eviction edge case in the "stuck offline forever" scenario) is a known, accepted follow-up — not fixed here.

### Testing
- New/updated reconciler + error-mapping tests (banner-clears-when-ready, plus the new guard/lock-aware clearing) — all green via the narrowest relevant `--lib` scope.
- `cargo clippy --bin dash-evo-tool --all-features -- -D warnings` clean, `cargo fmt --all` clean.
- Independently re-verified by qa-engineer-marvin during grumpy-review consolidation.

### Breaking changes
None.

### Checklist
- [x] Tests added (TDD)
- [x] User-facing strings are plain, complete sentences
- [x] No secrets in diff

### Prior work
- Addresses findings from the combined grumpy-review of PR #916/#917/#918.

### Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
