### PR TITLE
fix(ui): start window maximized on first launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **The app now opens maximized the very first time it runs**: on a fresh
+  install, the window used to open at a small default size that didn't fit
+  the onboarding page. It now opens maximized on first launch; any size or
+  position you set afterward is remembered and used on every later start, as
+  before.
+
 - **A sent payment whose confirmation couldn't be verified no longer tells you
   to retry it**: when the network doesn't confirm a payment quickly enough,
   the app used to show a generic "please retry" message — but the payment may

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,13 @@ async fn start(app_data_dir: &std::path::Path) -> Result<(), eframe::Error> {
         persistence_path: Some(app_data_dir.join("app.ron")),
         viewport: egui::ViewportBuilder::default()
             .with_icon(icon_data)
-            .with_app_id("org.dash.DashEvoTool"),
+            .with_app_id("org.dash.DashEvoTool")
+            // Only takes effect on a genuine first launch: once `persist_window`
+            // has written window geometry to `app.ron`, the persisted state
+            // (size/maximized/fullscreen) unconditionally overrides this on
+            // every later run. Without it, winit falls back to its own small
+            // platform-default size, which doesn't fit the onboarding page.
+            .with_maximized(true),
         // Use wgpu instead of glow (OpenGL) to avoid platform-specific rendering
         // issues, e.g. NSOpenGLContext idle/sleep crashes on macOS (#629)
         renderer: eframe::Renderer::Wgpu,


### PR DESCRIPTION
**TL;DR:** The app now opens as a maximized window the very first time you run it, instead of a small window that cuts off the onboarding page.

## User story
As a **first-time user**, I want the app window to open large enough to see the whole onboarding page, to achieve a usable setup experience without having to resize the window myself.

## Scenario
### Base flow
A user installs Dash Evo Tool and launches it for the very first time.

### Actual behavior
The window opens at a small default size that doesn't fit the onboarding page, forcing the user to resize or maximize it manually before they can comfortably use it.

### Expected behavior
On first launch, the window opens maximized. On every later launch, the window remembers whatever size/position the user left it at, exactly as before.

## Detailed discussion
### What was done
Added `.with_maximized(true)` to the `egui::ViewportBuilder` passed to `eframe::NativeOptions` in `src/main.rs`.

`persist_window: true` (with `persistence_path` pointing at `app.ron`) means eframe unconditionally overrides `inner_size`/`maximized`/`fullscreen` from the persisted `WindowSettings` once a valid entry exists in `app.ron` — which happens after the very first run. So `.with_maximized(true)` only ever takes effect on a genuine first launch (no persisted window state yet); it is silently overridden by the user's actual window state on every subsequent run and does not "stick" as forced-maximized forever.

Also adds the corresponding `CHANGELOG.md` entry under `[Unreleased] / Fixed`.

### Testing
- `cargo build --bin dash-evo-tool` — clean.
- `cargo clippy --bin dash-evo-tool --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — applied.

### Breaking changes
None.

### Checklist
- [x] `cargo fmt --all`
- [x] `cargo clippy` (scoped to the touched binary)
- [x] `cargo build`
- [ ] Manual verification of first-launch maximize on a real display (no persisted `app.ron`)

### Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now opens maximized on first launch.
  * Your preferred window size and position are remembered for subsequent launches.

* **Documentation**
  * Updated the changelog to document the window behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->