### PR TITLE
chore: add local /triage skill for GitHub issue triage

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: triage
+description: "Use when the user says \"triage\" or asks to triage a dash-evo-tool GitHub issue: reproduce, root-cause, attribute to a crate, estimate severity with the user, then post a short status comment."
+argument-hint: <issue-number-or-url>
+---
+
+# Triage
+
+Org = `dashpay`. Stable = `master` (release branch; `v1.0-dev` is active dev — see CLAUDE.md § Branching).
+
+1. Fetch the issue ($ARGUMENTS); check it against `master`.
+2. Reproduce and root-cause per `claudius:bug-investigation`. Prefer a unit/integration test (CLAUDE.md § Testing); fall back to `desktop-gui` (+ `docs/gui-testing/README.md`) only if a test can't reach it.
+3. Attribute the root cause to its owning crate: this repo, or an upstream `dashpay`-org git dependency (check `Cargo.toml` pins — currently `platform` for `dash-sdk`/`platform-wallet`/`platform-wallet-storage`/`rs-sdk-trusted-context-provider`, `grovestark` for `grovestark`).
+4. Estimate severity with `claudius:severity`; report it to the user.
+5. Discuss repro, root cause, crate, and severity with the user — before any GitHub write.
+6. Root cause in another `dashpay` repo → propose filing an issue there, link it from this one. Root cause in `dash-evo-tool` → normal fix flow.
+7. Once the user agrees: comment on the issue — status update, ≤200 characters, plus links to anything filed/related. Every GitHub write needs the user's go-ahead first (`git-and-github` Safety Rules).


### PR DESCRIPTION
**TL;DR:** Adds a project-local `/triage` skill that walks through reproducing, root-causing, and reporting on a GitHub issue.

## User story
As a **maintainer triaging a dash-evo-tool issue**, I want a consistent, guided workflow for reproducing it, finding the root cause, and reporting status, to achieve faster, more consistent triage with less manual process-following.

## Scenario
### Base flow
An issue lands with the `needs-triage` label. Today, checking it against stable, reproducing it, root-causing it, and deciding whether the fix belongs here or in an upstream `dashpay` dependency is done ad hoc, with no fixed procedure.

### Actual behavior
No repo-local skill encodes this triage procedure — each triage pass re-derives the same steps (check against `master`, reproduce, root-cause, attribute to a crate, estimate severity, discuss, comment) from scratch.

### Expected behavior
Saying "triage" (or `/triage <issue>`) now runs a fixed, short procedure: check the issue against `master` (stable), reproduce via a unit test or `desktop-gui` fallback, root-cause via `bug-investigation`, attribute the fix to the owning crate (this repo or an upstream `dashpay` dependency), estimate severity via `claudius:severity`, discuss findings with the user, and — only after explicit sign-off — post a ≤200-character status comment with any related links. Root causes traced into another `dashpay`-org repo get an issue filed there instead of a fix attempted here, linked back from the original issue.

## Detailed discussion
### What was done
Added `.claude/skills/triage/SKILL.md` — a short (~200-word) skill that delegates to existing `claudius` skills (`bug-investigation`, `severity`, `desktop-gui`, `git-and-github`) rather than re-explaining their content, and encodes this repo's own conventions (stable = `master` per CLAUDE.md § Branching, current upstream `dashpay` dependency crates from `Cargo.toml`).

### Testing
Documentation-only change (a skill definition, no code). Verified frontmatter parses as valid YAML.

### Breaking changes
None.

### Checklist
- [x] No versioning policy found in this repo's CLAUDE.md — no version bump needed
- [x] Frontmatter YAML validated

### Prior work
None.

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>