### PR TITLE
test(backend-e2e): reserve platform withdrawal fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The backend wallet lifecycle test reserves the withdrawal fee instead of
+  attempting to withdraw the entire Platform address balance.
+
 - Identity creation and top-up accounts are saved before payment and restored
   after restarting the app. Temporary save failures are retried a few times;
   if saving still fails, the payment stops and the app asks you to try again.

--- a/tests/backend-e2e/wallet_tasks.rs
+++ b/tests/backend-e2e/wallet_tasks.rs
@@ -9,6 +9,8 @@ use dash_evo_tool::backend_task::wallet::WalletTask;
 use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
 use dash_evo_tool::model::wallet::WalletSeedHash;
 use dash_sdk::dpp::identity::core_script::CoreScript;
+use dash_sdk::dpp::state_transition::address_credit_withdrawal_transition::AddressCreditWithdrawalTransition;
+use dash_sdk::dpp::version::PlatformVersion;
 use std::collections::BTreeMap;
 use std::time::Duration;
 
@@ -452,20 +454,60 @@ async fn step_transfer_credits(
     }
 }
 
-/// Fund a fresh platform address and withdraw its balance back to Core.
+fn withdrawal_amount(balance: u64, version: &PlatformVersion) -> Option<u64> {
+    // DeductFromInput charges the remaining balance; keep 10% fee headroom.
+    let fee = AddressCreditWithdrawalTransition::estimate_min_fee(1, false, version);
+    let reserve = fee.checked_add(fee / 10)?;
+    balance
+        .checked_sub(reserve)
+        .filter(|amount| *amount >= version.system_limits.min_withdrawal_amount)
+}
+
+#[test]
+fn tc_014_withdrawal_amount_covers_fees() {
+    use dash_sdk::dpp::address_funds::fee_strategy::deduct_fee_from_inputs_and_outputs::deduct_fee_from_outputs_or_remaining_balance_of_inputs;
+    use dash_sdk::dpp::address_funds::{AddressFundsFeeStrategyStep, PlatformAddress};
+
+    let version = PlatformVersion::latest();
+    let balance = 484_895_820;
+    let amount = withdrawal_amount(balance, version).expect("funded withdrawal");
+    let address = PlatformAddress::P2pkh([1; 20]);
+    let deduction = deduct_fee_from_outputs_or_remaining_balance_of_inputs(
+        BTreeMap::from([(address, (1, balance - amount))]),
+        BTreeMap::new(),
+        &vec![AddressFundsFeeStrategyStep::DeductFromInput(0)],
+        AddressCreditWithdrawalTransition::estimate_min_fee(1, false, version),
+        version,
+    )
+    .expect("valid fee strategy");
+
+    assert!(
+        deduction.fee_fully_covered,
+        "withdrawal must leave funds for fees"
+    );
+    assert!(amount >= version.system_limits.min_withdrawal_amount);
+}
+
+#[test]
+fn tc_014_withdrawal_amount_rejects_insufficient_balance() {
+    let version = PlatformVersion::latest();
+    let fee = AddressCreditWithdrawalTransition::estimate_min_fee(1, false, version);
+    let minimum_funding = fee + fee / 10 + version.system_limits.min_withdrawal_amount;
+    for balance in [0, fee, minimum_funding - 1] {
+        assert_eq!(withdrawal_amount(balance, version), None);
+    }
+    assert_eq!(
+        withdrawal_amount(minimum_funding, version),
+        Some(version.system_limits.min_withdrawal_amount)
+    );
+}
+
+/// Fund a fresh platform address and withdraw to Core, reserving the fee.
 async fn step_withdraw(
     ctx: &crate::framework::harness::BackendTestContext,
     seed_hash: WalletSeedHash,
 ) {
     tracing::info!("=== Step 4: Withdraw from platform address back to Core ===");
-
-    // TODO: This step fails because sync_address_balances returns a balance
-    // (~485M credits) that doesn't match what Platform's state transition
-    // processor sees (1 credit). The full tree scan proof says 485M but the
-    // withdrawal is rejected with AddressesNotEnoughFundsError. This is a
-    // Platform/SDK bug — the sync proof and the state transition processor
-    // disagree on the balance, possibly due to node height differences or
-    // proof verification issues. Needs investigation upstream.
 
     // Fund a fresh platform address so we have credits to withdraw,
     // regardless of what step 3 did to the original address.
@@ -537,9 +579,11 @@ async fn step_withdraw(
         tokio::time::sleep(poll_interval).await;
     };
 
+    let amount = withdrawal_amount(withdrawal_balance, ctx.app_context.platform_version())
+        .expect("step_withdraw: balance must cover the minimum withdrawal and fee reserve");
     tracing::info!(
         "step_withdraw: withdrawing {} credits from {:?}",
-        withdrawal_balance,
+        amount,
         withdrawal_addr
     );
 
@@ -568,7 +612,7 @@ async fn step_withdraw(
     let output_script = CoreScript::new(core_address.script_pubkey());
 
     let mut inputs = BTreeMap::new();
-    inputs.insert(withdrawal_addr, withdrawal_balance);
+    inputs.insert(withdrawal_addr, amount);
 
     let task = BackendTask::WalletTask(WalletTask::WithdrawFromPlatformAddress {
         seed_hash,


### PR DESCRIPTION
**TL;DR:** Fix the wallet lifecycle test so its withdrawal leaves enough funds to pay the fee. This changes test coverage only.

## Detailed discussion

TC-014 requests the entire funded address balance while using `DeductFromInput(0)`, which charges the remaining balance after the withdrawal. This leaves zero credits for the fee and produces `AddressesNotEnoughFundsError`; the `(1, 0)` error tuple is nonce 1 and remaining balance 0.

The test uses the SDK's one-input withdrawal fee estimate with a 10% reserve buffer, checks the minimum withdrawal amount, and sends only the amount left after reserving the fee. The inaccurate synchronization-bug TODO is removed. Deterministic tests verify actual DPP fee coverage and reject insufficient funding, including the minimum-withdrawal boundary.

### Testing

- Both new regression tests failed with the original whole-balance behavior and pass after the fix: `cargo test --test backend-e2e --all-features tc_014_withdrawal_amount -- --nocapture` (2 passed).
- `cargo fmt --all` and `git diff --check` passed.
- `cargo clippy --test backend-e2e --all-features -- -D warnings` passed.
- Attempted `tc_014_wallet_platform_lifecycle` on testnet. It still stops in Step 1, before this PR's withdrawal step, with `TransactionConfirmationUnknown` / `TransactionBroadcastUnconfirmed`: SPV received no acceptance signal within its timeout. This independent asset-lock broadcast problem is not changed here; the full lifecycle is not green.
- During the preceding diagnosis, an isolated real-network withdrawal on the same funded address failed when requesting all 484,895,820 credits and succeeded when requesting 34,895,820 credits with a 450,000,000-credit reserve. This was diagnostic evidence, not a successful full run of the modified TC-014.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated backend wallet lifecycle testing to reserve withdrawal fees and headroom before initiating withdrawals.
  * Withdrawals now respect the platform’s minimum withdrawal amount and reject insufficient balances.
  * Added coverage for fee handling and insufficient-balance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->