### PR TITLE
test(wallets): make the address-generation assertion genuinely isolate the regression

### DIFF
--- a/src/ui/wallets/wallets_screen/mod.rs
+++ b/src/ui/wallets/wallets_screen/mod.rs
@@ -799,14 +799,8 @@ impl WalletsBalancesScreen {
                     .button(RichText::new("➕ Add Receiving Address").size(14.0))
                     .clicked()
                 {
-                    // Same flow as the "Receive" button above + its "New Address"
-                    // control: open the Receive dialog and queue a fresh Core
-                    // address request through it, so the newly generated address
-                    // is actually visible to the user (see `queue_core_address_request`
-                    // / `open_receive_dialog`). Previously this issued the backend
-                    // task directly without opening the dialog, so the new address
-                    // landed silently in `receive_dialog.core_addresses` with
-                    // nothing on screen to show for the click.
+                    // Mirrors the "Receive" + "New Address" flow: open the dialog,
+                    // then queue a fresh Core address request so the result is visible.
                     if let Some(wallet) = self.selected_wallet.clone() {
                         action |= self.open_receive_dialog(ui.ctx());
                         self.queue_core_address_request(&wallet);

--- a/tests/kittest/wallets_screen.rs
+++ b/tests/kittest/wallets_screen.rs
@@ -1,11 +1,33 @@
 use crate::support::{fresh_app_context, with_isolated_data_dir};
 use dash_evo_tool::model::secret::Secret;
 use dash_evo_tool::model::wallet::Wallet;
+use dash_evo_tool::model::wallet::birth_height::WalletOrigin;
 use dash_evo_tool::ui::ScreenLike;
 use dash_evo_tool::ui::wallets::wallets_screen::WalletsBalancesScreen;
 use egui_kittest::Harness;
 use egui_kittest::kittest::Queryable;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+const WALLET_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn build_wallet_screen_harness(
+    runtime: tokio::runtime::Runtime,
+    app_context: Arc<dash_evo_tool::context::AppContext>,
+) -> Harness<'static, WalletsBalancesScreen> {
+    let screen = WalletsBalancesScreen::new(&app_context);
+    let mut harness = Harness::builder()
+        .with_size(egui::vec2(1280.0, 800.0))
+        .build_ui_state(
+            move |ui, screen: &mut WalletsBalancesScreen| {
+                let _runtime = &runtime;
+                screen.ui(ui);
+            },
+            screen,
+        );
+    harness.run();
+    harness
+}
 
 fn wallet_screen_harness(password: Option<&Secret>) -> Harness<'static, WalletsBalancesScreen> {
     let (runtime, app_context) = fresh_app_context();
@@ -26,18 +48,47 @@ fn wallet_screen_harness(password: Option<&Secret>) -> Harness<'static, WalletsB
         .expect("wallet map")
         .insert(seed_hash, Arc::new(RwLock::new(wallet)));
 
-    let screen = WalletsBalancesScreen::new(&app_context);
-    let mut harness = Harness::builder()
-        .with_size(egui::vec2(1280.0, 800.0))
-        .build_ui_state(
-            move |ui, screen: &mut WalletsBalancesScreen| {
-                let _runtime = &runtime;
-                screen.ui(ui);
-            },
-            screen,
-        );
-    harness.run();
-    harness
+    build_wallet_screen_harness(runtime, app_context)
+}
+
+fn registered_wallet_screen_harness() -> Harness<'static, WalletsBalancesScreen> {
+    let (runtime, app_context) = fresh_app_context();
+    let seed = [0x42; 64];
+    let wallet = Wallet::new_from_seed(
+        seed,
+        app_context.network(),
+        Some("Dialog wallet".to_string()),
+        None,
+    )
+    .expect("create wallet fixture");
+    let (seed_hash, _) = {
+        let _guard = runtime.enter();
+        app_context
+            .register_wallet(wallet, &seed, WalletOrigin::Imported)
+            .expect("register wallet fixture")
+    };
+    let backend = app_context
+        .wallet_backend()
+        .expect("wallet backend must be wired");
+    let monitored_addresses = runtime.block_on(async {
+        tokio::time::timeout(WALLET_REGISTRATION_TIMEOUT, async {
+            loop {
+                let addresses = backend.snapshot_monitored_receive_addresses(&seed_hash);
+                if !addresses.is_empty() {
+                    return addresses;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("wallet registration must publish monitored receive addresses")
+    });
+    assert!(
+        !monitored_addresses.is_empty(),
+        "the fixture must have a monitored receive address before the click"
+    );
+
+    build_wallet_screen_harness(runtime, app_context)
 }
 
 fn click_in_one_frame(harness: &mut Harness<'_, WalletsBalancesScreen>, label: &str) {
@@ -79,7 +130,7 @@ fn receive_dialog_stays_open_on_triggering_click() {
 #[test]
 fn add_receiving_address_button_opens_receive_dialog() {
     with_isolated_data_dir(|| {
-        let mut harness = wallet_screen_harness(None);
+        let mut harness = registered_wallet_screen_harness();
 
         click_in_one_frame(&mut harness, "➕ Add Receiving Address");
         assert!(


### PR DESCRIPTION
## Why this PR exists
- **Problem**: PR #920's regression test for the "Add Receiving Address" button claimed to catch a specific regression, but didn't.
- **What breaks without it**: A code review (round 2 of the grumpy-review on the original fix) proved the claim false: `wallet_screen_harness()` never registers its fixture wallet with `WalletBackend`, so `load_core_addresses_for_receive`'s self-heal branch fires the exact same `"Generating a new address…"` status regardless of whether the button handler's own explicit `queue_core_address_request` call exists. Removing that explicit call and re-running the test still passed — the assertion added in #920 to guard against exactly that regression didn't actually guard against it.

## What was done
Added `registered_wallet_screen_harness()`, used only by `add_receiving_address_button_opens_receive_dialog`: registers the fixture wallet with the backend and waits (bounded 5s timeout) for a genuine non-empty monitored-address snapshot before the click, so `load_core_addresses_for_receive` takes its non-self-heal branch and the status can only originate from the button handler's own explicit call. The other three dialog tests are untouched, still using the original in-memory fixture — no risk to their coverage.

Also trims an 8-line tombstone comment in the button handler (narrating removed-code history that already lives in the original PR's commit message) down to present-state rationale only.

## Testing
- **Acceptance criterion, verified directly**: removed the explicit `queue_core_address_request` call from the button handler — test now fails (`FAILED`, panics on the missing status assertion). Restored the call — test passes again.
- `cargo test --test kittest --all-features wallets_screen` — full module, 7/7 pass by name, no regressions in the other three dialog tests.
- `cargo clippy --all-features --bin dash-evo-tool -- -D warnings` and `--test kittest -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

## Breaking changes
None.

## Checklist
- [x] Tests added/updated
- [x] `cargo fmt --all`
- [x] Scoped `cargo clippy` clean
- [ ] User-facing docs (not needed — test-only fix)

## Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for the Wallets screen’s “Add Receiving Address” interaction.
  * Added test setup for registered wallets with monitored receiving addresses, ensuring the receive dialog flow is validated in a realistic state.
* **Documentation**
  * Clarified the inline explanation of how adding a receiving address mirrors the existing Receive and New Address flow.

No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->