### PR TITLE
feat(identity): add wallet-derived keys to existing identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Add wallet-derived identity keys**: the Add Key screen defaults to deriving
+  secp256k1 or HASH160 keys from the identity's wallet, selects the first free
+  index, and disables used indices. Uncheck derivation to enter a private key.
+  Derived keys retain their wallet path for signing and seed recovery.
+
 - **Keys saved on this device but not on the identity's key lists are now
   listed**: a key can be saved here while appearing on none of the identity's
   key lists — for example when adding it to the network did not finish. The

--- a/docs/ai-design/2026-09-10-derived-identity-key/README.md
+++ b/docs/ai-design/2026-09-10-derived-identity-key/README.md
@@ -1,0 +1,42 @@
+# Add wallet-derived identity keys
+
+The existing Add Key screen starts with “Derive from wallet” selected. It shows
+an index chooser; unchecking shows the manual private-key input and random-key
+button. Switching modes clears manual input. The first free index is selected,
+including after refreshing an identity or adding another key.
+
+## Derivation and storage
+
+- Support ECDSA_SECP256K1 and ECDSA_HASH160 using the existing canonical ECDSA
+  identity-authentication derivation path. Other key types require manual input.
+- Resolve the wallet and identity index from unambiguous canonical paths already
+  attached to that identity. An unrelated selected wallet is not a substitute.
+- Warm the public-key cache asynchronously through the existing secret-access
+  mechanism. Only public information reaches the index chooser.
+- Consider persisted paths and public-key hashes occupied, including disabled
+  keys and equivalent secp256k1/HASH160 representations. A missing cache blocks
+  selection until loaded; a failed load offers a retry.
+- Offer indices below `max_identity_key_id + 6`, capped at 4096 to bound work.
+  The range fits the existing seed-recovery scan. It grows as key IDs grow.
+- Send key attributes and the derivation index to the backend. Reload the local
+  identity and validate its wallet, type, index and occupancy there; recheck the
+  chosen key hash against a newly fetched network identity before broadcasting.
+- Store `AtWalletDerivationPath`, not a copied private key. Registration and
+  subsequent signing resolve the seed through the existing secret chokepoint.
+  Protected imported keys retain their current password preflight and sealing.
+- Keep contract bounds, key purpose, security level, fees and the existing master
+  key authorization flow. Derivation does not itself add HASH160 support to
+  platform-wallet's DashPay profile API.
+
+## Verification
+
+Offline tests cover index holes, disabled HASH160 aliases, wallet/network/index
+mismatch, derivation-path serialization, signing after persistence/reload, stale
+network duplicates, occupied local slots, checkbox visibility and clearing,
+disabled index selection, and submission without private-key bytes.
+
+Manual funded testnet follow-up: load a wallet identity, add a derived HIGH
+secp256k1 key, use it to sign a permitted operation, then restore the wallet in
+an isolated data directory and verify that the added key is rediscovered. Repeat
+with HASH160 for an operation whose backend supports that type. Never record
+recovery phrases or private keys in test artifacts.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -597,7 +597,11 @@ As an everyday user, I want to open a Receive view for my identity so that anoth
 As a power user, I want to add a new key to my identity so that I can authorize additional operations or devices.
 
 - Select key type and purpose.
-- Key is added via state transition.
+- “Derive from wallet” is selected by default; choose a key index instead of entering a private key.
+- The first unused index is selected automatically. Used indices, including disabled keys and HASH160 equivalents, cannot be selected.
+- Derived secp256k1 and HASH160 keys retain their wallet path for signing and seed recovery. Indices stay within the recovery search range.
+- Uncheck derivation to enter or randomly generate a private key. Identities without a known wallet path and other key types use this manual option.
+- Key is added via state transition; stale or reused derived selections are rejected before submission.
 
 ### IDN-008: View identity keys and details [Implemented]
 **Persona:** Alex, Priya, Jordan

--- a/src/backend_task/error.rs
+++ b/src/backend_task/error.rs
@@ -607,6 +607,15 @@ pub enum TaskError {
     )]
     IdentityKeySlotOccupied,
 
+    #[error("The wallet for this identity could not be determined. Load the identity from its wallet or enter a private key.")]
+    DerivedKeyWalletRequired,
+
+    #[error("This key type cannot be derived here. Choose secp256k1 or HASH160, or enter a private key.")]
+    DerivedKeyTypeUnsupported,
+
+    #[error("This key index is unavailable. Refresh the identity and choose an unused index.")]
+    DerivedKeyIndexUnavailable,
+
     /// An identity private key was found in the vault but its bytes are not a
     /// usable signing key (vault corruption or a truncated write). Distinct
     /// from [`Self::IdentityKeyMissing`] (genuinely absent) so the user gets

--- a/src/backend_task/identity/add_key_to_identity.rs
+++ b/src/backend_task/identity/add_key_to_identity.rs
@@ -2,18 +2,27 @@ use super::BackendTaskSuccessResult;
 use crate::backend_task::FeeResult;
 use crate::backend_task::error::TaskError;
 use crate::context::AppContext;
+use crate::model::derived_identity_key::{
+    derivation_index_limit, derivation_wallet, occupied_indices,
+};
 use crate::model::qualified_identity::PrivateKeyTarget::PrivateKeyOnMainIdentity;
 use crate::model::qualified_identity::QualifiedIdentity;
+use crate::model::qualified_identity::encrypted_key_storage::{
+    PrivateKeyData, WalletDerivationPath,
+};
 use crate::model::qualified_identity::qualified_identity_public_key::QualifiedIdentityPublicKey;
 use crate::wallet_backend::secret_prompt::SecretScope;
 use crate::wallet_backend::{SecretAccess, VerifiedIdentityPassword};
 use dash_sdk::Error as SdkError;
 use dash_sdk::Sdk;
 use dash_sdk::dpp::identity::KeyID;
+use dash_sdk::dpp::identity::KeyType;
 use dash_sdk::dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+use dash_sdk::dpp::identity::hash::IdentityPublicKeyHashMethodsV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::{
     IdentityPublicKeyGettersV0, IdentityPublicKeySettersV0,
 };
