### PR TITLE
chore(deps): fix quinn-proto Dependabot alert, document blocked serde_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Dependency advisory GHSA-4w2j-m93h-cj5j cleared**: the `quinn-proto` entry in
+  the lock file moves from 0.11.14 to 0.11.15, which fixes a remote
+  memory-exhaustion issue in out-of-order stream reassembly. The crate is an
+  inert optional entry that no build of this app actually links, so this is
+  dependency hygiene rather than a fix for reachable behavior.
+
+- **Dependency advisory GHSA-7gcf-g7xr-8hxj still open** (`serde_with` below
+  3.21.0, a panic when serializing empty key-value map entries): it cannot be
+  resolved in this repository. `serde_with` 2.x is required by
+  `dashcore-rpc-json`, which arrives through pinned revisions of
+  `dashpay/platform` and `dashpay/rust-dashcore`; both still declare
+  `serde_with = "2.1.0"` at their current development heads as of 2026-07-27.
+  Allowing 3.x needs an upstream change in `dashpay/rust-dashcore` first. A TODO
+  in `Cargo.toml` marks the re-check.
+
 ### Added
 
 - **Automatic Platform node refresh during upgrades**: migrating a pre-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the send-fee estimate from picking up the network's current rate. A
   temporary workaround is in place while the underlying issue is fixed
   upstream; the send-fee estimate will keep using its last known rate until
-  that lands.
+  that lands. The check only accepts a protocol version the connected network
+  actually confirms: when the network cannot be reached, shielded operations
+  stay unavailable and the app keeps retrying, instead of assuming the version
+  the app was built with.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6968,9 +6968,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ qrcode = "0.14.1"
 nix = { version = "0.31.1", features = ["signal"] }
 eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
+# TODO: GHSA-7gcf-g7xr-8hxj (serde_with <3.21.0) is unfixable from here — the 2.x pin lives in
+# dashcore-rpc-json (dashpay/rust-dashcore, rpc-json/Cargo.toml). Re-check when these pins move.
 dash-sdk = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d6085d2b3d6c7410210a0c95ba", features = [
     "core_key_wallet",
     "core_key_wallet_manager",

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -250,14 +250,23 @@ fn format_extended_epoch_info(
     )
 }
 
