### PR TITLE
fix(wallet): stop advising a retry when a broadcast outcome is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A sent payment whose confirmation couldn't be verified no longer tells you
+  to retry it**: when the network doesn't confirm a payment quickly enough,
+  the app used to show a generic "please retry" message — but the payment may
+  already be on its way, and sending it again risked sending it twice. The
+  app now tells you plainly that the payment was sent and its confirmation is
+  still unknown, and asks you to wait and check your balance before trying
+  again.
+
 - **Masternodes and evonodes are now recorded in the wallet store too**: a node
   loaded from its ProTxHash was only ever written to this app's own records, so
   the wallet store the app shares with the rest of the wallet stack had no entry

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -221,6 +221,23 @@ pub enum TaskError {
         source: std::sync::Arc<platform_wallet::error::PlatformWalletError>,
     },
 
+    /// A core transaction broadcast returned an ambiguous outcome — the
+    /// transaction may already be on the network. Carved out of
+    /// [`Self::WalletBackend`], whose "please retry" advice would invite a
+    /// double-spend here: upstream keeps the spent inputs reserved precisely so
+    /// a re-submission cannot go through, and a sync or the reservation TTL
+    /// reconciles the real outcome.
+    ///
+    /// The shielded siblings are [`Self::ShieldedConfirmationUnknown`] and the
+    /// per-operation `*ConfirmationUnknown` variants.
+    #[error(
+        "Your transaction was sent but the confirmation could not be verified. Wait a moment, then refresh your balance before sending it again."
+    )]
+    TransactionConfirmationUnknown {
+        #[source]
+        source: Box<platform_wallet::error::PlatformWalletError>,
+    },
+
     /// The wallet could not assemble and sign a payment transaction, for a
     /// reason other than insufficient balance or too many inputs (those get
     /// their own variants below — [`Self::InsufficientFunds`] and
@@ -5467,6 +5484,42 @@ mod tests {
                     "Expected no jargon ({jargon}) in user message, got: {msg}"
                 );
             }
+        }
+    }
+
+    /// The core-transaction sibling of the family above. Its whole reason to
+    /// exist is that `WalletBackend`'s "please retry in a moment" would invite
+    /// a double-spend of a payment that may already be on the network, so the
+    /// message must differ from that envelope's and must route the user to a
+    /// refresh instead of a resend.
+    #[test]
+    fn transaction_confirmation_unknown_message_does_not_advise_retrying() {
+        let msg = TaskError::TransactionConfirmationUnknown {
+            source: Box::new(platform_wallet::error::PlatformWalletError::Sdk(
+                dash_sdk::Error::Generic("boom".to_string()),
+            )),
+        }
+        .to_string();
+
+        assert!(
+            msg.contains("refresh") && msg.contains("Wait"),
+            "Expected concrete recovery guidance (wait + refresh), got: {msg}"
+        );
+        assert_ne!(
+            msg,
+            TaskError::WalletBackend {
+                source: std::sync::Arc::new(platform_wallet::error::PlatformWalletError::Sdk(
+                    dash_sdk::Error::Generic("boom".to_string())
+                )),
+            }
+            .to_string(),
+            "the carve-out must not reuse the generic envelope's retry advice"
+        );
+        for jargon in ["nonce", "state transition", "SDK", "RPC", "broadcast"] {
+            assert!(
+                !msg.contains(jargon),
+                "Expected no jargon ({jargon}) in user message, got: {msg}"
+            );
         }
     }
 }

--- a/src/wallet_backend/mod.rs
+++ b/src/wallet_backend/mod.rs
@@ -2918,6 +2918,15 @@ fn map_shielded_op_error(e: platform_wallet::error::PlatformWalletError) -> Task
             source: Arc::new(other),
         },
 
