### PR TITLE
fix(dashpay): accept HASH160 profile authentication keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Cancelling a network switch takes priority over simultaneous startup and
+  reports chain sync as stopped after shutting down the new backend.
+
 - Profile saves stop when their picture cannot be downloaded, explain unsupported
   signing keys, and retry failed display-timestamp storage on profile reads
   without submitting another paid write.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- DashPay profile writes use `platform-wallet`, enabling HIGH authentication
+  keys of type ECDSA_SECP256K1. HASH160 support remains an upstream limitation.
+  Writes require a wallet-linked identity; clearing existing profile fields
+  reports an explicit error because the upstream API preserves omitted fields.
+
 - Identity creation and top-up accounts are saved before payment and restored
   after restarting the app. Temporary save failures are retried a few times;
   if saving still fails, the payment stops and the app asks you to try again.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Profile saves stop when their picture cannot be downloaded, explain unsupported
+  signing keys, and retry failed display-timestamp storage on profile reads
+  without submitting another paid write.
+
 - DashPay profile writes use `platform-wallet`, enabling HIGH authentication
   keys of type ECDSA_SECP256K1. HASH160 support remains an upstream limitation.
   Writes require a wallet-linked identity; clearing existing profile fields

--- a/docs/ai-design/2026-09-10-platform-wallet-profile/README.md
+++ b/docs/ai-design/2026-09-10-platform-wallet-profile/README.md
@@ -7,6 +7,17 @@ selection, document construction, signing requests, broadcast, and profile
 persistence. DET validates inputs, determines create versus update from a
 network query, fetches optional avatar bytes, and maintains display timestamps.
 
+Avatar download or decoding failures stop the task before any profile query or
+write. Typed errors preserve the cause and tell the user how to correct the URL.
+DET checks the managing wallet's identity against the pinned upstream key policy
+before invoking the profile API; incompatible keys produce an actionable error.
+
+Failed display-timestamp writes remain in a per-network, per-identity in-memory
+repair queue. Profile reads retry only the local write and return the pending
+values even if storage still fails. A newer save replaces the pending values;
+a successful repair removes them. Pending repairs do not survive an application
+restart, and do not resubmit a paid profile transition.
+
 ## Scope and limitations
 
 - HIGH and CRITICAL authentication keys are selected upstream. The pinned
@@ -27,7 +38,8 @@ network query, fetches optional avatar bytes, and maintains display timestamps.
 
 Unit coverage checks validation before network/signing, omission of blank input
 fields, rejection of unsupported field removal, and failure without a managing