+use dash_sdk::dpp::key_wallet::bip32::{DerivationPath, KeyDerivationType};
 use dash_sdk::dpp::prelude::UserFeeIncrease;
 use dash_sdk::dpp::state_transition::identity_update_transition::IdentityUpdateTransition;
 use dash_sdk::dpp::state_transition::identity_update_transition::methods::IdentityUpdateTransitionMethodsV0;
@@ -25,9 +34,88 @@ impl AppContext {
     pub(super) async fn add_key_to_identity(
         &self,
         sdk: &Sdk,
+        qualified_identity: QualifiedIdentity,
+        public_key_to_add: QualifiedIdentityPublicKey,
+        private_key: [u8; 32],
+    ) -> Result<BackendTaskSuccessResult, TaskError> {
+        self.add_identity_key(
+            sdk,
+            qualified_identity,
+            public_key_to_add,
+            Some(private_key),
+        )
+        .await
+    }
+
+    pub(super) async fn add_derived_key_to_identity(
+        &self,
+        sdk: &Sdk,
+        identity: QualifiedIdentity,
+        mut key: QualifiedIdentityPublicKey,
+        index: u32,
+    ) -> Result<BackendTaskSuccessResult, TaskError> {
+        if !matches!(
+            key.identity_public_key.key_type(),
+            KeyType::ECDSA_SECP256K1 | KeyType::ECDSA_HASH160
+        ) {
+            return Err(TaskError::DerivedKeyTypeUnsupported);
+        }
+        let identity = self
+            .get_local_qualified_identity(&identity.identity.id())?
+            .ok_or(TaskError::IdentityNotFoundLocally)?;
+        let (seed_hash, identity_index) = derivation_wallet(&identity, self.network)
+            .ok_or(TaskError::DerivedKeyWalletRequired)?;
+        if index >= derivation_index_limit(identity.identity.get_public_key_max_id()) {
+            return Err(TaskError::DerivedKeyIndexUnavailable);
+        }
+        let wallet = self.wallet_arc(&seed_hash)?;
+        self.resolve_identity_auth_pubkeys_data_map(
+            &wallet,
+            true,
+            true,
+            identity_index,
+            index..index + 1,
+        )
+        .await?;
+        let cache = self
+            .wallet_backend()?
+            .auth_pubkey_cache()
+            .get(self.network, &seed_hash);
+        if occupied_indices(&identity, self.network, seed_hash, identity_index, &cache)
+            .contains(&index)
+        {
+            return Err(TaskError::DerivedKeyIndexUnavailable);
+        }
+        let public_key = cache
+            .get(self.network, identity_index, index)
+            .ok_or(TaskError::WalletKeyLookupFailed)?;
+        let data = match key.identity_public_key.key_type() {
+            KeyType::ECDSA_SECP256K1 => public_key.to_bytes(),
+            KeyType::ECDSA_HASH160 => {
+                let hash: [u8; 20] = public_key.pubkey_hash().into();
+                hash.to_vec()
+            }
+            _ => return Err(TaskError::DerivedKeyTypeUnsupported),
+        };
+        key.identity_public_key.set_data(data.into());
+        key.in_wallet_at_derivation_path = Some(WalletDerivationPath {
+            wallet_seed_hash: seed_hash,
+            derivation_path: DerivationPath::identity_authentication_path(
+                self.network,
+                KeyDerivationType::ECDSA,
+                identity_index,
+                index,
+            ),
+        });
+        self.add_identity_key(sdk, identity, key, None).await
+    }
+
+    async fn add_identity_key(
+        &self,
+        sdk: &Sdk,
         mut qualified_identity: QualifiedIdentity,
         mut public_key_to_add: QualifiedIdentityPublicKey,
-        private_key: [u8; 32],
+        private_key: Option<[u8; 32]>,
     ) -> Result<BackendTaskSuccessResult, TaskError> {
         // O-2: enforce the protected-identity precondition BEFORE any
         // on-chain side effect. If this identity is password-protected, prompt
@@ -63,13 +151,17 @@ impl AppContext {
         // broadcast (e.g. restored from an old blob) can hold `max_id + 1`,
         // and it may be a misfiled key's only private half — so refuse rather
         // than overwrite.
-        qualified_identity.private_keys.insert_non_encrypted(
-            (
-                PrivateKeyOnMainIdentity,
-                public_key_to_add.identity_public_key.id(),
-            ),
-            (public_key_to_add.clone(), private_key),
-        )?;
+        let placement = (
+            PrivateKeyOnMainIdentity,
+            public_key_to_add.identity_public_key.id(),
+        );
+        if let Some(private_key) = private_key {
+            qualified_identity
+                .private_keys
+                .insert_non_encrypted(placement, (public_key_to_add.clone(), private_key))?;
+        } else {
+            insert_derived_key(&mut qualified_identity, &public_key_to_add)?;
+        }
         // Track balance before operation for fee calculation
         let balance_before = qualified_identity.identity.balance();
         let estimated_fee = self.fee_estimator().estimate_identity_update();
@@ -165,7 +257,7 @@ impl AppContext {
         self.persist_added_identity_key(
             &mut qualified_identity,
             new_key,
-            &private_key,
+            private_key.as_ref(),
             verified_password,
         )?;
         Ok(BackendTaskSuccessResult::AddedKeyToIdentity(fee_result))
@@ -192,7 +284,7 @@ impl AppContext {
         &self,
         qualified_identity: &mut QualifiedIdentity,
         new_key: (crate::model::qualified_identity::PrivateKeyTarget, KeyID),
-        private_key: &[u8; 32],
+        private_key: Option<&[u8; 32]>,
         verified_password: Option<VerifiedIdentityPassword>,
     ) -> Result<(), TaskError> {
         let identity_id = qualified_identity.identity.id();
@@ -226,7 +318,7 @@ impl AppContext {
         // freeing disk space) instead of a silent loss or a misleading storage
         // error — and NEVER fall back to a keyless write (that would strip the
         // protection this branch exists to preserve).
-        if let Some(password) = verified_password {
+        if let (Some(password), Some(private_key)) = (verified_password, private_key) {
             self.wallet_backend()?
                 .secret_access()
                 .seal_new_identity_key_with_password(
@@ -253,6 +345,42 @@ impl AppContext {
 
         self.write_local_qualified_identity_locked(qualified_identity)
     }
+}
+
+fn insert_derived_key(
+    identity: &mut QualifiedIdentity,
+    key: &QualifiedIdentityPublicKey,
+) -> Result<(), TaskError> {
+    let placement = (PrivateKeyOnMainIdentity, key.identity_public_key.id());
+    // Recheck the fetched identity: another device may have used this key.
+    let hash = key
+        .identity_public_key
+        .public_key_hash()
+        .map_err(SdkError::Protocol)?;
+    if identity
+        .identity
+        .public_keys()
+        .values()
+        .any(|key| key.public_key_hash().ok() == Some(hash))
+    {
+        return Err(TaskError::DerivedKeyIndexUnavailable);
+    }
+    if identity
+        .private_keys
+        .get_cloned_private_key_data_and_wallet_info(&placement)
+        .is_some()
+    {
+        return Err(TaskError::IdentityKeySlotOccupied);
+    }
+    let path = key
+        .in_wallet_at_derivation_path
+        .clone()
+        .ok_or(TaskError::DerivedKeyWalletRequired)?;
+    identity.private_keys.insert_if_absent(
+        placement,
+        (key.clone(), PrivateKeyData::AtWalletDerivationPath(path)),
+    );
+    Ok(())
 }
 
 /// O-2 add-key precondition (no SDK, no network): when the target
@@ -310,6 +438,105 @@ mod tests {
         SecretBytes, SecretStore, SecretString, WalletId as SecretWalletId,
     };
     use std::sync::Arc;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn derived_key_persists_as_path_and_signs_after_reload() {
+        use crate::context::test_staging::stage_identity_with_vaulted_keys;
+        use crate::model::derived_identity_key::test_support::fixture;
+        use dash_sdk::dpp::dashcore::secp256k1::{Message, Secp256k1, SecretKey};
+
+        let staged = stage_identity_with_vaulted_keys([0xAA; 32], [0xBB; 32]).await;
+        let (mut identity, cache, seed_hash, seed) = fixture();
+        identity.identity.set_id(staged.id);
+        staged
+            .ctx
+            .wallets
+            .write()
+            .unwrap()
+            .extend(identity.associated_wallets.clone());
+        let mut key = identity.private_keys.identity_public_keys()[0].1.clone();
+        key.identity_public_key.set_id(5);
+        key.identity_public_key
+            .set_security_level(dash_sdk::dpp::identity::SecurityLevel::HIGH);
+        key.identity_public_key
+            .set_data(cache.get(Network::Testnet, 0, 3).unwrap().to_bytes().into());
+        key.in_wallet_at_derivation_path = Some(WalletDerivationPath {
+            wallet_seed_hash: seed_hash,
+            derivation_path: DerivationPath::identity_authentication_path(
+                Network::Testnet,
+                KeyDerivationType::ECDSA,
+                0,
+                3,
+            ),
+        });
+        insert_derived_key(&mut identity, &key).unwrap();
+        identity
+            .identity
+            .add_public_key(key.identity_public_key.clone());
+        let placement = (PrivateKeyOnMainIdentity, 5);
+        staged
+            .ctx
+            .persist_added_identity_key(&mut identity, placement.clone(), None, None)
+            .unwrap();
+        let restored = staged
+            .ctx
+            .get_local_qualified_identity(&staged.id)
+            .unwrap()
+            .unwrap();
+        let (data, path) = restored
+            .private_keys
+            .get_cloned_private_key_data_and_wallet_info(&placement)
+            .unwrap();
+        assert!(matches!(data, PrivateKeyData::AtWalletDerivationPath(_)));
+        assert_eq!(path, key.in_wallet_at_derivation_path);
+        assert!(
+            crate::wallet_backend::IdentityKeyView::new(&staged.store, staged.id.to_buffer())
+                .get(&placement.0, placement.1)
+                .unwrap()
+                .is_none()
+        );
+        let wallets = restored
+            .associated_wallets
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let (_, bytes) = restored
+            .private_keys
+            .get_resolve_with_seed(&placement, &wallets, &seed, Network::Testnet)
+            .unwrap()
+            .unwrap();
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(bytes.as_ref()).unwrap();
+        let message = Message::from_digest([1; 32]);
+        let signature = secp.sign_ecdsa(&message, &secret);
+        secp.verify_ecdsa(
+            &message,
+            &signature,
+            &cache.get(Network::Testnet, 0, 3).unwrap().inner,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn derived_key_rechecks_network_hash_aliases_and_local_slots() {
+        use crate::model::derived_identity_key::test_support::fixture;
+        let (mut identity, _, _, _) = fixture();
+        let mut key = identity.private_keys.identity_public_keys()[0].1.clone();
+        key.identity_public_key.set_id(1);
+        let hash = key.identity_public_key.public_key_hash().unwrap();
+        key.identity_public_key.set_key_type(KeyType::ECDSA_HASH160);
+        key.identity_public_key.set_data(hash.to_vec().into());
+        assert!(matches!(
+            insert_derived_key(&mut identity, &key),
+            Err(TaskError::DerivedKeyIndexUnavailable)
+        ));
+        identity.identity.set_public_keys(Default::default());
+        key.identity_public_key.set_id(0);
+        assert!(matches!(
+            insert_derived_key(&mut identity, &key),
+            Err(TaskError::IdentityKeySlotOccupied)
+        ));
+    }
 
     fn fresh_store(dir: &std::path::Path) -> Arc<SecretStore> {
         Arc::new(open_secret_store(&dir.join("secrets.pwsvault")).expect("open vault"))
@@ -408,7 +635,7 @@ mod tests {
             .persist_added_identity_key(
                 &mut qualified_identity,
                 (new_key.0.clone(), new_key.1),
-                &[0xCD; 32],
+                Some(&[0xCD; 32]),
                 Some(password),
             )
             .expect_err("an identity that is gone cannot take a new key");

--- a/src/backend_task/identity/mod.rs
+++ b/src/backend_task/identity/mod.rs
@@ -472,6 +472,8 @@ pub enum IdentityTask {
         wallet_seed_hash: WalletSeedHash,
     },
     AddKeyToIdentity(QualifiedIdentity, QualifiedIdentityPublicKey, [u8; 32]),
+    /// Add a key from the identity's wallet at the selected derivation index.
+    AddDerivedKeyToIdentity(QualifiedIdentity, QualifiedIdentityPublicKey, u32),
     /// Opt-in: seal every keyless (Tier-1) vault-stored key of this
     /// identity under ONE per-identity object `password` (Tier-2), and store
     /// `hint` for the sign-time prompt copy. Idempotent (an already-protected
@@ -881,6 +883,10 @@ impl AppContext {
             }
             IdentityTask::AddKeyToIdentity(qualified_identity, public_key_to_add, private_key) => {
                 self.add_key_to_identity(sdk, qualified_identity, public_key_to_add, private_key)
+                    .await
+            }
+            IdentityTask::AddDerivedKeyToIdentity(identity, key, index) => {
+                self.add_derived_key_to_identity(sdk, identity, key, index)
                     .await
             }
             IdentityTask::RegisterIdentity(registration_info) => {

--- a/src/model/derived_identity_key.rs
+++ b/src/model/derived_identity_key.rs
@@ -1,0 +1,287 @@
+use super::qualified_identity::PrivateKeyTarget;
+use super::qualified_identity::QualifiedIdentity;
+use super::wallet::{WalletSeedHash, auth_pubkey_cache::AuthPubkeyCache};
+use dash_sdk::dpp::dashcore::Network;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::hash::IdentityPublicKeyHashMethodsV0;
+use dash_sdk::dpp::key_wallet::bip32::{ChildNumber, DerivationPath, KeyDerivationType};
+use std::collections::BTreeSet;
+
+/// Stay inside the seed-recovery lookup window and bound derivation work.
+pub fn derivation_index_limit(max_key_id: u32) -> u32 {
+    max_key_id.saturating_add(6).min(4096)
+}
+
+/// Select the lowest unused index within the recoverable range.
+pub fn first_free_index(limit: u32, occupied: &BTreeSet<u32>) -> Option<u32> {
+    (0..limit).find(|index| !occupied.contains(index))
+}
+
+/// Resolve an unambiguous wallet and identity index from canonical ECDSA paths.
+pub fn derivation_wallet(
+    identity: &QualifiedIdentity,
+    network: Network,
+) -> Option<(WalletSeedHash, u32)> {
+    let mut found = None;
+    for (target, key) in identity.private_keys.identity_public_keys() {
+        if *target != PrivateKeyTarget::PrivateKeyOnMainIdentity {
+            continue;
+        }
+        let Some(path) = &key.in_wallet_at_derivation_path else {
+            continue;
+        };
+        let children = path.derivation_path.as_ref();
+        let [
+            ..,
+            ChildNumber::Hardened {
+                index: identity_index,
+            },
+            ChildNumber::Hardened { index: key_index },
+        ] = children
+        else {
+            continue;
+        };
+        if path.derivation_path
+            != DerivationPath::identity_authentication_path(
+                network,
+                KeyDerivationType::ECDSA,
+                *identity_index,
+                *key_index,
+            )
+        {
+            continue;
+        }
+        if identity
+            .wallet_index
+            .is_some_and(|index| index != *identity_index)
+        {
+            return None;
+        }
+        let coordinate = (path.wallet_seed_hash, *identity_index);
+        if found.is_some_and(|previous| previous != coordinate) {
+            return None;
+        }
+        found = Some(coordinate);
+    }
+    found.filter(|(seed_hash, _)| identity.associated_wallets.contains_key(seed_hash))
+}
+
+/// Include disabled keys and hash160 aliases: reusing their private key is unsafe.
+pub fn occupied_indices(
+    identity: &QualifiedIdentity,
+    network: Network,
+    seed_hash: WalletSeedHash,
+    identity_index: u32,
+    cache: &AuthPubkeyCache,
+) -> BTreeSet<u32> {
+    let mut occupied = BTreeSet::new();
+    for (_, key) in identity.private_keys.identity_public_keys() {
+        if let Some(path) = &key.in_wallet_at_derivation_path
+            && path.wallet_seed_hash == seed_hash
+            && let Some(ChildNumber::Hardened { index }) = path.derivation_path.as_ref().last()
+            && path.derivation_path
+                == DerivationPath::identity_authentication_path(
+                    network,
+                    KeyDerivationType::ECDSA,
+                    identity_index,
+                    *index,
+                )
+        {
+            occupied.insert(*index);
+        }
+    }
+    let hashes: BTreeSet<_> = identity
+        .identity
+        .public_keys()
+        .values()
+        .filter_map(|key| key.public_key_hash().ok())
+        .collect();
+    for index in 0..derivation_index_limit(identity.identity.get_public_key_max_id()) {
+        if let Some(key) = cache.get(network, identity_index, index)
+            && hashes.contains::<[u8; 20]>(&key.pubkey_hash().into())
+        {
+            occupied.insert(index);
+        }
+    }
+    occupied
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    use super::super::qualified_identity::encrypted_key_storage::{
+        KeyStorage, PrivateKeyData, WalletDerivationPath,
+    };
+    use super::super::qualified_identity::qualified_identity_public_key::QualifiedIdentityPublicKey;
+    use super::super::qualified_identity::{IdentityStatus, IdentityType};
+    use super::super::wallet::Wallet;
+    use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+    use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+    use dash_sdk::dpp::version::PlatformVersion;
+    use dash_sdk::platform::{Identifier, Identity};
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, RwLock};
+
+    pub(crate) fn fixture() -> (QualifiedIdentity, AuthPubkeyCache, WalletSeedHash, [u8; 64]) {
+        let seed = [42; 64];
+        let wallet = Wallet::new_from_seed(seed, Network::Testnet, None, None).unwrap();
+        let seed_hash = wallet.seed_hash();
+        let mut cache = AuthPubkeyCache::default();
+        for index in 0..8 {
+            let key = wallet
+                .identity_authentication_ecdsa_public_key_from_seed(
+                    &seed,
+                    Network::Testnet,
+                    0,
+                    index,
+                )
+                .unwrap();
+            cache.insert(Network::Testnet, 0, index, &key);
+        }
+        let mut identity = QualifiedIdentity {
+            identity: Identity::create_basic_identity(
+                Identifier::from([1; 32]),
+                PlatformVersion::latest(),
+            )
+            .unwrap(),
+            associated_voter_identity: None,
+            associated_operator_identity: None,
+            associated_owner_key_id: None,
+            identity_type: IdentityType::User,
+            alias: None,
+            private_keys: KeyStorage::default(),
+            dpns_names: vec![],
+            associated_wallets: BTreeMap::from([(seed_hash, Arc::new(RwLock::new(wallet)))]),
+            secret_access: None,
+            wallet_index: Some(0),
+            top_ups: BTreeMap::new(),
+            status: IdentityStatus::Active,
+            network: Network::Testnet,
+        };
+        let key = IdentityPublicKeyV0 {
+            id: 0,
+            key_type: KeyType::ECDSA_SECP256K1,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::MASTER,
+            contract_bounds: None,
+            read_only: false,
+            disabled_at: None,
+            data: cache.get(Network::Testnet, 0, 0).unwrap().to_bytes().into(),
+        };
+        identity.identity.add_public_key(key.clone().into());
+        let path = WalletDerivationPath {
+            wallet_seed_hash: seed_hash,
+            derivation_path: DerivationPath::identity_authentication_path(
+                Network::Testnet,
+                KeyDerivationType::ECDSA,
+                0,
+                0,
+            ),
+        };
+        identity.private_keys.insert_if_absent(
+            (PrivateKeyTarget::PrivateKeyOnMainIdentity, 0),
+            (
+                QualifiedIdentityPublicKey {
+                    identity_public_key: key.into(),
+                    in_wallet_at_derivation_path: Some(path.clone()),
+                },
+                PrivateKeyData::AtWalletDerivationPath(path),
+            ),
+        );
+        (identity, cache, seed_hash, seed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::qualified_identity::encrypted_key_storage::KeyStorage;
+    use super::test_support::fixture;
+    use super::*;
+    use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+    use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+    use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+    #[test]
+    fn disabled_hash160_without_metadata_reserves_its_derived_index() {
+        let (mut identity, cache, seed_hash, _) = fixture();
+        let hash: [u8; 20] = cache
+            .get(Network::Testnet, 0, 2)
+            .unwrap()
+            .pubkey_hash()
+            .into();
+        identity.identity.add_public_key(
+            IdentityPublicKeyV0 {
+                id: 4,
+                key_type: KeyType::ECDSA_HASH160,
+                purpose: Purpose::AUTHENTICATION,
+                security_level: SecurityLevel::HIGH,
+                contract_bounds: None,
+                read_only: false,
+                disabled_at: Some(1),
+                data: hash.to_vec().into(),
+            }
+            .into(),
+        );
+        let occupied = occupied_indices(&identity, Network::Testnet, seed_hash, 0, &cache);
+        assert_eq!(occupied, BTreeSet::from([0, 2]));
+        assert_eq!(first_free_index(10, &occupied), Some(1));
+    }
+
+    #[test]
+    fn wallet_resolution_rejects_wrong_network_and_identity_index() {
+        let (mut identity, _, seed_hash, _) = fixture();
+        assert_eq!(
+            derivation_wallet(&identity, Network::Testnet),
+            Some((seed_hash, 0))
+        );
+        assert_eq!(derivation_wallet(&identity, Network::Mainnet), None);
+        identity.wallet_index = Some(1);
+        assert_eq!(derivation_wallet(&identity, Network::Testnet), None);
+    }
+
+    #[test]
+    fn wallet_path_roundtrip_recovers_the_signing_key_from_seed() {
+        let (identity, cache, _, seed) = fixture();
+        let bytes =
+            bincode::encode_to_vec(&identity.private_keys, bincode::config::standard()).unwrap();
+        let (restored, _): (KeyStorage, _) =
+            bincode::decode_from_slice(&bytes, bincode::config::standard()).unwrap();
+        let wallets = identity
+            .associated_wallets
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let (public, secret) = restored
+            .get_resolve_with_seed(
+                &(PrivateKeyTarget::PrivateKeyOnMainIdentity, 0),
+                &wallets,
+                &seed,
+                Network::Testnet,
+            )
+            .unwrap()
+            .unwrap();
+        assert!(
+            public
+                .identity_public_key
+                .validate_private_key_bytes(&secret, Network::Testnet)
+                .unwrap()
+        );
+        assert_eq!(
+            public.identity_public_key.data().as_slice(),
+            cache.get(Network::Testnet, 0, 0).unwrap().to_bytes()
+        );
+    }
+
+    #[test]
+    fn first_free_fills_holes_and_excludes_used_indices() {
+        let occupied = BTreeSet::from([0, 2, 3]);
+        assert_eq!(first_free_index(5, &occupied), Some(1));
+        assert_eq!(first_free_index(1, &occupied), None);
+    }
+
+    #[test]
+    fn recovery_window_is_bounded_and_includes_new_key() {
+        assert_eq!(derivation_index_limit(1), 7);
+        assert_eq!(derivation_index_limit(u32::MAX), 4096);
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -5,6 +5,7 @@ pub mod contested_name;
 pub mod dashpay;
 pub mod dashpay_derivation;
 pub(crate) mod data_migration;
+pub mod derived_identity_key;
 pub mod dpns;
 pub mod fee_estimation;
 pub mod grovestark_prover;

--- a/src/ui/identity/keys/add_key_screen.rs
+++ b/src/ui/identity/keys/add_key_screen.rs
@@ -1,7 +1,11 @@
 use crate::app::AppAction;
 use crate::backend_task::identity::IdentityTask;
+use crate::backend_task::wallet::WalletTask;
 use crate::backend_task::{BackendTask, BackendTaskSuccessResult, FeeResult};
 use crate::context::AppContext;
+use crate::model::derived_identity_key::{
+    derivation_index_limit, derivation_wallet, first_free_index, occupied_indices,
+};
 use crate::model::fee_estimation::format_credits_as_dash;
 use crate::model::qualified_identity::QualifiedIdentity;
 use crate::model::qualified_identity::qualified_identity_public_key::QualifiedIdentityPublicKey;
@@ -43,6 +47,9 @@ pub struct AddKeyScreen {
     pub identity: QualifiedIdentity,
     pub app_context: Arc<AppContext>,
     private_key_input: PasswordInput,
+    derived: bool,
+    derivation_index: Option<u32>,
+    derivation_warming: bool,
     key_type: KeyType,
     purpose: Purpose,
     security_level: SecurityLevel,
@@ -74,6 +81,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
+            derived: true,
+            derivation_index: None,
+            derivation_warming: false,
             private_key_input: PasswordInput::new()
                 .with_hint_text("Private key (hex)")
                 .with_char_limit(64)
@@ -118,6 +128,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
+            derived: true,
+            derivation_index: None,
+            derivation_warming: false,
             private_key_input: PasswordInput::new()
                 .with_hint_text("Private key (hex)")
                 .with_char_limit(64)
@@ -162,6 +175,9 @@ impl AddKeyScreen {
         Self {
             identity,
             app_context: app_context.clone(),
+            derived: true,
+            derivation_index: None,
+            derivation_warming: false,
             private_key_input: PasswordInput::new()
                 .with_hint_text("Private key (hex)")
                 .with_char_limit(64)
@@ -183,6 +199,58 @@ impl AddKeyScreen {
 
     fn validate_and_add_key(&mut self) -> AppAction {
         let mut app_action = AppAction::None;
+        // Handle contract bounds if enabled
+        let contract_bounds = if self.enable_contract_bounds && !self.contract_id_input.is_empty() {
+            match Identifier::from_string(&self.contract_id_input, Encoding::Base58) {
+                Ok(contract_id) => {
+                    if self.document_type_input.is_empty() {
+                        Some(ContractBounds::SingleContract { id: contract_id })
+                    } else {
+                        Some(ContractBounds::SingleContractDocumentType {
+                            id: contract_id,
+                            document_type_name: self.document_type_input.clone(),
+                        })
+                    }
+                }
+                Err(error) => {
+                    self.add_key_status = AddKeyStatus::Error;
+                    MessageBanner::set_global(
+                        self.app_context.egui_ctx(),
+                        "The contract ID is not valid. Check the ID and try again.",
+                        MessageType::Error,
+                    )
+                    .with_details(error);
+                    return app_action;
+                }
+            }
+        } else {
+            None
+        };
+
+        if self.derived {
+            let Some(index) = self.derivation_index else {
+                return app_action;
+            };
+            let new_key = IdentityPublicKeyV0 {
+                id: 0,
+                key_type: self.key_type,
+                purpose: self.purpose,
+                security_level: self.security_level,
+                data: Vec::new().into(),
+                read_only: false,
+                disabled_at: None,
+                contract_bounds,
+            };
+            return AppAction::BackendTask(BackendTask::IdentityTask(
+                IdentityTask::AddDerivedKeyToIdentity(
+                    self.identity.clone(),
+                    QualifiedIdentityPublicKey::from(dash_sdk::platform::IdentityPublicKey::from(
+                        new_key,
+                    )),
+                    index,
+                ),
+            ));
+        }
         // Convert the input string to bytes (hex decoding)
         match hex::decode(self.private_key_input.text()) {
             Ok(private_key_bytes_vec) if private_key_bytes_vec.len() == 32 => {
@@ -202,36 +270,6 @@ impl AddKeyScreen {
                     )
                     .with_details(error);
                 } else {
-                    // Handle contract bounds if enabled
-                    let contract_bounds = if self.enable_contract_bounds
-                        && !self.contract_id_input.is_empty()
-                    {
-                        match Identifier::from_string(&self.contract_id_input, Encoding::Base58) {
-                            Ok(contract_id) => {
-                                if self.document_type_input.is_empty() {
-                                    Some(ContractBounds::SingleContract { id: contract_id })
-                                } else {
-                                    Some(ContractBounds::SingleContractDocumentType {
-                                        id: contract_id,
-                                        document_type_name: self.document_type_input.clone(),
-                                    })
-                                }
-                            }
-                            Err(error) => {
-                                self.add_key_status = AddKeyStatus::Error;
-                                MessageBanner::set_global(
-                                    self.app_context.egui_ctx(),
-                                    "The contract ID is not valid. Check the ID and try again.",
-                                    MessageType::Error,
-                                )
-                                .with_details(error);
-                                return app_action;
-                            }
-                        }
-                    } else {
-                        None
-                    };
-
                     let new_key = IdentityPublicKeyV0 {
                         id: self.identity.identity.get_public_key_max_id() + 1,
                         key_type: self.key_type,
@@ -300,6 +338,130 @@ impl AddKeyScreen {
         app_action
     }
 
+    fn show_key_source(&mut self, ui: &mut Ui) -> AppAction {
+        ui.label("Key source:");
+        if ui
+            .checkbox(&mut self.derived, "Derive from wallet")
+            .changed()
+        {
+            self.private_key_input.clear();
+        }
+        ui.end_row();
+        if self.derived {
+            return self.show_derivation_index(ui);
+        } else {
+            ui.label("Private Key:");
+            ui.horizontal(|ui| {
+                self.private_key_input.show(ui);
+                if ui.button("Generate Random").clicked() {
+                    self.generate_random_private_key();
+                }
+            });
+            ui.end_row();
+        }
+
+        AppAction::None
+    }
+
+    fn show_derivation_index(&mut self, ui: &mut Ui) -> AppAction {
+        ui.label("Key index:");
+        let Some((seed_hash, identity_index)) =
+            derivation_wallet(&self.identity, self.app_context.network)
+        else {
+            self.derivation_index = None;
+            ui.label(
+                "Load this identity from its wallet, or uncheck derivation to enter a private key.",
+            );
+            ui.end_row();
+            return AppAction::None;
+        };
+        if !matches!(
+            self.key_type,
+            KeyType::ECDSA_SECP256K1 | KeyType::ECDSA_HASH160
+        ) {
+            self.derivation_index = None;
+            ui.label("Choose secp256k1 or HASH160, or uncheck derivation to enter a private key.");
+            ui.end_row();
+            return AppAction::None;
+        }
+        let Ok(backend) = self.app_context.wallet_backend() else {
+            self.derivation_index = None;
+            ui.label("The wallet is unavailable. Reopen the wallet and try again.");
+            ui.end_row();
+            return AppAction::None;
+        };
+        let cache = backend
+            .auth_pubkey_cache()
+            .get(self.app_context.network, &seed_hash);
+        let limit = derivation_index_limit(self.identity.identity.get_public_key_max_id());
+        if (0..limit).any(|index| {
+            cache
+                .get(self.app_context.network, identity_index, index)
+                .is_none()
+        }) {
+            self.derivation_index = None;
+            if self.derivation_warming && self.add_key_status == AddKeyStatus::Error {
+                if crate::ui::components::styled::StyledButton::new("Retry loading indices")
+                    .show(ui)
+                    .clicked()
+                {
+                    self.derivation_warming = false;
+                    self.add_key_status = AddKeyStatus::NotStarted;
+                }
+            } else {
+                ui.label("Loading available indices…");
+            }
+            ui.end_row();
+            if !self.derivation_warming {
+                self.derivation_warming = true;
+                return AppAction::BackendTask(BackendTask::WalletTask(
+                    WalletTask::WarmIdentityAuthPubkeys {
+                        seed_hash,
+                        identity_index,
+                        key_count: limit,
+                    },
+                ));
+            }
+            return AppAction::None;
+        }
+        let occupied = occupied_indices(
+            &self.identity,
+            self.app_context.network,
+            seed_hash,
+            identity_index,
+            &cache,
+        );
+        if self
+            .derivation_index
+            .is_none_or(|index| index >= limit || occupied.contains(&index))
+        {
+            self.derivation_index = first_free_index(limit, &occupied);
+        }
+        egui::ComboBox::from_id_salt("derived_key_index")
+            .selected_text(
+                self.derivation_index
+                    .map_or_else(|| "No free indices".to_string(), |index| index.to_string()),
+            )
+            .show_ui(ui, |ui| {
+                for index in 0..limit {
+                    let used = occupied.contains(&index);
+                    ui.add_enabled_ui(!used, |ui| {
+                        ui.selectable_value(
+                            &mut self.derivation_index,
+                            Some(index),
+                            if used {
+                                format!("{index} (used)")
+                            } else {
+                                index.to_string()
+                            },
+                        );
+                    });
+                }
+            });
+        ui.end_row();
+        AppAction::None
+    }
+
     fn generate_random_private_key(&mut self) {
         // Create a new random number generator
         let mut rng = StdRng::from_entropy();
@@ -343,6 +505,8 @@ impl AddKeyScreen {
             && s == "add_another"
         {
             self.private_key_input.clear();
+            self.derivation_index = None;
+            self.derivation_warming = false;
             self.contract_id_input = String::new();
             self.document_type_input = String::new();
             self.enable_contract_bounds = false;
@@ -369,6 +533,8 @@ impl ScreenLike for AddKeyScreen {
             .find(|identity| identity.identity.id() == self.identity.identity.id())
         {
             self.identity = refreshed_identity.clone();
+            self.derivation_index = None;
+            self.derivation_warming = false;
         }
     }
 
@@ -386,6 +552,9 @@ impl ScreenLike for AddKeyScreen {
                 self.refresh_banner.take_and_clear();
                 self.completed_fee_result = Some(fee_result);
                 self.add_key_status = AddKeyStatus::Complete;
+            }
+            BackendTaskSuccessResult::IdentityAuthPubkeysWarmed { .. } => {
+                self.derivation_warming = false;
             }
             BackendTaskSuccessResult::RefreshedIdentity(_) => {
                 self.refresh();
@@ -621,13 +790,7 @@ impl ScreenLike for AddKeyScreen {
                         });
                     ui.end_row();
 
-                    // Private Key Input
-                    ui.label("Private Key:");
-                    self.private_key_input.show(ui);
-                    if ui.button("Generate Random").clicked() {
-                        self.generate_random_private_key();
-                    }
-                    ui.end_row();
+                    inner_action |= self.show_key_source(ui);
 
                     // Contract Bounds Toggle
                     ui.label("Enable Contract Bounds:");
@@ -695,7 +858,15 @@ impl ScreenLike for AddKeyScreen {
                 .fill(DashColors::DASH_BLUE)
                 .frame(true)
                 .corner_radius(3.0);
-            if ui.add(button).clicked() {
+            let can_add = self.add_key_status != AddKeyStatus::WaitingForResult
+                && (!self.derived
+                    || (self.derivation_index.is_some()
+                        && !self.derivation_warming
+                        && matches!(
+                            self.key_type,
+                            KeyType::ECDSA_SECP256K1 | KeyType::ECDSA_HASH160
+                        )));
+            if ui.add_enabled(can_add, button).clicked() {
                 let validation_action = self.validate_and_add_key();
                 if matches!(&validation_action, AppAction::BackendTask(_)) {
                     self.add_key_status = AddKeyStatus::WaitingForResult;
@@ -724,5 +895,106 @@ impl ScreenLike for AddKeyScreen {
         }
 
         action
+    }
+}
+
+#[cfg(test)]
+mod derived_key_tests {
+    use super::*;
+    use crate::context::test_staging::stage_identity_with_vaulted_keys;
+    use crate::model::derived_identity_key::test_support::fixture;
+    use egui_kittest::{
+        Harness,
+        kittest::{NodeT, Queryable},
+    };
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn derived_key_checkbox_defaults_on_and_switches_private_input() {
+        let staged = stage_identity_with_vaulted_keys([0xAA; 32], [0xBB; 32]).await;
+        let (identity, cache, seed_hash, _) = fixture();
+        staged
+            .ctx
+            .wallet_backend()
+            .unwrap()
+            .auth_pubkey_cache()
+            .put(staged.ctx.network, &seed_hash, &cache)
+            .unwrap();
+        let screen = AddKeyScreen::new(identity, &staged.ctx);
+        assert!(screen.derived);
+        let mut harness = Harness::builder().with_max_steps(30).build_ui_state(
+            |ui, screen: &mut AddKeyScreen| {
+                egui::Grid::new("source").show(ui, |ui| {
+                    screen.show_key_source(ui);
+                });
+            },
+            screen,
+        );
+        harness.run();
+        assert_eq!(harness.state().derivation_index, Some(1));
+        assert!(harness.query_by_label("Private Key:").is_none());
+        harness.get_by_label("Derive from wallet").click();
+        harness.run();
+        assert!(!harness.state().derived);
+        assert!(harness.query_by_label("Private Key:").is_some());
+        assert!(harness.query_by_label("Key index:").is_none());
+        harness
+            .state_mut()
+            .private_key_input
+            .set_text("sensitive input".to_string());
+        harness.get_by_label("Derive from wallet").click();
+        harness.run();
+        assert!(harness.state().private_key_input.text().is_empty());
+        assert_eq!(harness.state().derivation_index, Some(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn derived_key_occupied_index_cannot_be_selected_and_submit_carries_only_index() {
+        let staged = stage_identity_with_vaulted_keys([0xAA; 32], [0xBB; 32]).await;
+        let (identity, cache, seed_hash, _) = fixture();
+        staged
+            .ctx
+            .wallet_backend()
+            .unwrap()
+            .auth_pubkey_cache()
+            .put(staged.ctx.network, &seed_hash, &cache)
+            .unwrap();
+        let screen = AddKeyScreen::new(identity, &staged.ctx);
+        let mut harness = Harness::builder().with_max_steps(30).build_ui_state(
+            |ui, screen: &mut AddKeyScreen| {
+                egui::Grid::new("source").show(ui, |ui| {
+                    screen.show_key_source(ui);
+                });
+            },
+            screen,
+        );
+        harness.run();
+        harness.get_by_role(egui::accesskit::Role::ComboBox).click();
+        harness.run();
+        assert!(
+            harness
+                .get_by_label("0 (used)")
+                .accesskit_node()
+                .is_disabled()
+        );
+        harness.get_by_label("0 (used)").click();
+        harness.run();
+        assert_eq!(harness.state().derivation_index, Some(1));
+        if harness.query_by_label("2").is_none() {
+            harness.get_by_role(egui::accesskit::Role::ComboBox).click();
+            harness.run();
+        }
+        harness.get_by_label("2").click();
+        harness.run();
+        assert_eq!(harness.state().derivation_index, Some(2));
+        let AppAction::BackendTask(BackendTask::IdentityTask(
+            IdentityTask::AddDerivedKeyToIdentity(_, key, index),
+        )) = harness.state_mut().validate_and_add_key()
+        else {
+            panic!("derived submission must use the derived backend task");
+        };
+        assert_eq!(index, 2);
+        use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+        assert!(key.identity_public_key.data().is_empty());
+        assert!(key.in_wallet_at_derivation_path.is_none());
     }
 }


### PR DESCRIPTION
**TL;DR:** Add identity keys from the wallet with an unused index selected automatically, while keeping manual private-key entry available.

## User story
As an **identity owner**, I want to add a key recoverable from my wallet backup, so I do not have to back up a separate private key.

## Scenario
### Base flow
Open an identity's Add Key screen and choose the key's type, purpose and permissions.

### Actual behavior
The screen requires a private key supplied by the user or generated randomly.

### Expected behavior
“Derive from wallet” starts checked and shows an index chooser with the first free index selected. Used indices are disabled. Unchecking shows the private-key field and random-generation button. Switching modes clears manual input.

## Detailed discussion
Reuse canonical ECDSA identity-authentication paths, the existing public-key cache and secret-access mechanism. Support secp256k1 and HASH160; require an unambiguous wallet path already associated with the identity. Other types and identities without a known wallet path can use manual entry.

Track occupied paths and public-key hashes, including disabled keys and equivalent secp256k1/HASH160 representations. Reload local state and recheck the selected public-key hash against the freshly fetched network identity before broadcasting. Store the key as `AtWalletDerivationPath`; private bytes are derived when signing instead of copied into identity storage. Preserve existing imported-key password protection.

Keep selectable indices within the existing recovery window (`max_key_id + 6`, exclusive), capped at 4096 to bound derivation work. Warm the public-key cache asynchronously and offer retry when loading fails.

### Testing
- Nine new offline tests pass: index selection, disabled HASH160 aliases, wallet/network/index mismatch, path serialization, persistence/reload and signing, duplicate rejection, and checkbox/index interaction.
- The broader `derived_` filter passes 14 tests.
- All seven Add Key module tests pass, including protected-key and unload checks.
- Focused Clippy passes with `-D warnings`.
- Formatting and whitespace checks pass.
- No funded testnet broadcast or full wallet restore was run. The documented live scenario remains a manual follow-up.

### Prior work
Independent of #979 and based directly on `v1.0-dev`. Enables adding a wallet-derived secp256k1 key for supported operations; does not change platform-wallet's HASH160 profile-write limitation or fully close #760.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
