### PR TITLE
ci: re-pin the shared review engine and drop the redundant input

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -16,6 +16,4 @@ permissions:
   statuses: write
 jobs:
   policy:
-    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@d2978b05a15c8e29091958b0fa57b90a5ed5ff3b
-    with:
-      engine_revision: d2978b05a15c8e29091958b0fa57b90a5ed5ff3b
+    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@a95eab4ec0938e9022edd0c82591d052408a38a5


### PR DESCRIPTION
Re-pins the reusable workflow to `a95eab4ec0938e9022edd0c82591d052408a38a5` (dashpay/stale_prs_are_bad#9) and removes the `with: engine_revision:` block.

The engine commit used to be written twice — in `uses:` and in the input — with nothing verifying they matched, so a bump of one line could run unreviewed engine code behind a reviewed workflow reference. The callee now reads the pin out of this file's own `uses:` reference (from the branch GitHub ran the workflow from), so there is one commit in one place. It still refuses to run an engine that is not merged to the central default branch, and refuses to read policies unless that branch is protected.

Writes stay disabled: `PR_REVIEW_AUTOMATION_ENABLED` is not set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated pull request review workflow to use the latest approved review configuration.
  * Removed an outdated fixed engine version reference, allowing the workflow to follow the currently configured review engine revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->