### PR TITLE
fix(dashpay): accept a HIGH authentication key for profiles

### DIFF
--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -166,12 +166,18 @@ pub async fn update_profile(
     let identity_id = identity.identity.id();
     let dashpay_contract = app_context.dashpay_contract.clone();
 
-    // Get the appropriate identity key for signing
+    // Get the appropriate identity key for signing.
+    //
+    // CRITICAL or HIGH, the same set contact_requests.rs uses: Platform accepts
+    // either for document creation, and the DashPay contract declares no
+    // signature security level requirement of its own. Identities that use
+    // DashPay carry AUTHENTICATION keys at MASTER and HIGH with nothing at
+    // CRITICAL, so asking for CRITICAL alone rejected every one of them.
     let identity_key = identity
         .identity
         .get_first_public_key_matching(
             Purpose::AUTHENTICATION,
-            HashSet::from([SecurityLevel::CRITICAL]),
+            HashSet::from([SecurityLevel::CRITICAL, SecurityLevel::HIGH]),
             KeyType::all_key_types().into(),
             false,
         )


### PR DESCRIPTION
## The problem

Creating a DashPay profile fails with `DashPay(MissingAuthenticationKey)` — "This identity is missing an authentication key required for this operation" — on identities that do have authentication keys. It came up in the Dash Discord from a user whose identity carries:

```
key #0  AUTHENTICATION · MASTER   · ECDSA_HASH160
key #1  AUTHENTICATION · HIGH     · ECDSA_HASH160
key #2  TRANSFER       · CRITICAL · ECDSA_HASH160
```

`profile.rs` asks for an AUTHENTICATION key at CRITICAL and nothing else. The match is on set membership, so the MASTER key does not satisfy it either, even though MASTER is the stricter level.

## What Platform actually accepts

Traced through `rs-dpp` / `rs-drive` rather than inferred:

1. A profile write is a document batch transition. `BatchTransitionV1::purpose_requirement()` returns `[AUTHENTICATION]`; `security_level_requirement()` returns `[CRITICAL, HIGH, MEDIUM]`, with the comment that the contract narrows it further.
2. The DashPay document types declare no `signatureSecurityLevelRequirement`, and parsing falls back to `.unwrap_or(SecurityLevel::HIGH)` in `data_contract/document_type/class_methods/try_from_schema/common/mod.rs`.
3. `BatchTransitionAction::combined_security_level_requirement()` turns that into `(SecurityLevel::CRITICAL as u8..=highest_security_level as u8)`. With the requirement at HIGH, and `MASTER = 0, CRITICAL = 1, HIGH = 2, MEDIUM = 3`, the accepted set is exactly **{CRITICAL, HIGH}**.

So this is not a guess at a looser rule. It is the set Platform computes for this document type, and the same set `contact_requests.rs:759-764` already uses, under the comment "Platform requires CRITICAL or HIGH security level for document creation". `contact_info.rs:659-661` goes wider still and accepts MEDIUM. The profile path was the odd one out.

## Why it matters in practice

DashPay identities are built with AUTHENTICATION keys at MASTER and HIGH and no key at CRITICAL. I sampled ten `profile` documents on mainnet and looked up their owners; all ten have that shape:

```
AUTHENTICATION/MASTER  AUTHENTICATION/HIGH  ENCRYPTION/MEDIUM  [TRANSFER/CRITICAL]
```

- `9dQixko1C7TrmKYuZDZ8qAhgMQWT5fZ3tvyb13MVnQV6`
- `DZULWyxASVV41v5xMLAFsHhZLfad2MkqBGmmbatmMcgb`
- `F9KjnhLF8oJCNxuo6wDVx1e3pFYKvLFLtSRBuo15Kr39`
- `2XgeKK3SBZTWiYhzg5xCNJbQDkphXNw2SyLMQZWY1nma`

So the old check rejected every identity already using DashPay, for a key the protocol does not ask for. The only workaround is to add an AUTHENTICATION key at CRITICAL, and a CRITICAL key can never be disabled again, unlike HIGH.

## The change

```rust
HashSet::from([SecurityLevel::CRITICAL, SecurityLevel::HIGH]),
```

One functional line, plus a comment explaining the set.

## Testing

`cargo check` and `cargo fmt --check` pass on `v1.0-dev` with this applied; the one warning in the tree (an unused import in `wallet_backend/single_key.rs`) is present before the change as well. I have not exercised the profile flow end to end against a node, so this is verified against Platform's rules and the compiler, not against a live broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156ZqtTpDTz9LMyvAKg3PAY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Profile updates can now be signed using authentication keys with either **CRITICAL** or **HIGH** security levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->