+        // The funding core transaction's broadcast outcome is ambiguous. Its
+        // inputs stay reserved upstream, so the user must wait for a sync to
+        // reconcile rather than follow the generic envelope's retry advice.
+        other @ P::TransactionBroadcastUnconfirmed(_) => {
+            TaskError::TransactionConfirmationUnknown {
+                source: Box::new(other),
+            }
+        }
+
         // Every remaining variant → generic WalletBackend wrapper.
         other @ (P::WalletCreation(_)
         | P::PlatformNodePool(_)
@@ -2938,7 +2947,6 @@ fn map_shielded_op_error(e: platform_wallet::error::PlatformWalletError) -> Task
         | P::AssetLockAlreadyConsumed(_)
         | P::AssetLockFundingMismatch { .. }
         | P::TransactionBroadcast(_)
-        | P::TransactionBroadcastUnconfirmed(_)
         | P::TransactionBuild(_)
         | P::CoreInsufficientFunds { .. }
         | P::NoSpendableInputs { .. }
@@ -3037,6 +3045,9 @@ fn map_identity_register_error(e: platform_wallet::error::PlatformWalletError) -
         IdentityOpErrorKind::FinalityTimeout => TaskError::AssetLockFinalityTimeout {
             source: Box::new(e),
         },
+        IdentityOpErrorKind::ConfirmationUnknown => TaskError::TransactionConfirmationUnknown {
+            source: Box::new(e),
+        },
         // Registration creates the identity, so it cannot legitimately raise a
         // "not managed" lookup error — fold into the generic envelope.
         IdentityOpErrorKind::NotManaged | IdentityOpErrorKind::Other => TaskError::WalletBackend {
@@ -3075,6 +3086,9 @@ fn map_identity_top_up_error(
         },
         IdentityOpErrorKind::NotManaged => TaskError::IdentityNotManaged {
             identity_id,
+            source: Box::new(e),
+        },
+        IdentityOpErrorKind::ConfirmationUnknown => TaskError::TransactionConfirmationUnknown {
             source: Box::new(e),
         },
         IdentityOpErrorKind::Other => TaskError::WalletBackend {
@@ -3143,6 +3157,9 @@ fn map_platform_address_fund_error(e: platform_wallet::error::PlatformWalletErro
         IdentityOpErrorKind::FinalityTimeout => TaskError::AssetLockFinalityTimeout {
             source: Box::new(e),
         },
+        IdentityOpErrorKind::ConfirmationUnknown => TaskError::TransactionConfirmationUnknown {
+            source: Box::new(e),
+        },
         // Platform-address funding does not consult the identity manager, so a
         // "not managed" classification is not meaningful here — fold into the
         // generic envelope alongside the other preconditions.
@@ -3165,6 +3182,10 @@ enum IdentityOpErrorKind {
     /// op (top-up) cannot find it — retrying the same op cannot help; the
     /// identity must be reloaded.
     NotManaged,
+    /// The funding transaction's broadcast outcome is ambiguous — it may
+    /// already be on the network, so this is neither a rejection nor a finality
+    /// timeout, and the caller must not re-submit (the next sync reconciles).
+    ConfirmationUnknown,
     /// Anything else — preconditions, wallet state, builder failures.
     Other,
 }
@@ -3187,6 +3208,13 @@ fn identity_op_error_kind(e: &platform_wallet::error::PlatformWalletError) -> Id
         // The identity is absent from the wallet's active set — a missing
         // manager registration, not a transient fault.
         P::IdentityNotFound(_) | P::IdentityIndexNotSet(_) => IdentityOpErrorKind::NotManaged,
+
+        // Broadcast was accepted but its execution result is unconfirmed — the
+        // op may already be on chain, so it is neither a rejection nor a
+        // finality timeout. The upstream contract says the caller must not
+        // re-submit (the next sync reconciles), so this must not reach the
+        // generic envelope, whose message asks the user to retry.
+        P::TransactionBroadcastUnconfirmed(_) => IdentityOpErrorKind::ConfirmationUnknown,
 
         // Everything else — preconditions, wallet state, builder errors.
         P::WalletCreation(_)
@@ -3238,11 +3266,8 @@ fn identity_op_error_kind(e: &platform_wallet::error::PlatformWalletError) -> Id
         // Address nonce desync is a precondition/state fault unrelated to
         // identity registration; bucket as Other.
         | P::AddressNonceMismatch { .. }
-        // Broadcast was accepted but its execution result is unconfirmed — the
-        // op may already be on chain, so it is neither a rejection nor a
-        // finality timeout. Bucket as Other; the upstream contract says the
-        // caller must not re-submit (the next sync reconciles).
-        | P::TransactionBroadcastUnconfirmed(_)
+        // Shielded ambiguity is unreachable here — identity funding runs no
+        // shielded op. `map_shielded_op_error` routes it where it can occur.
         | P::ShieldedBroadcastUnconfirmed { .. }
         | P::ShieldedSpendUnconfirmed { .. }
         // Funding and credit shortfalls, like their `CoreInsufficientFunds`
@@ -4165,5 +4190,45 @@ mod tests {
             map_shielded_op_error(P::ShieldedNotBound),
             TaskError::ShieldedNotBound
         ));
+    }
+
+    fn broadcast_unconfirmed() -> platform_wallet::error::PlatformWalletError {
+        platform_wallet::error::PlatformWalletError::TransactionBroadcastUnconfirmed(
+            "peer timed out after send".to_string(),
+        )
+    }
+
+    /// An ambiguous core broadcast must never reach the generic `WalletBackend`
+    /// envelope, whose message tells the user to retry: upstream's contract is
+    /// that the transaction may already be on the network and must not be
+    /// re-submitted. Covers every façade that funds an operation from a core
+    /// transaction, so no path can regress to "please retry" independently.
+    #[test]
+    fn broadcast_unconfirmed_never_maps_to_retry_advice() {
+        let identity_id = dash_sdk::platform::Identifier::random();
+        let mapped = [
+            map_identity_register_error(broadcast_unconfirmed()),
+            map_identity_top_up_error(identity_id, broadcast_unconfirmed()),
+            map_platform_address_fund_error(broadcast_unconfirmed()),
+            map_shielded_op_error(broadcast_unconfirmed()),
+        ];
+        for error in mapped {
+            assert!(
+                matches!(error, TaskError::TransactionConfirmationUnknown { .. }),
+                "Expected TransactionConfirmationUnknown, got: {error:?}"
+            );
+        }
+    }
+
+    /// The bucket is distinct from `Other`: an ambiguous broadcast is not a
+    /// precondition fault, and collapsing the two would restore the retry
+    /// advice for every consumer of `identity_op_error_kind`.
+    #[test]
+    fn identity_op_error_kind_buckets_broadcast_unconfirmed_separately() {
+        let kind = identity_op_error_kind(&broadcast_unconfirmed());
+        assert!(
+            matches!(kind, IdentityOpErrorKind::ConfirmationUnknown),
+            "an ambiguous broadcast must not share a bucket with preconditions"
+        );
     }
 }

--- a/src/wallet_backend/payments.rs
+++ b/src/wallet_backend/payments.rs
@@ -783,9 +783,7 @@ impl WalletBackend {
                         &tx,
                     )
                     .await
-                    .map_err(|source| TaskError::WalletBackend {
-                        source: Arc::new(source),
-                    })?;
+                    .map_err(map_core_broadcast_error)?;
                 Ok(tx.txid())
             })
             .await
