### PR TITLE
chore(deps): bump platform pin to PR #3968 tip (fix empty-script UTXO wallet-brick)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **One damaged payment record no longer makes every wallet unopenable**: all
+  wallets are kept in a single file, and one unreadable payment record in it
+  stopped that whole file from opening — every wallet it held, funded ones
+  included, reported "Saved wallet data appears damaged and cannot be loaded."
+  Such a record is now skipped so the remaining wallets open normally, and the
+  records that caused it are no longer written in the first place. Wallets
+  already affected open again after updating, with their funds intact and no
+  need to restore from a recovery phrase. Amounts are still checked strictly:
+  a damaged record that carries a balance continues to stop the file from
+  opening rather than show a total that is quietly too low.
+
 - **"Max" now matches what your Core wallet can actually send**: pressing
   "Max" when shielding DASH, funding a Platform address through the Simple
   builder-driven form, sending directly to an identity, or funding an identity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "dash-async"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2100,7 +2100,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "heck",
  "quote",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2247,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "document-history-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2556,7 +2556,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2567,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2617,7 +2617,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6471,7 +6471,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "aes",
  "cbc",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6493,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6524,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 5.0.1",
@@ -6535,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet-storage"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -7574,7 +7574,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "backon",
  "chrono",
@@ -7600,7 +7600,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8842,7 +8842,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9687,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=a18bd1586858ef680124e150caad6a7dc21d0b64#a18bd1586858ef680124e150caad6a7dc21d0b64"
+source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 # TODO: GHSA-7gcf-g7xr-8hxj (serde_with <3.21.0) is unfixable from here — the 2.x pin lives in
 # dashcore-rpc-json (dashpay/rust-dashcore, rpc-json/Cargo.toml). Re-check when these pins move.
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "a18bd1586858ef680124e150caad6a7dc21d0b64", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -30,12 +30,12 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "a18bd1586858ef6
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "a18bd1586858ef680124e150caad6a7dc21d0b64" }
-platform-wallet = { git = "https://github.com/dashpay/platform", rev = "a18bd1586858ef680124e150caad6a7dc21d0b64", features = [
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e" }
+platform-wallet = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
     "serde",
     "shielded",
 ] }
-platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "a18bd1586858ef680124e150caad6a7dc21d0b64", features = [
+platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
     "shielded",
 ] }
 zip32 = "0.2.0"


### PR DESCRIPTION
**TL;DR:** Pull in an upstream fix so a single damaged payment record can no longer make an entire wallet file — every wallet in it — refuse to open.

## User story
As a **Dash Evo Tool user**, I want one unreadable internal record to never take down my whole wallet file, so a wallet that was working keeps working after a restart.

## Scenario
### Base flow
DET keeps all of a user's wallets in one on-disk file. Normal use — syncing, migrating from an older install, topping up an identity — can produce internal bookkeeping records for spent payments the wallet never had full details for.

### Actual behavior
One such record could end up with no readable script attached. On the next launch, DET tries to read every record in the file to build its address-reuse safeguard, hits the unreadable one, and — because that check historically failed the *entire* file's load rather than skipping the one bad record — rejects every wallet in it. A real user hit this: one bad record out of 668 locked all 12 of their wallets, reporting "Saved wallet data appears damaged and cannot be loaded. Restore the wallet from its recovery phrase to keep using it." — even though nothing about their actual funds or keys was damaged.

### Expected behavior
An unreadable record is skipped, with the rest of the wallet loading normally. The record that caused this is no longer written in the first place going forward.

## Detailed discussion
### What was done
Bumps the pinned `dashpay/platform` git dependency (`dash-sdk`, `rs-sdk-trusted-context-provider`, `platform-wallet`, `platform-wallet-storage` — all four share one revision by necessity, since splitting them would resolve two git sources for one repo and duplicate every shared platform type) from `a18bd158` to `762c66cf`, the current tip of upstream PR [dashpay/platform#3968](https://github.com/dashpay/platform/pull/3968).

`762c66cf` (`fix(platform-wallet-storage): stop one bad script row from bricking a wallet file`) is a direct child of the previous pin, touching only `rs-platform-wallet-storage`. It stops manufacturing a placeholder record with no script for a spent payment the wallet has no prior record of, and makes the address-reuse-guard readers skip and warn on an unreadable record instead of failing the whole load. The balance-bearing load path stays deliberately fail-hard — it only ever reads confirmed-unspent records, so a genuinely corrupt balance-affecting record still refuses to open rather than silently under-reporting funds.

No DET-side code change was needed: `load_used_addresses` and `AddressDecode` (the upstream types involved) don't appear anywhere in this repository, and every `Address::from_script` call site here already tolerates a decode failure and never touches the affected persisted-record path — verified by grep, not assumed.

Root cause was originally traced against a real user's broken database (a full investigation, separately documented) and led to two other, unrelated fixes already in [#951](https://github.com/dashpay/dash-evo-tool/pull/951) (a duplicate-identity-index guard and a top-up-account persistence fix) — those are real, independently confirmed bugs, but this PR is what actually fixes *that user's specific incident*.

### Testing
- `cargo clippy --locked --all-features --all-targets -- -D warnings` — clean (this is also the build check; a superset of compilation).
- `cargo test --locked --all-features --lib wallet` (covers `wallet_backend::{loader,hydration,single_key,snapshot,wallet_seed_store,wallet_meta}` and `context::wallet_lifecycle::tests`, the load/rehydration surface this touches) — 722 passed, 0 failed, 1 pre-existing ignored.
- `cargo fmt --all` — no source reformatted.
- `Cargo.lock` rewritten as a targeted rev substitution (28 platform `source =` lines only) rather than a plain `cargo update`, which would have also re-pointed unrelated dependencies (`prost-build`, `prost-derive`, `winapi-util`) onto older already-present versions for no reason. Both verification runs used `--locked`, which hard-fails on any lock/manifest mismatch.
- Full workspace suite left to CI per this repo's own CI policy.

### Breaking changes
None. Dependency bump only; no public API changed upstream, no DET code changed.

### Checklist
- [x] Upstream fix verified against the actual commit (single-parent child of current pin, scoped diff, own test coverage)
- [x] DET-side dependency on old behavior checked and confirmed absent
- [x] `cargo fmt --all`, `clippy --all-features --all-targets -- -D warnings` clean
- [x] CHANGELOG entry added (`Unreleased` → `Fixed`, Everyday User voice)
- [ ] CI full suite green

### Prior work
- [#951](https://github.com/dashpay/dash-evo-tool/pull/951) — two independent, real identity/account hardening fixes found during the same investigation; does not fix this specific incident, complementary to this PR.
- Upstream: [dashpay/platform#3968](https://github.com/dashpay/platform/pull/3968), tip commit `762c66cf`.

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallets can now remain loadable when individual payment records are unreadable.
  * Records containing balance information continue to block loading when they cannot be read, preventing wallet totals from being understated.

* **Documentation**
  * Added changelog documentation describing the updated handling of unreadable payment records and its effect on wallet loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->