### PR TITLE
test: triage regression tests (starting with #909 Max-send InsufficientFunds repro)

### DIFF
--- a/src/wallet_backend/payments.rs
+++ b/src/wallet_backend/payments.rs
@@ -278,8 +278,20 @@ mod tests {
 
     /// Reproduces <https://github.com/dashpay/dash-evo-tool/issues/909>.
     /// The root cause is upstream in `dashpay/rust-dashcore` key-wallet's
-    /// `coin_selection.rs`, pinned at revision `be6e776`.
+    /// `coin_selection.rs`, pinned at revision `be6e776`, tracked at
+    /// <https://github.com/dashpay/rust-dashcore/issues/911>.
+    ///
+    /// Asserts the *correct* behavior (a Max send folds the zero/dust remainder
+    /// into its fee), so it stays RED until the upstream fix lands. `#[ignore]`
+    /// keeps it out of the CI gate meanwhile; run it manually with:
+    ///
+    /// ```sh
+    /// cargo test --lib -- core_max_send_with_single_utxo_builds_without_change --ignored
+    /// ```
+    ///
+    /// Remove `#[ignore]` once the pinned key-wallet revision contains the fix.
     #[test]
+    #[ignore = "RED until upstream key-wallet coin-selection fix lands (rust-dashcore#911); run with --ignored"]
     fn core_max_send_with_single_utxo_builds_without_change() {
         const BALANCE_DUFFS: u64 = 10_000_000;
 

--- a/src/wallet_backend/payments.rs
+++ b/src/wallet_backend/payments.rs
@@ -266,3 +266,51 @@ impl WalletBackend {
             .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::model::fee_estimation::core_max_send_amount_duffs;
+    use dash_sdk::dpp::dashcore::hashes::Hash;
+    use dash_sdk::dpp::dashcore::{Address, Network, OutPoint, PublicKey, TxOut, Txid};
+    use dash_sdk::dpp::key_wallet::Utxo;
+    use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::coin_selection::SelectionStrategy;
+    use dash_sdk::dpp::key_wallet::wallet::managed_wallet_info::transaction_builder::TransactionBuilder;
+
+    /// Reproduces <https://github.com/dashpay/dash-evo-tool/issues/909>.
+    /// The root cause is upstream in `dashpay/rust-dashcore` key-wallet's
+    /// `coin_selection.rs`, pinned at revision `be6e776`.
+    #[test]
+    fn core_max_send_with_single_utxo_builds_without_change() {
+        const BALANCE_DUFFS: u64 = 10_000_000;
+
+        let address = Address::p2pkh(
+            &PublicKey::from_slice(&[0x02; 33]).expect("valid compressed public key"),
+            Network::Testnet,
+        );
+        let utxo = Utxo::new(
+            OutPoint::new(Txid::all_zeros(), 0),
+            TxOut {
+                value: BALANCE_DUFFS,
+                script_pubkey: address.script_pubkey(),
+            },
+            address.clone(),
+            1,
+            false,
+        );
+        let max_amount = core_max_send_amount_duffs(BALANCE_DUFFS, 1, 1)
+            .expect("the balance covers the Max-send fee reserve");
+
+        assert_eq!(max_amount, 9_999_780);
+        let (transaction, fee) = TransactionBuilder::new()
+            .set_current_height(200)
+            .set_selection_strategy(SelectionStrategy::LargestFirst)
+            .add_inputs([utxo])
+            .add_output(&address, max_amount)
+            .set_change_address(address)
+            .build_unsigned()
+            .expect("a Max send must fold the zero/dust remainder into its fee");
+
+        assert_eq!(transaction.output.len(), 1);
+        assert_eq!(fee, BALANCE_DUFFS - max_amount);
+    }
+}


### PR DESCRIPTION
**TL;DR:** Adds an offline regression test that pins down a still-open, upstream-rooted wallet bug found while triaging a user report — this branch is meant as a general home for triage-born repro tests, not a one-off.

## User story
As a **maintainer**, I want a bug confirmed during issue triage to leave behind a runnable, failing regression test, so the fix (wherever it lands) has a concrete pass/fail signal instead of relying on manual re-verification.
As a **contributor picking up dash-evo-tool#909 or its upstream counterpart**, I want an existing test that reproduces the exact reported numbers, so I can verify a fix without re-deriving the repro myself.

## Scenario

### Base flow
Triaging [dash-evo-tool#909](https://github.com/dashpay/dash-evo-tool/issues/909) ("Send fails with InsufficientFunds when change would be zero") required tracing from the Send screen's Max button through `send_payment` down into the vendored `key-wallet` coin-selection code to find the actual defect.

### Actual behavior
Today, that bug has no automated regression coverage in this repo — only a manual repro (single 0.1 DASH UTXO, click Max, Send) and a GitHub issue.

### Expected behavior
A committed test exercises the real `TransactionBuilder`/`CoinSelector` API (not a reimplementation) with a synthetic single-UTXO wallet and the exact amount dash-evo-tool's own `core_max_send_amount_duffs` computes, asserting the *correct* behavior (Max send succeeds). It is currently RED, which is expected and desired — it stays red until the upstream fix lands, at which point it flips green and proves the fix.

## Detailed discussion

- Test: `wallet_backend::payments::tests::core_max_send_with_single_utxo_builds_without_change` in `src/wallet_backend/payments.rs`.
- Root cause is **not in this repo** — it's in the vendored `key-wallet` crate (`dashpay/rust-dashcore`). Filed upstream with full detail: [dashpay/rust-dashcore#911](https://github.com/dashpay/rust-dashcore/issues/911).
- Original report: [dash-evo-tool#909](https://github.com/dashpay/dash-evo-tool/issues/909) (comment with full triage: [#909#issuecomment-5035888366](https://github.com/dashpay/dash-evo-tool/issues/909#issuecomment-5035888366)).
- A secondary complaint in the same issue (UTXO `height` never backfilled from `core_transactions`) is a separate, unrelated bug tracked at [dashpay/platform#4178](https://github.com/dashpay/platform/issues/4178) — no test added here for that one; out of scope for this PR.
- This branch (`test/triage-repro-tests`) is intended as a general drop point for future triage-born repro tests, not exclusively for #909 — expect more small, independent test additions to land here or on follow-up PRs from the same pattern.
- No functional/user-facing change — test-only addition, `CHANGELOG.md` intentionally not touched.

### Prior work
- [dashpay/rust-dashcore#911](https://github.com/dashpay/rust-dashcore/issues/911) — the actual upstream defect this test pins down.
- [dashpay/platform#4178](https://github.com/dashpay/platform/issues/4178) — related-but-distinct secondary complaint from the same original report.

### Testing
- `cargo fmt --all` — clean.
- Narrow-scope clippy (`--all-features --all-targets -- -D warnings` on the touched target) — clean.
- `cargo test --all-features --lib wallet_backend::payments::tests::core_max_send_with_single_utxo_builds_without_change -- --exact` — **FAILS as expected** (RED), reproducing the exact reported error: `CoinSelection(InsufficientFunds { available: 10000000, required: 9999780 })`. This is the intended state until the upstream fix lands.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering maximum-send transactions on Testnet.
  * Verifies that the transaction uses a single output with no separate change and calculates the expected fee correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->