### PR TITLE
test(wallets): assert address-generation status, not just dialog-open state

### DIFF
--- a/tests/kittest/wallets_screen.rs
+++ b/tests/kittest/wallets_screen.rs
@@ -87,6 +87,11 @@ fn add_receiving_address_button_opens_receive_dialog() {
             "clicking 'Add Receiving Address' must open the same Receive dialog as the \
              'Receive' button, not silently generate an address with no visible feedback"
         );
+        assert!(
+            harness
+                .query_by_label("Generating a new address…")
+                .is_some()
+        );
 
         harness.step();
         assert!(harness.query_by_label("Core Address").is_some());


### PR DESCRIPTION
**TL;DR:** Strengthen the "Add Receiving Address" regression test so it actually proves a new address was requested, not just that the dialog opened.

## Detailed discussion
This is a test-only hardening change with no user-observable effect, so `User story`/`Scenario` are omitted per convention.

### What was done
- Follow-up to #914 ("wire 'Add Receiving Address' to the same flow as 'Receive'"), which fixed the button but got squash-merged before this test-hardening commit could be pushed to the same branch — reapplied here as a standalone PR.
- The original kittest regression only asserted the Receive dialog's static "Core Address" label, which renders whenever the Core address type is selected — regardless of whether a new address was actually requested. A regression that reopens the dialog but silently drops the `queue_core_address_request` call would still have passed.
- Added an assertion on the "Generating a new address…" status label, which is only set when `queue_core_address_request` actually fires — so the test now proves the fix's actual behavior, not just a side effect of it.

### Testing
- `add_receiving_address_button_opens_receive_dialog` kittest — PASS (`cargo test --test kittest --all-features`, narrowest relevant scope).
- `cargo fmt --all -- --check` clean.

### Breaking changes
None.

### Checklist
- [x] Tests added
- [x] No secrets in diff

### Prior work
- Follow-up to #914 (merged) — the fix this test hardens.

### Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
