### PR TITLE
chore(deps): track platform PR #3968 branch for wallet-storage rehydration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "dash-async"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "heck",
  "quote",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "document-history-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2556,7 +2556,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6471,7 +6471,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "aes",
  "cbc",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6493,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6524,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 5.0.1",
@@ -6535,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet-storage"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -6859,7 +6859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -6880,7 +6880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "backon",
  "chrono",
@@ -7600,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8842,7 +8842,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10268,7 +10268,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#debf67bdae8d72ae76aba362c43daafba8a5c21d"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,8 +1876,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1978,8 +1978,8 @@ dependencies = [
 
 [[package]]
 name = "dash-async"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1988,8 +1988,8 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2099,8 +2099,8 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "heck",
  "quote",
@@ -2109,8 +2109,8 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2246,8 +2246,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2257,8 +2257,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2526,8 +2526,8 @@ dependencies = [
 
 [[package]]
 name = "document-history-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2555,8 +2555,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2566,8 +2566,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,8 +2616,8 @@ dependencies = [
 
 [[package]]
 name = "dpp-json-convertible-derive"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2626,8 +2626,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2651,8 +2651,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -5045,8 +5045,8 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5258,8 +5258,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6470,8 +6470,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-encryption"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "aes",
  "cbc",
@@ -6483,8 +6483,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6492,8 +6492,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6503,8 +6503,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6523,8 +6523,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 5.0.1",
@@ -6534,8 +6534,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6544,8 +6544,8 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6576,8 +6576,8 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet-storage"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -6859,7 +6859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6880,7 +6880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7573,8 +7573,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "backon",
  "chrono",
@@ -7599,8 +7599,8 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8841,8 +8841,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9686,8 +9686,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10268,7 +10268,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10942,8 +10942,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "4.1.0-rc.1"
-source = "git+https://github.com/dashpay/platform?rev=288a6cae4f9653d6085d2b3d6c7410210a0c95ba#288a6cae4f9653d6085d2b3d6c7410210a0c95ba"
+version = "4.1.0"
+source = "git+https://github.com/dashpay/platform?branch=feat%2Fplatform-wallet-storage-rehydration#0ed8b4d16b282b55b90c73bced6084082a455142"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 # TODO: GHSA-7gcf-g7xr-8hxj (serde_with <3.21.0) is unfixable from here — the 2.x pin lives in
 # dashcore-rpc-json (dashpay/rust-dashcore, rpc-json/Cargo.toml). Re-check when these pins move.
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d6085d2b3d6c7410210a0c95ba", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-storage-rehydration", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -30,12 +30,12 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d6085d2b3d6c7410210a0c95ba" }
-platform-wallet = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d6085d2b3d6c7410210a0c95ba", features = [
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-storage-rehydration" }
+platform-wallet = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-storage-rehydration", features = [
     "serde",
     "shielded",
 ] }
-platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "288a6cae4f9653d6085d2b3d6c7410210a0c95ba", features = [
+platform-wallet-storage = { git = "https://github.com/dashpay/platform", branch = "feat/platform-wallet-storage-rehydration", features = [
     "shielded",
 ] }
 zip32 = "0.2.0"


### PR DESCRIPTION
## TL;DR
Points this app's Dash Platform dependency at the in-progress work for embeddable SQLite wallet-storage persistence (with seedless rehydration), so it stays current with that work automatically instead of needing a manual re-pin on every commit.

## Detailed discussion

`dash-sdk`, `rs-sdk-trusted-context-provider`, `platform-wallet`, and `platform-wallet-storage` were pinned to a fixed commit (`rev = "288a6cae..."`) on `dashpay/platform`. This switches all four to `branch = "feat/platform-wallet-storage-rehydration"` — the head branch of [dashpay/platform#3968](https://github.com/dashpay/platform/pull/3968), currently open — so `Cargo.lock` tracks that branch's HEAD rather than a one-time snapshot.

`Cargo.lock` was regenerated (`cargo update -p dash-sdk -p platform-wallet -p platform-wallet-storage -p rs-sdk-trusted-context-provider`), pulling in the branch's current tip (`0ed8b4d1`) and bumping the affected platform crates from `4.1.0-rc.1` to `4.1.0`.

This is a **temporary branch tracking pin**, not a permanent arrangement — intended to ride PR #3968 while it's in review, and should be re-pinned to a fixed `rev` (or dropped in favor of whatever `dashpay/platform#3968` merges to) once that PR lands.

## Testing
- `cargo-cached.sh clippy --bin dash-evo-tool --all-features -- -D warnings` — clean, exit 0.
- `cargo fmt --all` — clean, no changes needed beyond the dependency edits.
- `git diff --check` — clean.
- Full workspace test/clippy sweep left to CI (`tests.yml`/`clippy.yml`), which this diff's `Cargo.toml`/`Cargo.lock` changes will trigger.

## Breaking changes
None to this app's own code — dependency-tracking change only. Note: since this tracks a branch rather than a fixed commit, a future push to `feat/platform-wallet-storage-rehydration` upstream will change `Cargo.lock`'s resolved commit on the next `cargo update` without any corresponding commit in this repo — worth knowing before merging as a base for other work.

## Attribution
<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal wallet and SDK components to align with the latest development updates.
  * No direct user-facing changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->