### PR TITLE
fix(platform): work around dash-sdk epoch-proof regression via version ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   different deposit or start a new one, instead of the generic rejection
   message that suggested retrying the same one.
 
+- **Shielded features now detect network support correctly**: the app's
+  live check of the connected network's protocol version — used to enable
+  shielded sending, receiving, and transfers — no longer gets stuck at its
+  startup default. It was silently keeping shielded operations unavailable
+  regardless of what the connected network actually supports, and also kept
+  the send-fee estimate from picking up the network's current rate. A
+  temporary workaround is in place while the underlying issue is fixed
+  upstream; the send-fee estimate will keep using its last known rate until
+  that lands.
+
 ### Changed
 
 - **Upstream wallet backend updated (`platform-wallet` / `platform-wallet-storage`)**:

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -10,6 +10,7 @@ use dash_sdk::dpp::block::extended_epoch_info::{
 use dash_sdk::dpp::core_types::validator_set::v0::ValidatorSetV0Getters;
 use dash_sdk::dpp::dashcore::hashes::Hash;
 use dash_sdk::dpp::dashcore::{Address, Network, ScriptBuf};
+use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dash_sdk::dpp::data_contracts::SystemDataContract;
 use dash_sdk::dpp::data_contracts::withdrawals_contract::WithdrawalStatus;
 use dash_sdk::dpp::data_contracts::withdrawals_contract::v1::document_types::withdrawal::properties::{
@@ -28,7 +29,9 @@ use dash_sdk::drive::query::{SelectProjection, OrderClause, WhereClause, WhereOp
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::platform::fetch_current_no_parameters::FetchCurrent;
 use dash_sdk::platform::proto::get_documents_request::get_documents_request_v0::Start;
-use dash_sdk::platform::{DocumentQuery, FetchMany, FetchUnproved, Identifier};
+use dash_sdk::platform::{
+    DataContract, DocumentQuery, Fetch, FetchMany, FetchUnproved, Identifier,
+};
 use dash_sdk::query_types::{
     AddressInfo, CurrentQuorumsInfo, NoParamQuery, ProtocolVersionUpgrades, TotalCreditsInPlatform,
 };
@@ -247,6 +250,16 @@ fn format_extended_epoch_info(
     )
 }
 
+fn format_unavailable_current_epoch_info(protocol_version: u32) -> String {
+    format!(
+        "Current Epoch Information:\n\
+         • Protocol Version: {protocol_version}\n\
+         • Epoch details and fee multiplier are temporarily unavailable while \
+         dashpay/platform#4231 is unresolved.\n\n\
+         (The fee multiplier cache was not updated.)"
+    )
+}
+
 fn format_current_quorums_info(current_quorums_info: &CurrentQuorumsInfo) -> String {
     let mut result = String::new();
     result.push_str("Current Validator Set Information:\n\n");
@@ -457,6 +470,23 @@ fn withdrawal_status_str(status: WithdrawalStatus) -> &'static str {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_workaround_reports_protocol_version_and_stale_fee_cache() {
+        assert_eq!(
+            format_unavailable_current_epoch_info(12),
+            "Current Epoch Information:\n\
+             • Protocol Version: 12\n\
+             • Epoch details and fee multiplier are temporarily unavailable while \
+             dashpay/platform#4231 is unresolved.\n\n\
+             (The fee multiplier cache was not updated.)"
+        );
+    }
+}
+
 /// Flatten one withdrawal [`Document`] into a [`WithdrawalRecord`].
 fn extract_withdrawal_record(
     document: &Document,
@@ -550,22 +580,44 @@ impl AppContext {
                 ))
             }
             PlatformInfoTaskRequestType::CurrentEpochInfo => {
-                let epoch_info = ExtendedEpochInfo::fetch_current(sdk)
-                    .await
-                    .map_err(TaskError::from)?;
+                if let Err(error) = DataContract::fetch(sdk, self.dpns_contract.id()).await {
+                    tracing::warn!(
+                        %error,
+                        "Protocol-version ratchet trigger (DPNS contract fetch) failed; \
+                         keeping the SDK's previous protocol version"
+                    );
+                }
+                let protocol_version = sdk.protocol_version_number();
+                self.set_platform_protocol_version(protocol_version);
 
-                let fee_multiplier = epoch_info.fee_multiplier_permille();
-                self.set_fee_multiplier_permille(fee_multiplier);
-                self.set_platform_protocol_version(epoch_info.protocol_version());
+                match ExtendedEpochInfo::fetch_current(sdk).await {
+                    Ok(epoch_info) => {
+                        let fee_multiplier = epoch_info.fee_multiplier_permille();
+                        self.set_fee_multiplier_permille(fee_multiplier);
 
-                let mut formatted = format_extended_epoch_info(epoch_info, self.network, true);
-                formatted.push_str(&format!(
-                    "\n\n(Fee multiplier cache updated: {}x)",
-                    fee_multiplier as f64 / 1000.0
-                ));
-                Ok(BackendTaskSuccessResult::PlatformInfo(
-                    PlatformInfoTaskResult::TextResult(formatted),
-                ))
+                        let mut formatted =
+                            format_extended_epoch_info(epoch_info, self.network, true);
+                        formatted.push_str(&format!(
+                            "\n\n(Fee multiplier cache updated: {}x)",
+                            fee_multiplier as f64 / 1000.0
+                        ));
+                        Ok(BackendTaskSuccessResult::PlatformInfo(
+                            PlatformInfoTaskResult::TextResult(formatted),
+                        ))
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            "Current epoch fetch is blocked by dashpay/platform#4231; \
+                             keeping the cached fee multiplier"
+                        );
+                        Ok(BackendTaskSuccessResult::PlatformInfo(
+                            PlatformInfoTaskResult::TextResult(
+                                format_unavailable_current_epoch_info(protocol_version),
+                            ),
+                        ))
+                    }
+                }
             }
             PlatformInfoTaskRequestType::TotalCreditsOnPlatform => {
                 let total_credits = TotalCreditsInPlatform::fetch_current(sdk)

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -41,7 +41,7 @@ use dash_sdk::dpp::state_transition::StateTransitionSigningOptions;
 use dash_sdk::dpp::state_transition::batch_transition::methods::StateTransitionCreationOptions;
 use dash_sdk::dpp::system_data_contracts::{SystemDataContract, load_system_data_contract};
 use dash_sdk::dpp::version::PlatformVersion;
-use dash_sdk::dpp::version::v11::PLATFORM_V11;
+use dash_sdk::dpp::version::v12::PLATFORM_V12;
 use dash_sdk::platform::DataContract;
 use dash_sdk::platform::Identifier;
 use egui::Context;
@@ -1532,15 +1532,34 @@ impl AppContext {
 }
 
 /// Returns the default platform version for the given network.
-// TODO: Ideally use sdk.load().version() but this is a free function with no sdk access.
-// Every network currently pins the same version.
+// TODO(platform#4231): Seeded at v12 (not pinned) so `Sdk`'s protocol-version
+// ratchet stays active. See `PlatformInfoTaskRequestType::CurrentEpochInfo` for
+// why `ExtendedEpochInfo::fetch_current` can't be used directly right now.
+// Revert to `.with_version()` (a hard pin) or otherwise reconsider this once
+// https://github.com/dashpay/platform/pull/4231 merges and this repo's platform
+// pin advances past it.
 pub(crate) const fn default_platform_version(_network: &Network) -> &'static PlatformVersion {
-    &PLATFORM_V11
+    &PLATFORM_V12
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn epoch_workaround_uses_v12_for_every_network() {
+        for network in [
+            Network::Mainnet,
+            Network::Testnet,
+            Network::Devnet,
+            Network::Regtest,
+        ] {
+            assert_eq!(
+                default_platform_version(&network).protocol_version,
+                PLATFORM_V12.protocol_version
+            );
+        }
+    }
 
     #[test]
     fn install_secret_prompt_recovers_poisoned_slot() {

--- a/src/sdk_wrapper.rs
+++ b/src/sdk_wrapper.rs
@@ -21,7 +21,7 @@ pub fn initialize_sdk<P: ContextProvider + 'static>(
     let platform_version = default_platform_version(&network);
 
     let sdk = SdkBuilder::new(address_list)
-        .with_version(platform_version)
+        .with_initial_version(platform_version)
         .with_network(network)
         .with_context_provider(context_provider)
         .with_settings(request_settings)


### PR DESCRIPTION
**TL;DR:** Fixes shielded features and send-fee estimates silently never updating after the app connects, by detecting the network's protocol version a different way while the real cause gets fixed upstream.

## User story
As a Dash Evo Tool user, I want the app to correctly detect that my network supports shielded transactions, so that shielded sending/receiving actually works instead of being silently unavailable.

## Scenario
### Base flow
A user opens DET, waits for SPV sync to complete, and expects to use shielded sending/receiving, or to see an accurate fee estimate when sending.

### Actual behavior
Right after sync completes, the app tries to look up the network's current protocol version — but that lookup fails every single time, because it sends a request shape the connected network's proof verification now rejects. Since that lookup never succeeds, the app never learns the network supports shielded transactions, so those features stay hidden even though the network fully supports them. The fee estimate used for sending also never updates from its built-in default. The only visible symptom is a generic "An unexpected error occurred" banner after every sync.

### Expected behavior
Right after sync, the app correctly learns the network's protocol version through a different, working request, so shielded features become available as intended. The fee estimate for sending still can't refresh yet (that specific piece needs the real upstream fix), but the app no longer treats this as an alarming error — it quietly notes the limitation instead.

## Detailed discussion

### What was done

**Root cause**: `ExtendedEpochInfo::fetch_current` (dash-sdk) issues a descending epoch query with no explicit start epoch; a proof-verifier tightening upstream now unconditionally rejects that exact shape (`"proved descending epoch queries require an explicit start epoch"`). This call is the app's *only* production writer of `AppContext::platform_protocol_version` (an `AtomicU32` that boots at `0`), so it was stuck at `0` forever — permanently failing `Capability::ShieldedProtocol`'s `>= activation` check (silently disabling shield/unshield/shielded-transfer/shielded-withdrawal on every network) and freezing `fee_multiplier_permille` at its hardcoded default.

Confirmed as a genuine regression, not longstanding: diffed against the platform pin used by the previous weekly build, which has no such guard in its proof verifier.

**Upstream fix in flight**: dashpay/platform#4231 (open, unmerged). Its branch diverged from an earlier point in `v4.1-dev` and is not safely consumable as a direct pin bump today — pinning to it directly would revert ~27k unrelated lines, including the `rs-platform-wallet-storage` rewrite this repo's platform pin already depends on.

**Workaround** (temporary — revert once #4231 merges and this repo's platform pin advances past it):

- `Sdk` is now built via `SdkBuilder::with_initial_version(PLATFORM_V12)` instead of `.with_version(...)`. `with_version` *pins* the protocol version and permanently disables the SDK's own built-in, upward-only version ratchet (`Sdk::maybe_update_protocol_version`, `fetch_max`-based, never accepts unverified data); `with_initial_version` seeds the same starting value but leaves the ratchet active.
- `PlatformInfoTaskRequestType::CurrentEpochInfo` now triggers that ratchet with a proved fetch of the DPNS system contract (cheap, always available, no wallet/identity dependency) instead of the broken `ExtendedEpochInfo::fetch_current` / `Sdk::refresh_protocol_version` helpers (the latter is just a thin wrapper around the former), then reads the ratcheted value back via `sdk.protocol_version_number()`.
- `fee_multiplier_permille` has no ratchet equivalent and stays on its hardcoded default until the real fix lands; its (still-failing) fetch now degrades to an informative text result instead of surfacing a generic error banner.
- A `TODO(platform#4231)` comment marks the seed constant for revisiting once the real fix is available.

### Testing

- New unit tests: `context::tests::epoch_workaround_uses_v12_for_every_network`, `backend_task::platform_info::tests::epoch_workaround_reports_protocol_version_and_stale_fee_cache`.
- `cargo test --lib epoch_workaround_ --all-features` — 2 passed, 0 failed (2137 filtered out).
- `cargo clippy --bin dash-evo-tool --all-features -- -D warnings` — clean.
- `cargo fmt --all` — clean.

### Breaking changes

None — internal SDK-construction and one backend task's error handling only; no persisted data, public API, or consensus-affecting change.

### Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features -- -D warnings` (scoped to `--bin dash-evo-tool`)
- [x] Relevant tests added and passing
- [ ] `docs/user-stories.md` updated — not applicable; no new story, this restores existing shielded stories' intended behavior rather than changing it
- [x] `CHANGELOG.md` updated

### Prior work

Root-caused via live-log triage in this same session (see the linked issue context below). dashpay/platform#4231 is the actual upstream fix this workaround stands in for; revisit once it merges.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Identity Home actions with clearer options: Add funds, Send to wallet, Send to another identity, and Add contact.
  * Send to wallet is now clearly disabled when no suitable key is available.
* **Bug Fixes**
  * Improved deposit error messages when a deposit has already been used.
  * Improved shielded feature availability and fee estimation based on network support.
  * Improved deposit verification stability.
  * Updated withdrawal screens with clearer guidance when keys are unavailable.
* **Documentation**
  * Added and updated identity operation stories and design documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->