### PR TITLE
fix: allow triage-permission bot to trigger Claudius review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,3 +36,9 @@ jobs:
           memcan_url: ${{ vars.MEMCAN_URL }}
           memcan_api_key: ${{ secrets.MEMCAN_API_KEY }}
           claude_extra_args: "--permission-mode auto"
+          # Claudius-Maginificent only has triage access to this repo (no git
+          # push), so the collaborator-permission API reports it as "read" —
+          # below claude-code-action's admin/write bar. It's a trusted bot
+          # that only ever applies the trigger label, so allow-list it by
+          # name instead of granting real write access.
+          allowed_non_write_users: Claudius-Maginificent


### PR DESCRIPTION
**TL;DR:** Fixes the Claudius PR review not starting when the trigger label is applied by our triage-permission bot instead of a human with write access.

## User story
As a **contributor whose PR gets labeled by the Claudius-Maginificent bot**, I want the AI code review to actually start, to achieve the same automated review any human-labeled PR gets.

## Scenario
### Base flow
`Claudius-Maginificent` (a bot account with triage-only access to this repo) applies the `claudius-review` label to a PR, which is meant to kick off the `claude-code-review.yml` workflow.

### Actual behavior
The workflow's underlying action rejects the trigger: its write-access preflight requires `admin`/`write` collaborator permission, and the GitHub API reports `Claudius-Maginificent`'s triage role as `read` (there's no way for that API to report "triage" directly). Verified in run [`29930647048`](https://github.com/dashpay/dash-evo-tool/actions/runs/29930647048) — review job failed immediately with "does not have write access to this repository (permission: read)".

### Expected behavior
The review runs normally when `Claudius-Maginificent` applies the label, without granting that bot actual write/push access to the repo.

## Detailed discussion
### What was done
Added `allowed_non_write_users: Claudius-Maginificent` to the `claude-code-review.yml` workflow's `with:` block, opting this specific trusted bot into the new allow-list bypass added upstream in `lklimek/claudius-review-action`.

This workflow references `lklimek/claudius-review-action@main`, so no version bump is needed here — it picks up the upstream fix automatically once that PR merges to `main`. **This PR depends on that upstream PR merging first** (`lklimek/claudius-review-action`, fix branch `fix/allow-triage-actor-trigger`); until then, this input has no effect (the older action build ignores unknown-to-it inputs it doesn't yet understand... actually is passed through untouched by composite action `inputs:` semantics either way, so merge order doesn't strictly matter, but the fix is inert until upstream lands).

### Testing
- YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Not yet exercised against a real workflow run — will confirm once both PRs are merged and a PR is next labeled `claudius-review`.

### Breaking changes
None — six added lines, no existing behavior changed.

### Checklist
- [x] YAML syntax validated
- [ ] End-to-end verified against a live triage-labeled PR (pending upstream merge)

### Prior work
- `lklimek/claudius-review-action` (fix branch `fix/allow-triage-actor-trigger`) — adds the `allowed_non_write_users` mechanism this PR opts into.

### Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
