### PR TITLE
chore(deps): bump platform pin to PR #3968 latest (4784de03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **A funding transaction found again on the network is now labelled honestly**:
+  when the app rediscovers a saved funding transaction from the chain rather
+  than tracking it from the start, it can tell that the network confirmed it but
+  not whether it was already spent on an identity. The funding list says exactly
+  that instead of claiming it is ready to use or already used. Selecting it still
+  works — the network has the final say and refuses one that was already spent.
+
 - **Upstream wallet backend updated (`platform-wallet` / `platform-wallet-storage`)**:
   the `dashpay/platform` dependency is bumped to the PR #3968 tip
   (`d18020f` → `288a6ca`), which lands an embeddable SQLite persistence backend with

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,8 +1876,8 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1978,18 +1978,20 @@ dependencies = [
 
 [[package]]
 name = "dash-async"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
+ "futures",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "dash-context-provider"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2081,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -2092,15 +2094,15 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "dash-network",
 ]
 
 [[package]]
 name = "dash-platform-macros"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "heck",
  "quote",
@@ -2108,9 +2110,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dash-platform-queries"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+dependencies = [
+ "dapi-grpc",
+ "dash-context-provider",
+ "dash-platform-macros",
+ "dpp",
+ "drive",
+ "drive-proof-verifier",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "dash-sdk"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2122,6 +2142,7 @@ dependencies = [
  "dash-context-provider",
  "dash-network-seeds",
  "dash-platform-macros",
+ "dash-platform-queries",
  "derive_more 1.0.0",
  "dotenvy",
  "dpp",
@@ -2148,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2177,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -2203,12 +2224,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -2221,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "bincode 2.0.1",
  "dashcore",
@@ -2236,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "bincode 2.0.1",
  "dashcore-private",
@@ -2246,8 +2267,8 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2257,8 +2278,8 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2526,8 +2547,8 @@ dependencies = [
 
 [[package]]
 name = "document-history-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2555,8 +2576,8 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dpns-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2566,8 +2587,8 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2616,8 +2637,8 @@ dependencies = [
 
 [[package]]
 name = "dpp-json-convertible-derive"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2626,8 +2647,8 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2651,8 +2672,8 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -3675,7 +3696,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 
 [[package]]
 name = "gl_generator"
@@ -3873,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -3896,7 +3917,7 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -3911,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
@@ -3936,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -3946,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -3972,7 +3993,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -3986,7 +4007,7 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "grovedb-costs 5.0.1",
  "hex",
@@ -4019,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "bincode_derive",
@@ -4041,7 +4062,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "blake3",
@@ -4059,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "hex",
 ]
@@ -4067,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -4090,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4108,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "5.0.1"
-source = "git+https://github.com/dashpay/grovedb?tag=v5.0.1#6bb2ebff62a842a3c416126bbcfcf7774dfe0262"
+source = "git+https://github.com/dashpay/grovedb?rev=a2791bbdca756d6a6113024aec48f09f7a33faa9#a2791bbdca756d6a6113024aec48f09f7a33faa9"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -4999,7 +5020,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "async-trait",
  "base58ck",
@@ -5022,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=dash-evo-tool#34f0921ee6881d6c88cbd58caad33a6fe6575f24"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=173ffac0fdc0c73dda0626cf385bbcfcf2437aeb#173ffac0fdc0c73dda0626cf385bbcfcf2437aeb"
 dependencies = [
  "async-trait",
  "dashcore",
@@ -5045,8 +5066,8 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5258,8 +5279,8 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6470,8 +6491,8 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-encryption"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "aes",
  "cbc",
@@ -6483,8 +6504,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6492,8 +6513,8 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6503,8 +6524,8 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6523,8 +6544,8 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 5.0.1",
@@ -6534,8 +6555,8 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6544,13 +6565,14 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "arc-swap",
  "async-trait",
  "bimap",
  "bs58",
+ "dash-async",
  "dash-sdk",
  "dash-spv",
  "dashcore",
@@ -6561,6 +6583,7 @@ dependencies = [
  "image",
  "key-wallet",
  "key-wallet-manager",
+ "log",
  "platform-encryption",
  "rusqlite",
  "serde",
@@ -6576,8 +6599,8 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet-storage"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -6859,7 +6882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -6880,7 +6903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7573,8 +7596,8 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "backon",
  "chrono",
@@ -7599,8 +7622,8 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8841,8 +8864,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9686,8 +9709,8 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10268,7 +10291,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -10942,8 +10965,8 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "4.1.0"
-source = "git+https://github.com/dashpay/platform?rev=762c66cf7716b9b3264868a49e8d29991c643c7e#762c66cf7716b9b3264868a49e8d29991c643c7e"
+version = "4.2.0-dev.1"
+source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "dapi-grpc"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1979,7 +1979,7 @@ dependencies = [
 [[package]]
 name = "dash-async"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "futures",
  "thiserror 2.0.18",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "dash-context-provider"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "dash-async",
  "dpp",
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-macros"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "heck",
  "quote",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "dash-platform-queries"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "dapi-grpc",
  "dash-context-provider",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "dash-sdk"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2268,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "dashpay-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2279,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "data-contracts"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "dashpay-contract",
  "document-history-contract",
@@ -2548,7 +2548,7 @@ dependencies = [
 [[package]]
 name = "document-history-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2577,7 +2577,7 @@ checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 [[package]]
 name = "dpns-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "dpp"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "dpp-json-convertible-derive"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2648,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "drive"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "bincode 2.0.1",
  "byteorder",
@@ -2673,7 +2673,7 @@ dependencies = [
 [[package]]
 name = "drive-proof-verifier"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "bincode 2.0.1",
  "dapi-grpc",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "keyword-search-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -5280,7 +5280,7 @@ dependencies = [
 [[package]]
 name = "masternode-reward-shares-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -6492,7 +6492,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "platform-encryption"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "aes",
  "cbc",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "bincode 2.0.1",
  "platform-version",
@@ -6514,7 +6514,7 @@ dependencies = [
 [[package]]
 name = "platform-serialization-derive"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "platform-value"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "platform-version"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "bincode 2.0.1",
  "grovedb-version 5.0.1",
@@ -6556,7 +6556,7 @@ dependencies = [
 [[package]]
 name = "platform-versioning"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6600,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "platform-wallet-storage"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "apple-native-keyring-store",
  "argon2",
@@ -6882,7 +6882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6903,7 +6903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7597,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "rs-dapi-client"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "backon",
  "chrono",
@@ -7623,7 +7623,7 @@ dependencies = [
 [[package]]
 name = "rs-sdk-trusted-context-provider"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "arc-swap",
  "dash-async",
@@ -8865,7 +8865,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token-history-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "wallet-utils-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -10291,7 +10291,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10966,7 +10966,7 @@ dependencies = [
 [[package]]
 name = "withdrawals-contract"
 version = "4.2.0-dev.1"
-source = "git+https://github.com/dashpay/platform?rev=993584a6b53831026f2f5fe30f21a8f4d14a06e8#993584a6b53831026f2f5fe30f21a8f4d14a06e8"
+source = "git+https://github.com/dashpay/platform?rev=4784de0369381e98b6f60504600990cd89cb705a#4784de0369381e98b6f60504600990cd89cb705a"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 # TODO: GHSA-7gcf-g7xr-8hxj (serde_with <3.21.0) is unfixable from here — the 2.x pin lives in
 # dashcore-rpc-json (dashpay/rust-dashcore, rpc-json/Cargo.toml). Re-check when these pins move.
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -30,12 +30,12 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e" }
-platform-wallet = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8" }
+platform-wallet = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
     "serde",
     "shielded",
 ] }
-platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "762c66cf7716b9b3264868a49e8d29991c643c7e", features = [
+platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
     "shielded",
 ] }
 zip32 = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ eframe = { version = "0.35.0", features = ["persistence", "wgpu"] }
 base64 = "0.22.1"
 # TODO: GHSA-7gcf-g7xr-8hxj (serde_with <3.21.0) is unfixable from here — the 2.x pin lives in
 # dashcore-rpc-json (dashpay/rust-dashcore, rpc-json/Cargo.toml). Re-check when these pins move.
-dash-sdk = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
+dash-sdk = { git = "https://github.com/dashpay/platform", rev = "4784de0369381e98b6f60504600990cd89cb705a", features = [
     "core_key_wallet",
     "core_key_wallet_manager",
     "core_bincode",
@@ -30,12 +30,12 @@ dash-sdk = { git = "https://github.com/dashpay/platform", rev = "993584a6b538310
     "core_spv",
     "shielded",
 ] }
-rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8" }
-platform-wallet = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
+rs-sdk-trusted-context-provider = { git = "https://github.com/dashpay/platform", rev = "4784de0369381e98b6f60504600990cd89cb705a" }
+platform-wallet = { git = "https://github.com/dashpay/platform", rev = "4784de0369381e98b6f60504600990cd89cb705a", features = [
     "serde",
     "shielded",
 ] }
-platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "993584a6b53831026f2f5fe30f21a8f4d14a06e8", features = [
+platform-wallet-storage = { git = "https://github.com/dashpay/platform", rev = "4784de0369381e98b6f60504600990cd89cb705a", features = [
     "shielded",
 ] }
 zip32 = "0.2.0"

--- a/src/backend_task/contract.rs
+++ b/src/backend_task/contract.rs
@@ -82,6 +82,7 @@ impl AppContext {
                                     data_contract: search_contract.clone(),
                                     document_type_name: "fullDescription".to_string(),
                                     limit: 1,
+                                    offset: None,
                                     start: None,
                                     where_clauses: vec![WhereClause {
                                         field: "contractId".to_string(),

--- a/src/backend_task/dashpay.rs
+++ b/src/backend_task/dashpay.rs
@@ -35,7 +35,7 @@ fn contact_request_query(app_context: &AppContext) -> Result<DocumentQuery, Dash
     DocumentQuery::new(app_context.dashpay_contract.clone(), "contactRequest").map_err(|e| {
         DashPayError::QueryCreation {
             query_target: "DashPay contactRequest",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         }
     })
 }

--- a/src/backend_task/dashpay/contact_info.rs
+++ b/src/backend_task/dashpay/contact_info.rs
@@ -510,7 +510,7 @@ async fn lookup_contact_info(
     let mut query = DocumentQuery::new(dashpay_contract, "contactInfo").map_err(|e| {
         DashPayError::QueryCreation {
             query_target: "DashPay contactInfo",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         }
     })?;
     query = query.with_where(WhereClause {

--- a/src/backend_task/dashpay/contact_requests.rs
+++ b/src/backend_task/dashpay/contact_requests.rs
@@ -667,6 +667,7 @@ async fn resolve_username_to_identity(
         having: Vec::new(),
         order_by_clauses: vec![],
         limit: 1,
+        offset: None,
         start: None,
     };
 

--- a/src/backend_task/dashpay/contacts.rs
+++ b/src/backend_task/dashpay/contacts.rs
@@ -215,7 +215,7 @@ pub async fn load_contacts(
     let mut contact_info_query = DocumentQuery::new(dashpay_contract.clone(), "contactInfo")
         .map_err(|e| DashPayError::QueryCreation {
             query_target: "DashPay contactInfo",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         })?;
 
     contact_info_query = contact_info_query.with_where(WhereClause {

--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -31,7 +31,7 @@ pub async fn load_profile(
     let mut profile_query = DocumentQuery::new(dashpay_contract, "profile").map_err(|e| {
         DashPayError::QueryCreation {
             query_target: "DashPay profile",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         }
     })?;
 
@@ -182,7 +182,7 @@ pub async fn update_profile(
         DocumentQuery::new(dashpay_contract.clone(), "profile").map_err(|e| {
             DashPayError::QueryCreation {
                 query_target: "DashPay profile",
-                source: Box::new(e),
+                source: Box::new(e.into()),
             }
         })?;
 
@@ -436,7 +436,7 @@ pub async fn fetch_contact_profile(
     let mut query = DocumentQuery::new(dashpay_contract, "profile").map_err(|e| {
         DashPayError::QueryCreation {
             query_target: "DashPay profile",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         }
     })?;
 
@@ -481,7 +481,7 @@ pub async fn search_profiles(
     let mut dpns_query =
         DocumentQuery::new(dpns_contract, "domain").map_err(|e| DashPayError::QueryCreation {
             query_target: "DPNS domain",
-            source: Box::new(e),
+            source: Box::new(e.into()),
         })?;
 
     dpns_query = dpns_query
@@ -532,7 +532,7 @@ pub async fn search_profiles(
             DocumentQuery::new(dashpay_contract.clone(), "profile").map_err(|e| {
                 DashPayError::QueryCreation {
                     query_target: "DashPay profile",
-                    source: Box::new(e),
+                    source: Box::new(e.into()),
                 }
             })?;
 

--- a/src/backend_task/document.rs
+++ b/src/backend_task/document.rs
@@ -110,6 +110,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 1,
+            offset: None,
             start: None,
         };
         let query_with_id = DocumentQuery::with_document_id(document_query, &document_id);

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -330,6 +330,15 @@ pub enum TaskError {
     )]
     AssetLockNotEligibleForTopUp,
 
+    /// A top-up of an identity outside this wallet was handed a funding mode
+    /// this path cannot build — currently only the whole-account drain, which
+    /// no flow here requests. Rejected before any funds move rather than
+    /// quietly substituting a different funding mode.
+    #[error(
+        "This way of paying is not available when topping up an identity from another wallet. Enter the amount to add, or choose a saved funding transaction instead."
+    )]
+    TopUpFundingMethodUnsupported,
+
     /// The asset-lock proof finalization (InstantSend → ChainLock fallback)
     /// timed out without producing a usable proof for Platform.
     #[error(

--- a/src/backend_task/grovestark.rs
+++ b/src/backend_task/grovestark.rs
@@ -173,7 +173,7 @@ impl GroveSTARKProver {
             .map_err(GroveSTARKError::InvalidDocumentId)?;
 
         let query = DocumentQuery::new(contract, document_type)
-            .map_err(|e| GroveSTARKError::Platform(Box::new(e)))?
+            .map_err(|e| GroveSTARKError::Platform(Box::new(e.into())))?
             .with_document_id(&document_id_identifier);
 
         let (document_opt, _metadata, proof) =
@@ -194,9 +194,12 @@ impl GroveSTARKProver {
         }
 
         // Step 4: Recover the current state root from the document proof.
-        let drive_document_query: DriveDocumentQuery = (&query)
-            .try_into()
-            .map_err(|e: dash_sdk::error::Error| GroveSTARKError::Platform(Box::new(e)))?;
+        let drive_document_query: DriveDocumentQuery =
+            (&query)
+                .try_into()
+                .map_err(|e: dash_sdk::dash_platform_queries::Error| {
+                    GroveSTARKError::Platform(Box::new(e.into()))
+                })?;
         let (state_root, _documents) = drive_document_query
             .verify_proof(&proof.grovedb_proof, sdk.version())
             .map_err(|e| GroveSTARKError::Platform(Box::new(dash_sdk::Error::Drive(e))))?;

--- a/src/backend_task/identity/discover_identities.rs
+++ b/src/backend_task/identity/discover_identities.rs
@@ -381,6 +381,7 @@ impl AppContext {
                 having: Vec::new(),
                 order_by_clauses: vec![],
                 limit: 100,
+                offset: None,
                 start: None,
             };
 

--- a/src/backend_task/identity/load_identity.rs
+++ b/src/backend_task/identity/load_identity.rs
@@ -413,6 +413,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 100,
+            offset: None,
             start: None,
         };
 

--- a/src/backend_task/identity/load_identity_by_dpns_name.rs
+++ b/src/backend_task/identity/load_identity_by_dpns_name.rs
@@ -42,6 +42,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 1,
+            offset: None,
             start: None,
         };
 
@@ -88,6 +89,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 100,
+            offset: None,
             start: None,
         };
 

--- a/src/backend_task/identity/load_identity_from_wallet.rs
+++ b/src/backend_task/identity/load_identity_from_wallet.rs
@@ -112,6 +112,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 100,
+            offset: None,
             start: None,
         };
 

--- a/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
+++ b/src/backend_task/identity/refresh_loaded_identities_dpns_names.rs
@@ -34,6 +34,7 @@ impl AppContext {
                 having: Vec::new(),
                 order_by_clauses: vec![],
                 limit: 100,
+                offset: None,
                 start: None,
             };
 

--- a/src/backend_task/identity/register_dpns_name.rs
+++ b/src/backend_task/identity/register_dpns_name.rs
@@ -199,6 +199,7 @@ impl AppContext {
             having: Vec::new(),
             order_by_clauses: vec![],
             limit: 100,
+            offset: None,
             start: None,
         };
 

--- a/src/backend_task/identity/top_up_identity.rs
+++ b/src/backend_task/identity/top_up_identity.rs
@@ -227,6 +227,12 @@ impl AppContext {
                     .resume_unbound_topup_asset_lock(seed_hash, out_point)
                     .await?
             }
+            // Unreachable from here — the caller builds only the two modes
+            // above — but this is a funds path, so an upstream funding mode
+            // this path cannot build fails closed instead of panicking.
+            AssetLockFunding::DrainAccountBalance { .. } => {
+                return Err(TaskError::TopUpFundingMethodUnsupported);
+            }
         };
 
         identity

--- a/src/backend_task/platform_info.rs
+++ b/src/backend_task/platform_info.rs
@@ -721,6 +721,7 @@ impl AppContext {
                     having: Vec::new(),
                     order_by_clauses: vec![],
                     limit: 50,
+                    offset: None,
                     start: None,
                 };
 
@@ -785,6 +786,7 @@ impl AppContext {
                         },
                     ],
                     limit: 100,
+                    offset: None,
                     start: None,
                 };
 
@@ -895,6 +897,7 @@ impl AppContext {
                     having: Vec::new(),
                     order_by_clauses,
                     limit: page_limit,
+                    offset: None,
                     start,
                 };
 

--- a/src/context/wallet_lifecycle/tests.rs
+++ b/src/context/wallet_lifecycle/tests.rs
@@ -3786,16 +3786,28 @@ async fn ensure_identity_funding_accounts_succeeds_on_cold_booted_watch_only_wal
     backend2.shutdown().await;
 }
 
-/// A malformed Orchard viewing key must be isolated to its own wallet during
-/// the real seedless cold-boot load.
+/// A shielded viewing-key row that will not decode fails the whole seedless
+/// cold boot, with the dedicated fatal local-data error naming the column.
+///
+/// Upstream gates every tolerated decode failure on `LoadPolicy`, which
+/// defaults to `Strict` — a row that will not decode aborts `load()` rather
+/// than being skipped, so no wallet in the file comes up half-formed. DET
+/// opens its persister under that default and therefore fails closed here.
+/// Graceful degradation (retrying the load under `LoadPolicy::Recovery` for
+/// read-only access) is deliberately not covered: it does not exist yet.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn cold_boot_skips_corrupt_fvk_for_one_wallet_and_restores_healthy_wallet() {
+async fn cold_boot_fails_closed_on_a_corrupt_fvk_row() {
+    use platform_wallet::changeset::{PersistenceError, PersistenceErrorKind};
+    use platform_wallet::error::PlatformWalletError;
+
     let _guard = backend_reopen_lock().await;
     let source_dir = tempfile::tempdir().expect("source tempdir");
     let corrupt_seed = [0xD5u8; 64];
     let healthy_seed = [0xD6u8; 64];
 
-    let (corrupt_hash, corrupt_wallet_id, healthy_hash, healthy_wallet_id) = {
+    // The seed hashes matter only inside the fixture block below; the strict
+    // load fails before any wallet is registered, so nothing outside reads them.
+    let (corrupt_wallet_id, healthy_wallet_id) = {
         let password = Secret::new("cold-boot-fvk-password");
         let corrupt_wallet = crate::model::wallet::Wallet::new_from_seed(
             corrupt_seed,
@@ -3881,12 +3893,7 @@ async fn cold_boot_skips_corrupt_fvk_for_one_wallet_and_restores_healthy_wallet(
 
         backend.shutdown().await;
         let _ = ctx.subtasks.shutdown_async().await;
-        (
-            corrupt_hash,
-            corrupt_wallet_id,
-            healthy_hash,
-            healthy_wallet_id,
-        )
+        (corrupt_wallet_id, healthy_wallet_id)
     };
 
     let cold_dir = tempfile::tempdir().expect("cold tempdir");
@@ -3906,48 +3913,49 @@ async fn cold_boot_skips_corrupt_fvk_for_one_wallet_and_restores_healthy_wallet(
     );
     drop(connection);
 
-    let (ctx, sender) = offline_testnet_context_at(cold_dir.path());
-    ctx.ensure_wallet_backend(sender)
-        .await
-        .expect("one corrupt FVK must not prevent cold boot");
-    let backend = ctx.wallet_backend().expect("cold-boot backend");
-
-    assert!(
-        ctx.wallets.read_recover().contains_key(&corrupt_hash),
-        "the corrupt-FVK DET wallet must remain registered"
-    );
-    assert!(
-        ctx.wallets.read_recover().contains_key(&healthy_hash),
-        "the healthy DET wallet must remain registered"
-    );
-    assert!(
-        backend.is_wallet_registered(&corrupt_hash),
-        "the corrupt-FVK wallet must remain registered upstream"
-    );
-    assert!(
-        backend.is_wallet_registered(&healthy_hash),
-        "the healthy wallet must remain registered upstream"
-    );
-    assert!(
-        !backend
-            .bind_shielded_from_persisted_for_test(&corrupt_hash)
-            .await
-            .expect("probe skipped corrupt viewing key"),
-        "the corrupt wallet must not restore a shielded binding"
-    );
-    assert!(
-        backend
-            .bind_shielded_from_persisted_for_test(&healthy_hash)
-            .await
-            .expect("restore healthy viewing key"),
-        "the healthy wallet must restore its shielded binding"
-    );
     assert_ne!(
         corrupt_wallet_id, healthy_wallet_id,
         "fixture wallets must have distinct upstream ids"
     );
 
-    backend.shutdown().await;
+    let (ctx, sender) = offline_testnet_context_at(cold_dir.path());
+    let error = ctx
+        .ensure_wallet_backend(sender)
+        .await
+        .expect_err("a corrupt FVK row must fail the strict cold-boot load");
+
+    // Assert the whole chain, not just the outer variant: the boot classifier
+    // only maps a `Fatal` backend load failure onto the dedicated error, and
+    // the column label is what says WHICH row aborted the load.
+    let TaskError::WalletLocalDataLoadFailed { source } = &error else {
+        panic!("fatal persisted-wallet corruption must use the dedicated error, got: {error:?}");
+    };
+    let PlatformWalletError::PersisterLoad(PersistenceError::Backend { kind, source }) =
+        source.as_ref()
+    else {
+        panic!("the corrupt row must surface as a persister load failure, got: {source:?}");
+    };
+    assert_eq!(
+        *kind,
+        PersistenceErrorKind::Fatal,
+        "a row that will not decode is not retryable"
+    );
+    let storage = source
+        .downcast_ref::<platform_wallet_storage::WalletStorageError>()
+        .expect("the SQLite backend boxes a typed WalletStorageError");
+    assert!(
+        matches!(
+            storage,
+            platform_wallet_storage::WalletStorageError::BlobDecode { reason }
+                if *reason == "shielded_viewing_keys.viewing_key"
+        ),
+        "the error must name the column that failed to decode, got: {storage:?}"
+    );
+
+    assert!(
+        ctx.wallet_backend().is_err(),
+        "a failed load must leave no half-wired backend behind"
+    );
     let _ = ctx.subtasks.shutdown_async().await;
 }
 

--- a/src/ui/contracts_documents/contracts_documents_screen.rs
+++ b/src/ui/contracts_documents/contracts_documents_screen.rs
@@ -230,8 +230,10 @@ impl DocumentQueryScreen {
                 self.selected_document_type = self.pending_document_type.clone();
                 self.document_fields_selection = self.pending_fields_selection.clone();
 
-                let parser =
-                    DocumentQueryTextInputParser::new(self.selected_data_contract.contract.clone());
+                let parser = DocumentQueryTextInputParser::new(
+                    self.selected_data_contract.contract.clone(),
+                    self.app_context.platform_version(),
+                );
                 match parser.parse_input(&self.document_query) {
                     Ok(parsed_query) => {
                         // Set the status to waiting

--- a/src/ui/contracts_documents/document_action_screen.rs
+++ b/src/ui/contracts_documents/document_action_screen.rs
@@ -776,7 +776,8 @@ impl DocumentActionScreen {
                                     .background_color(DashColors::input_background(dark_mode)),
                             );
                         }
-                        DocumentPropertyType::Identifier => {
+                        DocumentPropertyType::Identifier
+                        | DocumentPropertyType::IdentifierWithReference(_) => {
                             let dark_mode = ui.style().visuals.dark_mode;
                             ui.add(
                                 egui::TextEdit::singleline(val)
@@ -1352,7 +1353,8 @@ impl DocumentActionScreen {
                     };
                     Value::Bytes(bytes)
                 }
-                DocumentPropertyType::Identifier => {
+                DocumentPropertyType::Identifier
+                | DocumentPropertyType::IdentifierWithReference(_) => {
                     let id = Identifier::from_string(input_str, Encoding::Base58)
                         .map_err(|_| format!("{} is not a valid Identifier (base58)", name))?;
                     id.into()
@@ -1529,7 +1531,8 @@ impl DocumentActionScreen {
                     };
                     Value::Bytes(bytes)
                 }
-                DocumentPropertyType::Identifier => {
+                DocumentPropertyType::Identifier
+                | DocumentPropertyType::IdentifierWithReference(_) => {
                     let id = Identifier::from_string(input_str, Encoding::Base58)
                         .map_err(|_| format!("{} is not a valid Identifier (base58)", name))?;
                     id.into()

--- a/src/ui/identities/funding_common.rs
+++ b/src/ui/identities/funding_common.rs
@@ -251,6 +251,11 @@ pub fn asset_lock_status_label(status: &AssetLockStatus) -> &'static str {
         AssetLockStatus::InstantSendLocked => "Confirmed and ready to use.",
         AssetLockStatus::ChainLocked => "Confirmed and ready to use.",
         AssetLockStatus::Consumed => "Already used to fund an identity.",
+        // Core-side finality is proven, but whether Platform already spent this
+        // lock is unknown, so it must claim neither "ready" nor "already used".
+        AssetLockStatus::RecoveredFromChain => {
+            "Confirmed on the network. It may already have been used to fund an identity."
+        }
     }
 }
 

--- a/src/ui/tokens/view_token_claims_screen.rs
+++ b/src/ui/tokens/view_token_claims_screen.rs
@@ -76,6 +76,7 @@ impl ViewTokenClaimsScreen {
                 having: Vec::new(),
                 order_by_clauses: vec![],
                 limit: 0,
+                offset: None,
                 start: None,
             },
             fetch_status: FetchStatus::NotFetching,

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -1,6 +1,7 @@
 //! Parsers for text input.
 
 use dash_sdk::dpp::prelude::DataContract;
+use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::platform::{DocumentQuery, DriveDocumentQuery};
 
 pub(crate) trait TextInputParser {
@@ -10,11 +11,20 @@ pub(crate) trait TextInputParser {
 
 pub(crate) struct DocumentQueryTextInputParser {
     data_contract: DataContract,
+    /// Selects the where-clause grammar the input is parsed under, so the app
+    /// accepts locally exactly what the network it talks to accepts.
+    platform_version: &'static PlatformVersion,
 }
 
 impl DocumentQueryTextInputParser {
-    pub(crate) fn new(data_contract: DataContract) -> Self {
-        DocumentQueryTextInputParser { data_contract }
+    pub(crate) fn new(
+        data_contract: DataContract,
+        platform_version: &'static PlatformVersion,
+    ) -> Self {
+        DocumentQueryTextInputParser {
+            data_contract,
+            platform_version,
+        }
     }
 }
 
@@ -22,7 +32,7 @@ impl TextInputParser for DocumentQueryTextInputParser {
     type Output = DocumentQuery;
 
     fn parse_input(&self, input: &str) -> Result<Self::Output, String> {
-        DriveDocumentQuery::from_sql_expr(input, &self.data_contract, None)
+        DriveDocumentQuery::from_sql_expr(input, &self.data_contract, None, self.platform_version)
             .map(Into::into)
             .map_err(|e| e.to_string())
     }

--- a/src/wallet_backend/mod.rs
+++ b/src/wallet_backend/mod.rs
@@ -1674,22 +1674,16 @@ impl WalletBackend {
         }
         // `pwm.shutdown()` quiesces the periodic coordinators — draining any
         // in-flight pass and its persister / host-callback fan-out — then drains
-        // the wallet-event adapter task. Best-effort: a non-clean report used to
-        // flag a still-live worker or orphan, which teardown proceeds past
-        // regardless — log it rather than surface it.
-        //
-        // TODO(platform-pr3954): `shutdown()` returns `()` at this rev (no
-        // clean-shutdown report type yet) — the report check below is
-        // commented out rather than dropped outright; restore once platform
-        // re-adds the report type. User-confirmed removal of the
-        // shutdown-failure warning log for this rev.
-        self.inner.pwm.shutdown().await;
-        // if !report.all_clean() {
-        //     tracing::warn!(
-        //         ?report,
-        //         "Wallet manager shutdown did not complete cleanly; continuing teardown"
-        //     );
-        // }
+        // the wallet-event adapter task. Best-effort: a non-clean report flags a
+        // still-live worker or orphan, which teardown proceeds past regardless —
+        // log it rather than surface it.
+        let report = self.inner.pwm.shutdown().await;
+        if !report.all_clean() {
+            tracing::warn!(
+                ?report,
+                "Wallet manager shutdown did not complete cleanly; continuing teardown"
+            );
+        }
     }
 
     /// Stop chain sync **in place**, keeping this backend (and its
@@ -1740,9 +1734,24 @@ impl WalletBackend {
         // 2. Quiesce the coordinators (consumers) directly — do NOT call
         //    `pwm.shutdown()`, which would also tear down the non-restartable
         //    wallet-event adapter.
-        self.inner.pwm.platform_address_sync_arc().quiesce().await;
-        self.inner.pwm.identity_sync_arc().quiesce().await;
-        self.inner.pwm.shielded_sync_arc().quiesce().await;
+        //    A coordinator that does not drain within its budget leaves its
+        //    upstream quiescing gate closed, so the reconnect cannot restart
+        //    it — name the one that wedged instead of reconnecting silently.
+        if !self.inner.pwm.platform_address_sync_arc().quiesce().await {
+            tracing::warn!(
+                "Platform address sync did not drain during disconnect; it stays inactive until a later stop drains it"
+            );
+        }
+        if !self.inner.pwm.identity_sync_arc().quiesce().await {
+            tracing::warn!(
+                "Identity sync did not drain during disconnect; it stays inactive until a later stop drains it"
+            );
+        }
+        if !self.inner.pwm.shielded_sync_arc().quiesce().await {
+            tracing::warn!(
+                "Shielded sync did not drain during disconnect; it stays inactive until a later stop drains it"
+            );
+        }
         // 3. Re-arm the DET start gates for the next start() on this backend.
         self.inner.start_latch.reset();
         self.inner.coordinator_gate.reset();
@@ -2869,10 +2878,6 @@ fn map_shielded_op_error(e: platform_wallet::error::PlatformWalletError) -> Task
         },
 
         // Every remaining variant → generic WalletBackend wrapper.
-        //
-        // TODO(platform-pr3954): `ShieldedShutdownIncomplete` doesn't exist on
-        // `PlatformWalletError` at this rev; it belongs in this bucket once
-        // platform re-adds it.
         other @ (P::WalletCreation(_)
         | P::PlatformNodePool(_)
         | P::PersisterLoad(_)
@@ -2924,7 +2929,21 @@ fn map_shielded_op_error(e: platform_wallet::error::PlatformWalletError) -> Task
         | P::ShieldedTreeUpdateFailed(_)
         | P::ShieldedStoreError(_)
         | P::ShieldedMerkleWitnessUnavailable(_)
-        | P::ShieldedKeyDerivation(_)) => TaskError::WalletBackend {
+        | P::ShieldedKeyDerivation(_)
+        | P::PlatformShieldCapacityExceeded { .. }
+        | P::CorePooledInsufficientFunds { .. }
+        | P::InsufficientIdentityCredits { .. }
+        | P::IdentityDiscoveryIncomplete { .. }
+        | P::DpnsNameNotFound { .. }
+        | P::ContestedNameNotTradable { .. }
+        | P::DocumentNotForSale { .. }
+        | P::DocumentPriceChanged { .. }
+        | P::InvalidParameter(_)
+        | P::MessageSigningAddressInvalid { .. }
+        | P::MessageSigningMessageInvalid { .. }
+        | P::MessageSigningKeyUnavailable { .. }
+        | P::MessageSigningFailed { .. }
+        | P::ShutdownIncomplete(_)) => TaskError::WalletBackend {
             source: Arc::new(other),
         },
     }
@@ -3184,10 +3203,33 @@ fn identity_op_error_kind(e: &platform_wallet::error::PlatformWalletError) -> Id
         // caller must not re-submit (the next sync reconciles).
         | P::TransactionBroadcastUnconfirmed(_)
         | P::ShieldedBroadcastUnconfirmed { .. }
-        | P::ShieldedSpendUnconfirmed { .. } => IdentityOpErrorKind::Other,
-        // TODO(platform-pr3954): `ShieldedShutdownIncomplete` doesn't exist on
-        // `PlatformWalletError` at this rev; it belongs in the `Other` bucket
-        // once platform re-adds it.
+        | P::ShieldedSpendUnconfirmed { .. }
+        // Funding and credit shortfalls, like their `CoreInsufficientFunds`
+        // sibling above: the submission never reached Platform.
+        | P::CorePooledInsufficientFunds { .. }
+        | P::InsufficientIdentityCredits { .. }
+        | P::PlatformShieldCapacityExceeded { .. }
+        // DPNS / document-trading preconditions. No identity register or
+        // top-up reaches them, and none describes a Platform rejection of
+        // *this* op.
+        | P::DpnsNameNotFound { .. }
+        | P::ContestedNameNotTradable { .. }
+        | P::DocumentNotForSale { .. }
+        | P::DocumentPriceChanged { .. }
+        | P::InvalidParameter(_)
+        // Message signing is a wallet-local operation with no Platform
+        // submission at all.
+        | P::MessageSigningAddressInvalid { .. }
+        | P::MessageSigningMessageInvalid { .. }
+        | P::MessageSigningKeyUnavailable { .. }
+        | P::MessageSigningFailed { .. }
+        // A gap-limit scan that left probes unanswered means "we do not
+        // know", so it is not `NotManaged` (which asserts the identity is
+        // absent and must be reloaded); upstream's contract is to retry.
+        | P::IdentityDiscoveryIncomplete { .. }
+        // Background sync failed to quiesce — a shutdown fault, unrelated to
+        // whether this op reached Platform.
+        | P::ShutdownIncomplete(_) => IdentityOpErrorKind::Other,
     }
 }
 
@@ -3564,6 +3606,30 @@ mod tests {
         assert!(
             matches!(mapped, TaskError::WalletBackend { .. }),
             "Expected WalletBackend fallthrough, got: {mapped:?}"
+        );
+    }
+
+    /// An incomplete identity-discovery scan means "we do not know", not "this
+    /// identity is not in the wallet": it must not classify as `NotManaged`,
+    /// whose user-facing advice is to reload the identity.
+    #[test]
+    fn map_identity_register_error_discovery_incomplete_is_not_not_managed() {
+        let inner = platform_wallet::error::PlatformWalletError::IdentityDiscoveryIncomplete {
+            start_index: 0,
+            probed: 20,
+            failed_probes: 3,
+            source: Box::new(dash_sdk::Error::Config("no node reachable".to_string())),
+        };
+        assert!(
+            matches!(identity_op_error_kind(&inner), IdentityOpErrorKind::Other),
+            "an unanswered discovery probe must not claim the identity is unmanaged"
+        );
+        assert!(
+            matches!(
+                map_identity_register_error(inner),
+                TaskError::WalletBackend { .. }
+            ),
+            "the register façade wraps it in the generic envelope"
         );
     }
 

--- a/src/wallet_backend/payments.rs
+++ b/src/wallet_backend/payments.rs
@@ -129,12 +129,11 @@ fn dry_run_asset_lock_amount(
 // bounded by rust-dashcore#919's suffix-sum feasibility prune and node budget,
 // which closes rust-dashcore#918. The aggregate quote still has a deadline
 // because it performs many individually bounded selections under a write lock.
-// Confirmed present: `platform`'s `key-wallet` dep tracks rust-dashcore's
-// `dash-evo-tool` integration branch (rev 34f0921e, which merges #919's
-// source branch directly), and this crate's own `Cargo.toml` pins `platform`
-// to rev a18bd1586858ef680124e150caad6a7dc21d0b64 (feat/platform-wallet-
-// storage-rehydration tip) or later, which resolves to that same key-wallet
-// rev or newer. If either pin ever moves backward, re-verify this holds.
+// Confirmed present: this crate's `Cargo.toml` pins `platform` to rev
+// 993584a6b53831026f2f5fe30f21a8f4d14a06e8, whose `key-wallet` dep pins
+// rust-dashcore rev 173ffac0, and that rev's `coin_selection.rs` is
+// byte-identical to the one carrying #919. Re-verify whenever either pin
+// moves — the key-wallet reference is a rev, so it cannot drift on its own.
 fn dry_run_asset_lock_amount_with_strategy(
     managed_account: &ManagedCoreFundsAccount,
     account: &Account,
@@ -152,20 +151,24 @@ fn dry_run_asset_lock_amount_with_strategy(
                 script_pubkey: ScriptBuf::from_bytes(vec![0; P2PKH_CREDIT_OUTPUT_SCRIPT_LEN]),
             }]),
         ))
-        .set_funding(&mut dry_run_account, account);
+        .add_funding(&mut dry_run_account, account);
     if let Some(strategy) = selection_strategy {
         builder = builder.set_selection_strategy(strategy);
     }
-    let result = builder.require_final_inputs().build_unsigned();
+    let result = builder.require_final_inputs().build_unsigned_reserved();
 
     match result {
-        Ok((transaction, _)) => {
+        Ok((transaction, _, reservation)) => {
             // `ManagedCoreFundsAccount::clone` shares the live `ReservationSet`
             // (`Arc<Mutex<_>>`; source of truth: key-wallet's
             // `managed_account/reservation.rs` doc comment). Every successful probe
             // reserves real wallet outpoints, so this call MUST run on every success
             // path; deleting it silently strands real UTXOs for the 24-block TTL.
-            dry_run_account.release_reservation(&transaction);
+            // The owner guard frees only what this build reserved, never a
+            // concurrent build's re-reservation of the same outpoint.
+            if let Some(token) = reservation {
+                dry_run_account.release_reservation_if_owner(&transaction, token);
+            }
             Ok(AssetLockDryRun::Builds)
         }
         Err(BuilderError::CoinSelection(SelectionError::NoUtxosAvailable)) => {
@@ -203,18 +206,22 @@ fn asset_lock_drain_ceiling(
                 script_pubkey: ScriptBuf::from_bytes(vec![0; P2PKH_CREDIT_OUTPUT_SCRIPT_LEN]),
             }]),
         ))
-        .set_funding(&mut dry_run_account, account)
+        .add_funding(&mut dry_run_account, account)
         .require_final_inputs()
-        .build_unsigned();
+        .build_unsigned_reserved();
 
     match result {
-        Ok((transaction, _)) => {
+        Ok((transaction, _, reservation)) => {
             // `ManagedCoreFundsAccount::clone` shares the live `ReservationSet`
             // (`Arc<Mutex<_>>`; source of truth: key-wallet's
             // `managed_account/reservation.rs` doc comment). Every successful probe
             // reserves real wallet outpoints, so this call MUST run on every success
             // path; deleting it silently strands real UTXOs for the 24-block TTL.
-            dry_run_account.release_reservation(&transaction);
+            // The owner guard frees only what this build reserved, never a
+            // concurrent build's re-reservation of the same outpoint.
+            if let Some(token) = reservation {
+                dry_run_account.release_reservation_if_owner(&transaction, token);
+            }
             transaction
                 .output
                 .first()
@@ -700,7 +707,7 @@ impl WalletBackend {
                 let wallet_id = wallet.wallet_id();
 
                 // Assemble and sign under one uninterrupted hold of the
-                // wallet-manager write lock: `set_funding` reads the funding
+                // wallet-manager write lock: `add_funding` reads the funding
                 // account's free UTXOs and `build_signed` reserves the ones it
                 // selects. Holding the lock across both closes the
                 // read-then-reserve window a concurrent build could otherwise use
@@ -726,7 +733,7 @@ impl WalletBackend {
                     let mut builder = TransactionBuilder::new()
                         .set_current_height(current_height)
                         .set_selection_strategy(SelectionStrategy::LargestFirst)
-                        .set_funding(managed_account, account);
+                        .add_funding(managed_account, account);
                     for (address, amount) in &recipients {
                         builder = builder.add_output(address, *amount);
                     }
@@ -1018,13 +1025,13 @@ mod tests {
             .expect("the balance covers the Max-send fee reserve");
 
         assert_eq!(max_amount, 9_999_780);
-        let (transaction, fee) = TransactionBuilder::new()
+        let (transaction, fee, _no_reservation) = TransactionBuilder::new()
             .set_current_height(200)
             .set_selection_strategy(SelectionStrategy::LargestFirst)
             .add_inputs([utxo])
             .add_output(&address, max_amount)
             .set_change_address(address)
-            .build_unsigned()
+            .build_unsigned_reserved()
             .expect("a Max send must fold the zero/dust remainder into its fee");
 
         assert_eq!(transaction.output.len(), 1);
@@ -1089,7 +1096,7 @@ mod tests {
         );
 
         let mut dry_run_account = managed_account.clone();
-        let (transaction, _) = TransactionBuilder::new()
+        let (transaction, _, reservation) = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(ASSET_LOCK_FEE_PER_KB))
             .set_current_height(CURRENT_HEIGHT)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(
@@ -1098,11 +1105,13 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut dry_run_account, account)
+            .add_funding(&mut dry_run_account, account)
             .require_final_inputs()
-            .build_unsigned()
+            .build_unsigned_reserved()
             .expect("quoted Max must build through the real asset-lock selector");
-        dry_run_account.release_reservation(&transaction);
+        if let Some(token) = reservation {
+            dry_run_account.release_reservation_if_owner(&transaction, token);
+        }
 
         let mut one_over_account = managed_account.clone();
         let one_over = TransactionBuilder::new()
@@ -1114,9 +1123,9 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut one_over_account, account)
+            .add_funding(&mut one_over_account, account)
             .require_final_inputs()
-            .build_unsigned();
+            .build_unsigned_reserved();
         assert!(
             one_over.is_err(),
             "one duff above the quoted Max must fail through the real selector"
@@ -1132,9 +1141,9 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut overshoot_account, account)
+            .add_funding(&mut overshoot_account, account)
             .require_final_inputs()
-            .build_unsigned();
+            .build_unsigned_reserved();
         assert!(
             overshoot.is_err(),
             "the display-only snapshot amount must reproduce the builder rejection"
@@ -1206,7 +1215,7 @@ mod tests {
         );
 
         let mut dry_run_account = managed_account.clone();
-        let (transaction, _) = TransactionBuilder::new()
+        let (transaction, _, reservation) = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(ASSET_LOCK_FEE_PER_KB))
             .set_current_height(CURRENT_HEIGHT)
             .set_special_payload(TransactionPayload::AssetLockPayloadType(
@@ -1215,15 +1224,17 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut dry_run_account, account)
+            .add_funding(&mut dry_run_account, account)
             .require_final_inputs()
-            .build_unsigned()
+            .build_unsigned_reserved()
             .expect("quoted Max must build from an in-cap subset");
         assert!(
             transaction.input.len() <= INPUT_CAP,
             "the achievable quote must respect the builder's input cap"
         );
-        dry_run_account.release_reservation(&transaction);
+        if let Some(token) = reservation {
+            dry_run_account.release_reservation_if_owner(&transaction, token);
+        }
 
         let mut one_over_account = managed_account.clone();
         let one_over = TransactionBuilder::new()
@@ -1235,9 +1246,9 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut one_over_account, account)
+            .add_funding(&mut one_over_account, account)
             .require_final_inputs()
-            .build_unsigned();
+            .build_unsigned_reserved();
         assert!(
             one_over.is_err(),
             "one duff above the quote must exceed the achievable in-cap subset"

--- a/src/wallet_backend/snapshot.rs
+++ b/src/wallet_backend/snapshot.rs
@@ -279,17 +279,19 @@ fn observe_asset_lock_inputs_locked(
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(&mut dry_run_account, account)
+            .add_funding(&mut dry_run_account, account)
             .require_final_inputs()
-            .build_unsigned();
+            .build_unsigned_reserved();
         match result {
-            Ok((transaction, _)) => {
+            Ok((transaction, _, reservation)) => {
                 observed.extend(transaction.input.iter().filter_map(|input| {
                     values
                         .get(&input.previous_output)
                         .map(|value| (input.previous_output, *value))
                 }));
-                dry_run_account.release_reservation(&transaction);
+                if let Some(token) = reservation {
+                    dry_run_account.release_reservation_if_owner(&transaction, token);
+                }
             }
             Err(BuilderError::CoinSelection(SelectionError::NoUtxosAvailable)) => {}
             Err(BuilderError::CoinSelection(SelectionError::InsufficientFunds { .. }))
@@ -1419,7 +1421,7 @@ mod tests {
         );
         let initial_revision = store.snapshot(&seed(0x51)).asset_lock_input_revision;
 
-        let (reserved_tx, _) = TransactionBuilder::new()
+        let (reserved_tx, _, reservation) = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(1_000))
             .set_current_height(CURRENT_HEIGHT)
             .set_selection_strategy(SelectionStrategy::All)
@@ -1429,9 +1431,9 @@ mod tests {
                     script_pubkey: ScriptBuf::new(),
                 }]),
             ))
-            .set_funding(managed_account, account)
+            .add_funding(managed_account, account)
             .require_final_inputs()
-            .build_unsigned()
+            .build_unsigned_reserved()
             .expect("reservation-producing build");
 
         let after = asset_lock_final_input_state(
@@ -1459,7 +1461,9 @@ mod tests {
             store.snapshot(&seed(0x51)).asset_lock_input_revision > initial_revision,
             "taking a live reservation must advance the display-side input revision"
         );
-        managed_account.release_reservation(&reserved_tx);
+        if let Some(token) = reservation {
+            managed_account.release_reservation_if_owner(&reserved_tx, token);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## TL;DR

Updates the app's connection to `dashpay/platform` (the shared library that talks to Dash Core and the Dash network) to its latest version. This brings in a fix for a bug where certain wallets, damaged by an older release, would refuse to open at all — those wallets now open again automatically, with funds intact.

## User story

As an **Everyday User** who updated from an older Dash Evo Tool release, I want a wallet damaged by that older release to open normally again, so that I don't have to restore from a recovery phrase to get back to my funds.

## Scenario

**Actual behavior (before this PR):** A wallet database written by certain earlier app versions could contain one leftover, unreadable record. On any later version, that single bad record stopped the *entire* wallet file from opening — every wallet inside it, funded ones included — reporting "Saved wallet data appears damaged and cannot be loaded."

**Expected behavior (after this PR):** The bad record is cleared automatically, once, the first time the updated app opens the file. The affected wallets open normally afterward, with their balances and history intact.

Separately, this PR also changes how the app reacts to *other*, unrelated forms of data corruption it detects while loading a wallet: instead of silently skipping the damaged piece and continuing, it now stops and reports the problem plainly, rather than risking a partial or misleading picture of the wallet's state. This matches the app's general policy: prevent bad data from being written in the first place, and refuse to guess when it's found anyway.

## Detailed discussion

Moves all four `dashpay/platform` git dependencies (`dash-sdk`, `rs-sdk-trusted-context-provider`, `platform-wallet`, `platform-wallet-storage`) from `762c66cf` to `4784de03`, the current head of upstream PR #3968. This is a merge of `v4.2-dev` into that branch, so unlike the previous bump it carries a release cycle of unrelated upstream development (`4.1.0` → `4.2.0-dev.1`, key-wallet's `rust-dashcore` reference `branch=` → `rev=173ffac0`, grovedb `tag=` → `rev=a2791bbd`) and required adaptation across ~44 call sites, landed as three commits on this branch.

### What moved upstream, and how DET adapted (`chore(deps): bump platform pin to PR #3968 head`)

- **Document-query pagination + crate move** — `DocumentQuery` now lives in `dash-platform-queries` and gained a required `offset: Option<u32>`. All 14 literals set `None`, matching upstream's own constructor default: a set offset is served only by the protocol-v14 ranked surface and rejected everywhere else, so `None` keeps the wire bytes identical.
- **Transaction-builder redesign** — `set_funding` → additive `add_funding`; `build_unsigned` replaced by `build_unsigned_reserved`, which returns the `ReservationToken` from `dashpay/platform#4185`. DET's asset-lock dry-run probes — which reserve real wallet outpoints through an `Arc`-shared `ReservationSet` — now release with the owner-guarded `release_reservation_if_owner`.
- **New wallet-error and asset-lock variants** — 14 new `PlatformWalletError` variants bucketed explicitly in both no-wildcard matches; `AssetLockStatus::RecoveredFromChain` given its own honest label; `AssetLockFunding::DrainAccountBalance` fails closed through a new typed `TaskError`; `DocumentPropertyType::IdentifierWithReference` folded into the existing `Identifier` handling.
- **Restored `#[must_use]` returns** — the shutdown report and coordinator drain flags are inspected again, retiring three stale `TODO(platform-pr3954)`s.

### Load-failure policy (`test(wallet): assert the fail-closed load contract on a corrupt viewing-key row`)

Upstream converted `platform-wallet-storage`'s per-row corruption skips into a `LoadPolicy` gate defaulting to `Strict`: a row that will not decode aborts the load rather than being silently skipped. That is the intended, documented upstream design, and DET adopts it. The cold-boot test that asserted the old silent-skip contract is rewritten and renamed (`cold_boot_fails_closed_on_a_corrupt_fvk_row`), asserting the full typed error chain down to the column that failed, plus that a failed load leaves no half-wired backend behind.

A `Strict` → `Recovery` fallback (degraded, read-only wallet access instead of no access) is deliberately deferred — it's its own feature: `LoadPolicy` is fixed at persister-open time, `Recovery` makes the *entire* persister read-only (including the per-network KV backing settings, scheduled votes, DashPay overlays and the token cache), and it needs a new persistent read-only UI surface.

### Legacy-row migration (`chore(deps): bump platform pin to PR #3968 latest`)

The `Strict` policy exposed one previously-silent gap: upstream's used-address readers have no `LoadCtx` tolerance at all, so a leftover placeholder row an older DET build could write for a spend of an output it never recorded would fail the load of every wallet in the file. This is fixed upstream by `fix(platform-wallet-storage): purge legacy empty-script spent UTXO rows`, landing migration `V012`, which deletes exactly those rows (`spent = 1 AND script = ''`) once per database — balance-neutral, address-reuse-guard-neutral. A DET-side stopgap for this same gap was considered and dropped in favor of this upstream fix, per the project's "fix producers, migrate existing data upstream" policy. No DET-side mitigation exists or is needed after this bump.

### Verification

- `cargo build --all-features` — clean, no source changes required beyond the earlier 44-call-site adaptation.
- `cargo fmt --all` — clean.
- `cargo clippy --all-features --all-targets -- -D warnings` — exit 0, zero warnings.
- Scoped `cargo test --all-features --lib` runs green for the rewritten cold-boot test and its neighbours.
- CI owns the full workspace sweep.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing and creating documents with identifier fields that include references.
  * Added a clear message when an unsupported funding method is selected for identity top-ups.

* **Bug Fixes**
  * Funding transactions rediscovered from the network now accurately show that network confirmation is known, while spent status remains unknown.
  * Wallet loading now fails safely when local viewing-key data is corrupted, avoiding partial setup.
  * Improved transaction reservation handling to prevent releasing funds reserved by another operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->