-fn format_unavailable_current_epoch_info(protocol_version: u32) -> String {
-    format!(
-        "Current Epoch Information:\n\
-         • Protocol Version: {protocol_version}\n\
-         • Epoch details and fee multiplier are temporarily unavailable while \
-         dashpay/platform#4231 is unresolved.\n\n\
-         (The fee multiplier cache was not updated.)"
-    )
+/// `protocol_version` is `None` while the connected network has not confirmed one.
+fn format_unavailable_current_epoch_info(protocol_version: Option<u32>) -> String {
+    match protocol_version {
+        Some(protocol_version) => format!(
+            "Current Epoch Information:\n\
+             • Protocol Version: {protocol_version}\n\
+             • Epoch details and fee multiplier are temporarily unavailable while \
+             dashpay/platform#4231 is unresolved.\n\n\
+             (The fee multiplier cache was not updated.)"
+        ),
+        None => "Current Epoch Information:\n\
+             • Protocol Version: the connected network has not confirmed one yet.\n\
+             • Epoch details and fee multiplier are temporarily unavailable while \
+             dashpay/platform#4231 is unresolved.\n\n\
+             (The fee multiplier cache was not updated.)"
+            .to_string(),
+    }
 }
 
 fn format_current_quorums_info(current_quorums_info: &CurrentQuorumsInfo) -> String {
@@ -470,23 +479,6 @@ fn withdrawal_status_str(status: WithdrawalStatus) -> &'static str {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn epoch_workaround_reports_protocol_version_and_stale_fee_cache() {
-        assert_eq!(
-            format_unavailable_current_epoch_info(12),
-            "Current Epoch Information:\n\
-             • Protocol Version: 12\n\
-             • Epoch details and fee multiplier are temporarily unavailable while \
-             dashpay/platform#4231 is unresolved.\n\n\
-             (The fee multiplier cache was not updated.)"
-        );
-    }
-}
-
 /// Flatten one withdrawal [`Document`] into a [`WithdrawalRecord`].
 fn extract_withdrawal_record(
     document: &Document,
@@ -580,20 +572,23 @@ impl AppContext {
                 ))
             }
             PlatformInfoTaskRequestType::CurrentEpochInfo => {
-                if let Err(error) = DataContract::fetch(sdk, self.dpns_contract.id()).await {
-                    tracing::warn!(
+                // dashpay/platform#4231 breaks `ExtendedEpochInfo::fetch_current`, so the
+                // network's version is learned from the ratchet a proved DPNS fetch drives.
+                // Only a successful fetch proves it came from the network, not the local seed.
+                match DataContract::fetch(sdk, self.dpns_contract.id()).await {
+                    Ok(_) => self.set_platform_protocol_version(sdk.protocol_version_number()),
+                    Err(error) => tracing::warn!(
                         %error,
                         "Protocol-version ratchet trigger (DPNS contract fetch) failed; \
-                         keeping the SDK's previous protocol version"
-                    );
+                         the network's protocol version stays unconfirmed"
+                    ),
                 }
-                let protocol_version = sdk.protocol_version_number();
-                self.set_platform_protocol_version(protocol_version);
 
                 match ExtendedEpochInfo::fetch_current(sdk).await {
                     Ok(epoch_info) => {
                         let fee_multiplier = epoch_info.fee_multiplier_permille();
                         self.set_fee_multiplier_permille(fee_multiplier);
+                        self.set_platform_protocol_version(epoch_info.protocol_version());
 
                         let mut formatted =
                             format_extended_epoch_info(epoch_info, self.network, true);
@@ -611,9 +606,13 @@ impl AppContext {
                             "Current epoch fetch is blocked by dashpay/platform#4231; \
                              keeping the cached fee multiplier"
                         );
+                        let confirmed = match self.platform_protocol_version() {
+                            0 => None,
+                            version => Some(version),
+                        };
                         Ok(BackendTaskSuccessResult::PlatformInfo(
                             PlatformInfoTaskResult::TextResult(
-                                format_unavailable_current_epoch_info(protocol_version),
+                                format_unavailable_current_epoch_info(confirmed),
                             ),
                         ))
                     }
@@ -932,5 +931,53 @@ impl AppContext {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_workaround_reports_protocol_version_and_stale_fee_cache() {
+        assert_eq!(
+            format_unavailable_current_epoch_info(Some(12)),
+            "Current Epoch Information:\n\
+             • Protocol Version: 12\n\
+             • Epoch details and fee multiplier are temporarily unavailable while \
+             dashpay/platform#4231 is unresolved.\n\n\
+             (The fee multiplier cache was not updated.)"
+        );
+    }
+
+    #[test]
+    fn epoch_workaround_never_reports_an_unconfirmed_protocol_version_as_a_number() {
+        let formatted = format_unavailable_current_epoch_info(None);
+        assert!(
+            formatted
+                .contains("• Protocol Version: the connected network has not confirmed one yet."),
+            "an unconfirmed version must be named as such, got: {formatted}"
+        );
+    }
+
+    /// A failed ratchet trigger leaves the SDK reporting its local seed, which is
+    /// not a network observation: caching it would open the shielded capability
+    /// gate and defeat the `0` retry sentinel `mcp::resolve` polls.
+    #[tokio::test]
+    async fn a_failed_ratchet_trigger_leaves_the_protocol_version_unconfirmed() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let ctx = crate::context::test_support::test_app_context(temp_dir.path());
+        let sdk = dash_sdk::Sdk::new_mock();
+        assert_ne!(
+            sdk.protocol_version_number(),
+            0,
+            "precondition: the mock SDK seeds a local version of its own"
+        );
+
+        ctx.run_platform_info_task(PlatformInfoTaskRequestType::CurrentEpochInfo, &sdk)
+            .await
+            .expect("the epoch workaround degrades to a text result");
+
+        assert_eq!(ctx.platform_protocol_version(), 0);
     }
 }


### PR DESCRIPTION
## TL;DR

Two open Dependabot alerts. One is fixed here with a one-line lockfile bump; the other is
provably not fixable from this repository, so it is documented instead of worked around.

## What changed

**`quinn-proto` 0.11.14 → 0.11.15 (HIGH, GHSA-4w2j-m93h-cj5j)** — remote memory exhaustion from
unbounded out-of-order stream reassembly. `cargo update -p quinn-proto --precise 0.11.15`
touched exactly two lines of `Cargo.lock` (version + checksum); 192 other resolved dependencies
are unchanged.

Worth knowing for reviewers: the crate is an inert optional entry reached through `reqwest`'s
http3 feature chain, and it is **not** in this app's active dependency graph — `cargo tree -i
quinn-proto` reports nothing with or without `--all-features`, and the verification run below
never compiles it. Dependabot flags on lockfile presence regardless of reachability, so the bump
is dependency hygiene rather than a fix for behavior a user could ever hit.

**`serde_with` (MEDIUM, GHSA-7gcf-g7xr-8hxj) — documented as blocked, not fixed.** A panic when
serializing empty `KeyValueMap` entries; the advisory wants ≥ 3.21.0, the lock holds 2.3.3. The
2.x constraint is not ours: `dashcore-rpc-json` declares `serde_with = "2.1.0"` in its own
manifest, and it reaches us through two levels of pinned git revisions this repo does not
control — `dashpay/platform` @ `288a6cae`, which itself pins `dashpay/rust-dashcore` @
`18c68d4c`. `cargo update -p serde_with --precise 3.21.0` therefore fails outright ("candidate
versions found which didn't match: 3.21.0 ... required by package `dashcore-rpc-json`").

There is also no newer upstream revision to move to: both `dashpay/rust-dashcore`'s current `dev`
head and the newer rev (`70d4bf8e`) that `dashpay/platform` HEAD now pins still declare
`serde_with = "2.1.0"` in `rpc-json/Cargo.toml` as of 2026-07-27.

## Why no workaround

A `[patch]` override or a fork would force a 2 → 3 major-version jump on a crate this repo does
not consume directly, with the API-break risk landing on upstream code we do not own. That is a
maintainer decision and belongs in a PR against `dashpay/rust-dashcore`, not in a mechanical
dependency bump. This PR records the blocker in two places instead:

- a two-line `TODO` in `Cargo.toml` above the pinned `dashpay/platform` dependency block, naming
  the advisory, where the real constraint lives, and when to re-check;
- a `### Security` section in `CHANGELOG.md` carrying the full story for both advisories.

## Also in this PR: two CI failures inherited from `v1.0-dev`, one of them a live bug

This branch was cut after #936 ("work around dash-sdk epoch-proof regression via version
ratchet") merged to `v1.0-dev`, and CI came back red on both Clippy and the test suite —
neither caused by the dependency bump above (confirmed: `v1.0-dev`'s own CI shows the same two
failures before this PR existed; nothing in this PR's original diff touches either file).

- **Clippy — `clippy::items_after_test_module`**: #936 left a `#[cfg(test)] mod tests` block
  ahead of real functions in `src/backend_task/platform_info.rs`. Moved it to the end of the
  file — mechanical, no logic change.
- **Test Suite — a real regression, not a stale test**: three `mcp::resolve` tests were failing
  because #936 made `CurrentEpochInfo` cache `sdk.protocol_version_number()` unconditionally,
  including when the DPNS "ratchet trigger" fetch that's supposed to justify trusting that value
  had just failed. On failure, that call returns the SDK's local hardcoded seed (11 on the
  Mainnet mock, 12 in production) — not anything the network confirmed — and #936 wrote it into
  the cache as if it had been. Concretely, that means `Capability::ShieldedProtocol` (activation
  v12) could open off the app's own seed with zero network evidence, and the `0` sentinel that
  the best-effort protocol-version refresh relies on to keep retrying was destroyed on the very
  first failed attempt, silencing retries for the rest of the session. **This is a live bug on
  `v1.0-dev` today** (#936 is already merged), found and fixed while chasing a CI failure, not
  discovered by intentional review. Fix: only cache the ratcheted value when the trigger fetch
  actually succeeded; restore the direct, network-sourced assignment on the epoch-fetch success
  path; and surface "not confirmed yet" in the fee-multiplier-unavailable message instead of a
  bogus `0`. All three tests pass **unmodified** — confirmed with a RED-first reproduction
  (temporarily reinstating #936's exact unconditional-cache line reproduces the failure on
  demand) before restoring the fix. `ProtocolRefresh::Required` still returns `Ok` when both
  fetches fail — deliberately left alone, since the capability gate fails closed downstream
  either way; this is a logging-loudness gap, not a safety one.

## Testing

`cargo build --all-features`, `cargo fmt --all -- --check`, and
`cargo clippy --all-features --all-targets -- -D warnings` all clean. Scoped
`cargo nextest run --all-features -E 'test(backend_task::platform_info) + test(mcp::resolve)'`:
**7 passed, 0 failed** — includes the three previously-failing `mcp::resolve` tests (unmodified)
plus two `platform_info` tests updated for the `Option<u32>` signature change and one new
regression test (`a_failed_ratchet_trigger_leaves_the_protocol_version_unconfirmed`) proven via
RED-first reproduction. `cargo check --all-features --all-targets` on the original dependency
bump alone was exit 0, zero warnings, as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated unreleased security tracking: marked the memory-exhaustion advisory as resolved via a dependency lockfile bump.
  * Kept the key-value map serialization panic advisory open, with noted constraints from an existing pinned dependency version.
  * Improved shielded network protocol availability messaging: shielded operations remain unavailable when the network can’t be reached, while the app continues retrying rather than assuming the built-in protocol version.
* **Bug Fixes**
  * Refined “unavailable epoch info” text to reflect whether a confirmed protocol version is available. 
* **Documentation**
  * Added guidance to re-check the open security item once upstream dependency pins change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
