### PR TITLE
fix(logging): install SA_ONSTACK + alternate signal stack for fatal handler

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -219,6 +219,16 @@ fn redirect_stderr_to(_path: &Path) {
     );
 }
 
+/// Size of the alternate signal stack used by [`install_alt_signal_stack`].
+///
+/// The fatal-signal handler itself does a single `write(2)` call with
+/// nothing beneath it, but the kernel/libc signal-delivery machinery needs
+/// some stack space of its own to build the signal frame before the handler
+/// runs. 64 KiB is a generous multiple of `libc::SIGSTKSZ` (8 KiB on this
+/// target) for what is a one-time, process-lifetime allocation per thread.
+#[cfg(unix)]
+const ALT_SIGNAL_STACK_SIZE: usize = 64 * 1024;
+
 /// Installs a handler for the synchronous fatal signals (`SIGSEGV`, `SIGABRT`,
 /// `SIGBUS`, `SIGILL`, `SIGFPE`) that writes a one-line marker to stderr before
 /// the process dies, then lets the default handler take over.
@@ -235,9 +245,65 @@ fn redirect_stderr_to(_path: &Path) {
 /// normal crash / core dump.
 ///
 /// Call once, after [`capture_stderr_to_file`], so the marker lands in the
-/// sidecar file rather than a lost terminal. Best-effort no-op on non-Unix.
+/// sidecar file rather than a lost terminal. This also installs an alternate
+/// signal stack for the calling thread. Other threads need to call
+/// [`install_alt_signal_stack`] separately; `src/main.rs` does so for every
+/// Tokio worker/blocking thread through `Builder::on_thread_start`.
+/// Best-effort no-op on non-Unix.
 pub fn install_fatal_signal_handler() {
     install_fatal_signal_handler_impl();
+}
+
+/// Installs an alternate signal stack for the *calling* thread, so a
+/// `SA_ONSTACK` handler installed by [`install_fatal_signal_handler`] can
+/// still run when this thread's normal stack is exhausted (a guard-page
+/// stack-overflow SIGSEGV).
+///
+/// `sigaltstack(2)` is per-thread: registering it on one thread does
+/// nothing for a fault on any other thread. [`install_fatal_signal_handler`]
+/// calls this once for the thread that calls it (normally `main`), but any
+/// other thread that can run deep, stack-hungry code must call this too —
+/// in this project, every Tokio worker/blocking thread, via
+/// `Builder::on_thread_start` in `src/main.rs`.
+///
+/// The backing buffer is intentionally leaked: the alternate stack must
+/// stay valid for the entire lifetime of the thread that registered it,
+/// since a fatal signal can arrive at any time. Best-effort no-op (with a
+/// warning on failure) on Unix; a true no-op on non-Unix targets, since
+/// `sigaltstack` and the fatal-signal handler itself are Unix-only.
+pub fn install_alt_signal_stack() {
+    install_alt_signal_stack_impl();
+}
+
+#[cfg(unix)]
+fn install_alt_signal_stack_impl() {
+    // Leaked intentionally -- see doc comment on `install_alt_signal_stack`.
+    let stack = vec![0u8; ALT_SIGNAL_STACK_SIZE].into_boxed_slice();
+    let stack_ptr = Box::leak(stack).as_mut_ptr();
+
+    let alt_stack = nix::libc::stack_t {
+        ss_sp: stack_ptr as *mut nix::libc::c_void,
+        ss_flags: 0,
+        ss_size: ALT_SIGNAL_STACK_SIZE,
+    };
+
+    // SAFETY: `stack_ptr` points at a leaked buffer of exactly
+    // `ALT_SIGNAL_STACK_SIZE` bytes. `sigaltstack` copies `alt_stack`, and the
+    // retained `ss_sp` remains valid for the rest of the process.
+    let ret = unsafe { nix::libc::sigaltstack(&alt_stack, std::ptr::null_mut()) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        tracing::warn!(
+            error = %err,
+            "Could not install alternate signal stack; a stack-overflow SIGSEGV on this thread may leave no crash marker"
+        );
+    }
+}
+
+#[cfg(not(unix))]
+fn install_alt_signal_stack_impl() {
+    // No-op: sigaltstack is a POSIX/Unix mechanism, and the fatal-signal
+    // handler itself is already Unix-only.
 }
 
 /// Maps a fatal signal number to a fixed `'static` marker line written to
@@ -260,6 +326,9 @@ fn marker_for_signal(sig: nix::libc::c_int) -> &'static [u8] {
 fn install_fatal_signal_handler_impl() {
     use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
 
+    // Cover the calling (normally main) thread before installing the handler.
+    install_alt_signal_stack_impl();
+
     extern "C" fn handle_fatal(sig: nix::libc::c_int) {
         let marker = marker_for_signal(sig);
         // SAFETY: `write` is async-signal-safe. `marker` is a 'static byte
@@ -276,12 +345,14 @@ fn install_fatal_signal_handler_impl() {
         // fault (or lets abort() proceed) for the normal crash / core dump.
     }
 
+    // SA_ONSTACK: use the registered alternate stack so a guard-page overflow
+    // can run the handler; unregistered threads fall back to their normal stack.
     // SA_RESETHAND: one-shot, then default disposition re-raises the crash.
     // SA_NODEFER: don't block the signal during the handler, so a fault while
     // the default handler is being restored still terminates cleanly.
     let action = SigAction::new(
         SigHandler::Handler(handle_fatal),
-        SaFlags::SA_RESETHAND | SaFlags::SA_NODEFER,
+        SaFlags::SA_RESETHAND | SaFlags::SA_NODEFER | SaFlags::SA_ONSTACK,
         SigSet::empty(),
     );
 
@@ -511,6 +582,23 @@ mod tests {
         rotate_log_in_dir(dir.path(), "det-stderr");
         let count = fs::read_dir(dir.path()).expect("read_dir").count();
         assert_eq!(count, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_alt_signal_stack_registers_stack_for_calling_thread() {
+        install_alt_signal_stack();
+
+        let mut current_stack = std::mem::MaybeUninit::<nix::libc::stack_t>::uninit();
+        // SAFETY: a null first argument queries the calling thread's current
+        // alternate stack into the valid `current_stack` out-pointer.
+        let ret = unsafe { nix::libc::sigaltstack(std::ptr::null(), current_stack.as_mut_ptr()) };
+
+        assert_eq!(ret, 0, "sigaltstack query should succeed");
+        // SAFETY: a successful query initialized every field of `current_stack`.
+        let current_stack = unsafe { current_stack.assume_init() };
+        assert_eq!(current_stack.ss_flags & nix::libc::SS_DISABLE, 0);
+        assert_eq!(current_stack.ss_size, ALT_SIGNAL_STACK_SIZE);
     }
 
     #[cfg(unix)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -266,38 +266,63 @@ pub fn install_fatal_signal_handler() {
 /// in this project, every Tokio worker/blocking thread, via
 /// `Builder::on_thread_start` in `src/main.rs`.
 ///
-/// The backing buffer is intentionally leaked: the alternate stack must
-/// stay valid for the entire lifetime of the thread that registered it,
-/// since a fatal signal can arrive at any time. Best-effort no-op (with a
-/// warning on failure) on Unix; a true no-op on non-Unix targets, since
-/// `sigaltstack` and the fatal-signal handler itself are Unix-only.
+/// The backing buffer is owned by a thread-local, not leaked: Tokio's
+/// blocking-pool threads are not one-time (idle ones are reaped after a
+/// short keep-alive and fresh ones are spawned per task on demand), and this
+/// function runs on every one of them via `Builder::on_thread_start`, so a
+/// process-lifetime leak (`Box::leak`) would grow unboundedly over a long
+/// session instead of costing a fixed, one-time amount. Storing the buffer
+/// in a `thread_local!` frees it via the TLS destructor at thread exit --
+/// exactly when the registration stops mattering, since a dead thread can't
+/// receive signals. Best-effort no-op (with a warning on failure) on Unix; a
+/// true no-op on non-Unix targets, since `sigaltstack` and the fatal-signal
+/// handler itself are Unix-only.
 pub fn install_alt_signal_stack() {
     install_alt_signal_stack_impl();
 }
 
 #[cfg(unix)]
+thread_local! {
+    /// Backing buffer for this thread's alternate signal stack. Kept alive
+    /// for the thread's lifetime by owning it here rather than leaking it;
+    /// freed by the TLS destructor at thread exit, after `sigaltstack`
+    /// registration for this thread has stopped mattering.
+    static ALT_SIGNAL_STACK_BUF: std::cell::RefCell<Option<Box<[u8]>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(unix)]
 fn install_alt_signal_stack_impl() {
-    // Leaked intentionally -- see doc comment on `install_alt_signal_stack`.
-    let stack = vec![0u8; ALT_SIGNAL_STACK_SIZE].into_boxed_slice();
-    let stack_ptr = Box::leak(stack).as_mut_ptr();
+    ALT_SIGNAL_STACK_BUF.with(|cell| {
+        let mut buf = cell.borrow_mut();
+        // `get_or_insert_with` keeps a prior call's buffer (and its already
+        // -registered address) if this runs twice on the same thread, rather
+        // than allocating and registering a second one.
+        let stack = buf.get_or_insert_with(|| vec![0u8; ALT_SIGNAL_STACK_SIZE].into_boxed_slice());
+        let stack_ptr = stack.as_mut_ptr();
 
-    let alt_stack = nix::libc::stack_t {
-        ss_sp: stack_ptr as *mut nix::libc::c_void,
-        ss_flags: 0,
-        ss_size: ALT_SIGNAL_STACK_SIZE,
-    };
+        let alt_stack = nix::libc::stack_t {
+            ss_sp: stack_ptr as *mut nix::libc::c_void,
+            ss_flags: 0,
+            ss_size: ALT_SIGNAL_STACK_SIZE,
+        };
 
-    // SAFETY: `stack_ptr` points at a leaked buffer of exactly
-    // `ALT_SIGNAL_STACK_SIZE` bytes. `sigaltstack` copies `alt_stack`, and the
-    // retained `ss_sp` remains valid for the rest of the process.
-    let ret = unsafe { nix::libc::sigaltstack(&alt_stack, std::ptr::null_mut()) };
-    if ret != 0 {
-        let err = std::io::Error::last_os_error();
-        tracing::warn!(
-            error = %err,
-            "Could not install alternate signal stack; a stack-overflow SIGSEGV on this thread may leave no crash marker"
-        );
-    }
+        // SAFETY: `stack_ptr` points into `stack`, owned by this thread's
+        // `ALT_SIGNAL_STACK_BUF` cell for as long as the thread lives (a
+        // `Box`'s heap allocation does not move when the `Box` itself does).
+        // `sigaltstack` copies `alt_stack` by value; the kernel only needs
+        // `ss_sp` to stay valid while this thread could still fault, which
+        // holds until the thread exits and the buffer is freed together with
+        // it.
+        let ret = unsafe { nix::libc::sigaltstack(&alt_stack, std::ptr::null_mut()) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            tracing::warn!(
+                error = %err,
+                "Could not install alternate signal stack; a stack-overflow SIGSEGV on this thread may leave no crash marker"
+            );
+        }
+    });
 }
 
 #[cfg(not(unix))]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -603,6 +603,44 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn install_fatal_signal_handler_sets_sa_onstack() {
+        use nix::sys::signal::{SaFlags, SigAction, SigHandler, SigSet, Signal, sigaction};
+
+        install_fatal_signal_handler_impl();
+
+        for signal in [
+            Signal::SIGSEGV,
+            Signal::SIGABRT,
+            Signal::SIGBUS,
+            Signal::SIGILL,
+            Signal::SIGFPE,
+        ] {
+            // Reset to the default disposition and capture what was
+            // installed in the same call -- this test binary never installs
+            // a real OS signal handler for these signals on its own, so
+            // `SigDfl` is the correct prior state to restore, and doing the
+            // restore and the read in one `sigaction` call means a fatal
+            // signal can never find these left mid-swap.
+            //
+            // SAFETY: `SigDfl` is always a valid disposition to install.
+            let installed = unsafe {
+                sigaction(
+                    signal,
+                    &SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty()),
+                )
+            }
+            .unwrap_or_else(|e| panic!("query/reset {signal:?} disposition: {e}"));
+
+            assert!(
+                installed.flags().contains(SaFlags::SA_ONSTACK),
+                "{signal:?} handler should be installed with SA_ONSTACK, got {:?}",
+                installed.flags()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn marker_for_signal_names_each_fatal_signal() {
         use nix::sys::signal::Signal;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use dash_evo_tool::*;
 use crate::boot::prepare_environment;
 use crate::cpu_compatibility::check_cpu_compatibility;
 use crate::logging::{
-    capture_stderr_to_file, install_fatal_signal_handler, report_startup_failure_to_terminal,
+    capture_stderr_to_file, install_alt_signal_stack, install_fatal_signal_handler,
+    report_startup_failure_to_terminal,
 };
 
 fn main() -> eframe::Result<()> {
@@ -27,6 +28,8 @@ fn main() -> eframe::Result<()> {
     // Initialize the Tokio runtime
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(12)
+        // Each worker/blocking thread needs its own alternate signal stack.
+        .on_thread_start(install_alt_signal_stack)
         .enable_all()
         .build()
         .expect("multi-threading runtime cannot be initialized");


### PR DESCRIPTION
## Summary

- Installs a per-thread alternate signal stack (`sigaltstack(2)`, 64 KiB) and adds `SA_ONSTACK` to the fatal-signal handler (`SIGSEGV`/`SIGABRT`/`SIGBUS`/`SIGILL`/`SIGFPE`) so a guard-page **stack-overflow** SIGSEGV can still run the handler and leave a crash marker — today it can't, because there's no stack space left to enter a handler that has no alternate stack.
- `sigaltstack` is per-thread, not process-wide. Covers the main thread directly from `install_fatal_signal_handler()`, and every Tokio worker/blocking thread via `Builder::on_thread_start` in `src/main.rs`.
- `nix` 0.31.3 (pinned) doesn't expose a safe `sigaltstack` wrapper, so this goes through raw `nix::libc::sigaltstack`/`stack_t`, matching this file's existing `nix::libc` FFI convention (`dup`/`dup2`/`write`).

## Context

Found while investigating a SIGSEGV report (core → Platform address funding, proof verification in `grovedb`'s `Op::decode`). `det-stderr.log` was completely empty after the crash — no marker, nothing. Root cause of *that* silence: `install_fatal_signal_handler` was replacing Rust's own default stack-overflow handler (the one that normally prints `"thread '...' has overflowed its stack"`) with a marker-writing handler that had no alternate stack — so on a true stack-overflow SIGSEGV, neither Rust's message nor our own marker could ever be written. This PR closes that gap.

This is a diagnostics fix, not a fix for the SIGSEGV itself — it ensures that *if* a stack-overflow-class crash happens again, `det-stderr.log` will actually say so instead of staying silent. (Separately, production's Tokio runtime has no `.thread_stack_size()` override, so worker threads run on Rust's 2 MiB default while this project's own backend-e2e harness documents a 16 MB floor for the SDK's proof-verification recursion — a real gap, tracked separately.)

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --lib logging:: --all-features` — 13/13 passed, including new `install_alt_signal_stack_registers_stack_for_calling_thread` (registers the stack, reads it back via `sigaltstack(NULL, &old)`, asserts `SS_DISABLE` unset and size matches)
- [x] `cargo clippy --bin dash-evo-tool --all-features -- -D warnings` — clean
- [ ] CI (full suite + clippy) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Codex Sol <noreply@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fatal-signal handling by using a dedicated alternate signal stack.
  * Applied the safeguard consistently across runtime worker and blocking threads.
  * Preserved existing crash-reporting behavior while improving reliability during stack-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->