-wallet. The narrow backend E2E module is enabled independently of the deferred
+wallet, avatar failures before network access, key compatibility, and timestamp
+repair after transient storage failures. The narrow backend E2E module is enabled independently of the deferred
 contact-flow suite:
 
 ```sh

--- a/docs/ai-design/2026-09-10-platform-wallet-profile/README.md
+++ b/docs/ai-design/2026-09-10-platform-wallet-profile/README.md
@@ -1,0 +1,43 @@
+# DashPay profile writes through platform-wallet
+
+The profile backend task uses the managing wallet's external-signer profile
+API. `QualifiedIdentity` remains the signer, so imported and wallet-derived
+private keys use the existing secret-access path. Platform-wallet owns key
+selection, document construction, signing requests, broadcast, and profile
+persistence. DET validates inputs, determines create versus update from a
+network query, fetches optional avatar bytes, and maintains display timestamps.
+
+## Scope and limitations
+
+- HIGH and CRITICAL authentication keys are selected upstream. The pinned
+  platform-wallet supports ECDSA_SECP256K1 only for profile writes. ECDSA_HASH160
+  support belongs in dashpay/platform; this migration does not close #760 for
+  HASH160-only identities. Related PRs: #762 and #978.
+- An identity must be managed by a loaded wallet. An out-of-wallet identity
+  cannot use this upstream API and receives an explicit error.
+- Upstream `ProfileUpdate` treats omitted fields as unchanged. Clearing an
+  existing field is rejected before broadcast, including removing an avatar,
+  rather than reporting success with the old field still present.
+- Upstream uses its own write settings; DET's custom state-transition creation
+  options are not accepted by this API.
+- Adding a wallet-derived key to an existing identity is separate work, tracked
+  in MemCan TODO `d8c3a858-4de9-44a6-b59b-4a7c5439df03`.
+
+## Validation
+
+Unit coverage checks validation before network/signing, omission of blank input
+fields, rejection of unsupported field removal, and failure without a managing
+wallet. The narrow backend E2E module is enabled independently of the deferred
+contact-flow suite:
+
+```sh
+cargo test --test backend-e2e --all-features \
+  profile_create_and_replace_with_high_derived_key -- \
+  --ignored --nocapture --test-threads=1
+```
+
+It requires a funded testnet `E2E_WALLET_MNEMONIC`. It creates a fresh identity
+with a wallet-derived HIGH secp256k1 authentication key and no CRITICAL
+authentication key, creates a profile, replaces it, and checks both the upstream
+cache and the published document. No recovery phrase or private key belongs in
+this document or test fixtures.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -837,6 +837,9 @@ As a user who has requested a username that is not yet awarded, I want to see th
 As a user, I want to create and edit my DashPay profile (name, bio, avatar) so that contacts can identify me.
 
 - Set display name, bio, and profile image.
+- Profile writes require a wallet-linked identity with an active HIGH or CRITICAL
+  ECDSA_SECP256K1 authentication key. HASH160 profile signing and clearing existing
+  fields await upstream platform-wallet support.
 - Changes are published as a state transition.
 
 ### DPY-002: Search DashPay profiles [Implemented]

--- a/src/backend_task/dashpay/avatar_processing.rs
+++ b/src/backend_task/dashpay/avatar_processing.rs
@@ -6,6 +6,27 @@ use std::sync::Arc;
 /// Maximum allowed size for avatar images (5MB)
 const MAX_IMAGE_SIZE: usize = 5 * 1024 * 1024;
 
+/// Typed failures while downloading or decoding a profile picture.
+#[derive(Debug, thiserror::Error)]
+pub enum AvatarProcessingError {
+    #[error("The picture URL must use HTTPS. Enter an HTTPS URL and try again.")]
+    HttpsRequired,
+    #[error("The picture URL is too long. Use a URL with at most 2048 characters.")]
+    UrlTooLong,
+    #[error("The picture could not be downloaded. Check its URL and try again.")]
+    Download(#[from] reqwest::Error),
+    #[error("The picture server returned an invalid header. Try a different picture URL.")]
+    InvalidHeader(#[from] reqwest::header::ToStrError),
+    #[error("The picture server returned an invalid size. Try a different picture URL.")]
+    InvalidLength(#[from] std::num::ParseIntError),
+    #[error("The picture URL did not return an image. Try a different picture URL.")]
+    InvalidContentType,
+    #[error("The picture is too large. Choose an image smaller than 5 MB.")]
+    ImageTooLarge,
+    #[error("The picture could not be read. Choose a different image and try again.")]
+    InvalidImage(#[from] image::ImageError),
+}
+
 /// Resolve an avatar's image bytes for `url`, serving the DET avatar disk cache
 /// on a hit and fetching + populating it on a miss. The single avatar fetch
 /// path for every DashPay screen (contacts list, profile, contact viewer).
@@ -55,10 +76,9 @@ pub fn calculate_avatar_hash(image_bytes: &[u8]) -> [u8; 32] {
 /// 2. Resize to 9x8 pixels
 /// 3. Compare each pixel with its right neighbor
 /// 4. Generate 64-bit hash based on comparisons
-pub fn calculate_dhash_fingerprint(image_bytes: &[u8]) -> Result<[u8; 8], String> {
+pub fn calculate_dhash_fingerprint(image_bytes: &[u8]) -> Result<[u8; 8], AvatarProcessingError> {
     // Load the image from bytes
-    let img =
-        image::load_from_memory(image_bytes).map_err(|e| format!("Failed to load image: {}", e))?;
+    let img = image::load_from_memory(image_bytes)?;
 
     // Convert to grayscale and resize to 9x8
     let grayscale = img.grayscale();
@@ -201,90 +221,63 @@ pub fn are_images_similar(hash1: &[u8; 8], hash2: &[u8; 8], threshold: u32) -> b
 }
 
 /// Fetch image from URL and return bytes
-pub async fn fetch_image_bytes(url: &str) -> Result<Vec<u8>, String> {
+pub async fn fetch_image_bytes(url: &str) -> Result<Vec<u8>, AvatarProcessingError> {
     // Check URL is valid and uses HTTPS
     if !url.starts_with("https://") {
-        return Err("Avatar URL must use HTTPS".to_string());
+        return Err(AvatarProcessingError::HttpsRequired);
     }
 
     // Validate URL length per DIP-0015 (max 2048 characters)
     if url.len() > 2048 {
-        return Err("Avatar URL exceeds maximum length of 2048 characters".to_string());
+        return Err(AvatarProcessingError::UrlTooLong);
     }
 
     // Create HTTP client with timeout
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+        .build()?;
 
     // Send GET request
-    let response = client
-        .get(url)
-        .send()
-        .await
-        .map_err(|e| format!("Failed to fetch image: {}", e))?;
-
-    // Check status code
-    if !response.status().is_success() {
-        return Err(format!("HTTP error: {}", response.status()));
-    }
+    let response = client.get(url).send().await?.error_for_status()?;
 
     // Check content type
     if let Some(content_type) = response.headers().get("content-type") {
-        let content_type_str = content_type
-            .to_str()
-            .map_err(|e| format!("Invalid content-type header: {}", e))?;
+        let content_type_str = content_type.to_str()?;
 
         if !content_type_str.starts_with("image/") {
-            return Err(format!(
-                "Invalid content type: expected image/*, got {}",
-                content_type_str
-            ));
+            return Err(AvatarProcessingError::InvalidContentType);
         }
     }
 
     // Check content length if provided
     if let Some(content_length) = response.headers().get("content-length") {
-        let length_str = content_length
-            .to_str()
-            .map_err(|e| format!("Invalid content-length header: {}", e))?;
+        let length_str = content_length.to_str()?;
 
-        let length: usize = length_str
-            .parse()
-            .map_err(|e| format!("Failed to parse content-length: {}", e))?;
+        let length: usize = length_str.parse()?;
 
         if length > MAX_IMAGE_SIZE {
-            return Err(format!(
-                "Image too large: {} bytes (max {} bytes)",
-                length, MAX_IMAGE_SIZE
-            ));
+            return Err(AvatarProcessingError::ImageTooLarge);
         }
     }
 
     // Download the image bytes
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| format!("Failed to download image: {}", e))?;
+    let bytes = response.bytes().await?;
 
     // Verify actual size
     if bytes.len() > MAX_IMAGE_SIZE {
-        return Err(format!(
-            "Image too large: {} bytes (max {} bytes)",
-            bytes.len(),
-            MAX_IMAGE_SIZE
-        ));
+        return Err(AvatarProcessingError::ImageTooLarge);
     }
 
     // Try to validate it's actually an image by attempting to load it
-    image::load_from_memory(&bytes).map_err(|e| format!("Invalid image data: {}", e))?;
+    image::load_from_memory(&bytes)?;
 
     Ok(bytes.to_vec())
 }
 
 /// Process an avatar image: fetch, validate, and calculate hashes
-pub async fn process_avatar(url: &str) -> Result<(Vec<u8>, [u8; 32], [u8; 8]), String> {
+pub async fn process_avatar(
+    url: &str,
+) -> Result<(Vec<u8>, [u8; 32], [u8; 8]), AvatarProcessingError> {
     // Fetch the image
     let image_bytes = fetch_image_bytes(url).await?;
 
@@ -503,13 +496,19 @@ mod tests {
         // Test non-HTTPS URL
         let result = fetch_image_bytes("http://example.com/image.jpg").await;
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Avatar URL must use HTTPS");
+        assert!(matches!(
+            result.unwrap_err(),
+            AvatarProcessingError::HttpsRequired
+        ));
 
         // Test URL that's too long
         let long_url = format!("https://example.com/{}", "a".repeat(2100));
         let result = fetch_image_bytes(&long_url).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("exceeds maximum length"));
+        assert!(matches!(
+            result.unwrap_err(),
+            AvatarProcessingError::UrlTooLong
+        ));
     }
 
     #[tokio::test]
@@ -517,7 +516,10 @@ mod tests {
         // HTTP URLs should be rejected immediately
         let result = fetch_image_bytes("http://example.com/avatar.png").await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("HTTPS"));
+        assert!(matches!(
+            result.unwrap_err(),
+            AvatarProcessingError::HttpsRequired
+        ));
     }
 
     #[tokio::test]
@@ -531,7 +533,10 @@ mod tests {
         let url_over_limit = format!("https://example.com/{}", "x".repeat(2100));
         let result = fetch_image_bytes(&url_over_limit).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("maximum length"));
+        assert!(matches!(
+            result.unwrap_err(),
+            AvatarProcessingError::UrlTooLong
+        ));
     }
 
     #[tokio::test]

--- a/src/backend_task/dashpay/errors.rs
+++ b/src/backend_task/dashpay/errors.rs
@@ -5,6 +5,29 @@ use thiserror::Error;
 /// Comprehensive error types for DashPay operations
 #[derive(Error, Debug)]
 pub enum DashPayError {
+    #[error(
+        "The profile contains invalid fields. Check the name, bio, and picture URL, then retry."
+    )]
+    ProfileValidationFailed {
+        errors: Vec<crate::model::dashpay::ProfileFieldError>,
+    },
+
+    #[error(
+        "Clearing profile fields is not supported yet. Keep the existing values or enter replacements."
+    )]
+    ProfileFieldRemovalUnsupported,
+
+    #[error(
+        "Saving a profile requires a wallet-linked identity. Load its wallet and refresh the identity, then retry."
+    )]
+    ProfileWalletRequired,
+
+    #[error("The profile could not be saved. Refresh the identity and try again.")]
+    ProfileWriteFailed {
+        #[source]
+        source: std::sync::Arc<platform_wallet::PlatformWalletError>,
+    },
+
     // Contact Request Errors
     #[error("This contact could not be found on the network. Please check the ID and try again.")]
     IdentityNotFound { identity_id: Identifier },

--- a/src/backend_task/dashpay/errors.rs
+++ b/src/backend_task/dashpay/errors.rs
@@ -5,6 +5,15 @@ use thiserror::Error;
 /// Comprehensive error types for DashPay operations
 #[derive(Error, Debug)]
 pub enum DashPayError {
+    /// A profile picture must be available before publishing its URL and hashes.
+    #[error(transparent)]
+    ProfileAvatarFailed(#[from] super::avatar_processing::AvatarProcessingError),
+
+    #[error(
+        "This identity's keys cannot save profiles yet. Use a different wallet-linked identity with profile support."
+    )]
+    ProfileSigningKeyUnsupported,
+
     #[error(
         "The profile contains invalid fields. Check the name, bio, and picture URL, then retry."
     )]
@@ -177,6 +186,8 @@ impl DashPayError {
                 | DashPayError::MissingEncryptionKey
                 | DashPayError::ContactInfoValidationFailed { .. }
                 | DashPayError::CannotContactSelf
+                | DashPayError::ProfileSigningKeyUnsupported
+                | DashPayError::ProfileAvatarFailed(_)
         )
     }
 }

--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -1,22 +1,15 @@
-use super::avatar_processing::{calculate_avatar_hash, calculate_dhash_fingerprint};
 use crate::backend_task::BackendTaskSuccessResult;
 use crate::backend_task::dashpay::errors::DashPayError;
 use crate::backend_task::error::TaskError;
 use crate::context::AppContext;
 use crate::model::qualified_identity::QualifiedIdentity;
 use dash_sdk::Sdk;
-use dash_sdk::dpp::data_contract::accessors::v0::DataContractV0Getters;
-use dash_sdk::dpp::document::{DocumentV0, DocumentV0Getters, DocumentV0Setters};
+use dash_sdk::dpp::document::DocumentV0Getters;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
 use dash_sdk::dpp::platform_value::{Value, string_encoding::Encoding};
 use dash_sdk::drive::query::{OrderClause, WhereClause, WhereOperator};
-use dash_sdk::platform::documents::transitions::{
-    DocumentCreateTransitionBuilder, DocumentReplaceTransitionBuilder,
-};
 use dash_sdk::platform::{Document, DocumentQuery, FetchMany, Identifier};
-use rand::RngCore;
-use std::collections::{BTreeMap, HashSet};
+use platform_wallet::ProfileUpdate;
 use std::sync::Arc;
 
 pub async fn load_profile(
@@ -68,8 +61,14 @@ pub async fn load_profile(
                 display_name: non_empty(display_name),
                 bio: non_empty(bio),
                 avatar_url: non_empty(avatar_url),
-                avatar_hash: None,
-                avatar_fingerprint: None,
+                avatar_hash: doc
+                    .get("avatarHash")
+                    .and_then(|value| value.as_bytes_slice().ok())
+                    .and_then(|bytes| bytes.try_into().ok()),
+                avatar_fingerprint: doc
+                    .get("avatarFingerprint")
+                    .and_then(|value| value.as_bytes_slice().ok())
+                    .and_then(|bytes| bytes.try_into().ok()),
             }),
         )
         .await;
@@ -105,13 +104,7 @@ fn non_empty(s: &str) -> Option<String> {
     }
 }
 
-/// Push the profile through the `WalletBackend` adapter, updating the
-/// upstream `ManagedIdentity` and refreshing the DET-local timestamp
-/// sidecar so [`DashpayView`] reports the current state.
-///
-/// Logs at `debug!` on failure rather than propagating — the platform
-/// document write already succeeded, and a local mirror miss does not
-/// break correctness (next refresh will re-fetch from platform).
+/// Cache a fetched profile; a mirror failure leaves the next refresh to retry.
 async fn mirror_profile_to_backend(
     app_context: &Arc<AppContext>,
     owner: &Identifier,
@@ -130,11 +123,11 @@ async fn mirror_profile_to_backend(
 
     let profile = fields.map(|f| DashPayProfile {
         display_name: f.display_name,
+        public_message: f.bio.clone(),
         bio: f.bio,
         avatar_url: f.avatar_url,
         avatar_hash: f.avatar_hash,
         avatar_fingerprint: f.avatar_fingerprint,
-        public_message: None,
     });
 
     if let Err(e) = backend.dashpay_set_profile(owner, profile).await {
@@ -163,229 +156,91 @@ pub async fn update_profile(
     bio: Option<String>,
     avatar_url: Option<String>,
 ) -> Result<BackendTaskSuccessResult, TaskError> {
+    let mut input = profile_update_input(display_name, bio, avatar_url)?;
+    let backend = app_context.wallet_backend()?;
     let identity_id = identity.identity.id();
-    let dashpay_contract = app_context.dashpay_contract.clone();
-
-    // Get the appropriate identity key for signing
-    let identity_key = identity
-        .identity
-        .get_first_public_key_matching(
-            Purpose::AUTHENTICATION,
-            HashSet::from([SecurityLevel::CRITICAL]),
-            KeyType::all_key_types().into(),
-            false,
-        )
-        .ok_or_else(|| TaskError::DashPay(DashPayError::MissingAuthenticationKey))?;
-
-    // Check if profile already exists
-    let mut profile_query =
-        DocumentQuery::new(dashpay_contract.clone(), "profile").map_err(|e| {
+    let mut query =
+        DocumentQuery::new(app_context.dashpay_contract.clone(), "profile").map_err(|e| {
             DashPayError::QueryCreation {
                 query_target: "DashPay profile",
                 source: Box::new(e.into()),
             }
         })?;
-
-    profile_query = profile_query.with_where(WhereClause {
+    query = query.with_where(WhereClause {
         field: "$ownerId".to_string(),
         operator: WhereOperator::Equal,
         value: identity_id.to_buffer().into(),
     });
-    profile_query.limit = 1;
+    query.limit = 1;
+    let profiles = Document::fetch_many(sdk, query).await?;
+    let existing = profiles.values().flatten().next();
+    ensure_profile_fields_preserved(existing, &input)?;
 
-    let existing_profile = Document::fetch_many(sdk, profile_query).await?;
-
-    // Prepare profile data
-    let mut profile_data = BTreeMap::new();
-
-    // Keep copies for database save later
-    let display_name_for_db = display_name.clone();
-    let bio_for_db = bio.clone();
-    let avatar_url_for_db = avatar_url.clone();
-
-    // Only add non-empty fields according to DashPay DIP
-    if let Some(name) = display_name.filter(|name| !name.is_empty()) {
-        profile_data.insert("displayName".to_string(), Value::Text(name));
-    }
-    if let Some(bio_text) = bio.filter(|bio| !bio.is_empty()) {
-        profile_data.insert("publicMessage".to_string(), Value::Text(bio_text));
-    }
-    if let Some(url) = avatar_url.as_ref().filter(|url| !url.is_empty()) {
-        profile_data.insert("avatarUrl".to_string(), Value::Text(url.clone()));
-
-        // Try to fetch and process the avatar image
-        // Note: This requires an HTTP client which may not be available
-        // In production, this should be done asynchronously
+    if let Some(url) = &input.avatar_url {
         match super::avatar_processing::fetch_image_bytes(url).await {
-            Ok(image_bytes) => {
-                // Calculate SHA-256 hash of the image
-                let avatar_hash = calculate_avatar_hash(&image_bytes);
-                profile_data.insert("avatarHash".to_string(), Value::Bytes(avatar_hash.to_vec()));
-
-                // Calculate DHash perceptual fingerprint
-                match calculate_dhash_fingerprint(&image_bytes) {
-                    Ok(fingerprint) => {
-                        profile_data.insert(
-                            "avatarFingerprint".to_string(),
-                            Value::Bytes(fingerprint.to_vec()),
-                        );
-                    }
-                    Err(e) => {
-                        tracing::warn!("Could not calculate avatar fingerprint: {}", e);
-                        // Continue without fingerprint - it's optional
-                    }
-                }
-            }
-            Err(e) => {
-                // If we can't fetch the image, just set the URL without hash/fingerprint
-                // These fields are optional according to DIP-0015
-                tracing::warn!("Could not fetch avatar image for processing: {}", e);
+            Ok(bytes) => input.avatar_bytes = Some(bytes),
+            Err(error) => {
+                tracing::debug!(
+                    ?error,
+                    "Profile avatar could not be downloaded; saving its URL only"
+                );
             }
         }
     }
 
-    if let Some((_, Some(existing_doc))) = existing_profile.iter().next() {
-        // Update existing profile using DocumentReplaceTransitionBuilder
-        let mut updated_document = existing_doc.clone();
+    backend
+        .dashpay_write_profile(&identity, input, existing.is_none())
+        .await?;
+    Ok(BackendTaskSuccessResult::DashPayProfileUpdated(identity_id))
+}
 
-        // Update the document's properties
-        for (key, value) in profile_data {
-            updated_document.set(&key, value);
-        }
-
-        // Handle avatar removal: if avatar_url is None or empty, remove avatar-related fields
-        if avatar_url.as_ref().is_none_or(|url| url.is_empty()) {
-            // Remove avatar-related fields from the document
-            let Document::V0(ref mut doc_v0) = updated_document;
-            doc_v0.properties_mut().remove("avatarUrl");
-            doc_v0.properties_mut().remove("avatarHash");
-            doc_v0.properties_mut().remove("avatarFingerprint");
-        }
-
-        // Bump revision for replacement
-        updated_document.bump_revision();
-
-        let mut builder = DocumentReplaceTransitionBuilder::new(
-            dashpay_contract,
-            "profile".to_string(),
-            updated_document,
-        );
-
-        // Add state transition options if available
-        let maybe_options = app_context.state_transition_options();
-        if let Some(options) = maybe_options {
-            builder = builder.with_state_transition_creation_options(options);
-        }
-
-        let result = sdk
-            .document_replace(builder, identity_key, &identity)
-            .await?;
-
-        // Log the proof-verified document for audit trail
-        match result {
-            dash_sdk::platform::documents::transitions::DocumentReplaceResult::Document(doc) => {
-                tracing::info!(
-                    "Profile updated: doc_id={}, revision={:?}",
-                    doc.id(),
-                    doc.revision()
-                );
-            }
-        }
-
-        // Mirror updated profile into upstream so DashpayView sees it.
-        mirror_profile_to_backend(
-            app_context,
-            &identity_id,
-            Some(BackendProfileFields {
-                display_name: display_name_for_db.clone(),
-                bio: bio_for_db.clone(),
-                avatar_url: avatar_url_for_db.clone(),
-                avatar_hash: None,
-                avatar_fingerprint: None,
-            }),
-        )
-        .await;
-
-        Ok(BackendTaskSuccessResult::DashPayProfileUpdated(
-            identity.identity.id(),
-        ))
-    } else {
-        // Create new profile using DocumentCreateTransitionBuilder
-        // Generate random entropy for document ID (security: prevents predictable IDs)
-        let mut entropy = [0u8; 32];
-        rand::rng().fill_bytes(&mut entropy);
-
-        let profile_doc_id = Document::generate_document_id_v0(
-            &dashpay_contract.id(),
-            &identity_id,
-            "profile",
-            &entropy,
-        );
-
-        let document = Document::V0(DocumentV0 {
-            id: profile_doc_id,
-            owner_id: identity_id,
-            creator_id: None,
-            properties: profile_data,
-            revision: None,
-            created_at: None,
-            updated_at: None,
-            transferred_at: None,
-            created_at_block_height: None,
-            updated_at_block_height: None,
-            transferred_at_block_height: None,
-            created_at_core_block_height: None,
-            updated_at_core_block_height: None,
-            transferred_at_core_block_height: None,
-            contract_version: None,
-        });
-
-        let mut builder = DocumentCreateTransitionBuilder::new(
-            dashpay_contract,
-            "profile".to_string(),
-            document,
-            entropy, // Use same entropy as document ID generation
-        );
-
-        // Add state transition options if available
-        let maybe_options = app_context.state_transition_options();
-        if let Some(options) = maybe_options {
-            builder = builder.with_state_transition_creation_options(options);
-        }
-
-        let result = sdk
-            .document_create(builder, identity_key, &identity)
-            .await?;
-
-        // Log the proof-verified document for audit trail
-        match result {
-            dash_sdk::platform::documents::transitions::DocumentCreateResult::Document(doc) => {
-                tracing::info!(
-                    "Profile created: doc_id={}, revision={:?}",
-                    doc.id(),
-                    doc.revision()
-                );
-            }
-        }
-
-        // Mirror new profile into upstream so DashpayView sees it.
-        mirror_profile_to_backend(
-            app_context,
-            &identity_id,
-            Some(BackendProfileFields {
-                display_name: display_name_for_db.clone(),
-                bio: bio_for_db.clone(),
-                avatar_url: avatar_url_for_db.clone(),
-                avatar_hash: None,
-                avatar_fingerprint: None,
-            }),
-        )
-        .await;
-
-        Ok(BackendTaskSuccessResult::DashPayProfileUpdated(
-            identity.identity.id(),
-        ))
+fn profile_update_input(
+    display_name: Option<String>,
+    bio: Option<String>,
+    avatar_url: Option<String>,
+) -> Result<ProfileUpdate, TaskError> {
+    let display_name = display_name.unwrap_or_default();
+    let bio = bio.unwrap_or_default();
+    let avatar_url = avatar_url.unwrap_or_default();
+    let errors = crate::model::dashpay::validate_profile_fields(
+        display_name.trim(),
+        bio.trim(),
+        avatar_url.trim(),
+    );
+    if !errors.is_empty() {
+        return Err(DashPayError::ProfileValidationFailed { errors }.into());
     }
+    Ok(ProfileUpdate {
+        display_name: non_empty(display_name.trim()),
+        public_message: non_empty(bio.trim()),
+        avatar_url: non_empty(avatar_url.trim()),
+        avatar_bytes: None,
+    })
+}
+
+fn ensure_profile_fields_preserved(
+    existing: Option<&Document>,
+    input: &ProfileUpdate,
+) -> Result<(), TaskError> {
+    let Some(existing) = existing else {
+        return Ok(());
+    };
+    // Upstream treats None as unchanged, so it cannot fulfill a request to clear a field.
+    for (field, replacement) in [
+        ("displayName", &input.display_name),
+        ("publicMessage", &input.public_message),
+        ("avatarUrl", &input.avatar_url),
+    ] {
+        if replacement.is_none()
+            && existing
+                .get(field)
+                .and_then(Value::as_text)
+                .is_some_and(|value| !value.is_empty())
+        {
+            return Err(DashPayError::ProfileFieldRemovalUnsupported.into());
+        }
+    }
+    Ok(())
 }
 
 pub async fn load_payment_history(
@@ -558,4 +413,132 @@ pub async fn search_profiles(
     Ok(BackendTaskSuccessResult::DashPayProfileSearchResults(
         results,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_identity() -> QualifiedIdentity {
+        QualifiedIdentity {
+            identity: dash_sdk::platform::Identity::default_versioned(
+                dash_sdk::dpp::version::LATEST_PLATFORM_VERSION,
+            )
+            .expect("identity"),
+            associated_voter_identity: None,
+            associated_operator_identity: None,
+            associated_owner_key_id: None,
+            identity_type: crate::model::qualified_identity::IdentityType::User,
+            alias: None,
+            private_keys: Default::default(),
+            dpns_names: Vec::new(),
+            associated_wallets: Default::default(),
+            secret_access: None,
+            wallet_index: None,
+            top_ups: Default::default(),
+            status: Default::default(),
+            network: dash_sdk::dpp::dashcore::Network::Testnet,
+        }
+    }
+
+    #[tokio::test]
+    async fn profile_write_validates_fields_before_network_or_signing() {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let context = crate::context::test_support::test_app_context(dir.path());
+        let sdk = context.sdk.load_full();
+        let error = update_profile(
+            &context,
+            &sdk,
+            empty_identity(),
+            Some("x".repeat(256)),
+            None,
+            None,
+        )
+        .await
+        .expect_err("invalid input must not reach the network or signer");
+        assert!(
+            matches!(
+                error,
+                TaskError::DashPay(DashPayError::ProfileValidationFailed { .. })
+            ),
+            "unexpected error: {error:?}"
+        );
+    }
+
+    #[test]
+    fn profile_input_omits_blank_fields_and_maps_bio_to_public_message() {
+        let input = profile_update_input(
+            Some("  Alice  ".into()),
+            Some(" About me ".into()),
+            Some(" \n ".into()),
+        )
+        .expect("valid input");
+        assert_eq!(input.display_name.as_deref(), Some("Alice"));
+        assert_eq!(input.public_message.as_deref(), Some("About me"));
+        assert!(input.avatar_url.is_none());
+        assert!(input.avatar_bytes.is_none());
+        let blank = profile_update_input(Some(" ".into()), None, None).expect("empty profile");
+        assert!(blank.display_name.is_none());
+        assert!(blank.public_message.is_none());
+        assert!(ensure_profile_fields_preserved(None, &blank).is_ok());
+    }
+
+    #[test]
+    fn profile_removal_is_rejected_instead_of_silently_retaining_fields() {
+        for field in ["displayName", "publicMessage", "avatarUrl"] {
+            let existing = Document::V0(dash_sdk::dpp::document::DocumentV0 {
+                properties: [(field.to_string(), Value::Text("existing value".into()))].into(),
+                ..Default::default()
+            });
+            let input = profile_update_input(None, None, None).expect("blank input");
+            assert!(
+                matches!(
+                    ensure_profile_fields_preserved(Some(&existing), &input),
+                    Err(TaskError::DashPay(
+                        DashPayError::ProfileFieldRemovalUnsupported
+                    ))
+                ),
+                "clearing {field} must not report a successful save"
+            );
+        }
+    }
+
+    #[test]
+    fn profile_replacement_is_allowed_with_unchanged_optional_fields() {
+        let existing = Document::V0(dash_sdk::dpp::document::DocumentV0 {
+            properties: [("displayName".to_string(), Value::Text("Alice".into()))].into(),
+            ..Default::default()
+        });
+        let input = profile_update_input(Some("Bob".into()), None, None).expect("replacement");
+        assert!(ensure_profile_fields_preserved(Some(&existing), &input).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn profile_write_without_managing_wallet_is_an_error() {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let context = crate::context::test_support::test_app_context(dir.path());
+        let (sender, _receiver) = tokio::sync::mpsc::channel(32);
+        context
+            .ensure_wallet_backend(crate::utils::egui_mpsc::SenderAsync::new(
+                sender,
+                context.egui_ctx().clone(),
+            ))
+            .await
+            .expect("offline wallet backend");
+        let backend = context.wallet_backend().expect("backend");
+        for create in [true, false] {
+            let error = backend
+                .dashpay_write_profile(
+                    &empty_identity(),
+                    profile_update_input(Some("Alice".into()), None, None).expect("input"),
+                    create,
+                )
+                .await
+                .expect_err("a write cannot silently skip an unowned identity");
+            assert!(matches!(
+                error,
+                TaskError::DashPay(DashPayError::ProfileWalletRequired)
+            ));
+        }
+    }
 }

--- a/src/backend_task/dashpay/profile.rs
+++ b/src/backend_task/dashpay/profile.rs
@@ -139,11 +139,11 @@ async fn mirror_profile_to_backend(
         return;
     }
 
-    if let Err(e) = backend.dashpay_set_timestamps(owner, now_ms, now_ms) {
+    if let Err(e) = backend.dashpay_set_profile_timestamps(owner, now_ms, now_ms) {
         tracing::debug!(
             owner = %owner.to_string(Encoding::Base58),
             error = ?e,
-            "DashPay profile timestamp sidecar write failed; created_at/updated_at will read 0"
+            "Fetched profile timestamps are pending persistence; the next profile read will retry"
         );
     }
 }
@@ -157,6 +157,13 @@ pub async fn update_profile(
     avatar_url: Option<String>,
 ) -> Result<BackendTaskSuccessResult, TaskError> {
     let mut input = profile_update_input(display_name, bio, avatar_url)?;
+    if let Some(url) = &input.avatar_url {
+        input.avatar_bytes = Some(
+            super::avatar_processing::fetch_image_bytes(url)
+                .await
+                .map_err(DashPayError::from)?,
+        );
+    }
     let backend = app_context.wallet_backend()?;
     let identity_id = identity.identity.id();
     let mut query =
@@ -175,18 +182,6 @@ pub async fn update_profile(
     let profiles = Document::fetch_many(sdk, query).await?;
     let existing = profiles.values().flatten().next();
     ensure_profile_fields_preserved(existing, &input)?;
-
-    if let Some(url) = &input.avatar_url {
-        match super::avatar_processing::fetch_image_bytes(url).await {
-            Ok(bytes) => input.avatar_bytes = Some(bytes),
-            Err(error) => {
-                tracing::debug!(
-                    ?error,
-                    "Profile avatar could not be downloaded; saving its URL only"
-                );
-            }
-        }
-    }
 
     backend
         .dashpay_write_profile(&identity, input, existing.is_none())
@@ -439,6 +434,32 @@ mod tests {
             status: Default::default(),
             network: dash_sdk::dpp::dashcore::Network::Testnet,
         }
+    }
+
+    #[tokio::test]
+    async fn profile_write_rejects_unfetchable_avatar_before_network_or_signing() {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let context = crate::context::test_support::test_app_context(dir.path());
+        let sdk = context.sdk.load_full();
+        let error = update_profile(
+            &context,
+            &sdk,
+            empty_identity(),
+            Some("Alice".into()),
+            None,
+            Some("http://example.com/avatar.png".into()),
+        )
+        .await
+        .expect_err("an unfetchable avatar must stop profile submission");
+        assert!(
+            matches!(
+                error,
+                TaskError::DashPay(DashPayError::ProfileAvatarFailed(
+                    super::super::avatar_processing::AvatarProcessingError::HttpsRequired
+                ))
+            ),
+            "unexpected error: {error:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/backend_task/mod.rs
+++ b/src/backend_task/mod.rs
@@ -1265,11 +1265,13 @@ impl AppContext {
                 };
 
                 let cancellation_token = self.subtasks.cancellation_token.clone();
-                let spv_started = if start_spv
+                let mut spv_started = if start_spv
                     && backend_wired
                     && !cancellation_token.is_cancelled()
                 {
                     tokio::select! {
+                        biased;
+                        _ = cancellation_token.cancelled() => false,
                         result = new_ctx.ensure_wallet_backend_and_start_spv(sender.clone()) => {
                             match result {
                                 Ok(()) => {
@@ -1286,7 +1288,6 @@ impl AppContext {
                                 }
                             }
                         }
-                        _ = cancellation_token.cancelled() => false,
                     }
                 } else {
                     false
@@ -1296,6 +1297,7 @@ impl AppContext {
                 {
                     backend.forget_all_secrets();
                     backend.shutdown().await;
+                    spv_started = false;
                 }
                 Ok(BackendTaskSuccessResult::NetworkContextCreated {
                     network,

--- a/src/wallet_backend/dashpay.rs
+++ b/src/wallet_backend/dashpay.rs
@@ -830,6 +830,54 @@ fn kv_payment_timestamps(kv: &DetKv, tx_id: &str) -> (i64, Option<i64>) {
 // ---------------------------------------------------------------------------
 
 impl WalletBackend {
+    /// Publish a profile through the managing wallet, signing through DET's secret-access path.
+    pub(crate) async fn dashpay_write_profile(
+        &self,
+        identity: &crate::model::qualified_identity::QualifiedIdentity,
+        input: platform_wallet::ProfileUpdate,
+        create: bool,
+    ) -> Result<(), TaskError> {
+        use crate::backend_task::dashpay::errors::DashPayError;
+        use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+
+        let owner = identity.identity.id();
+        let wallet = self
+            .find_wallet_for_identity(&owner)
+            .await
+            .ok_or(DashPayError::ProfileWalletRequired)?;
+        let identity_wallet = wallet.identity();
+        let dashpay = identity_wallet.dashpay();
+        let result = if create {
+            dashpay
+                .create_profile_with_external_signer(&owner, input, identity)
+                .await
+        } else {
+            dashpay
+                .update_profile_with_external_signer(&owner, input, identity)
+                .await
+        };
+        result.map_err(|source| DashPayError::ProfileWriteFailed {
+            source: Arc::new(source),
+        })?;
+
+        let now = chrono::Utc::now().timestamp_millis().max(0);
+        let created_at = self
+            .dashpay_view()
+            .profile(&owner)
+            .await
+            .map(|profile| profile.created_at)
+            .filter(|created_at| *created_at > 0)
+            .unwrap_or(now);
+        if let Err(error) = self.dashpay_set_timestamps(&owner, created_at, now) {
+            // The broadcast succeeded; a display-metadata failure must not invite a paid retry.
+            tracing::warn!(
+                ?error,
+                "Profile saved but its local display timestamps could not be updated"
+            );
+        }
+        Ok(())
+    }
+
     /// Read-only DashPay accessor. Cheap to construct (borrow only).
     pub fn dashpay_view(&self) -> DashpayView<'_> {
         DashpayView::new(self)

--- a/src/wallet_backend/dashpay.rs
+++ b/src/wallet_backend/dashpay.rs
@@ -246,6 +246,54 @@ const KV_PREFIX_REQUEST_ACTION: &str = "det:dashpay:request_action:";
 /// DET-local `(created_at, updated_at)` timestamps for an entity (contact, request).
 /// Value: `(i64, i64)` encoded by the [`DetKv`] schema. Scope: [`DetScope::Global`].
 const KV_PREFIX_TIMESTAMPS: &str = "det:dashpay:timestamps:";
+
+/// Session-local repair queue for display metadata after a successful profile write.
+/// Reads retry persistence and use pending values until storage recovers. Holding
+/// the lock through each put prevents an old repair from overwriting a newer save.
+#[derive(Default)]
+pub(super) struct ProfileTimestamps {
+    pending: std::sync::Mutex<std::collections::BTreeMap<Identifier, (i64, i64)>>,
+}
+
+impl ProfileTimestamps {
+    fn set(&self, kv: &DetKv, owner: &Identifier, value: (i64, i64)) -> Result<(), TaskError> {
+        let mut pending = self.pending.lock().unwrap_or_else(|e| e.into_inner());
+        pending.insert(*owner, value);
+        kv.put(
+            DetScope::Global,
+            &sidecar_key(KV_PREFIX_TIMESTAMPS, owner),
+            &value,
+        )
+        .map_err(|source| TaskError::DashpaySidecarStorage { source })?;
+        pending.remove(owner);
+        Ok(())
+    }
+
+    fn get(&self, kv: &DetKv, owner: &Identifier) -> (i64, i64) {
+        let mut pending = self.pending.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(value) = pending.get(owner).copied() else {
+            return kv_timestamps(kv, owner);
+        };
+        if kv
+            .put(
+                DetScope::Global,
+                &sidecar_key(KV_PREFIX_TIMESTAMPS, owner),
+                &value,
+            )
+            .is_ok()
+        {
+            pending.remove(owner);
+        }
+        value
+    }
+
+    pub(super) fn clear(&self) {
+        self.pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+    }
+}
 /// DET-local private memo for a contact (nickname / notes / hidden).
 /// Value: bincode-encoded [`ContactPrivateInfo`].
 /// Scope: [`DetScope::Identity(&owner)`]. Key shape: `det:dashpay:private:<contact_b58>`.
@@ -363,7 +411,7 @@ impl<'a> DashpayView<'a> {
     /// `f`. Returns `None` when no registered wallet manages `owner` (unknown
     /// or wrong-network identity), so each caller maps that to its own empty
     /// default. The wallet-state read guard is held for the closure's
-    /// duration, so `f` must stay synchronous (pure translation only).
+    /// duration, so `f` must stay synchronous and must not acquire wallet state.
     async fn with_managed<R>(
         &self,
         owner: &Identifier,
@@ -515,7 +563,7 @@ impl<'a> DashpayView<'a> {
     pub async fn profile(&self, owner: &Identifier) -> Option<StoredProfile> {
         self.with_managed(owner, |managed, kv| {
             let profile = managed.dashpay().profile.as_ref()?;
-            let (created_at, updated_at) = kv_timestamps(kv, owner);
+            let (created_at, updated_at) = self.backend.inner.profile_timestamps.get(kv, owner);
             Some(profile_to_det(owner, profile, created_at, updated_at))
         })
         .await
@@ -829,6 +877,23 @@ fn kv_payment_timestamps(kv: &DetKv, tx_id: &str) -> (i64, Option<i64>) {
 // WalletBackend integration
 // ---------------------------------------------------------------------------
 
+/// Match the pinned upstream profile API's signing-key policy before its network work.
+fn ensure_profile_signing_key(identity: &dash_sdk::platform::Identity) -> Result<(), TaskError> {
+    use crate::backend_task::dashpay::errors::DashPayError;
+    use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+    use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+
+    identity
+        .get_first_public_key_matching(
+            Purpose::AUTHENTICATION,
+            [SecurityLevel::HIGH, SecurityLevel::CRITICAL].into(),
+            [KeyType::ECDSA_SECP256K1].into(),
+            false,
+        )
+        .ok_or(DashPayError::ProfileSigningKeyUnsupported)?;
+    Ok(())
+}
+
 impl WalletBackend {
     /// Publish a profile through the managing wallet, signing through DET's secret-access path.
     pub(crate) async fn dashpay_write_profile(
@@ -845,6 +910,15 @@ impl WalletBackend {
             .find_wallet_for_identity(&owner)
             .await
             .ok_or(DashPayError::ProfileWalletRequired)?;
+        {
+            // Upstream selects from its managed identity, which may be newer than the UI copy.
+            let state = wallet.state().await;
+            let managed = state
+                .identity_manager
+                .managed_identity(&owner)
+                .ok_or(DashPayError::ProfileWalletRequired)?;
+            ensure_profile_signing_key(&managed.identity)?;
+        }
         let identity_wallet = wallet.identity();
         let dashpay = identity_wallet.dashpay();
         let result = if create {
@@ -868,19 +942,31 @@ impl WalletBackend {
             .map(|profile| profile.created_at)
             .filter(|created_at| *created_at > 0)
             .unwrap_or(now);
-        if let Err(error) = self.dashpay_set_timestamps(&owner, created_at, now) {
+        if let Err(error) = self.dashpay_set_profile_timestamps(&owner, created_at, now) {
             // The broadcast succeeded; a display-metadata failure must not invite a paid retry.
             tracing::warn!(
                 ?error,
-                "Profile saved but its local display timestamps could not be updated"
+                "Profile saved; pending display timestamps will be persisted on the next profile read"
             );
         }
         Ok(())
     }
 
-    /// Read-only DashPay accessor. Cheap to construct (borrow only).
+    /// DashPay accessor; profile reads also retry pending local timestamp writes.
     pub fn dashpay_view(&self) -> DashpayView<'_> {
         DashpayView::new(self)
+    }
+
+    /// Persist profile display times, retaining failed writes for repair on profile reads.
+    pub(crate) fn dashpay_set_profile_timestamps(
+        &self,
+        owner: &Identifier,
+        created_at: i64,
+        updated_at: i64,
+    ) -> Result<(), TaskError> {
+        self.inner
+            .profile_timestamps
+            .set(&self.kv(), owner, (created_at, updated_at))
     }
 
     /// Trigger an upstream DashPay refresh (contact requests + profiles)
@@ -1853,6 +1939,151 @@ mod tests {
         let det = established_to_det(&owner, &contact, status, 0, 0);
         assert_eq!(det.contact_status, ContactStatus::Blocked);
         assert_eq!(det.display_name.as_deref(), Some("Friend"));
+    }
+
+    #[test]
+    fn profile_signing_key_policy_matches_upstream() {
+        use crate::backend_task::dashpay::errors::DashPayError;
+        use dash_sdk::dpp::identity::accessors::IdentitySettersV0;
+        use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+        use dash_sdk::dpp::identity::{IdentityPublicKey, KeyType, Purpose, SecurityLevel};
+
+        let mut identity = dash_sdk::platform::Identity::default_versioned(
+            dash_sdk::dpp::version::LATEST_PLATFORM_VERSION,
+        )
+        .unwrap();
+        assert!(matches!(
+            ensure_profile_signing_key(&identity),
+            Err(TaskError::DashPay(
+                DashPayError::ProfileSigningKeyUnsupported
+            ))
+        ));
+        for (key_type, purpose, level, disabled, supported) in [
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::HIGH,
+                false,
+                true,
+            ),
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::CRITICAL,
+                false,
+                true,
+            ),
+            (
+                KeyType::ECDSA_HASH160,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::HIGH,
+                false,
+                false,
+            ),
+            (
+                KeyType::ECDSA_HASH160,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::CRITICAL,
+                false,
+                false,
+            ),
+            (
+                KeyType::BLS12_381,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::HIGH,
+                false,
+                false,
+            ),
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::MASTER,
+                false,
+                false,
+            ),
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::MEDIUM,
+                false,
+                false,
+            ),
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::ENCRYPTION,
+                SecurityLevel::HIGH,
+                false,
+                false,
+            ),
+            (
+                KeyType::ECDSA_SECP256K1,
+                Purpose::AUTHENTICATION,
+                SecurityLevel::HIGH,
+                true,
+                false,
+            ),
+        ] {
+            identity.set_public_keys(
+                [(
+                    0,
+                    IdentityPublicKey::V0(IdentityPublicKeyV0 {
+                        id: 0,
+                        purpose,
+                        security_level: level,
+                        contract_bounds: None,
+                        key_type,
+                        read_only: false,
+                        data: vec![0; key_type.default_size()].into(),
+                        disabled_at: disabled.then_some(1),
+                    }),
+                )]
+                .into(),
+            );
+            assert_eq!(
+                ensure_profile_signing_key(&identity).is_ok(),
+                supported,
+                "{key_type:?} {purpose:?} {level:?} disabled={disabled}"
+            );
+        }
+    }
+
+    #[test]
+    fn profile_timestamps_repair_failed_writes_on_read() {
+        use crate::wallet_backend::kv_test_support::FailingKv;
+
+        let store = Arc::new(FailingKv::default());
+        let kv = DetKv::from_store(store.clone());
+        let timestamps = ProfileTimestamps::default();
+        let owner = id_from_byte(1);
+        store.fail_next_puts(2);
+        assert!(timestamps.set(&kv, &owner, (111, 222)).is_err());
+        // Even while storage is unavailable the view must see the successful write's times.
+        assert_eq!(timestamps.get(&kv, &owner), (111, 222));
+        assert_eq!(kv_timestamps(&kv, &owner), (0, 0));
+        assert_eq!(timestamps.get(&kv, &owner), (111, 222));
+        assert_eq!(kv_timestamps(&kv, &owner), (111, 222));
+        assert_eq!(store.put_count(), 3);
+        // Once repaired, reads must not issue further writes.
+        assert_eq!(timestamps.get(&kv, &owner), (111, 222));
+        assert_eq!(store.put_count(), 3);
+    }
+
+    #[test]
+    fn profile_timestamp_repair_cannot_overwrite_a_newer_save() {
+        use crate::wallet_backend::kv_test_support::FailingKv;
+
+        let store = Arc::new(FailingKv::default());
+        let kv = DetKv::from_store(store.clone());
+        let timestamps = ProfileTimestamps::default();
+        let owner = id_from_byte(1);
+        let other = id_from_byte(2);
+        store.fail_next_puts(1);
+        assert!(timestamps.set(&kv, &owner, (111, 222)).is_err());
+        assert_eq!(timestamps.get(&kv, &other), (0, 0));
+        timestamps.set(&kv, &owner, (111, 333)).unwrap();
+        assert_eq!(timestamps.get(&kv, &owner), (111, 333));
+        assert_eq!(kv_timestamps(&kv, &owner), (111, 333));
+        assert_eq!(store.put_count(), 2);
     }
 
     #[test]

--- a/src/wallet_backend/kv_test_support.rs
+++ b/src/wallet_backend/kv_test_support.rs
@@ -86,10 +86,16 @@ pub(crate) struct FailingKv {
     inner: InMemoryKv,
     fail_reads: AtomicBool,
     fail_deletes: AtomicBool,
+    fail_puts_remaining: AtomicUsize,
     puts: AtomicUsize,
 }
 
 impl FailingKv {
+    /// Fail the next `count` writes, then resume normal persistence.
+    pub(crate) fn fail_next_puts(&self, count: usize) {
+        self.fail_puts_remaining.store(count, Ordering::Relaxed);
+    }
+
     /// Make every subsequent `get` fail with [`KvError::LockPoisoned`] (`true`),
     /// or restore normal reads (`false`). Stored values are never touched, so a
     /// read armed to fail and then restored still yields the original blob.
@@ -122,6 +128,15 @@ impl KvStore for FailingKv {
         // Counted before delegating: an attempted write is what the assertions
         // are about, whether or not the store would have accepted it.
         self.puts.fetch_add(1, Ordering::Relaxed);
+        if self
+            .fail_puts_remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return Err(KvError::LockPoisoned);
+        }
         self.inner.put(scope, key, value)
     }
 

--- a/src/wallet_backend/mod.rs
+++ b/src/wallet_backend/mod.rs
@@ -429,6 +429,8 @@ struct Inner {
     /// DashPay screens have separate UI state, so backend serialization is the
     /// final guard against two callers paying for the same request concurrently.
     dashpay_request_action_locks: dashpay::ContactRequestActionLocks,
+    /// Failed profile timestamp writes, retried locally without another broadcast.
+    profile_timestamps: dashpay::ProfileTimestamps,
     /// Cache of `Arc<PlatformWallet>` keyed by `WalletId`, populated at
     /// registration. Lets sync code reach an upstream wallet handle without an
     /// async hop (e.g. DashPay address-pool scanning).
@@ -647,6 +649,7 @@ impl WalletBackend {
                 swallow_next_unowned_removal: std::sync::atomic::AtomicBool::new(false),
                 registration_flights: std::sync::Mutex::new(std::collections::BTreeMap::new()),
                 dashpay_request_action_locks: dashpay::ContactRequestActionLocks::default(),
+                profile_timestamps: dashpay::ProfileTimestamps::default(),
                 wallets: std::sync::RwLock::new(std::collections::BTreeMap::new()),
                 peer,
                 network,
@@ -1690,6 +1693,7 @@ impl WalletBackend {
     /// off-thread — plus every delete failure. Resilient to partial failure:
     /// every wallet is attempted even after one fails.
     pub(crate) fn forget_all_wallets_local(&self) -> ClearAllOutcome {
+        self.inner.profile_timestamps.clear();
         let network = self.inner.network;
 
         // HD wallets: enumerate from the persisted wallet-meta sidecar so a

--- a/tests/backend-e2e/dashpay_profile.rs
+++ b/tests/backend-e2e/dashpay_profile.rs
@@ -1,0 +1,109 @@
+//! Profile writes through platform-wallet, independent of the contact-flow suite.
+
+use crate::framework::{harness, identity_helpers, task_runner::run_task};
+use dash_evo_tool::backend_task::dashpay::DashPayTask;
+use dash_evo_tool::backend_task::identity::{IdentityKeyEntry, IdentityKeySpecs, IdentityTask};
+use dash_evo_tool::backend_task::wallet::WalletTask;
+use dash_evo_tool::backend_task::{BackendTask, BackendTaskSuccessResult};
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::{KeyType, Purpose, SecurityLevel};
+
+#[ignore = "requires a funded E2E_WALLET_MNEMONIC and live testnet"]
+#[tokio_shared_rt::test(shared, flavor = "multi_thread", worker_threads = 12)]
+async fn profile_create_and_replace_with_high_derived_key() {
+    let ctx = harness::ctx().await;
+    let (seed_hash, wallet) = ctx.create_funded_test_wallet(30_000_000).await;
+    let mut registration =
+        identity_helpers::build_identity_registration(&ctx.app_context, &wallet, seed_hash).await;
+    run_task(
+        &ctx.app_context,
+        BackendTask::WalletTask(WalletTask::WarmIdentityAuthPubkeys {
+            seed_hash,
+            identity_index: 0,
+            key_count: 2,
+        }),
+    )
+    .await
+    .expect("derive public authentication keys");
+    let backend = ctx.app_context.wallet_backend().expect("wallet backend");
+    let network = ctx.app_context.network();
+    let cache = backend.auth_pubkey_cache().get(network, &seed_hash);
+    let entry = |index, security_level| {
+        IdentityKeyEntry::from_cached_public_key(
+            cache.get(network, 0, index).expect("derived public key"),
+            network,
+            0,
+            index,
+            KeyType::ECDSA_SECP256K1,
+            Purpose::AUTHENTICATION,
+            security_level,
+            None,
+        )
+    };
+    registration.keys = IdentityKeySpecs::new(
+        Some(entry(0, SecurityLevel::MASTER)),
+        vec![entry(1, SecurityLevel::HIGH)],
+    );
+
+    let result = run_task(
+        &ctx.app_context,
+        BackendTask::IdentityTask(IdentityTask::RegisterIdentity(registration)),
+    )
+    .await
+    .expect("register a wallet-derived HIGH authentication key");
+    let BackendTaskSuccessResult::RegisteredIdentity(identity, _) = result else {
+        panic!("expected a registered identity, got {result:?}");
+    };
+    let owner = identity.identity.id();
+
+    for (name, bio) in [
+        ("Profile creation", "First bio"),
+        ("Profile replacement", "Updated bio"),
+    ] {
+        let result = run_task(
+            &ctx.app_context,
+            BackendTask::DashPayTask(Box::new(DashPayTask::UpdateProfile {
+                identity: identity.clone(),
+                display_name: Some(name.into()),
+                bio: Some(bio.into()),
+                avatar_url: None,
+            })),
+        )
+        .await
+        .expect("write the profile using its HIGH key");
+        assert!(
+            matches!(result, BackendTaskSuccessResult::DashPayProfileUpdated(id) if id == owner)
+        );
+
+        let backend = ctx.app_context.wallet_backend().expect("wallet backend");
+        let profile = backend
+            .dashpay_view()
+            .profile(&owner)
+            .await
+            .expect("profile cache");
+        assert_eq!(profile.display_name.as_deref(), Some(name));
+        assert_eq!(profile.bio.as_deref(), Some(bio));
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+        loop {
+            let result = run_task(
+                &ctx.app_context,
+                BackendTask::DashPayTask(Box::new(DashPayTask::LoadProfile {
+                    identity: identity.clone(),
+                })),
+            )
+            .await;
+            if matches!(&result,
+                Ok(BackendTaskSuccessResult::DashPayProfile(Some((actual_name, actual_bio, _))))
+                    if actual_name == name && actual_bio == bio
+            ) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "published profile did not propagate: {result:?}"
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        }
+    }
+}

--- a/tests/backend-e2e/main.rs
+++ b/tests/backend-e2e/main.rs
@@ -30,6 +30,7 @@ mod spv_reconnect;
 
 mod core_tasks;
 mod cross_wallet_topup;
+mod dashpay_profile;
 // TODO(dashpay-e2e): deferred — dashpay backend depends on upstream platform-wallet dashpay completion. Re-enable once dashpay/platform#3841 ("complete dashpay", shumkov) lands and the platform-wallet dep is bumped. Tests: 12 tests (TC-031 to TC-046): tc_031/032/033/034/035/036/037/041/043/044/045/046.
 // mod dashpay_tasks;
 mod event_bridge_live;


### PR DESCRIPTION
**TL;DR:** Enable DashPay profile creation and updates with hashed ECDSA identity keys, including identities with only some private keys available.

## User story

As a wallet user, I want to save my DashPay profile using an eligible identity key available in my wallet.

## Scenario

A wallet-linked identity has an unavailable HIGH-security HASH160 authentication key at a lower ID and an available ECDSA authentication key at a higher ID. Profile creation and replacement skip the unavailable key and use the available key. Fully provisioned HASH160-only identities are supported too.

## Detailed discussion

### Dependencies and scope

- Targets `v1.0-dev`, including the merged profile-publication work from #979.
- Depends on [Platform #4764](https://github.com/dashpay/platform/pull/4764). All four Platform dependencies and the lockfile pin its revision `f73f5d6098a739d29a1cebc2f7941e062ee8a517`, which includes [Platform #4653](https://github.com/dashpay/platform/pull/4653). Merge the upstream fix before this PR.
- Platform advances from 4.2.0-dev.10 to 4.2.0-dev.11; its GroveDB dependency advances to 6.0.1. The pin includes additional upstream changes beyond HASH160 and signer availability.
- Related to #760. Wallet linkage remains required. Clearing existing profile fields remains unsupported. Contact ECDH key selection is unchanged.

### What changed

- Accept active `AUTHENTICATION` keys of type `ECDSA_SECP256K1` or `ECDSA_HASH160` at HIGH/CRITICAL security, reusing `QualifiedIdentity` as the signer.
- Upstream profile creation and replacement select the first eligible key in key-ID order reported available by `Signer::can_sign_with` and pass that exact key to the document writer. Actual signing failures propagate without cross-key retries.
- Cover accepted/rejected key policies and add ignored E2E cases for HASH160-only and partially imported mixed-key identities, exercising both create and replace.
- Adapt the updated API: preserve cached shielded balances when checked totals fail, pass the current Platform version to token reward calculations, and include terminal `FAILED` withdrawals in history and structured responses.
- Update profile documentation, user story, changelog, and withdrawal status schema descriptions.

### Validation

- `cargo test --lib --all-features profile --locked`: **43 passed**.
- Upstream profile tests at the pinned revision: **12 passed**. Restoring the old selector in an isolated checkout caused the missing-key and mixed-key regression tests to fail; restoring the fixed selector made them pass.
- `cargo fmt --all` and `git diff --check`: passed.
- `cargo clippy --all-features --lib --bins --test backend-e2e --locked -- -D warnings`: passed, including compilation of `profile_create_and_replace_skips_unavailable_hash160_key`.
- Live E2E was not run because no funded `E2E_WALLET_MNEMONIC` is configured.
- Earlier validation of the shielded-balance adaptation ran 27 event-bridge tests successfully; these were not rerun for the signer follow-up.

### Review limitations

- Signer availability reflects stored key placements; an actual vault access or signing error still fails the operation.
- The earlier dependency review reported existing Rustls and h2 advisories in unchanged registry versions. This follow-up did not repeat that audit or independently audit every upstream consensus change.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DashPay profiles now support HASH160 authentication keys, in addition to SECP256K1 keys, at HIGH or CRITICAL security levels.
  - Failed withdrawals are now recognized and displayed alongside completed and expired withdrawals.

- **Bug Fixes**
  - Shielded balance summaries now safely handle invalid or overflowing totals without replacing cached balances.
  - Token reward calculations now use the appropriate platform version.

- **Documentation**
  - Updated profile authentication requirements and added HASH160 create-and-replace coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->