@@ -965,11 +963,31 @@ fn unbound_topup_lock_eligible(
     }
 }
 
+/// Classify a broadcast failure from the payment path. Pure — unit-testable.
+///
+/// An ambiguous outcome gets its own [`TaskError::TransactionConfirmationUnknown`]
+/// rather than the generic envelope: the payment may already be on the network,
+/// and upstream deliberately keeps its inputs reserved so it cannot be sent
+/// twice, so telling the user to retry would be both wrong and unactionable.
+/// Every definitive failure keeps the generic envelope.
+fn map_core_broadcast_error(source: platform_wallet::error::PlatformWalletError) -> TaskError {
+    match source {
+        platform_wallet::error::PlatformWalletError::TransactionBroadcastUnconfirmed(_) => {
+            TaskError::TransactionConfirmationUnknown {
+                source: Box::new(source),
+            }
+        }
+        other => TaskError::WalletBackend {
+            source: Arc::new(other),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         ASSET_LOCK_FEE_PER_KB, MAX_MONEY, asset_lock_builder_height,
-        asset_lock_max_amount_from_account, unbound_topup_lock_eligible,
+        asset_lock_max_amount_from_account, map_core_broadcast_error, unbound_topup_lock_eligible,
     };
     use crate::backend_task::error::TaskError;
     use crate::model::fee_estimation::core_max_send_amount_duffs;
@@ -1544,6 +1562,38 @@ mod tests {
         assert!(
             matches!(err, TaskError::AssetLockAlreadyUsed),
             "expected AssetLockAlreadyUsed, got: {err:?}"
+        );
+    }
+
+    /// A send whose broadcast outcome is ambiguous must not be reported with
+    /// the generic wallet-backend message, which tells the user to retry: the
+    /// payment may already be on the network, and upstream keeps its inputs
+    /// reserved so it must not be sent a second time.
+    #[test]
+    fn an_ambiguous_broadcast_does_not_ask_the_user_to_retry() {
+        let err = map_core_broadcast_error(
+            platform_wallet::error::PlatformWalletError::TransactionBroadcastUnconfirmed(
+                "peer timed out after send".to_string(),
+            ),
+        );
+        assert!(
+            matches!(err, TaskError::TransactionConfirmationUnknown { .. }),
+            "expected TransactionConfirmationUnknown, got: {err:?}"
+        );
+    }
+
+    /// An unambiguous broadcast rejection keeps the generic envelope — the
+    /// carve-out above must not swallow the ordinary failure path.
+    #[test]
+    fn a_definitive_broadcast_rejection_keeps_the_generic_envelope() {
+        let err = map_core_broadcast_error(
+            platform_wallet::error::PlatformWalletError::TransactionBroadcast(
+                "rejected by peer".to_string(),
+            ),
+        );
+        assert!(
+            matches!(err, TaskError::WalletBackend { .. }),
+            "expected WalletBackend, got: {err:?}"
         );
     }
 }


### PR DESCRIPTION
**TL;DR:** When a sent payment's network confirmation can't be verified in time, the app now says so plainly instead of telling you to retry a payment that may already be on its way.

## User story
As a **wallet user**, I want to be told honestly when my payment's confirmation status is unknown, so I don't accidentally send it a second time.

## Scenario
### Base flow
You send a payment (a plain transfer, an identity top-up, a registration funding, or a shielded operation). The app broadcasts it to the network and waits briefly for confirmation that it was accepted.

### Actual behavior
If no confirmation signal arrives in time — which can happen even when the payment went through fine — the app shows a generic message: "The wallet service could not complete this operation. Please retry in a moment." That's misleading: the payment may already be in flight, and retrying risks sending it twice.

### Expected behavior
The app now shows a dedicated message for this exact situation: "Your transaction was sent but the confirmation could not be verified. Wait a moment, then refresh your balance before sending it again." It never suggests an immediate resend.

## Detailed discussion
### What was done
`PlatformWalletError::TransactionBroadcastUnconfirmed` previously fell into the generic `TaskError::WalletBackend` catch-all in four places (`map_shielded_op_error`, `identity_op_error_kind` — covering identity register / top-up / platform-address funding — and the plain send-funds path in `wallet_backend/payments.rs`). It now gets its own `TaskError::TransactionConfirmationUnknown` variant, named and worded to match the repo's existing `*ConfirmationUnknown` family (`ShieldedConfirmationUnknown` and siblings). All four sites route to it consistently, so the "must not re-submit" contract this outcome carries is now enforced by the type rather than living only as a comment.

Root-caused from a user-reported `WalletBackend { source: TransactionBroadcastUnconfirmed(...) }` error after investigating `platform-wallet`'s `SpvBroadcaster` (30s acceptance-timeout window, ambiguous-by-design outcome when no withheld-peer echo / InstantSend lock / confirmation arrives in time). That upstream timeout/race behavior itself is out of scope for this PR — this PR only fixes DET's user-facing handling of the outcome once it occurs.

### Testing
Added 5 unit tests in `src/wallet_backend/mod.rs` and `src/backend_task/error.rs`, confirmed RED against the pre-fix code (asserted `TransactionConfirmationUnknown`, got `WalletBackend { source: TransactionBroadcastUnconfirmed(...) }`), now green: `broadcast_unconfirmed_never_maps_to_retry_advice`, `identity_op_error_kind_buckets_broadcast_unconfirmed_separately`, `an_ambiguous_broadcast_does_not_ask_the_user_to_retry`, `a_definitive_broadcast_rejection_keeps_the_generic_envelope`, `transaction_confirmation_unknown_message_does_not_advise_retrying`.

```
cargo test --lib --all-features -- broadcast_unconfirmed an_ambiguous_broadcast a_definitive_broadcast \
  transaction_confirmation_unknown identity_op_error_kind_buckets map_shielded_op_error \
  map_identity_register_error map_identity_top_up_error map_platform_address_fund \
  shielded_confirmation_unknown
# 24 passed, 0 failed (5 new + 19 pre-existing neighboring tests, no regressions)

cargo clippy --lib --tests --all-features -- -D warnings
# zero warnings

cargo fmt --all
# clean
```

### Breaking changes
None — this only narrows an internal error classification and changes displayed copy; no public API or behavior change beyond the message text.

### Checklist
- [x] Dedicated `TaskError` variant added (no `String` message field, `#[source]` preserves the error chain)
- [x] Message follows this repo's error-copy conventions (Everyday User audience, what-happened + what-to-do, no jargon)
- [x] Tests confirmed RED before the fix, GREEN after
- [x] `cargo fmt --all` / `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] CHANGELOG.md entry added under `[Unreleased] / Fixed`
- [ ] User-stories catalog: not updated — this is a copy/classification fix, not a new feature, per this repo's CLAUDE.md guidance to skip non-functional changes

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
